### PR TITLE
feat(FND-008): core data model — partner_orgs, org_memberships, audit_log, consents + seed

### DIFF
--- a/docs/schema.md
+++ b/docs/schema.md
@@ -1,0 +1,108 @@
+# Database schema
+
+Source of truth: `src/db/schema/*.ts`. Migrations in `drizzle/migrations/`.
+
+## Phase 0 (current)
+
+The Phase-0 schema is intentionally minimal — identity, organizations, audit
+log, and consent records. **No client (PHI) data lives in the database yet.**
+That comes in Phase 1 stories, gated behind the BAA with Owensboro Health.
+
+```mermaid
+erDiagram
+    PARTNER_ORGS ||--o{ ORG_MEMBERSHIPS : has
+    USERS ||--o{ ORG_MEMBERSHIPS : "belongs to"
+    USERS ||--o{ AUDIT_LOG : "performs"
+
+    USERS {
+        uuid id PK
+        text clerk_user_id UK
+        text email
+        text first_name
+        text last_name
+        user_role role
+        timestamptz created_at
+        timestamptz updated_at
+    }
+
+    PARTNER_ORGS {
+        uuid id PK
+        text name
+        text slug UK
+        partner_org_type type
+        text contact_email
+        text contact_phone
+        bool active
+        timestamptz created_at
+        timestamptz updated_at
+    }
+
+    ORG_MEMBERSHIPS {
+        uuid id PK
+        uuid user_id FK
+        uuid partner_org_id FK
+        user_role role
+        timestamptz created_at
+    }
+
+    AUDIT_LOG {
+        uuid id PK
+        uuid actor_user_id FK
+        text action
+        text target_table
+        text target_id
+        jsonb metadata
+        timestamptz created_at
+    }
+
+    CONSENTS {
+        uuid id PK
+        text subject_external_id
+        consent_type consent_type
+        consent_channel granted_via
+        timestamptz granted_at
+        timestamptz revoked_at
+        text notes
+        timestamptz created_at
+    }
+
+    HEALTH_CHECK {
+        uuid id PK
+        timestamptz created_at
+    }
+```
+
+## Tables
+
+| Table | Purpose | PHI risk |
+|---|---|---|
+| `users` | Identity mirror of Clerk users + their primary global role | none |
+| `partner_orgs` | Coalition member organizations (hospital, legal aid, shelter, etc.) | none |
+| `org_memberships` | M:N user↔org with per-org role for multi-tenant access | none |
+| `audit_log` | Append-only record of significant system actions | none — never log PHI in `metadata` |
+| `consents` | Subject consent records (PHI sharing, SMS, etc.). Subject linkage is by external ID until clients table lands in Phase 1. | non-PHI |
+| `health_check` | DB roundtrip target for `/api/health` | none |
+
+## Enums
+
+| Enum | Values |
+|---|---|
+| `user_role` | attorney, caseworker, ed_coordinator, shelter_staff, admin |
+| `partner_org_type` | hospital, legal_aid, shelter, community_org, government, other |
+| `consent_type` | phi_share_within_coalition, sms_communication, data_for_program_eval |
+| `consent_channel` | sms, in_person, web_form, phone, paper |
+
+## Conventions
+
+- All PKs are `uuid` with `default gen_random_uuid()`.
+- Timestamps are `timestamp with time zone` and default to `now()`.
+- Every FK column has a btree index.
+- `audit_log` is append-only — never `UPDATE` or `DELETE` rows. Use
+  `logAuditEvent()` from `src/lib/audit.ts` to write.
+- `consents` revocations set `revoked_at`; rows are never deleted.
+- Schema files live in `src/db/schema/{table}.ts`, exported via `index.ts`.
+
+## Seeding
+
+`pnpm db:seed` creates a baseline of fixture data (1 org + 5 users, one per
+role, + 3 audit entries). Idempotent — safe to re-run.

--- a/drizzle/migrations/0002_fearless_domino.sql
+++ b/drizzle/migrations/0002_fearless_domino.sql
@@ -1,0 +1,56 @@
+CREATE TYPE "public"."consent_channel" AS ENUM('sms', 'in_person', 'web_form', 'phone', 'paper');--> statement-breakpoint
+CREATE TYPE "public"."consent_type" AS ENUM('phi_share_within_coalition', 'sms_communication', 'data_for_program_eval');--> statement-breakpoint
+CREATE TYPE "public"."partner_org_type" AS ENUM('hospital', 'legal_aid', 'shelter', 'community_org', 'government', 'other');--> statement-breakpoint
+CREATE TABLE "audit_log" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"actor_user_id" uuid,
+	"action" text NOT NULL,
+	"target_table" text,
+	"target_id" text,
+	"metadata" jsonb,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "consents" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"subject_external_id" text NOT NULL,
+	"consent_type" "consent_type" NOT NULL,
+	"granted_via" "consent_channel" NOT NULL,
+	"granted_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"revoked_at" timestamp with time zone,
+	"notes" text,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "org_memberships" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"user_id" uuid NOT NULL,
+	"partner_org_id" uuid NOT NULL,
+	"role" "user_role" NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "partner_orgs" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"name" text NOT NULL,
+	"slug" text NOT NULL,
+	"type" "partner_org_type" NOT NULL,
+	"contact_email" text,
+	"contact_phone" text,
+	"active" boolean DEFAULT true NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "audit_log" ADD CONSTRAINT "audit_log_actor_user_id_users_id_fk" FOREIGN KEY ("actor_user_id") REFERENCES "public"."users"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "org_memberships" ADD CONSTRAINT "org_memberships_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "org_memberships" ADD CONSTRAINT "org_memberships_partner_org_id_partner_orgs_id_fk" FOREIGN KEY ("partner_org_id") REFERENCES "public"."partner_orgs"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "audit_log_actor_idx" ON "audit_log" USING btree ("actor_user_id");--> statement-breakpoint
+CREATE INDEX "audit_log_action_idx" ON "audit_log" USING btree ("action");--> statement-breakpoint
+CREATE INDEX "audit_log_created_at_idx" ON "audit_log" USING btree ("created_at");--> statement-breakpoint
+CREATE INDEX "consents_subject_idx" ON "consents" USING btree ("subject_external_id");--> statement-breakpoint
+CREATE INDEX "consents_type_idx" ON "consents" USING btree ("consent_type");--> statement-breakpoint
+CREATE UNIQUE INDEX "org_memberships_user_org_idx" ON "org_memberships" USING btree ("user_id","partner_org_id");--> statement-breakpoint
+CREATE INDEX "org_memberships_user_idx" ON "org_memberships" USING btree ("user_id");--> statement-breakpoint
+CREATE INDEX "org_memberships_partner_org_idx" ON "org_memberships" USING btree ("partner_org_id");--> statement-breakpoint
+CREATE UNIQUE INDEX "partner_orgs_slug_idx" ON "partner_orgs" USING btree ("slug");

--- a/drizzle/migrations/meta/0002_snapshot.json
+++ b/drizzle/migrations/meta/0002_snapshot.json
@@ -1,0 +1,599 @@
+{
+  "id": "efc6d751-663a-46bf-9023-00dd8a601ade",
+  "prevId": "d68f68e9-74d4-4b27-bab6-e4da63da94de",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.audit_log": {
+      "name": "audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_table": {
+          "name": "target_table",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "audit_log_actor_idx": {
+          "name": "audit_log_actor_idx",
+          "columns": [
+            {
+              "expression": "actor_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_log_action_idx": {
+          "name": "audit_log_action_idx",
+          "columns": [
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_log_created_at_idx": {
+          "name": "audit_log_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audit_log_actor_user_id_users_id_fk": {
+          "name": "audit_log_actor_user_id_users_id_fk",
+          "tableFrom": "audit_log",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.consents": {
+      "name": "consents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "subject_external_id": {
+          "name": "subject_external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consent_type": {
+          "name": "consent_type",
+          "type": "consent_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "granted_via": {
+          "name": "granted_via",
+          "type": "consent_channel",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "granted_at": {
+          "name": "granted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "consents_subject_idx": {
+          "name": "consents_subject_idx",
+          "columns": [
+            {
+              "expression": "subject_external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "consents_type_idx": {
+          "name": "consents_type_idx",
+          "columns": [
+            {
+              "expression": "consent_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.health_check": {
+      "name": "health_check",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_memberships": {
+      "name": "org_memberships",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "partner_org_id": {
+          "name": "partner_org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "org_memberships_user_org_idx": {
+          "name": "org_memberships_user_org_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "partner_org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "org_memberships_user_idx": {
+          "name": "org_memberships_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "org_memberships_partner_org_idx": {
+          "name": "org_memberships_partner_org_idx",
+          "columns": [
+            {
+              "expression": "partner_org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "org_memberships_user_id_users_id_fk": {
+          "name": "org_memberships_user_id_users_id_fk",
+          "tableFrom": "org_memberships",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "org_memberships_partner_org_id_partner_orgs_id_fk": {
+          "name": "org_memberships_partner_org_id_partner_orgs_id_fk",
+          "tableFrom": "org_memberships",
+          "tableTo": "partner_orgs",
+          "columnsFrom": [
+            "partner_org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.partner_orgs": {
+      "name": "partner_orgs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "partner_org_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_email": {
+          "name": "contact_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_phone": {
+          "name": "contact_phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "partner_orgs_slug_idx": {
+          "name": "partner_orgs_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "clerk_user_id": {
+          "name": "clerk_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'caseworker'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "users_clerk_user_id_idx": {
+          "name": "users_clerk_user_id_idx",
+          "columns": [
+            {
+              "expression": "clerk_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.consent_channel": {
+      "name": "consent_channel",
+      "schema": "public",
+      "values": [
+        "sms",
+        "in_person",
+        "web_form",
+        "phone",
+        "paper"
+      ]
+    },
+    "public.consent_type": {
+      "name": "consent_type",
+      "schema": "public",
+      "values": [
+        "phi_share_within_coalition",
+        "sms_communication",
+        "data_for_program_eval"
+      ]
+    },
+    "public.partner_org_type": {
+      "name": "partner_org_type",
+      "schema": "public",
+      "values": [
+        "hospital",
+        "legal_aid",
+        "shelter",
+        "community_org",
+        "government",
+        "other"
+      ]
+    },
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "attorney",
+        "caseworker",
+        "ed_coordinator",
+        "shelter_staff",
+        "admin"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/migrations/meta/_journal.json
+++ b/drizzle/migrations/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1777160718880,
       "tag": "0001_useful_guardian",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "7",
+      "when": 1777161985393,
+      "tag": "0002_fearless_domino",
+      "breakpoints": true
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "db:generate": "drizzle-kit generate",
     "db:migrate": "drizzle-kit migrate",
     "db:push": "drizzle-kit push",
-    "db:studio": "drizzle-kit studio"
+    "db:studio": "drizzle-kit studio",
+    "db:seed": "tsx src/db/seed.ts"
   },
   "dependencies": {
     "@base-ui/react": "^1.4.1",
@@ -42,6 +43,7 @@
     "dotenv": "^17.4.2",
     "drizzle-kit": "^0.31.10",
     "tailwindcss": "^4",
+    "tsx": "^4.21.0",
     "typescript": "^5"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -78,6 +78,9 @@ importers:
       tailwindcss:
         specifier: ^4
         version: 4.2.4
+      tsx:
+        specifier: ^4.21.0
+        version: 4.21.0
       typescript:
         specifier: ^5
         version: 5.9.3

--- a/src/db/schema/audit-log.ts
+++ b/src/db/schema/audit-log.ts
@@ -1,0 +1,30 @@
+import { index, jsonb, pgTable, text, timestamp, uuid } from 'drizzle-orm/pg-core';
+import { users } from './users';
+
+/**
+ * Immutable record of significant system actions. Append-only — never UPDATE
+ * or DELETE rows here. Use `logAuditEvent` from src/lib/audit.ts to write.
+ *
+ * Designed to outlive table renames: target_table + target_id are strings,
+ * not foreign keys (polymorphic).
+ */
+export const auditLog = pgTable(
+  'audit_log',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    actorUserId: uuid('actor_user_id').references(() => users.id, { onDelete: 'set null' }),
+    action: text('action').notNull(), // e.g. 'user.created', 'consent.granted'
+    targetTable: text('target_table'),
+    targetId: text('target_id'),
+    metadata: jsonb('metadata').$type<Record<string, unknown>>(),
+    createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+  },
+  (t) => [
+    index('audit_log_actor_idx').on(t.actorUserId),
+    index('audit_log_action_idx').on(t.action),
+    index('audit_log_created_at_idx').on(t.createdAt),
+  ],
+);
+
+export type AuditLog = typeof auditLog.$inferSelect;
+export type NewAuditLog = typeof auditLog.$inferInsert;

--- a/src/db/schema/consents.ts
+++ b/src/db/schema/consents.ts
@@ -1,0 +1,34 @@
+import { index, pgTable, text, timestamp, uuid } from 'drizzle-orm/pg-core';
+import { consentChannelEnum, consentTypeEnum } from './enums';
+
+/**
+ * Consent records for individuals to share PHI within the coalition, receive
+ * SMS communication, etc. Phase 0 captures the structure; client linkage
+ * (subject_external_id -> a real clients.id) lands in a Phase 1 story when
+ * the clients table exists and PHI flows are unlocked post-BAA.
+ *
+ * Append-only in spirit: revocations are recorded by setting revoked_at,
+ * NOT by deleting the row.
+ */
+export const consents = pgTable(
+  'consents',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    // External identifier for the subject — phone number, intake ID, etc.
+    // Not a FK yet; will become a clients.id in Phase 1.
+    subjectExternalId: text('subject_external_id').notNull(),
+    consentType: consentTypeEnum('consent_type').notNull(),
+    grantedVia: consentChannelEnum('granted_via').notNull(),
+    grantedAt: timestamp('granted_at', { withTimezone: true }).notNull().defaultNow(),
+    revokedAt: timestamp('revoked_at', { withTimezone: true }),
+    notes: text('notes'),
+    createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+  },
+  (t) => [
+    index('consents_subject_idx').on(t.subjectExternalId),
+    index('consents_type_idx').on(t.consentType),
+  ],
+);
+
+export type Consent = typeof consents.$inferSelect;
+export type NewConsent = typeof consents.$inferInsert;

--- a/src/db/schema/enums.ts
+++ b/src/db/schema/enums.ts
@@ -9,3 +9,32 @@ export const userRoleEnum = pgEnum('user_role', [
 ]);
 
 export type UserRole = (typeof userRoleEnum.enumValues)[number];
+
+export const partnerOrgTypeEnum = pgEnum('partner_org_type', [
+  'hospital',
+  'legal_aid',
+  'shelter',
+  'community_org',
+  'government',
+  'other',
+]);
+
+export type PartnerOrgType = (typeof partnerOrgTypeEnum.enumValues)[number];
+
+export const consentTypeEnum = pgEnum('consent_type', [
+  'phi_share_within_coalition',
+  'sms_communication',
+  'data_for_program_eval',
+]);
+
+export type ConsentType = (typeof consentTypeEnum.enumValues)[number];
+
+export const consentChannelEnum = pgEnum('consent_channel', [
+  'sms',
+  'in_person',
+  'web_form',
+  'phone',
+  'paper',
+]);
+
+export type ConsentChannel = (typeof consentChannelEnum.enumValues)[number];

--- a/src/db/schema/index.ts
+++ b/src/db/schema/index.ts
@@ -1,3 +1,7 @@
+export * from './audit-log';
+export * from './consents';
 export * from './enums';
 export * from './health-check';
+export * from './org-memberships';
+export * from './partner-orgs';
 export * from './users';

--- a/src/db/schema/org-memberships.ts
+++ b/src/db/schema/org-memberships.ts
@@ -1,0 +1,34 @@
+import { index, pgTable, timestamp, uniqueIndex, uuid } from 'drizzle-orm/pg-core';
+import { userRoleEnum } from './enums';
+import { partnerOrgs } from './partner-orgs';
+import { users } from './users';
+
+/**
+ * A user can belong to multiple partner orgs, with a possibly different role
+ * per org (e.g. admin at their home org, caseworker observer at a partner).
+ *
+ * The `users.role` column remains the user's primary/global role; this table
+ * captures org-scoped role assignments for multi-tenant access checks.
+ */
+export const orgMemberships = pgTable(
+  'org_memberships',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    userId: uuid('user_id')
+      .notNull()
+      .references(() => users.id, { onDelete: 'cascade' }),
+    partnerOrgId: uuid('partner_org_id')
+      .notNull()
+      .references(() => partnerOrgs.id, { onDelete: 'cascade' }),
+    role: userRoleEnum('role').notNull(),
+    createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+  },
+  (t) => [
+    uniqueIndex('org_memberships_user_org_idx').on(t.userId, t.partnerOrgId),
+    index('org_memberships_user_idx').on(t.userId),
+    index('org_memberships_partner_org_idx').on(t.partnerOrgId),
+  ],
+);
+
+export type OrgMembership = typeof orgMemberships.$inferSelect;
+export type NewOrgMembership = typeof orgMemberships.$inferInsert;

--- a/src/db/schema/partner-orgs.ts
+++ b/src/db/schema/partner-orgs.ts
@@ -1,0 +1,21 @@
+import { boolean, pgTable, text, timestamp, uniqueIndex, uuid } from 'drizzle-orm/pg-core';
+import { partnerOrgTypeEnum } from './enums';
+
+export const partnerOrgs = pgTable(
+  'partner_orgs',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    name: text('name').notNull(),
+    slug: text('slug').notNull(),
+    type: partnerOrgTypeEnum('type').notNull(),
+    contactEmail: text('contact_email'),
+    contactPhone: text('contact_phone'),
+    active: boolean('active').notNull().default(true),
+    createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),
+  },
+  (t) => [uniqueIndex('partner_orgs_slug_idx').on(t.slug)],
+);
+
+export type PartnerOrg = typeof partnerOrgs.$inferSelect;
+export type NewPartnerOrg = typeof partnerOrgs.$inferInsert;

--- a/src/db/seed.ts
+++ b/src/db/seed.ts
@@ -1,0 +1,151 @@
+/**
+ * Idempotent dev seed script. Run with: `pnpm db:seed`
+ *
+ * Creates a baseline of fixture data so the app is usable end-to-end without
+ * Clerk-signed-in users. SAFE to re-run — uses ON CONFLICT DO NOTHING for
+ * external identifiers and counts existing rows for idempotency.
+ *
+ * NEVER load real PHI here. This is synthetic / placeholder data only.
+ */
+import { config } from 'dotenv';
+import { eq } from 'drizzle-orm';
+import { db } from './client';
+import { auditLog } from './schema/audit-log';
+import type { UserRole } from './schema/enums';
+import { orgMemberships } from './schema/org-memberships';
+import { partnerOrgs } from './schema/partner-orgs';
+import { users } from './schema/users';
+
+config({ path: ['.env.local', '.env'] });
+
+async function main() {
+  console.log('[seed] starting…');
+
+  // ---- 1 partner org ----
+  const orgSlug = 'audubon-area-community-services';
+  let [org] = await db.select().from(partnerOrgs).where(eq(partnerOrgs.slug, orgSlug)).limit(1);
+  if (!org) {
+    [org] = await db
+      .insert(partnerOrgs)
+      .values({
+        name: 'Audubon Area Community Services',
+        slug: orgSlug,
+        type: 'community_org',
+        contactEmail: 'info@audubon-area.example',
+        contactPhone: '+1-270-555-0100',
+      })
+      .returning();
+    console.log('[seed]   + partner org', org.slug);
+  } else {
+    console.log('[seed]   = partner org', org.slug, '(exists)');
+  }
+
+  // ---- 5 users, one per role ----
+  const sampleUsers: Array<{ role: UserRole; email: string; firstName: string; lastName: string }> =
+    [
+      {
+        role: 'attorney',
+        email: 'attorney+seed@example.test',
+        firstName: 'Ada',
+        lastName: 'Attorney',
+      },
+      {
+        role: 'caseworker',
+        email: 'caseworker+seed@example.test',
+        firstName: 'Carl',
+        lastName: 'Caseworker',
+      },
+      {
+        role: 'ed_coordinator',
+        email: 'edcoord+seed@example.test',
+        firstName: 'Eve',
+        lastName: 'Coordinator',
+      },
+      {
+        role: 'shelter_staff',
+        email: 'shelter+seed@example.test',
+        firstName: 'Sam',
+        lastName: 'Shelter',
+      },
+      { role: 'admin', email: 'admin+seed@example.test', firstName: 'Alex', lastName: 'Admin' },
+    ];
+
+  for (const u of sampleUsers) {
+    const fakeClerkId = `seed_${u.role}`;
+    const [existing] = await db
+      .select()
+      .from(users)
+      .where(eq(users.clerkUserId, fakeClerkId))
+      .limit(1);
+    let user = existing;
+    if (!user) {
+      [user] = await db
+        .insert(users)
+        .values({
+          clerkUserId: fakeClerkId,
+          email: u.email,
+          firstName: u.firstName,
+          lastName: u.lastName,
+          role: u.role,
+        })
+        .returning();
+      console.log('[seed]   + user', u.role, user.email);
+    } else {
+      console.log('[seed]   = user', u.role, user.email, '(exists)');
+    }
+
+    // Org membership for each.
+    const [hasMembership] = await db
+      .select()
+      .from(orgMemberships)
+      .where(eq(orgMemberships.userId, user.id))
+      .limit(1);
+    if (!hasMembership) {
+      await db
+        .insert(orgMemberships)
+        .values({ userId: user.id, partnerOrgId: org.id, role: u.role })
+        .onConflictDoNothing();
+    }
+  }
+
+  // ---- 3 sample audit entries ----
+  const existingAudits = await db.select({ action: auditLog.action }).from(auditLog).limit(1);
+  if (existingAudits.length === 0) {
+    const [adminUser] = await db
+      .select()
+      .from(users)
+      .where(eq(users.clerkUserId, 'seed_admin'))
+      .limit(1);
+    await db.insert(auditLog).values([
+      {
+        actorUserId: adminUser?.id ?? null,
+        action: 'partner_org.created',
+        targetTable: 'partner_orgs',
+        targetId: org.id,
+        metadata: { source: 'seed' },
+      },
+      {
+        actorUserId: adminUser?.id ?? null,
+        action: 'org_membership.added',
+        targetTable: 'org_memberships',
+        metadata: { source: 'seed', count: sampleUsers.length },
+      },
+      {
+        actorUserId: adminUser?.id ?? null,
+        action: 'system.seed_completed',
+        metadata: { source: 'seed', at: new Date().toISOString() },
+      },
+    ]);
+    console.log('[seed]   + 3 audit entries');
+  } else {
+    console.log('[seed]   = audit entries (exist)');
+  }
+
+  console.log('[seed] done.');
+  process.exit(0);
+}
+
+main().catch((err) => {
+  console.error('[seed] failed', err);
+  process.exit(1);
+});

--- a/src/lib/audit.ts
+++ b/src/lib/audit.ts
@@ -1,0 +1,46 @@
+import { db } from '@/db/client';
+import { auditLog } from '@/db/schema/audit-log';
+
+export type AuditAction =
+  | 'user.created'
+  | 'user.updated'
+  | 'user.deleted'
+  | 'consent.granted'
+  | 'consent.revoked'
+  | 'org_membership.added'
+  | 'org_membership.removed'
+  | (string & {}); // allow new actions without enum churn — keep narrow types for known ones
+
+export interface LogAuditEventInput {
+  /** UUID of the user who took the action. Null/undefined for system events. */
+  actorUserId?: string | null;
+  /** Dot-notated action name. See `AuditAction` for known values. */
+  action: AuditAction;
+  /** Polymorphic target (e.g. table name + row id). Optional. */
+  targetTable?: string;
+  targetId?: string;
+  /** Arbitrary JSON metadata. Avoid PHI here. */
+  metadata?: Record<string, unknown>;
+}
+
+/**
+ * Append-only audit log writer. Use from server components, server actions,
+ * and webhooks to record significant events.
+ *
+ * Failures are logged but never throw — audit must never break the user-facing
+ * action. (We trade observability for availability; an alert on missing-audit
+ * dropouts comes in FND-006.)
+ */
+export async function logAuditEvent(input: LogAuditEventInput): Promise<void> {
+  try {
+    await db.insert(auditLog).values({
+      actorUserId: input.actorUserId ?? null,
+      action: input.action,
+      targetTable: input.targetTable,
+      targetId: input.targetId,
+      metadata: input.metadata,
+    });
+  } catch (err) {
+    console.error('[audit] write failed', { input, err });
+  }
+}

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -4,6 +4,7 @@ import { notFound, redirect } from 'next/navigation';
 import { db } from '@/db/client';
 import type { UserRole } from '@/db/schema/enums';
 import { type User, users } from '@/db/schema/users';
+import { logAuditEvent } from './audit';
 
 /**
  * Server-only helper: returns the current user from our DB, lazy-creating
@@ -46,7 +47,16 @@ export async function requireUser(): Promise<User> {
     .values({ clerkUserId: userId, email: primaryEmail, firstName, lastName })
     .onConflictDoNothing({ target: users.clerkUserId })
     .returning();
-  if (created) return created;
+  if (created) {
+    await logAuditEvent({
+      actorUserId: created.id,
+      action: 'user.created',
+      targetTable: 'users',
+      targetId: created.id,
+      metadata: { source: 'clerk_lazy_upsert', clerkUserId: userId },
+    });
+    return created;
+  }
 
   const [winner] = await db.select().from(users).where(eq(users.clerkUserId, userId)).limit(1);
   return winner;


### PR DESCRIPTION
Closes #8

## Summary
- Drizzle schemas: `partner_orgs`, `org_memberships`, `audit_log`, `consents` (+ enums)
- All FK columns have btree indexes
- `logAuditEvent()` helper; wired into `requireUser` first-sign-in path
- `pnpm db:seed` — idempotent: 1 partner org + 5 users (one per role) + memberships + 3 audit entries
- `docs/schema.md` with ER diagram + conventions

## Acceptance criteria
- [x] Drizzle schema files for: users, partner_orgs, roles (=org_memberships), audit_log, consents
- [x] Migrations generated + applied locally without errors (0002_fearless_domino.sql)
- [x] Seed script: 1 partner org, 5 users, 3 audit entries
- [x] FKs + btree indexes on all FK columns
- [x] audit_log capture: app-level helper used by user.created (in src/lib/auth.ts)
- [x] Schema diagram added to docs/schema.md

## Verification
```
$ pnpm db:generate && pnpm db:migrate    # clean
$ pnpm db:seed                            # creates fixtures
$ pnpm db:seed                            # idempotent (= "exists" lines)
$ pnpm lint && pnpm typecheck && pnpm build   # all green
```

## Notes
- Interpreted "roles" from CLAUDE.md as the org_memberships table (per-org role assignment) since the user_role enum already exists from FND-003.
- Consents table doesn't FK a clients table yet — Phase 1, post-BAA. Subject linkage by `subject_external_id` for now.
- HIPAA fence respected: schema is non-PHI; seed data is synthetic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)