### PR TITLE
feat(FND-003): Clerk auth + protected routes + user mirror

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,10 +13,14 @@ NEXT_PUBLIC_SUPABASE_URL=https://<project-ref>.supabase.co
 NEXT_PUBLIC_SUPABASE_ANON_KEY=sb_publishable_xxx
 SUPABASE_SERVICE_ROLE_KEY=  # service_role JWT, server-only, never ship to browser
 
-# ---- Auth (Clerk) ----  added in FND-003
-# NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=
-# CLERK_SECRET_KEY=
-# CLERK_WEBHOOK_SECRET=
+# ---- Auth (Clerk) ----
+NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=pk_test_xxx
+CLERK_SECRET_KEY=sk_test_xxx
+NEXT_PUBLIC_CLERK_SIGN_IN_URL=/sign-in
+NEXT_PUBLIC_CLERK_SIGN_UP_URL=/sign-up
+NEXT_PUBLIC_CLERK_SIGN_IN_FALLBACK_REDIRECT_URL=/app/dashboard
+NEXT_PUBLIC_CLERK_SIGN_UP_FALLBACK_REDIRECT_URL=/app/dashboard
+# CLERK_WEBHOOK_SECRET=  # set after configuring the user.* webhook in Clerk Dashboard
 
 # ---- Observability ----  added in FND-006
 # NEXT_PUBLIC_SENTRY_DSN=

--- a/drizzle/migrations/0001_useful_guardian.sql
+++ b/drizzle/migrations/0001_useful_guardian.sql
@@ -1,0 +1,13 @@
+CREATE TYPE "public"."user_role" AS ENUM('attorney', 'caseworker', 'ed_coordinator', 'shelter_staff', 'admin');--> statement-breakpoint
+CREATE TABLE "users" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"clerk_user_id" text NOT NULL,
+	"email" text NOT NULL,
+	"first_name" text,
+	"last_name" text,
+	"role" "user_role" DEFAULT 'caseworker' NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX "users_clerk_user_id_idx" ON "users" USING btree ("clerk_user_id");

--- a/drizzle/migrations/meta/0001_snapshot.json
+++ b/drizzle/migrations/meta/0001_snapshot.json
@@ -1,0 +1,140 @@
+{
+  "id": "d68f68e9-74d4-4b27-bab6-e4da63da94de",
+  "prevId": "363e1062-6db4-4a39-a114-d87d24fc443d",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.health_check": {
+      "name": "health_check",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "clerk_user_id": {
+          "name": "clerk_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'caseworker'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "users_clerk_user_id_idx": {
+          "name": "users_clerk_user_id_idx",
+          "columns": [
+            {
+              "expression": "clerk_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "attorney",
+        "caseworker",
+        "ed_coordinator",
+        "shelter_staff",
+        "admin"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/migrations/meta/_journal.json
+++ b/drizzle/migrations/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1777159840170,
       "tag": "0000_lean_blacklash",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "7",
+      "when": 1777160718880,
+      "tag": "0001_useful_guardian",
+      "breakpoints": true
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   },
   "dependencies": {
     "@base-ui/react": "^1.4.1",
+    "@clerk/nextjs": "^7.2.7",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "drizzle-orm": "^0.45.2",
@@ -27,6 +28,7 @@
     "react": "19.2.4",
     "react-dom": "19.2.4",
     "shadcn": "^4.5.0",
+    "svix": "^1.92.2",
     "tailwind-merge": "^3.5.0",
     "tw-animate-css": "^1.4.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@base-ui/react':
         specifier: ^1.4.1
         version: 1.4.1(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@clerk/nextjs':
+        specifier: ^7.2.7
+        version: 7.2.7(next@16.2.4(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -38,6 +41,9 @@ importers:
       shadcn:
         specifier: ^4.5.0
         version: 4.5.0(@types/node@20.19.39)(typescript@5.9.3)
+      svix:
+        specifier: ^1.92.2
+        version: 1.92.2
       tailwind-merge:
         specifier: ^3.5.0
         version: 3.5.0
@@ -291,6 +297,37 @@ packages:
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [win32]
+
+  '@clerk/backend@3.4.1':
+    resolution: {integrity: sha512-+Tgo1uPEFpBRvyFW3JtPbrTMRgiP+pWBo9gi2tTB0AxEqR2I/kSYy5l3+KqWciUpbVZtVvLXm1j+NEE2WEG+jg==}
+    engines: {node: '>=20.9.0'}
+
+  '@clerk/nextjs@7.2.7':
+    resolution: {integrity: sha512-n0t/r033IT1rfK+b046xTt7VadZA0H8J+DXYBUdaNveQ2pV+MrtxHOSXfCWhjqghonKVImCchXNalX+mZGDaDQ==}
+    engines: {node: '>=20.9.0'}
+    peerDependencies:
+      next: ^15.2.8 || ^15.3.8 || ^15.4.10 || ^15.5.9 || ^15.6.0-0 || ^16.0.10 || ^16.1.0-0
+      react: ^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0
+      react-dom: ^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0
+
+  '@clerk/react@6.4.5':
+    resolution: {integrity: sha512-RxRfBwZF8aMxMZFtceAnjmQC4xLn7vyHOre9/toBXIfDlVU3bH35EGdKu8Js5OPa3GMKdQHDtNJ40UXPPLw38Q==}
+    engines: {node: '>=20.9.0'}
+    peerDependencies:
+      react: ^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0
+      react-dom: ^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0
+
+  '@clerk/shared@4.8.5':
+    resolution: {integrity: sha512-YxgUWHoKEXEbRPWPEcB2Q0o+NJkDc0/zQRp4QCsnGIM5e32hlBUwxcYpyDjDlZ2lYB+GUXHuEc3KETnxWGp26g==}
+    engines: {node: '>=20.9.0'}
+    peerDependencies:
+      react: ^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0
+      react-dom: ^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0
+    peerDependenciesMeta:
+      react:
+        optional: true
+      react-dom:
+        optional: true
 
   '@dotenvx/dotenvx@1.63.0':
     resolution: {integrity: sha512-jjkmzIRu19uH78AjFInqfcALehbDCZZ7M09hurVawyqNxtOXEg2LR73L59y4QnzfYDEzjbhVzGAd2uDHu0D1aQ==}
@@ -1077,6 +1114,9 @@ packages:
     resolution: {integrity: sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==}
     engines: {node: '>=18'}
 
+  '@stablelib/base64@1.0.1':
+    resolution: {integrity: sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==}
+
   '@swc/helpers@0.5.15':
     resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
 
@@ -1167,6 +1207,9 @@ packages:
 
   '@tailwindcss/postcss@4.2.4':
     resolution: {integrity: sha512-wgAVj6nUWAolAu8YFvzT2cTBIElWHkjZwFYovF+xsqKsW2ADxM/X2opxj5NsF/qVccAOjRNe8X2IdPzMsWyHTg==}
+
+  '@tanstack/query-core@5.90.16':
+    resolution: {integrity: sha512-MvtWckSVufs/ja463/K4PyJeqT+HMlJWtw6PrCpywznd2NSgO3m4KwO9RqbFqGg6iDE8vVMFWMeQI4Io3eEYww==}
 
   '@ts-morph/common@0.27.0':
     resolution: {integrity: sha512-Wf29UqxWDpc+i61k3oIOzcUfQt79PIT9y/MWfAGlrkjg6lBC1hwDECLXPVJAhWjiGbfBCxZd65F/LIZF3+jeJQ==}
@@ -1418,6 +1461,10 @@ packages:
     resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
     engines: {node: '>= 0.8'}
 
+  dequal@2.0.3:
+    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
+    engines: {node: '>=6'}
+
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
@@ -1637,6 +1684,9 @@ packages:
     resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
     engines: {node: '>=8.6.0'}
 
+  fast-sha256@1.3.0:
+    resolution: {integrity: sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==}
+
   fast-string-truncated-width@3.0.3:
     resolution: {integrity: sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g==}
 
@@ -1742,6 +1792,9 @@ packages:
   glob-parent@5.1.2:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
     engines: {node: '>= 6'}
+
+  glob-to-regexp@0.4.1:
+    resolution: {integrity: sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==}
 
   gopd@1.2.0:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
@@ -1896,6 +1949,10 @@ packages:
 
   jose@6.2.2:
     resolution: {integrity: sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==}
+
+  js-cookie@3.0.5:
+    resolution: {integrity: sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==}
+    engines: {node: '>=14'}
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
@@ -2344,6 +2401,9 @@ packages:
     resolution: {integrity: sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==}
     engines: {node: '>= 18'}
 
+  server-only@0.0.1:
+    resolution: {integrity: sha512-qepMx2JxAa5jjfzxG79yPPq+8BuFToHd1hm7kI+Z4zAq1ftQiP7HcxMhDDItrbtwVeLg/cY2JnKnrcFkmiswNA==}
+
   set-cookie-parser@3.1.0:
     resolution: {integrity: sha512-kjnC1DXBHcxaOaOXBHBeRtltsDG2nUiUni+jP92M9gYdW12rsmx92UsfpH7o5tDRs7I1ZZPSQJQGv3UaRfCiuw==}
 
@@ -2403,9 +2463,15 @@ packages:
     resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
     engines: {node: '>=0.10.0'}
 
+  standardwebhooks@1.0.0:
+    resolution: {integrity: sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==}
+
   statuses@2.0.2:
     resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
     engines: {node: '>= 0.8'}
+
+  std-env@3.10.0:
+    resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
 
   stdin-discarder@0.2.2:
     resolution: {integrity: sha512-UhDfHmA92YAlNnCfhmq0VeNL5bDbiZGg7sZ2IvPsXubGkiNa9EC+tUTsjBRsYUAz87btI6/1wf4XoVvQ3uRnmQ==}
@@ -2458,6 +2524,9 @@ packages:
         optional: true
       babel-plugin-macros:
         optional: true
+
+  svix@1.92.2:
+    resolution: {integrity: sha512-ZmuA3UVvlnF9EgxlzmPtF7CKjQb64Z6OFlyfdDfU0sdcC7dJa+3aOYX5B9mA+RS6ch1AxBa4UP/l6KmqfGtWBQ==}
 
   tagged-tag@1.0.0:
     resolution: {integrity: sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==}
@@ -2871,6 +2940,44 @@ snapshots:
 
   '@biomejs/cli-win32-x64@2.4.13':
     optional: true
+
+  '@clerk/backend@3.4.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@clerk/shared': 4.8.5(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      standardwebhooks: 1.0.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - react
+      - react-dom
+
+  '@clerk/nextjs@7.2.7(next@16.2.4(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@clerk/backend': 3.4.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@clerk/react': 6.4.5(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@clerk/shared': 4.8.5(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      next: 16.2.4(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+      server-only: 0.0.1
+      tslib: 2.8.1
+
+  '@clerk/react@6.4.5(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@clerk/shared': 4.8.5(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+      tslib: 2.8.1
+
+  '@clerk/shared@4.8.5(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@tanstack/query-core': 5.90.16
+      dequal: 2.0.3
+      glob-to-regexp: 0.4.1
+      js-cookie: 3.0.5
+      std-env: 3.10.0
+    optionalDependencies:
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
 
   '@dotenvx/dotenvx@1.63.0':
     dependencies:
@@ -3384,6 +3491,8 @@ snapshots:
 
   '@sindresorhus/merge-streams@4.0.0': {}
 
+  '@stablelib/base64@1.0.1': {}
+
   '@swc/helpers@0.5.15':
     dependencies:
       tslib: 2.8.1
@@ -3456,6 +3565,8 @@ snapshots:
       '@tailwindcss/oxide': 4.2.4
       postcss: 8.5.10
       tailwindcss: 4.2.4
+
+  '@tanstack/query-core@5.90.16': {}
 
   '@ts-morph/common@0.27.0':
     dependencies:
@@ -3663,6 +3774,8 @@ snapshots:
   define-lazy-prop@3.0.0: {}
 
   depd@2.0.0: {}
+
+  dequal@2.0.3: {}
 
   detect-libc@2.1.2: {}
 
@@ -3895,6 +4008,8 @@ snapshots:
       merge2: 1.4.1
       micromatch: 4.0.8
 
+  fast-sha256@1.3.0: {}
+
   fast-string-truncated-width@3.0.3: {}
 
   fast-string-width@3.0.2:
@@ -4000,6 +4115,8 @@ snapshots:
   glob-parent@5.1.2:
     dependencies:
       is-glob: 4.0.3
+
+  glob-to-regexp@0.4.1: {}
 
   gopd@1.2.0: {}
 
@@ -4107,6 +4224,8 @@ snapshots:
   jiti@2.6.1: {}
 
   jose@6.2.2: {}
+
+  js-cookie@3.0.5: {}
 
   js-tokens@4.0.0: {}
 
@@ -4521,6 +4640,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  server-only@0.0.1: {}
+
   set-cookie-parser@3.1.0: {}
 
   setprototypeof@1.2.0: {}
@@ -4649,7 +4770,14 @@ snapshots:
 
   source-map@0.6.1: {}
 
+  standardwebhooks@1.0.0:
+    dependencies:
+      '@stablelib/base64': 1.0.1
+      fast-sha256: 1.3.0
+
   statuses@2.0.2: {}
+
+  std-env@3.10.0: {}
 
   stdin-discarder@0.2.2: {}
 
@@ -4693,6 +4821,10 @@ snapshots:
       react: 19.2.4
     optionalDependencies:
       '@babel/core': 7.29.0
+
+  svix@1.92.2:
+    dependencies:
+      standardwebhooks: 1.0.0
 
   tagged-tag@1.0.0: {}
 

--- a/src/app/api/webhooks/clerk/route.ts
+++ b/src/app/api/webhooks/clerk/route.ts
@@ -1,0 +1,82 @@
+import { eq } from 'drizzle-orm';
+import { headers } from 'next/headers';
+import { NextResponse } from 'next/server';
+import { Webhook } from 'svix';
+import { db } from '@/db/client';
+import { users } from '@/db/schema/users';
+
+export const dynamic = 'force-dynamic';
+
+type ClerkEmailAddress = { id: string; email_address: string };
+type ClerkUserPayload = {
+  id: string;
+  email_addresses: ClerkEmailAddress[];
+  primary_email_address_id: string | null;
+  first_name: string | null;
+  last_name: string | null;
+};
+
+type ClerkEvent =
+  | { type: 'user.created' | 'user.updated'; data: ClerkUserPayload }
+  | { type: 'user.deleted'; data: { id: string } };
+
+/**
+ * Clerk webhook for production user sync (mirrors lazy upsert in src/lib/auth.ts).
+ * Configure in Clerk Dashboard once a public URL exists (FND-005).
+ * Until CLERK_WEBHOOK_SECRET is set, this returns 503 — the lazy upsert handles dev.
+ */
+export async function POST(req: Request) {
+  const secret = process.env.CLERK_WEBHOOK_SECRET;
+  if (!secret) {
+    return NextResponse.json({ error: 'webhook not configured' }, { status: 503 });
+  }
+
+  const hdrs = await headers();
+  const svixId = hdrs.get('svix-id');
+  const svixTs = hdrs.get('svix-timestamp');
+  const svixSig = hdrs.get('svix-signature');
+  if (!svixId || !svixTs || !svixSig) {
+    return NextResponse.json({ error: 'missing svix headers' }, { status: 400 });
+  }
+
+  const body = await req.text();
+  let event: ClerkEvent;
+  try {
+    event = new Webhook(secret).verify(body, {
+      'svix-id': svixId,
+      'svix-timestamp': svixTs,
+      'svix-signature': svixSig,
+    }) as ClerkEvent;
+  } catch (err) {
+    console.error('[clerk webhook] signature verification failed:', err);
+    return NextResponse.json({ error: 'invalid signature' }, { status: 400 });
+  }
+
+  try {
+    if (event.type === 'user.created' || event.type === 'user.updated') {
+      const u = event.data;
+      const email =
+        u.email_addresses.find((e) => e.id === u.primary_email_address_id)?.email_address ??
+        u.email_addresses[0]?.email_address ??
+        '';
+      await db
+        .insert(users)
+        .values({
+          clerkUserId: u.id,
+          email,
+          firstName: u.first_name,
+          lastName: u.last_name,
+        })
+        .onConflictDoUpdate({
+          target: users.clerkUserId,
+          set: { email, firstName: u.first_name, lastName: u.last_name, updatedAt: new Date() },
+        });
+    } else if (event.type === 'user.deleted') {
+      await db.delete(users).where(eq(users.clerkUserId, event.data.id));
+    }
+    return NextResponse.json({ ok: true });
+  } catch (err) {
+    console.error('[clerk webhook] handler error:', err);
+    return NextResponse.json({ ok: false }, { status: 500 });
+  }
+}

--- a/src/app/app/dashboard/page.tsx
+++ b/src/app/app/dashboard/page.tsx
@@ -1,0 +1,30 @@
+import { UserButton } from '@clerk/nextjs';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { requireUser } from '@/lib/auth';
+
+export default async function DashboardPage() {
+  const user = await requireUser();
+
+  return (
+    <main className="flex min-h-screen flex-col gap-8 bg-background p-8">
+      <header className="flex items-center justify-between">
+        <h1 className="text-3xl font-bold tracking-tight">Dashboard</h1>
+        <UserButton />
+      </header>
+
+      <Card className="max-w-2xl">
+        <CardHeader>
+          <CardTitle>Welcome, {user.firstName ?? user.email}</CardTitle>
+          <CardDescription>
+            Signed in as <code className="font-mono">{user.email}</code> · role{' '}
+            <code className="font-mono">{user.role}</code>
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="text-sm text-muted-foreground">
+          Phase 0 placeholder. Real role-aware surfaces ship in Phase 1 (eviction defense,
+          super-utilizer care, caseworker tools).
+        </CardContent>
+      </Card>
+    </main>
+  );
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,3 +1,4 @@
+import { ClerkProvider } from '@clerk/nextjs';
 import type { Metadata } from 'next';
 import { Geist, Geist_Mono } from 'next/font/google';
 import './globals.css';
@@ -24,8 +25,10 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en" className={`${geistSans.variable} ${geistMono.variable} h-full antialiased`}>
-      <body className="min-h-full flex flex-col">{children}</body>
-    </html>
+    <ClerkProvider>
+      <html lang="en" className={`${geistSans.variable} ${geistMono.variable} h-full antialiased`}>
+        <body className="min-h-full flex flex-col">{children}</body>
+      </html>
+    </ClerkProvider>
   );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,7 +1,11 @@
+import { auth } from '@clerk/nextjs/server';
+import Link from 'next/link';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 
-export default function Home() {
+export default async function Home() {
+  const { userId } = await auth();
+
   return (
     <main className="flex min-h-screen flex-col items-center justify-center gap-8 bg-background p-8">
       <div className="max-w-2xl text-center space-y-4">
@@ -19,8 +23,20 @@ export default function Home() {
           <CardDescription>This is a scaffold. Real surfaces ship in Phase 1.</CardDescription>
         </CardHeader>
         <CardContent className="flex gap-3">
-          <Button>Get started</Button>
-          <Button variant="outline">View backlog</Button>
+          {userId ? (
+            <Link href="/app/dashboard">
+              <Button>Open dashboard</Button>
+            </Link>
+          ) : (
+            <>
+              <Link href="/sign-in">
+                <Button>Sign in</Button>
+              </Link>
+              <Link href="/sign-up">
+                <Button variant="outline">Create account</Button>
+              </Link>
+            </>
+          )}
         </CardContent>
       </Card>
     </main>

--- a/src/app/sign-in/[[...sign-in]]/page.tsx
+++ b/src/app/sign-in/[[...sign-in]]/page.tsx
@@ -1,0 +1,9 @@
+import { SignIn } from '@clerk/nextjs';
+
+export default function SignInPage() {
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-background p-8">
+      <SignIn />
+    </div>
+  );
+}

--- a/src/app/sign-up/[[...sign-up]]/page.tsx
+++ b/src/app/sign-up/[[...sign-up]]/page.tsx
@@ -1,0 +1,9 @@
+import { SignUp } from '@clerk/nextjs';
+
+export default function SignUpPage() {
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-background p-8">
+      <SignUp />
+    </div>
+  );
+}

--- a/src/db/schema/enums.ts
+++ b/src/db/schema/enums.ts
@@ -1,0 +1,11 @@
+import { pgEnum } from 'drizzle-orm/pg-core';
+
+export const userRoleEnum = pgEnum('user_role', [
+  'attorney',
+  'caseworker',
+  'ed_coordinator',
+  'shelter_staff',
+  'admin',
+]);
+
+export type UserRole = (typeof userRoleEnum.enumValues)[number];

--- a/src/db/schema/index.ts
+++ b/src/db/schema/index.ts
@@ -1,1 +1,3 @@
+export * from './enums';
 export * from './health-check';
+export * from './users';

--- a/src/db/schema/users.ts
+++ b/src/db/schema/users.ts
@@ -1,0 +1,20 @@
+import { pgTable, text, timestamp, uniqueIndex, uuid } from 'drizzle-orm/pg-core';
+import { userRoleEnum } from './enums';
+
+export const users = pgTable(
+  'users',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    clerkUserId: text('clerk_user_id').notNull(),
+    email: text('email').notNull(),
+    firstName: text('first_name'),
+    lastName: text('last_name'),
+    role: userRoleEnum('role').notNull().default('caseworker'),
+    createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => [uniqueIndex('users_clerk_user_id_idx').on(table.clerkUserId)],
+);
+
+export type User = typeof users.$inferSelect;
+export type NewUser = typeof users.$inferInsert;

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,0 +1,40 @@
+import { auth, clerkClient } from '@clerk/nextjs/server';
+import { eq } from 'drizzle-orm';
+import { redirect } from 'next/navigation';
+import { db } from '@/db/client';
+import { type User, users } from '@/db/schema/users';
+
+/**
+ * Server-only helper: returns the current user from our DB, lazy-creating
+ * the row on first call (mirrors Clerk identity into Postgres).
+ *
+ * Use this from any protected server component or server action. Redirects
+ * to /sign-in if no Clerk session is present (defense-in-depth — middleware
+ * should have already protected the route).
+ */
+export async function requireUser(): Promise<User> {
+  const { userId } = await auth();
+  if (!userId) redirect('/sign-in');
+
+  const existing = await db.select().from(users).where(eq(users.clerkUserId, userId)).limit(1);
+  if (existing.length > 0) return existing[0];
+
+  // First sign-in: mirror to DB. Pull canonical email + name from Clerk.
+  const client = await clerkClient();
+  const clerkUser = await client.users.getUser(userId);
+  const primaryEmail =
+    clerkUser.emailAddresses.find((e) => e.id === clerkUser.primaryEmailAddressId)?.emailAddress ??
+    clerkUser.emailAddresses[0]?.emailAddress ??
+    '';
+
+  const [created] = await db
+    .insert(users)
+    .values({
+      clerkUserId: userId,
+      email: primaryEmail,
+      firstName: clerkUser.firstName,
+      lastName: clerkUser.lastName,
+    })
+    .returning();
+  return created;
+}

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -20,21 +20,33 @@ export async function requireUser(): Promise<User> {
   if (existing.length > 0) return existing[0];
 
   // First sign-in: mirror to DB. Pull canonical email + name from Clerk.
-  const client = await clerkClient();
-  const clerkUser = await client.users.getUser(userId);
-  const primaryEmail =
-    clerkUser.emailAddresses.find((e) => e.id === clerkUser.primaryEmailAddressId)?.emailAddress ??
-    clerkUser.emailAddresses[0]?.emailAddress ??
-    '';
+  let primaryEmail = '';
+  let firstName: string | null = null;
+  let lastName: string | null = null;
+  try {
+    const client = await clerkClient();
+    const clerkUser = await client.users.getUser(userId);
+    primaryEmail =
+      clerkUser.emailAddresses.find((e) => e.id === clerkUser.primaryEmailAddressId)
+        ?.emailAddress ??
+      clerkUser.emailAddresses[0]?.emailAddress ??
+      '';
+    firstName = clerkUser.firstName;
+    lastName = clerkUser.lastName;
+  } catch (err) {
+    console.error('[requireUser] clerk lookup failed for', userId, err);
+    redirect('/sign-in?error=user_lookup_failed');
+  }
 
+  // onConflictDoNothing handles the race where two concurrent first-requests
+  // both pass the SELECT and try to INSERT; the loser re-SELECTs.
   const [created] = await db
     .insert(users)
-    .values({
-      clerkUserId: userId,
-      email: primaryEmail,
-      firstName: clerkUser.firstName,
-      lastName: clerkUser.lastName,
-    })
+    .values({ clerkUserId: userId, email: primaryEmail, firstName, lastName })
+    .onConflictDoNothing({ target: users.clerkUserId })
     .returning();
-  return created;
+  if (created) return created;
+
+  const [winner] = await db.select().from(users).where(eq(users.clerkUserId, userId)).limit(1);
+  return winner;
 }

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,0 +1,32 @@
+import { clerkMiddleware, createRouteMatcher } from '@clerk/nextjs/server';
+import { NextResponse } from 'next/server';
+
+// Routes that REQUIRE auth. Everything else (including /, /sign-in, /sign-up)
+// is public until added here.
+const isProtectedRoute = createRouteMatcher(['/app(.*)', '/api/protected(.*)']);
+
+export default clerkMiddleware(async (auth, req) => {
+  if (!isProtectedRoute(req)) return;
+
+  const { userId } = await auth();
+  if (userId) return;
+
+  // No session: 401 for API requests, redirect-to-sign-in for pages.
+  // (Clerk's auth.protect() defaults to a 404 for unauthenticated requests,
+  // which is hostile to UX.)
+  if (req.nextUrl.pathname.startsWith('/api/')) {
+    return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
+  }
+  const signIn = new URL('/sign-in', req.url);
+  signIn.searchParams.set('redirect_url', req.nextUrl.pathname + req.nextUrl.search);
+  return NextResponse.redirect(signIn);
+});
+
+export const config = {
+  matcher: [
+    // Skip Next.js internals and all static files unless found in search params.
+    '/((?!_next|[^?]*\\.(?:html?|css|js(?!on)|jpe?g|webp|png|gif|svg|ttf|woff2?|ico|csv|docx?|xlsx?|zip|webmanifest)).*)',
+    // Always run for API routes.
+    '/(api|trpc)(.*)',
+  ],
+};

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -17,7 +17,8 @@ export default clerkMiddleware(async (auth, req) => {
   if (req.nextUrl.pathname.startsWith('/api/')) {
     return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
   }
-  const signIn = new URL('/sign-in', req.url);
+  const signInPath = process.env.NEXT_PUBLIC_CLERK_SIGN_IN_URL ?? '/sign-in';
+  const signIn = new URL(signInPath, req.url);
   signIn.searchParams.set('redirect_url', req.nextUrl.pathname + req.nextUrl.search);
   return NextResponse.redirect(signIn);
 });


### PR DESCRIPTION
Closes #3

## Summary
- Clerk wired (provider, sign-in/up routes, UserButton on dashboard)
- `src/proxy.ts` (renamed from `middleware.ts` per Next 16) protects `/app(.*)` and `/api/protected(.*)`; pages redirect to `/sign-in?redirect_url=...`, API requests get 401
- `users` table + `user_role` enum (Drizzle migration `0001_useful_guardian.sql`)
- `requireUser()` lazy-mirrors Clerk identity into Postgres on first sign-in (avoids needing a webhook secret + public URL during dev)
- `/api/webhooks/clerk` signed handler ready for prod (returns 503 until `CLERK_WEBHOOK_SECRET` is set post-deploy)

## Acceptance criteria
- [x] Clerk app created; pub + secret keys in `.env.example`
- [x] `<ClerkProvider>` wraps app; `/sign-in` and `/sign-up` work
- [x] Middleware (proxy.ts) protects `/app/*`; `/` and marketing pages public
- [x] First sign-in mirrors user row to Postgres `users` table
- [x] Role enum: `attorney`, `caseworker`, `ed_coordinator`, `shelter_staff`, `admin`
- [x] Default role on signup = `caseworker`

## Verification
```
$ pnpm lint && pnpm typecheck && pnpm build  # all green
$ pnpm db:generate && pnpm db:migrate         # users table created
$ curl -o /dev/null -w "%{http_code}" /app/dashboard       # 307 -> /sign-in
$ curl -o /dev/null -w "%{http_code}" /api/protected/x     # 401
$ curl -o /dev/null -w "%{http_code}" /                    # 200
$ curl -o /dev/null -w "%{http_code}" /sign-in             # 200
```

## Notes
- `users` table is intentionally minimal here. FND-008 expands the data model
  (partner_orgs, org_memberships, audit_log, consents).
- HIPAA fence respected: no PHI in schema; lazy-upsert pulls only Clerk-supplied
  identity (email, name) — same fields the user gave Clerk at signup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)