### PR TITLE
feat(EVDT-004): eviction_filings schema + enums

### DIFF
--- a/docs/schema.md
+++ b/docs/schema.md
@@ -70,6 +70,24 @@ erDiagram
         uuid id PK
         timestamptz created_at
     }
+
+    EVICTION_FILINGS {
+        uuid id PK
+        text case_number
+        timestamptz filed_at
+        text court_division
+        text plaintiff
+        text defendant_first_name
+        text defendant_last_name
+        text defendant_address
+        eviction_cause_type cause_type
+        int amount_claimed_cents
+        eviction_filing_status status
+        eviction_filing_source source
+        jsonb raw_json
+        timestamptz created_at
+        timestamptz updated_at
+    }
 ```
 
 ## Tables
@@ -82,6 +100,7 @@ erDiagram
 | `audit_log` | Append-only record of significant system actions | none — never log PHI in `metadata` |
 | `consents` | Subject consent records (PHI sharing, SMS, etc.). Subject linkage is by external ID until clients table lands in Phase 1. | non-PHI |
 | `health_check` | DB roundtrip target for `/api/health` | none |
+| `eviction_filings` | Public court records of filed eviction cases. Source-tagged so we can land synthetic, manual, and CourtNet rows side-by-side. | non-PHI (public record) |
 
 ## Enums
 
@@ -91,6 +110,9 @@ erDiagram
 | `partner_org_type` | hospital, legal_aid, shelter, community_org, government, other |
 | `consent_type` | phi_share_within_coalition, sms_communication, data_for_program_eval |
 | `consent_channel` | sms, in_person, web_form, phone, paper |
+| `eviction_cause_type` | non_payment, lease_violation, holdover, other |
+| `eviction_filing_status` | filed, served, judgment, dismissed, sealed |
+| `eviction_filing_source` | courtnet, manual, synthetic |
 
 ## Conventions
 

--- a/drizzle/migrations/0003_fine_black_queen.sql
+++ b/drizzle/migrations/0003_fine_black_queen.sql
@@ -1,0 +1,24 @@
+CREATE TYPE "public"."eviction_cause_type" AS ENUM('non_payment', 'lease_violation', 'holdover', 'other');--> statement-breakpoint
+CREATE TYPE "public"."eviction_filing_source" AS ENUM('courtnet', 'manual', 'synthetic');--> statement-breakpoint
+CREATE TYPE "public"."eviction_filing_status" AS ENUM('filed', 'served', 'judgment', 'dismissed', 'sealed');--> statement-breakpoint
+CREATE TABLE "eviction_filings" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"case_number" text NOT NULL,
+	"filed_at" timestamp with time zone NOT NULL,
+	"court_division" text,
+	"plaintiff" text NOT NULL,
+	"defendant_first_name" text NOT NULL,
+	"defendant_last_name" text NOT NULL,
+	"defendant_address" text,
+	"cause_type" "eviction_cause_type" NOT NULL,
+	"amount_claimed_cents" integer,
+	"status" "eviction_filing_status" DEFAULT 'filed' NOT NULL,
+	"source" "eviction_filing_source" NOT NULL,
+	"raw_json" jsonb,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX "eviction_filings_case_source_idx" ON "eviction_filings" USING btree ("case_number","source");--> statement-breakpoint
+CREATE INDEX "eviction_filings_filed_at_idx" ON "eviction_filings" USING btree ("filed_at");--> statement-breakpoint
+CREATE INDEX "eviction_filings_status_idx" ON "eviction_filings" USING btree ("status");

--- a/drizzle/migrations/meta/0003_snapshot.json
+++ b/drizzle/migrations/meta/0003_snapshot.json
@@ -1,0 +1,791 @@
+{
+  "id": "b75a38d4-34e3-41cc-9ac1-d77821f0a000",
+  "prevId": "efc6d751-663a-46bf-9023-00dd8a601ade",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.audit_log": {
+      "name": "audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_table": {
+          "name": "target_table",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "audit_log_actor_idx": {
+          "name": "audit_log_actor_idx",
+          "columns": [
+            {
+              "expression": "actor_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_log_action_idx": {
+          "name": "audit_log_action_idx",
+          "columns": [
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_log_created_at_idx": {
+          "name": "audit_log_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audit_log_actor_user_id_users_id_fk": {
+          "name": "audit_log_actor_user_id_users_id_fk",
+          "tableFrom": "audit_log",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.consents": {
+      "name": "consents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "subject_external_id": {
+          "name": "subject_external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consent_type": {
+          "name": "consent_type",
+          "type": "consent_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "granted_via": {
+          "name": "granted_via",
+          "type": "consent_channel",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "granted_at": {
+          "name": "granted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "consents_subject_idx": {
+          "name": "consents_subject_idx",
+          "columns": [
+            {
+              "expression": "subject_external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "consents_type_idx": {
+          "name": "consents_type_idx",
+          "columns": [
+            {
+              "expression": "consent_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.eviction_filings": {
+      "name": "eviction_filings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "case_number": {
+          "name": "case_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filed_at": {
+          "name": "filed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "court_division": {
+          "name": "court_division",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plaintiff": {
+          "name": "plaintiff",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "defendant_first_name": {
+          "name": "defendant_first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "defendant_last_name": {
+          "name": "defendant_last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "defendant_address": {
+          "name": "defendant_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cause_type": {
+          "name": "cause_type",
+          "type": "eviction_cause_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_claimed_cents": {
+          "name": "amount_claimed_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "eviction_filing_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'filed'"
+        },
+        "source": {
+          "name": "source",
+          "type": "eviction_filing_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "raw_json": {
+          "name": "raw_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "eviction_filings_case_source_idx": {
+          "name": "eviction_filings_case_source_idx",
+          "columns": [
+            {
+              "expression": "case_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "eviction_filings_filed_at_idx": {
+          "name": "eviction_filings_filed_at_idx",
+          "columns": [
+            {
+              "expression": "filed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "eviction_filings_status_idx": {
+          "name": "eviction_filings_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.health_check": {
+      "name": "health_check",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_memberships": {
+      "name": "org_memberships",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "partner_org_id": {
+          "name": "partner_org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "org_memberships_user_org_idx": {
+          "name": "org_memberships_user_org_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "partner_org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "org_memberships_user_idx": {
+          "name": "org_memberships_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "org_memberships_partner_org_idx": {
+          "name": "org_memberships_partner_org_idx",
+          "columns": [
+            {
+              "expression": "partner_org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "org_memberships_user_id_users_id_fk": {
+          "name": "org_memberships_user_id_users_id_fk",
+          "tableFrom": "org_memberships",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "org_memberships_partner_org_id_partner_orgs_id_fk": {
+          "name": "org_memberships_partner_org_id_partner_orgs_id_fk",
+          "tableFrom": "org_memberships",
+          "tableTo": "partner_orgs",
+          "columnsFrom": [
+            "partner_org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.partner_orgs": {
+      "name": "partner_orgs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "partner_org_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_email": {
+          "name": "contact_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_phone": {
+          "name": "contact_phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "partner_orgs_slug_idx": {
+          "name": "partner_orgs_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "clerk_user_id": {
+          "name": "clerk_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'caseworker'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "users_clerk_user_id_idx": {
+          "name": "users_clerk_user_id_idx",
+          "columns": [
+            {
+              "expression": "clerk_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.consent_channel": {
+      "name": "consent_channel",
+      "schema": "public",
+      "values": [
+        "sms",
+        "in_person",
+        "web_form",
+        "phone",
+        "paper"
+      ]
+    },
+    "public.consent_type": {
+      "name": "consent_type",
+      "schema": "public",
+      "values": [
+        "phi_share_within_coalition",
+        "sms_communication",
+        "data_for_program_eval"
+      ]
+    },
+    "public.eviction_cause_type": {
+      "name": "eviction_cause_type",
+      "schema": "public",
+      "values": [
+        "non_payment",
+        "lease_violation",
+        "holdover",
+        "other"
+      ]
+    },
+    "public.eviction_filing_source": {
+      "name": "eviction_filing_source",
+      "schema": "public",
+      "values": [
+        "courtnet",
+        "manual",
+        "synthetic"
+      ]
+    },
+    "public.eviction_filing_status": {
+      "name": "eviction_filing_status",
+      "schema": "public",
+      "values": [
+        "filed",
+        "served",
+        "judgment",
+        "dismissed",
+        "sealed"
+      ]
+    },
+    "public.partner_org_type": {
+      "name": "partner_org_type",
+      "schema": "public",
+      "values": [
+        "hospital",
+        "legal_aid",
+        "shelter",
+        "community_org",
+        "government",
+        "other"
+      ]
+    },
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "attorney",
+        "caseworker",
+        "ed_coordinator",
+        "shelter_staff",
+        "admin"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/migrations/meta/_journal.json
+++ b/drizzle/migrations/meta/_journal.json
@@ -22,6 +22,13 @@
       "when": 1777161985393,
       "tag": "0002_fearless_domino",
       "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "7",
+      "when": 1777164429337,
+      "tag": "0003_fine_black_queen",
+      "breakpoints": true
     }
   ]
 }

--- a/scripts/seed-acceptance-criteria-sprint2.py
+++ b/scripts/seed-acceptance-criteria-sprint2.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""Update Sprint 2 GitHub issues with concrete acceptance criteria."""
+import json
+import re
+import subprocess
+import sys
+
+REPO = "DobbsBoldry/homeless"
+
+CRITERIA = {
+    "EVDT-004": [
+        "Drizzle schema `eviction_filings` (snake_case plural per CLAUDE.md)",
+        "Columns: id (uuid pk), case_number (text, unique), filed_at (timestamptz), court_division (text), plaintiff (text), defendant_first_name, defendant_last_name, defendant_address (text, nullable), cause_type (enum: non_payment, lease_violation, holdover, other), amount_claimed_cents (integer, nullable), status (enum: filed, served, judgment, dismissed, sealed), source (text — e.g. 'courtnet', 'manual', 'synthetic'), raw_json (jsonb), created_at, updated_at",
+        "New enum: `eviction_cause_type` and `eviction_filing_status`",
+        "Indexes: unique on (case_number, source); btree on filed_at, status",
+        "Migration generated + applied; types exported from `src/db/schema/eviction-filings.ts`",
+        "Schema diagram updated in `docs/schema.md`",
+    ],
+    "EVDT-006": [
+        "Pure function `parseEvictionFiling(raw): ParsedFiling | ParseError` in `src/lib/eviction/parser.ts`",
+        "Handles the synthetic shape produced by EVDT-024",
+        "Extracts: case number, filed_at, plaintiff, defendant first/last, defendant address, cause type, amount claimed (cents), status",
+        "Returns structured ParseError (not throw) on missing/malformed fields with field-level reasons",
+        "Unit tests in `src/lib/eviction/parser.test.ts` covering: happy path, each cause type, missing fields, malformed dates, sealed/redacted records",
+        "Test runner: `pnpm test` runs vitest (replaces stub script from FND-001)",
+        "Parses the full EVDT-024 fixture file (50 records) with <2 ParseErrors",
+    ],
+    "EVDT-008": [
+        "New protected page at `/app/cases/filings` (admin + attorney + caseworker)",
+        "Server-rendered table of the most recent 50 filings (descending by filed_at)",
+        "Columns: case number, filed at, plaintiff, defendant (initials only by default — toggle 'show full names' button for authorized roles), cause type, amount, status",
+        "Empty state: 'No filings ingested yet — run `pnpm tsx scripts/load-fixtures.ts` to seed synthetic data'",
+        "Source filter pills: All / synthetic / courtnet / manual (defaults to All)",
+        "Linked from sidebar nav under 'Cases > Filings' (rename existing 'Cases' nav)",
+        "No PHI/PII export; no row-click action yet (case detail comes in EVDT-016)",
+    ],
+    "CWT-001": [
+        "CLI: `pnpm tsx scripts/gen-synthetic-intake.ts --count 20 --out fixtures/intakes.json`",
+        "Generates realistic shelter-intake conversation transcripts via Claude API",
+        "Conversation shape: array of { role: 'caseworker' | 'client', text: string, timestamp } turns",
+        "Diversity: presenting issues (eviction, ED super-utilizer, family separation, mental health, substance use, working poor), household compositions, urgency levels",
+        "Reproducible with `--seed N`",
+        "AI prompt in `src/ai/prompts/synthetic-intake.ts` (per CLAUDE.md convention — no inline prompt strings)",
+        "All names + addresses synthetic (clearly fake — e.g. 'Synth-Smith', 'Fake-Drive')",
+        "README: 'Generating synthetic test data' section gains intake bullet alongside filings",
+        "Anthropic API key wired via `process.env.ANTHROPIC_API_KEY` (added to .env.example)",
+    ],
+}
+
+
+def get_issue(story_id):
+    r = subprocess.run(
+        ["gh", "issue", "list", "--repo", REPO, "--state", "open",
+         "--search", f"[{story_id}] in:title", "--json", "number,title,body"],
+        capture_output=True, text=True, check=True,
+    )
+    issues = json.loads(r.stdout)
+    for i in issues:
+        if f"[{story_id}]" in i["title"]:
+            return i
+    return None
+
+
+def update_body(num, new_body):
+    subprocess.run(
+        ["gh", "issue", "edit", str(num), "--repo", REPO, "--body", new_body],
+        check=True, capture_output=True,
+    )
+
+
+def main():
+    for story_id, criteria in CRITERIA.items():
+        issue = get_issue(story_id)
+        if not issue:
+            print(f"  {story_id}: NOT FOUND")
+            continue
+        body = issue["body"]
+        new_ac = "## Acceptance criteria\n\n" + \
+                 "\n".join(f"- [ ] {c}" for c in criteria) + \
+                 "\n- [ ] passes Definition of Done (see CLAUDE.md)\n"
+        new_body = re.sub(
+            r"## Acceptance criteria\n\n.*?(?=\n---)",
+            new_ac.rstrip() + "\n",
+            body,
+            flags=re.DOTALL,
+        )
+        update_body(issue["number"], new_body)
+        print(f"  {story_id} (#{issue['number']}): {len(criteria)} criteria")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/db/schema/enums.ts
+++ b/src/db/schema/enums.ts
@@ -38,3 +38,30 @@ export const consentChannelEnum = pgEnum('consent_channel', [
 ]);
 
 export type ConsentChannel = (typeof consentChannelEnum.enumValues)[number];
+
+export const evictionCauseTypeEnum = pgEnum('eviction_cause_type', [
+  'non_payment',
+  'lease_violation',
+  'holdover',
+  'other',
+]);
+
+export type EvictionCauseType = (typeof evictionCauseTypeEnum.enumValues)[number];
+
+export const evictionFilingStatusEnum = pgEnum('eviction_filing_status', [
+  'filed',
+  'served',
+  'judgment',
+  'dismissed',
+  'sealed',
+]);
+
+export type EvictionFilingStatus = (typeof evictionFilingStatusEnum.enumValues)[number];
+
+export const evictionFilingSourceEnum = pgEnum('eviction_filing_source', [
+  'courtnet',
+  'manual',
+  'synthetic',
+]);
+
+export type EvictionFilingSource = (typeof evictionFilingSourceEnum.enumValues)[number];

--- a/src/db/schema/eviction-filings.ts
+++ b/src/db/schema/eviction-filings.ts
@@ -1,0 +1,54 @@
+import {
+  index,
+  integer,
+  jsonb,
+  pgTable,
+  text,
+  timestamp,
+  uniqueIndex,
+  uuid,
+} from 'drizzle-orm/pg-core';
+import { evictionCauseTypeEnum, evictionFilingSourceEnum, evictionFilingStatusEnum } from './enums';
+
+/**
+ * Public record of a filed eviction case.
+ *
+ * Eviction filings ARE public court records and not PHI — safe to land in
+ * the database pre-BAA. The defendant's name and address are public via
+ * the court docket. We still segregate `defendant_*` columns from any
+ * client-linked tables (the join to a real `clients` row happens in a
+ * later story, post-BAA, mediated by a consent record).
+ *
+ * Multiple sources may produce a row for the same case (manual import,
+ * production CourtNet scraper, synthetic generator) — uniqueness is
+ * enforced on (case_number, source) so dedup logic in EVDT-007 can
+ * resolve preferred-source winners explicitly.
+ */
+export const evictionFilings = pgTable(
+  'eviction_filings',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    caseNumber: text('case_number').notNull(),
+    filedAt: timestamp('filed_at', { withTimezone: true }).notNull(),
+    courtDivision: text('court_division'),
+    plaintiff: text('plaintiff').notNull(),
+    defendantFirstName: text('defendant_first_name').notNull(),
+    defendantLastName: text('defendant_last_name').notNull(),
+    defendantAddress: text('defendant_address'),
+    causeType: evictionCauseTypeEnum('cause_type').notNull(),
+    amountClaimedCents: integer('amount_claimed_cents'),
+    status: evictionFilingStatusEnum('status').notNull().default('filed'),
+    source: evictionFilingSourceEnum('source').notNull(),
+    rawJson: jsonb('raw_json').$type<Record<string, unknown>>(),
+    createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),
+  },
+  (t) => [
+    uniqueIndex('eviction_filings_case_source_idx').on(t.caseNumber, t.source),
+    index('eviction_filings_filed_at_idx').on(t.filedAt),
+    index('eviction_filings_status_idx').on(t.status),
+  ],
+);
+
+export type EvictionFiling = typeof evictionFilings.$inferSelect;
+export type NewEvictionFiling = typeof evictionFilings.$inferInsert;

--- a/src/db/schema/index.ts
+++ b/src/db/schema/index.ts
@@ -1,6 +1,7 @@
 export * from './audit-log';
 export * from './consents';
 export * from './enums';
+export * from './eviction-filings';
 export * from './health-check';
 export * from './org-memberships';
 export * from './partner-orgs';


### PR DESCRIPTION
Closes #19

## Summary
- `eviction_filings` table (15 columns) for public court records
- 3 new enums: `eviction_cause_type`, `eviction_filing_status`, `eviction_filing_source`
- Unique on (case_number, source) so synthetic / manual / courtnet rows can coexist for the same case (dedup logic in EVDT-007 picks the winner)
- Btree indexes on filed_at + status for ranking
- raw_json preserves source-specific fields

## Acceptance criteria
- [x] Drizzle schema `eviction_filings`
- [x] Columns per spec (id, case_number, filed_at, court_division, plaintiff, defendant_*, cause_type, amount_claimed_cents, status, source, raw_json, created_at, updated_at)
- [x] New enums: eviction_cause_type, eviction_filing_status (added eviction_filing_source too)
- [x] Indexes: unique on (case_number, source); btree on filed_at, status
- [x] Migration generated + applied; types exported
- [x] Schema diagram updated in docs/schema.md

## HIPAA fence
Eviction filings are public court records per CLAUDE.md — safe to land pre-BAA. Defendant names + addresses are public via the court docket. The join to a real `clients` row happens in a later story, post-BAA, mediated by a consent record.

## Verification
```
$ pnpm db:generate    # 0003_fine_black_queen.sql
$ pnpm db:migrate     # applied
$ pnpm lint && pnpm typecheck && pnpm build  # all green
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)