### PR TITLE
docs(EVDT-001, EVDT-002): CourtNet research + Daviess Clerk outreach playbook

### DIFF
--- a/docs/research/daviess-clerk-outreach-result.md
+++ b/docs/research/daviess-clerk-outreach-result.md
@@ -1,0 +1,42 @@
+# Daviess District Court Clerk's Office — Outreach Result
+
+**Story:** EVDT-002. **Status:** template — fill in after call.
+
+## Call summary
+
+- **Date of call:** _YYYY-MM-DD_
+- **Time:** _HH:MM Central_
+- **Who I reached:** _Name + title_
+- **Length of call:** _N minutes_
+- **Outcome category:** _yes / yes-with-paperwork / no / referred-elsewhere / voicemail-only_
+
+## Answers to the 5 questions
+
+1. **Daily docket exists?** _Yes/no — describe_
+2. **Format:** _PDF / printout / on-screen only / other_
+3. **Sharing options:** _email subscription / fax / pickup / portal login / nothing offered_
+4. **Fee structure:** _free / per-page / monthly / TBD_
+5. **Ongoing contact:** _name, email, phone_
+
+## Other notes from the conversation
+
+_Anything else they volunteered — pain points, related contacts, what
+they wish someone would build, who else has tried this before._
+
+## Decision
+
+- **Pursue this path?** _yes / no / parallel-with-KCOJ-scraper_
+- **Next concrete step:** _e.g. "send ORA request via KOGC template", "drive to courthouse Tuesday for in-person follow-up", "drop this path, lean on KCOJ scraper alone"_
+- **Owner of next step:** _Bo / KLA / nobody-blocking_
+
+## Email follow-up
+
+- [ ] Sent within 24 hours of call
+- Date sent: _YYYY-MM-DD_
+- Their response: _summary or "no response yet"_
+
+## Update CLAUDE.md / BACKLOG?
+
+- [ ] If a daily docket email is now arriving, add to CLAUDE.md as a known data source
+- [ ] If this unblocks a Phase-1 story, update BACKLOG sequencing
+- [ ] If this is a dead end, note in `ky-courtnet-access.md` so we don't re-research

--- a/docs/research/daviess-clerk-outreach.md
+++ b/docs/research/daviess-clerk-outreach.md
@@ -1,0 +1,126 @@
+# Daviess District Court Clerk's Office — Outreach Playbook
+
+**Story:** EVDT-002. **Owner of the call:** Bo. **Time required:** ~10 minutes.
+
+This is a backup / parallel path to EVDT-001 (KY CourtNet). Even if the
+KCOJ scraper lands and works, having a direct relationship with the
+Daviess District Court Clerk's office gives us:
+
+1. A human escalation path when the scraper breaks at 6am
+2. A way to access sealed-but-served records that don't show on the public docket
+3. A potential daily manual export (fax/email/CSV) as a Phase-0 redundant feed
+4. Goodwill — KLA, our legal-aid partner, will need this relationship anyway
+
+## Who to call
+
+**Daviess District Court Clerk's Office**
+Susan Tipmore — Circuit Court Clerk (also handles District Court records)
+Address: 100 East 2nd Street, Owensboro, KY 42303
+Phone: **(270) 687-7327**
+Web: https://daviesscircuitcourtclerk.com/
+
+> Note: The Circuit Court Clerk in KY counties is the records keeper for
+> BOTH Circuit and District Court (forcible-detainer / eviction filings
+> live in District Court). One office, one call.
+
+## When to call
+
+- **Best window:** Tuesday–Thursday, 9:00–11:00 AM Central
+- **Avoid:** Mondays (busiest), end-of-month (filings deadline rush), 1st of the month (rent-due eviction surge)
+- **Phone is far more likely to land than email** for first contact
+
+## Who to ask for
+
+> "Hi, I'm calling about access to the daily forcible-detainer docket. May
+> I speak with whoever handles records requests, or your records clerk?"
+
+If routed to voicemail, say:
+> "My name is Bo Thompson, I'm with a Daviess County homelessness coalition
+> partnering with Kentucky Legal Aid. We're building a tool to help with
+> tenant outreach before court dates. I'd like to ask 5 short questions
+> about the daily docket. Best callback number is `<your number>`."
+
+## The 5 questions to get answered
+
+Lead with intent and end with the ask — clerks are busy, don't bury the lede.
+
+> "Quick context: we're building a coalition tool to flag eviction
+> filings and offer tenants legal help **before** their first court date.
+> KLA is on the legal side. The tool needs the daily list of forcible-
+> detainer filings — defendant name, plaintiff, case number, court date.
+> All public-record stuff. Five quick questions:"
+
+1. **Daily availability.** Does your office produce a daily forcible-detainer docket — printed, emailed, or otherwise? When is it generated each day?
+2. **Format.** What format is it in? (PDF? Word? CSV? On the public-terminal screen only?)
+3. **Sharing.** Is there a way for me to receive that docket every business day — a standing email, a pickup, a fax, or a portal login?
+4. **Fee.** Is there a fee for ongoing access? (Open Records Act allows reasonable copy fees but typically waives for media/research/non-commercial public-interest use.)
+5. **Contact.** Who's the right ongoing point of contact for this kind of arrangement, and what's the best way to reach them?
+
+If they offer a meeting in person, take it — drive to Owensboro, sit down,
+shake hands. The relationship matters more than the data feed.
+
+## Email follow-up template
+
+Send the same day, within 1 hour of the call. Keep it short.
+
+> Subject: Following up — Daviess District Court daily forcible-detainer docket
+>
+> Hi `<name>`,
+>
+> Thanks for taking my call this morning. I appreciated the conversation.
+>
+> Recapping what we discussed:
+>
+> - We're building a coalition tool with Kentucky Legal Aid to help
+>   tenants get representation before their first court date in
+>   forcible-detainer cases.
+> - I asked about access to the daily docket. Here's what I heard:
+>     - Daily docket is `<format>`, generated `<when>`.
+>     - Sharing options you mentioned: `<options>`.
+>     - Fee structure: `<fee>`.
+>     - Best ongoing contact: `<name + email/phone>`.
+>
+> If I have any of that wrong, please correct me. Otherwise, my next step
+> is to `<concrete next step from the call>`. If a written records request
+> is needed, I can send one — just let me know the form.
+>
+> Grateful for your time. The coalition partners (KLA, Audubon Area
+> Community Services, Owensboro Health) are all working on different
+> pieces of this; the daily docket is the hinge.
+>
+> Best,
+> Bo Thompson
+> `<phone>` | `<email>`
+
+## After the call
+
+Capture answers in `docs/research/daviess-clerk-outreach-result.md`
+(template stub committed alongside this file). Even a "no" is a result —
+write down what they said and why, so we don't lose the context.
+
+If the answer is yes-but-needs-paperwork, file an Open Records Act request
+(KRS 61.870–884). The court itself is exempt from ORA but the **clerk's
+office records of public filings** are generally honored under common-law
+public-records access. The KY Open Government Coalition has templates:
+https://kyopengov.org/
+
+## Fallback paths if this call goes nowhere
+
+In rough preference order:
+
+1. **Try Audubon Area Community Services or KLA Owensboro** — they
+   already have the relationship; ask if they'll forward a daily docket
+   email they already receive.
+2. **In-person visit to the courthouse public terminal** — the docket is
+   public. Worst case: someone drives to Owensboro daily and snaps photos.
+   Not scalable but proves the concept.
+3. **Lean on the EVDT-001 KCOJ scraper** — that's the primary path
+   anyway; the clerk relationship was always the safety net.
+
+## Definition of done
+
+- [x] Playbook committed at this path
+- [ ] Bo makes the call (target: within 1 week)
+- [ ] Answers captured in `daviess-clerk-outreach-result.md`
+- [ ] If yes-with-paperwork: ORA letter sent
+- [ ] If no: failure mode documented, fallback path picked

--- a/docs/research/ky-courtnet-access.md
+++ b/docs/research/ky-courtnet-access.md
@@ -1,0 +1,95 @@
+# Kentucky Court Eviction Filing Data — Access Options
+
+**Status:** research memo
+**Author:** Claude (research session, reviewed by Bo)
+**Date:** 2026-04-25
+**Scope:** Daviess District Court (Owensboro, KY) forcible-detainer filings, daily cadence, Phase-1 budget. Public court records only — no PHI.
+
+---
+
+## Recommendation (TL;DR)
+
+**Build a polite daily scraper against the public KCOJ guest docket portal at `https://kcoj.kycourts.net/dockets/`, filtered to Daviess / District / Forcible Detainer, and complement it with a paid CourtNet 2.0 subscription (~$5–$50/mo) under a sponsoring KY-licensed attorney for case-detail enrichment.** Treat the LSC Civil Court Data Initiative as a sanity-check baseline (county-level monthly aggregates), not a primary source. Do not bet the pilot on a vendor (UniCourt / Trellis / Docket Alarm) — coverage of KY District Court forcible-detainer dockets at case level is unverified and pricing is enterprise-scale. Open-records requests to AOC for bulk case data will be denied.
+
+This gets us flowing within ~2 weeks at <$100/mo recurring, with one significant fragility: the scraper breaks if KCOJ redesigns the docket portal (low-frequency event historically, but real). The CourtNet attorney subscription is the backstop — it's the only sanctioned programmatic-ish channel, and a coalition attorney partner already has standing to subscribe.
+
+**What blocks us from a cleaner answer:** AOC has no public API, doesn't publish a robots.txt declaration we could find, and the KCOJ Terms of Use PDF didn't parse cleanly in this research pass. Before any scraping goes live we need a human read of `https://kcoj.kycourts.net/Content/docs/TermsOfUse2-4-13.pdf` and ideally a written "we plan to do X, is that OK?" email to `OpenRecords@kycourts.net`. That's a one-day task, not a blocker for spike work.
+
+---
+
+## Access mechanism inventory
+
+### 1. KCOJ guest docket portal (public web, no login) — **primary**
+
+- **What it is:** `https://kcoj.kycourts.net/dockets/` lets anyone (no account) generate a docket filtered by County → Division (District) → Date → Courtroom. Daviess District Court forcible-detainer hearings appear here. ([KCOJ Docket](https://kcoj.kycourts.net/dockets/))
+- **Cost:** $0 setup, $0 ongoing.
+- **Latency to first data:** ~1–2 weeks of dev (build scraper, parse docket HTML, normalize defendant/plaintiff/case-number/hearing-date, dedupe, store).
+- **Maintenance burden:** Solo-dev tractable. Selector/HTML breakage maybe 1–2x/year based on AOC's historical change cadence. Budget ~4 hrs/quarter.
+- **Freshness:** Daily cron is achievable; the docket is publicly described as "near real-time" upstream of the portal. ([CourtNet 2.0 overview, ehelp.kycourts.net](https://ehelp.kycourts.net/courtnetserviceplans/))
+- **Legal/TOS posture:** **Yellow.** The portal explicitly invites guest searches of public case info. KY case records are public under the Supreme Court's open-records framework ([KOGC summary](https://kyopengov.org/law/court-records); [AOC Open Records Policy, 2017](https://www.kycourts.gov/Courts/Supreme-Court/Supreme%20Court%20Orders/201709.pdf)). Forcible-detainer filings are public records — there is no PHI gate here. **However**, the KCOJ Terms of Use ([PDF](https://kcoj.kycourts.net/Content/docs/TermsOfUse2-4-13.pdf)) was not legible to this research pass; before scraping at scale a human must read it for any anti-automation, no-bulk-extract, or no-redistribution clauses. The portal also displays a disclaimer ("NOT AN OFFICIAL DOCKET — SUBJECT TO CHANGE") that we'd need to surface to downstream users.
+- **Failure modes:** (a) AOC rebuilds the portal — they did this once already in the CourtNet 1.0 → 2.0 migration; (b) Tyler Technologies' new "File & Serve" rollout changes the public-facing surface ([CourtNet/eFiling, KBA](https://kybar.org/For-Members/Courtnet-and-eFiling)); (c) AOC interprets scraping as TOS-violating and sends a cease-and-desist. Mitigation: low request volume (one query per day per county), realistic User-Agent identifying the coalition, contact email in the UA string, throttle aggressively.
+
+### 2. CourtNet 2.0 subscription (paid, attorney-gated) — **enrichment + backstop**
+
+- **What it is:** AOC's official subscription portal for civil/criminal case detail across all 120 counties, ~10,000 attorney subscribers. Six service plans, five paid; cheapest is **$5/mo** with per-image $0.35 charges and per-case overage above plan allotment. Subaccounts $10/mo/user. Specific tier-by-tier case caps are behind a table image we couldn't OCR — call eCourt Support 502-573-2350 x50109 to size correctly. ([CourtNet 2.0 Service Plans](https://ehelp.kycourts.net/courtnetserviceplans/); [CourtNet FAQs](https://ehelp.kycourts.net/courtnet-faqs/))
+- **Eligibility:** **KY-licensed attorneys and AOC-eligible media only.** A homelessness nonprofit cannot subscribe in its own name. We need a coalition attorney partner (eviction-defense bar, Legal Aid of Western KY, or a private pro-bono partner) to hold the account and let us operate it under a written agreement. ([KOGC](https://kyopengov.org/law/court-records))
+- **Cost:** $5–$50/mo realistic for our volume (Daviess ran ~46 forcible-detainer filings in Feb 2026 per LSC CCDI — small).
+- **Latency to first data:** 1–3 weeks (find sponsoring attorney → contracting → account creation).
+- **Maintenance:** Low technical burden, moderate relationship burden — the attorney is the legal subscriber and shares responsibility for TOS compliance.
+- **Freshness:** Near real-time. ([CourtNet 2.0 overview](https://ehelp.kycourts.net/courtnetserviceplans/))
+- **Legal posture:** **Green** for what it's chartered for. **Unknown** whether automated access is sanctioned — no public API is documented and the FAQ doesn't address scraping the authenticated portal. Default assumption: manual or lightly-scripted use under the attorney account is fine; high-volume programmatic extraction is not. Confirm with eCourt Support before automating.
+- **Failure modes:** AOC tightens eligibility (rare); attorney partner exits the coalition; AOC bans automation against the authenticated portal.
+
+### 3. Kentucky eFiling system
+
+- KY eFiling is the *submission* side (lawyers filing documents into cases), not a public read API. Tyler Technologies is rolling out a "File & Serve" replacement now. ([CourtNet/eFiling, KBA](https://kybar.org/For-Members/Courtnet-and-eFiling)) **Not a data source for us.** Worth re-checking in 12 months in case the new platform exposes any public read endpoints.
+
+### 4. PACER-equivalent for KY state courts
+
+- **None exists.** PACER is federal. KY state courts have CourtNet (subscription) and the KCOJ guest portal (public web). No bulk-data feed, no RSS, no documented API. ([KOGC](https://kyopengov.org/law/court-records))
+
+### 5. Third-party aggregators (UniCourt, Trellis, Docket Alarm, CourtListener)
+
+- **CourtListener / RECAP** (Free Law Project) — federal-court focused. State-court coverage exists but is uneven; **no confirmed Kentucky District Court forcible-detainer coverage**. Pricing is means-based. ([CourtListener APIs](https://www.courtlistener.com/help/api/); [REST API v4.3](https://www.courtlistener.com/help/api/rest/)) Worth a 30-min spike to query their KY collection, but don't plan around it.
+- **UniCourt** — markets KY state-court search but coverage is shallow at the District Court forcible-detainer level; pricing is enterprise (typically four figures/mo for API, not published). ([UniCourt KY](https://unicourt.com/courts/state-kentucky)) Not viable for solo-dev/low-budget.
+- **Trellis, Docket Alarm** — neither surfaced in KY-specific searches with usable Daviess District coverage. Both are enterprise-priced. **Dead end for Phase 1.**
+- **LexisNexis Risk Solutions / American Information Research Services** — these are who Eviction Lab buys from. Six-figure contracts. ([Eviction Lab Methods](https://evictionlab.org/methods/)) Not for us.
+
+### 6. Legal Services Corporation Civil Court Data Initiative — **baseline only**
+
+- **What it is:** LSC tracks all 120 KY counties for forcible-detainer filings; **Daviess is covered**, showing 46 filings in Feb 2026. ([Daviess data page](https://civilcourtdata.lsc.gov/data/eviction/kentucky/daviess/); [KY landing](https://civilcourtdata.lsc.gov/data/eviction/kentucky/))
+- **Granularity:** Public dashboard is **county-level monthly aggregates only**. CSV export is at the same aggregate level. Case-level data (defendant name, address, case number — i.e. what we actually need to do outreach) is gated behind a **data-sharing agreement with LSC** (`civilcourtdata@lsc.gov`). LSC commonly signs these with academic researchers and federal agencies. ([CCDI FAQ](https://civilcourtdata.lsc.gov/about/faq/))
+- **Cost:** $0 for aggregates. Unknown for case-level access.
+- **Latency:** Months — institutional contracting, not a Phase-1 path. Worth pursuing in parallel as a Phase-2 unlock and as evidence/sanity-check for our own scraper counts.
+- **Failure mode:** LSC declines the agreement because we're not a federally-funded grantee.
+
+### 7. KY Open Records Act (KRS 61.870–884) for bulk case data
+
+- **Will not work.** AOC's Open Records Policy explicitly excludes "court case records or compiled information" from what AOC must produce under the open-records framework — it covers only AOC *administrative* records (budgets, contracts, etc.). Bulk eviction-data requests will be refused, and KY agencies have no obligation to compile data on request. ([AOC Open Records Policy, 2017](https://www.kycourts.gov/Courts/Supreme-Court/Supreme%20Court%20Orders/201709.pdf); [KOGC](https://kyopengov.org/law/court-records)) The recourse for case data is the public docket portal or CourtNet — i.e. options 1 and 2.
+
+### 8. Existing civic-tech / legal-aid precedent in KY
+
+- Kentucky Justice Online (`kyjustice.org`) and Kentucky Equal Justice Center publish *guidance* on eviction defense but no published data pipeline. ([KEJC](https://www.kyequaljustice.org/); [KY Justice Online Evictions](https://www.kyjustice.org/topics/housing/evictions))
+- AppalReD Legal Aid (Eastern KY) and Legal Aid of the Bluegrass have advocated on eviction policy but we found no public scraper repo or data partnership we could plug into. ([AppalReD](https://www.ardfky.org/page/451/amid-housing-crisis-advocates-push-tenants-rights))
+- **Eviction Lab** (Princeton) covers KY's urban centers well, rural less so, via a mix of scraping and purchased LexisNexis data. Their data is published as aggregates; case-level is not redistributed. ([Eviction Lab Methods](https://evictionlab.org/methods/))
+- **Closest open-source analogue:** Searchlight New Mexico's eviction scraper repo — different state, but a useful pattern reference. ([searchlight NM repo](https://github.com/searchlightdata/New-Mexico-evictions-database))
+- **No KY coalition has solved this publicly.** That's both an opportunity (we'd be first) and a small warning (nobody's done it because it's annoying, not because there's a magic shortcut we're missing).
+
+---
+
+## What I marked unknown
+
+- Exact CourtNet 2.0 tier table — pricing image didn't OCR; need a phone call to eCourt Support.
+- KCOJ Terms of Use specifics on automation/scraping — PDF didn't parse; needs a human read.
+- Whether AOC will respond constructively to a written "we intend to do X" notification — unknown until tried.
+- LSC CCDI's appetite for a case-level data-sharing agreement with a county-level coalition (vs. their typical academic/federal partners) — unknown until asked.
+- CourtListener's actual KY District Court coverage — unverified; cheap to spike.
+
+---
+
+## Suggested next actions
+
+1. **Spike (1 day):** human-read the KCOJ Terms of Use PDF; pull the docket page for Daviess District tomorrow morning and inspect the HTML structure; write a one-page assessment.
+2. **Spike (½ day):** call eCourt Support, get the tier table, and ask explicitly whether scripted access from an attorney account is permitted.
+3. **Outreach (parallel, low-priority):** email `civilcourtdata@lsc.gov` introducing the coalition and asking about case-level data-sharing terms. Worst case: free baseline numbers we can audit our scraper against.
+4. **Sequencing:** if the spike clears the legal posture, build the scraper as the first EVDT story. Treat a sponsoring-attorney CourtNet account as a Phase-1.5 enrichment, not a blocker.

--- a/scripts/seed-acceptance-criteria-sprint3.py
+++ b/scripts/seed-acceptance-criteria-sprint3.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""Update Sprint 3 GitHub issues with concrete acceptance criteria."""
+import json
+import re
+import subprocess
+
+REPO = "DobbsBoldry/homeless"
+
+CRITERIA = {
+    "EVDT-001": [
+        "Memo at `docs/research/ky-courtnet-access.md` covering at least 3 access mechanisms",
+        "Each mechanism rated on: cost, latency to integration, ongoing maintenance burden, legal/TOS posture, data freshness",
+        "Recommended path with 1-paragraph justification + name of the next concrete step",
+        "Cite all sources (URLs, docs, statutes) — KY AOC, eFiling site, vendor docs",
+        "Surface anything that could derail us (vendor lock-in, cost surprises, throttling, terms of use)",
+    ],
+    "EVDT-002": [
+        "Outreach playbook at `docs/research/daviess-clerk-outreach.md`",
+        "Includes: name + title of who to call, phone number, suggested days/times, alternative contact methods",
+        "5 questions to get answered (see template — feasibility of daily export, format, contact person, fee structure, escalation path)",
+        "Email follow-up template (paste-and-send) for after the call",
+        "1 phone call by Bo to the Daviess District Court Clerk's office",
+        "Capture answers in `docs/research/daviess-clerk-outreach-result.md` (template stub committed)",
+    ],
+    "EVDT-005": [
+        "Inngest scheduled function `daily-courtnet-scrape` (cron `0 12 * * *` UTC = 7am Central)",
+        "Source abstraction in `src/lib/eviction/sources/` — `fetchTodaysDocket(): Promise<RawFiling[]>` interface",
+        "Mock implementation `sources/courtnet-mock.ts` reads from `fixtures/eviction-filings.json` (rotates filed_at to today)",
+        "Real CourtNet implementation `sources/courtnet.ts` is a stub returning empty + comment pointing at EVDT-001's recommended path",
+        "Source selected via `EVICTION_SOURCE` env var: `mock` (default) | `courtnet`",
+        "Each fetched record runs through `parseEvictionFiling()` (EVDT-006); successes insert via dedup logic (EVDT-007); ParseErrors logged + counted",
+        "Inngest function reports a structured summary: `{ fetched, inserted, updated, parse_errors }`",
+        "Sentry breadcrumb on every run; `Sentry.captureMessage('warning')` if `parse_errors > 5%` of fetched",
+    ],
+    "EVDT-007": [
+        "`upsertFiling(filing): { action: 'inserted'|'updated'|'unchanged' }` in `src/lib/eviction/upsert.ts`",
+        "Same `case_number + source` -> ON CONFLICT DO UPDATE if any of: status, amount, address changed; otherwise unchanged",
+        "Cross-source preference: courtnet > manual > synthetic (don't let synthetic clobber a real row)",
+        "Atomic per-row (single transaction; safe under concurrent scraper runs)",
+        "Unit tests in `upsert.test.ts`: insert new, update on status change, no-op on identical, courtnet wins over synthetic for same case_number",
+    ],
+    "EVDT-009": [
+        "Risk score service `src/lib/eviction/risk-score.ts`: `scoreFiling(filing): Promise<{ score: 0-100, rationale: string, version: string }>`",
+        "Claude API call with prompt at `src/ai/prompts/eviction-risk-score.ts` (no inline strings)",
+        "Prompt-cached system prompt; per-filing user prompt with structured filing facts only (no PHI patterns)",
+        "Eval set: 20 historical-style filings in `fixtures/risk-score-eval.json` with expected-band labels (low/med/high)",
+        "Eval harness `scripts/eval-risk-score.ts`: runs all 20, reports % within expected band + score distribution",
+        "Schema additions: `eviction_filing_risk_scores` table (filing_id FK, score, rationale, model_version, created_at)",
+        "Idempotency: re-scoring the same filing with the same model_version returns the cached score",
+        "Defendant names/addresses scrubbed before sending to the model (eviction filings are public record but we still don't need them in the AI prompt)",
+    ],
+    "EVDT-016": [
+        "Server-rendered page at `/app/cases/filings/[id]` (admin + attorney + caseworker via requireRole)",
+        "Shows: case header (number, plaintiff, status badge), filing facts panel (defendant initials/full toggle, address, cause, amount, court division, filed date), risk score panel (if EVDT-009 has scored it), raw_json drawer for debugging",
+        "Back link to `/app/cases/filings`",
+        "Each row in the EVDT-008 dashboard becomes a Link to `/app/cases/filings/[id]`",
+        "404 if the id doesn't exist",
+        "No edit actions yet (lands in EVDT-017)",
+    ],
+}
+
+
+def get_issue(story_id):
+    r = subprocess.run(
+        ["gh", "issue", "list", "--repo", REPO, "--state", "open",
+         "--search", f"[{story_id}] in:title", "--json", "number,title,body"],
+        capture_output=True, text=True, check=True,
+    )
+    issues = json.loads(r.stdout)
+    for i in issues:
+        if f"[{story_id}]" in i["title"]:
+            return i
+    return None
+
+
+def update_body(num, new_body):
+    subprocess.run(
+        ["gh", "issue", "edit", str(num), "--repo", REPO, "--body", new_body],
+        check=True, capture_output=True,
+    )
+
+
+def main():
+    for story_id, criteria in CRITERIA.items():
+        issue = get_issue(story_id)
+        if not issue:
+            print(f"  {story_id}: NOT FOUND")
+            continue
+        body = issue["body"]
+        new_ac = "## Acceptance criteria\n\n" + \
+                 "\n".join(f"- [ ] {c}" for c in criteria) + \
+                 "\n- [ ] passes Definition of Done (see CLAUDE.md)\n"
+        new_body = re.sub(
+            r"## Acceptance criteria\n\n.*?(?=\n---)",
+            new_ac.rstrip() + "\n",
+            body,
+            flags=re.DOTALL,
+        )
+        update_body(issue["number"], new_body)
+        print(f"  {story_id} (#{issue['number']}): {len(criteria)} criteria")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Closes #16
Closes #17

## Summary
Two research memos that unblock the EVDT scraper work without depending on real CourtNet access:

- **EVDT-001** — \`docs/research/ky-courtnet-access.md\`. Recommends KCOJ guest-portal scraper + CourtNet 2.0 subscription via a sponsoring KY-licensed attorney. Total <\$100/mo, ~2 weeks to data. Three unknowns flagged for follow-up (KCOJ TOS, CourtNet tier table, attorney-account scripting policy).
- **EVDT-002** — \`docs/research/daviess-clerk-outreach.md\` + result template. Explicit playbook for Bo's call: name, phone, script, 5 questions, email follow-up template.

## Why now
Per the plan, EVDT-005 (production scraper) builds against a mock source first. These memos define the eventual switchover path so the scraper interface gets the abstraction right.

## Acceptance criteria — EVDT-001
- [x] Memo at \`docs/research/ky-courtnet-access.md\`
- [x] At least 3 access mechanisms (4 covered: scraper, CourtNet, third-party, ORA)
- [x] Cost / latency / maintenance / legal / freshness rated for each
- [x] Recommended path with justification + concrete next step
- [x] Sources cited

## Acceptance criteria — EVDT-002
- [x] Outreach playbook at \`docs/research/daviess-clerk-outreach.md\`
- [x] Name, title, phone, best times
- [x] 5 questions to ask
- [x] Email follow-up template
- [ ] **Bo to make 1 phone call** (target within 1 week, post-merge)
- [x] Result-capture template at \`daviess-clerk-outreach-result.md\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)