### PR TITLE
feat(EVDT-008): filings dashboard + fixture loader

### DIFF
--- a/scripts/load-fixtures.ts
+++ b/scripts/load-fixtures.ts
@@ -1,0 +1,70 @@
+#!/usr/bin/env tsx
+/**
+ * Idempotent loader for the EVDT-024 synthetic eviction filings fixture.
+ *
+ * Usage:
+ *   pnpm tsx scripts/load-fixtures.ts
+ *   pnpm tsx scripts/load-fixtures.ts --file fixtures/eviction-filings.json
+ *
+ * - Reads the JSON file produced by gen-synthetic-filings.ts
+ * - Parses each row through src/lib/eviction/parser.ts
+ * - Inserts via onConflictDoNothing on the unique (case_number, source) idx
+ * - Skips parse errors with a warning (doesn't fail the whole load)
+ *
+ * Safe to re-run; existing rows are not touched.
+ */
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { parseArgs } from 'node:util';
+import { config } from 'dotenv';
+import { db } from '@/db/client';
+import { evictionFilings } from '@/db/schema/eviction-filings';
+import { parseEvictionFiling } from '@/lib/eviction/parser';
+
+config({ path: ['.env.local', '.env'], override: true });
+
+const { values } = parseArgs({
+  options: {
+    file: { type: 'string', default: 'fixtures/eviction-filings.json' },
+  },
+});
+
+async function main() {
+  const filePath = resolve(process.cwd(), values.file);
+  console.log(`[load] reading ${filePath}`);
+
+  const raw = JSON.parse(readFileSync(filePath, 'utf8')) as { filings: unknown[] };
+  if (!Array.isArray(raw.filings)) {
+    throw new Error('fixture file missing top-level "filings" array');
+  }
+
+  let inserted = 0;
+  let skipped = 0;
+  let errored = 0;
+
+  for (const record of raw.filings) {
+    const result = parseEvictionFiling(record, 'synthetic');
+    if (!result.ok) {
+      console.warn('[load] parse error', { errors: result.errors });
+      errored++;
+      continue;
+    }
+    const [row] = await db
+      .insert(evictionFilings)
+      .values(result.filing)
+      .onConflictDoNothing({
+        target: [evictionFilings.caseNumber, evictionFilings.source],
+      })
+      .returning({ id: evictionFilings.id });
+    if (row) inserted++;
+    else skipped++;
+  }
+
+  console.log(`[load] inserted=${inserted} skipped=${skipped} errored=${errored}`);
+  process.exit(0);
+}
+
+main().catch((err) => {
+  console.error('[load] failed', err);
+  process.exit(1);
+});

--- a/src/app/app/cases/filings/page.tsx
+++ b/src/app/app/cases/filings/page.tsx
@@ -1,0 +1,56 @@
+import { CaseFilingsRoles } from '@/components/eviction/case-filings-roles';
+import { FilingsTable } from '@/components/eviction/filings-table';
+import { SourceFilter } from '@/components/eviction/source-filter';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { listRecentFilings } from '@/db/queries/eviction-filings';
+import type { EvictionFilingSource } from '@/db/schema/enums';
+import { requireRole } from '@/lib/auth';
+
+const ALLOWED_SOURCES: EvictionFilingSource[] = ['synthetic', 'manual', 'courtnet'];
+
+export default async function FilingsPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ source?: string }>;
+}) {
+  await requireRole(CaseFilingsRoles);
+
+  const params = await searchParams;
+  const source = ALLOWED_SOURCES.find((s) => s === params.source);
+  const filings = await listRecentFilings({ limit: 50, source });
+
+  return (
+    <div className="mx-auto max-w-6xl p-6 space-y-4">
+      <header>
+        <h1 className="font-serif text-3xl font-bold text-primary">Filings</h1>
+        <p className="text-sm text-muted-foreground">
+          Most recent {filings.length} eviction filings (Daviess District Court).
+        </p>
+      </header>
+
+      <SourceFilter selected={source} />
+
+      {filings.length === 0 ? (
+        <Card>
+          <CardHeader>
+            <CardTitle>No filings yet</CardTitle>
+            <CardDescription>
+              The eviction_filings table is empty. To seed synthetic test data:
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <pre className="overflow-x-auto rounded-md bg-muted p-3 text-xs">
+              <code>pnpm tsx scripts/load-fixtures.ts</code>
+            </pre>
+            <p className="mt-2 text-xs text-muted-foreground">
+              Production CourtNet data lands once EVDT-001/002 spikes resolve and EVDT-005 ships the
+              daily scraper.
+            </p>
+          </CardContent>
+        </Card>
+      ) : (
+        <FilingsTable filings={filings} />
+      )}
+    </div>
+  );
+}

--- a/src/components/app-shell/nav-config.ts
+++ b/src/components/app-shell/nav-config.ts
@@ -14,6 +14,11 @@ export type NavItem = {
 export const NAV_ITEMS: NavItem[] = [
   { label: 'Dashboard', href: '/app/dashboard', roles: 'all' },
   {
+    label: 'Filings',
+    href: '/app/cases/filings',
+    roles: ['attorney', 'caseworker', 'admin'],
+  },
+  {
     label: 'Cases',
     href: '/app/cases',
     roles: ['attorney', 'caseworker', 'admin'],

--- a/src/components/eviction/case-filings-roles.ts
+++ b/src/components/eviction/case-filings-roles.ts
@@ -1,0 +1,4 @@
+import type { UserRole } from '@/db/schema/enums';
+
+/** Roles allowed to view the filings dashboard. Mirrors the sidebar nav config. */
+export const CaseFilingsRoles: readonly UserRole[] = ['attorney', 'caseworker', 'admin'];

--- a/src/components/eviction/filings-table.tsx
+++ b/src/components/eviction/filings-table.tsx
@@ -1,0 +1,105 @@
+'use client';
+
+import { useState } from 'react';
+import { Button } from '@/components/ui/button';
+import type { EvictionFiling } from '@/db/schema/eviction-filings';
+
+const fmtDate = (d: Date) =>
+  new Intl.DateTimeFormat('en-US', { dateStyle: 'medium' }).format(new Date(d));
+
+const fmtMoney = (cents: number | null) => {
+  if (cents == null) return '—';
+  return new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' }).format(cents / 100);
+};
+
+const initials = (first: string, last: string) =>
+  `${first.charAt(0).toUpperCase()}.${last.charAt(0).toUpperCase()}.`;
+
+const causeLabel: Record<EvictionFiling['causeType'], string> = {
+  non_payment: 'Non-payment',
+  lease_violation: 'Lease violation',
+  holdover: 'Holdover',
+  other: 'Other',
+};
+
+const statusClass: Record<EvictionFiling['status'], string> = {
+  filed: 'bg-secondary text-secondary-foreground',
+  served: 'bg-accent text-accent-foreground',
+  judgment: 'bg-destructive/15 text-destructive',
+  dismissed: 'bg-muted text-muted-foreground',
+  sealed: 'bg-muted text-muted-foreground italic',
+};
+
+export function FilingsTable({ filings }: { filings: EvictionFiling[] }) {
+  const [showFullNames, setShowFullNames] = useState(false);
+
+  return (
+    <div className="space-y-2">
+      <div className="flex justify-end">
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() => setShowFullNames((v) => !v)}
+          aria-pressed={showFullNames}
+        >
+          {showFullNames ? 'Hide full names' : 'Show full names'}
+        </Button>
+      </div>
+
+      <div className="overflow-x-auto rounded-md border border-border">
+        <table className="w-full text-sm">
+          <thead className="bg-muted/40 text-left text-xs uppercase tracking-wide text-muted-foreground">
+            <tr>
+              <th scope="col" className="px-3 py-2">
+                Case #
+              </th>
+              <th scope="col" className="px-3 py-2">
+                Filed
+              </th>
+              <th scope="col" className="px-3 py-2">
+                Plaintiff
+              </th>
+              <th scope="col" className="px-3 py-2">
+                Defendant
+              </th>
+              <th scope="col" className="px-3 py-2">
+                Cause
+              </th>
+              <th scope="col" className="px-3 py-2 text-right">
+                Amount
+              </th>
+              <th scope="col" className="px-3 py-2">
+                Status
+              </th>
+              <th scope="col" className="px-3 py-2">
+                Source
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {filings.map((f) => (
+              <tr key={f.id} className="border-t border-border align-top">
+                <td className="px-3 py-2 font-mono text-xs">{f.caseNumber}</td>
+                <td className="px-3 py-2 whitespace-nowrap">{fmtDate(f.filedAt)}</td>
+                <td className="px-3 py-2">{f.plaintiff}</td>
+                <td className="px-3 py-2">
+                  {showFullNames
+                    ? `${f.defendantFirstName} ${f.defendantLastName}`
+                    : initials(f.defendantFirstName, f.defendantLastName)}
+                </td>
+                <td className="px-3 py-2">{causeLabel[f.causeType]}</td>
+                <td className="px-3 py-2 text-right font-mono">{fmtMoney(f.amountClaimedCents)}</td>
+                <td className="px-3 py-2">
+                  <span className={`rounded px-2 py-0.5 text-xs ${statusClass[f.status]}`}>
+                    {f.status}
+                  </span>
+                </td>
+                <td className="px-3 py-2 text-xs text-muted-foreground">{f.source}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/src/components/eviction/source-filter.tsx
+++ b/src/components/eviction/source-filter.tsx
@@ -1,0 +1,34 @@
+import Link from 'next/link';
+import type { EvictionFilingSource } from '@/db/schema/enums';
+
+const PILLS: Array<{ label: string; value?: EvictionFilingSource }> = [
+  { label: 'All', value: undefined },
+  { label: 'Synthetic', value: 'synthetic' },
+  { label: 'CourtNet', value: 'courtnet' },
+  { label: 'Manual', value: 'manual' },
+];
+
+export function SourceFilter({ selected }: { selected?: EvictionFilingSource }) {
+  return (
+    <nav className="flex gap-2" aria-label="Filter by source">
+      {PILLS.map((p) => {
+        const active = p.value === selected;
+        const href = p.value ? `/app/cases/filings?source=${p.value}` : '/app/cases/filings';
+        return (
+          <Link
+            key={p.label}
+            href={href}
+            aria-current={active ? 'page' : undefined}
+            className={`rounded-full border px-3 py-1 text-xs transition-colors ${
+              active
+                ? 'border-primary bg-primary text-primary-foreground'
+                : 'border-border hover:bg-muted'
+            }`}
+          >
+            {p.label}
+          </Link>
+        );
+      })}
+    </nav>
+  );
+}

--- a/src/db/queries/eviction-filings.ts
+++ b/src/db/queries/eviction-filings.ts
@@ -1,0 +1,18 @@
+import { desc, eq } from 'drizzle-orm';
+import { db } from '@/db/client';
+import type { EvictionFilingSource } from '@/db/schema/enums';
+import { type EvictionFiling, evictionFilings } from '@/db/schema/eviction-filings';
+
+/**
+ * Fetch the most recent N filings, ordered by filed_at desc.
+ * Optional filter on source (synthetic / manual / courtnet) for the dashboard
+ * source-pill control.
+ */
+export async function listRecentFilings(
+  opts: { limit?: number; source?: EvictionFilingSource } = {},
+): Promise<EvictionFiling[]> {
+  const { limit = 50, source } = opts;
+  const base = db.select().from(evictionFilings);
+  const filtered = source ? base.where(eq(evictionFilings.source, source)) : base;
+  return await filtered.orderBy(desc(evictionFilings.filedAt)).limit(limit);
+}


### PR DESCRIPTION
Closes #23

## Summary
- \`scripts/load-fixtures.ts\` — idempotent loader for the EVDT-024 baseline fixture (50 rows in <1s)
- \`/app/cases/filings\` — protected, server-rendered table of recent 50 filings with source-pill filter
- Defendant names default to initials with explicit "Show full names" toggle (defense-in-depth even though synthetic data is fake)

## Acceptance criteria
- [x] Protected page at \`/app/cases/filings\` (admin + attorney + caseworker via \`requireRole\`)
- [x] Server-rendered table of most recent 50 filings (DESC by filed_at)
- [x] Columns: case#, filed, plaintiff, defendant (initials toggle), cause, amount, status, source
- [x] Empty state with \`pnpm tsx scripts/load-fixtures.ts\` instructions
- [x] Source filter pills: All / synthetic / courtnet / manual
- [x] Sidebar nav links to Filings (under Cases group)
- [x] No row-click action (case detail comes in EVDT-016)

## Verification
\`\`\`
$ pnpm tsx scripts/load-fixtures.ts
[load] inserted=50 skipped=0 errored=0
$ pnpm dev
# /app/cases/filings renders 50 filings
# /app/cases/filings?source=synthetic filters correctly
$ pnpm lint && pnpm typecheck && pnpm test && pnpm build  # all green
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)