### PR TITLE
feat(EVDT-009a): wire risk score into case detail page

### DIFF
--- a/src/app/actions/eviction.ts
+++ b/src/app/actions/eviction.ts
@@ -1,0 +1,27 @@
+'use server';
+
+import * as Sentry from '@sentry/nextjs';
+import { revalidatePath } from 'next/cache';
+import { CaseFilingsRoles } from '@/components/eviction/case-filings-roles';
+import { getFilingById } from '@/db/queries/eviction-filings';
+import { requireRole } from '@/lib/auth';
+import { scoreFiling } from '@/lib/eviction/risk-score';
+
+export type ScoreFilingResult = { ok: true } | { ok: false; error: string };
+
+export async function scoreFilingAction(filingId: string): Promise<ScoreFilingResult> {
+  await requireRole(CaseFilingsRoles);
+
+  const filing = await getFilingById(filingId);
+  if (!filing) return { ok: false, error: 'Filing not found.' };
+
+  try {
+    await scoreFiling(filing);
+  } catch (err) {
+    Sentry.captureException(err, { tags: { action: 'scoreFilingAction', filingId } });
+    return { ok: false, error: 'Scoring failed. Please try again.' };
+  }
+
+  revalidatePath(`/app/cases/filings/${filingId}`);
+  return { ok: true };
+}

--- a/src/app/app/cases/filings/[id]/page.tsx
+++ b/src/app/app/cases/filings/[id]/page.tsx
@@ -4,6 +4,7 @@ import { CaseFilingsRoles } from '@/components/eviction/case-filings-roles';
 import { FilingDetail } from '@/components/eviction/filing-detail';
 import { getFilingById } from '@/db/queries/eviction-filings';
 import { requireRole } from '@/lib/auth';
+import { getLatestScore } from '@/lib/eviction/risk-score';
 
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
@@ -17,6 +18,8 @@ export default async function FilingDetailPage({ params }: { params: Promise<{ i
   const filing = await getFilingById(id);
   if (!filing) notFound();
 
+  const score = await getLatestScore(filing.id);
+
   return (
     <div className="mx-auto max-w-4xl p-6 space-y-4">
       <div className="text-xs">
@@ -24,7 +27,7 @@ export default async function FilingDetailPage({ params }: { params: Promise<{ i
           ← Back to filings
         </Link>
       </div>
-      <FilingDetail filing={filing} />
+      <FilingDetail filing={filing} score={score} />
     </div>
   );
 }

--- a/src/components/eviction/filing-detail.tsx
+++ b/src/components/eviction/filing-detail.tsx
@@ -1,8 +1,10 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useTransition } from 'react';
+import { scoreFilingAction } from '@/app/actions/eviction';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import type { EvictionFilingRiskScore } from '@/db/schema/eviction-filing-risk-scores';
 import type { EvictionFiling } from '@/db/schema/eviction-filings';
 
 const fmtDate = (d: Date) =>
@@ -28,7 +30,13 @@ const statusClass: Record<EvictionFiling['status'], string> = {
   sealed: 'bg-muted text-muted-foreground italic',
 };
 
-export function FilingDetail({ filing }: { filing: EvictionFiling }) {
+export function FilingDetail({
+  filing,
+  score,
+}: {
+  filing: EvictionFiling;
+  score: EvictionFilingRiskScore | null;
+}) {
   const [showFullName, setShowFullName] = useState(false);
   const [showRawJson, setShowRawJson] = useState(false);
 
@@ -94,14 +102,7 @@ export function FilingDetail({ filing }: { filing: EvictionFiling }) {
         </CardContent>
       </Card>
 
-      <Card className="opacity-70">
-        <CardHeader>
-          <CardTitle className="text-base">Risk score</CardTitle>
-        </CardHeader>
-        <CardContent className="text-sm text-muted-foreground">
-          Not yet scored. Risk scoring lands in EVDT-009.
-        </CardContent>
-      </Card>
+      <RiskScorePanel filing={filing} score={score} />
 
       {filing.rawJson != null && (
         <Card>
@@ -128,5 +129,83 @@ export function FilingDetail({ filing }: { filing: EvictionFiling }) {
         </Card>
       )}
     </div>
+  );
+}
+
+const scoreBandClass = (score: number) => {
+  if (score >= 70) return 'text-destructive';
+  if (score >= 40) return 'text-amber-600 dark:text-amber-400';
+  return 'text-emerald-600 dark:text-emerald-400';
+};
+
+const scoreBandLabel = (score: number) => {
+  if (score >= 70) return 'High risk';
+  if (score >= 40) return 'Moderate risk';
+  return 'Lower risk';
+};
+
+function RiskScorePanel({
+  filing,
+  score,
+}: {
+  filing: EvictionFiling;
+  score: EvictionFilingRiskScore | null;
+}) {
+  const [pending, startTransition] = useTransition();
+  const [error, setError] = useState<string | null>(null);
+
+  const onClick = () => {
+    setError(null);
+    startTransition(async () => {
+      const result = await scoreFilingAction(filing.id);
+      if (!result.ok) setError(result.error);
+    });
+  };
+
+  if (!score) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">Risk score</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-3 text-sm">
+          <p className="text-muted-foreground">
+            This case has not been scored yet. Scoring uses Claude to assess displacement risk from
+            public filing facts only — no PHI.
+          </p>
+          <div className="flex items-center gap-3">
+            <Button onClick={onClick} disabled={pending} size="sm">
+              {pending ? 'Scoring…' : 'Score this case'}
+            </Button>
+            {error ? <span className="text-destructive text-xs">{error}</span> : null}
+          </div>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-base">Risk score</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        <div className="flex items-baseline gap-3">
+          <span className={`text-5xl font-semibold tabular-nums ${scoreBandClass(score.score)}`}>
+            {score.score}
+          </span>
+          <span className={`text-sm font-medium ${scoreBandClass(score.score)}`}>
+            {scoreBandLabel(score.score)}
+          </span>
+        </div>
+        <p className="text-sm leading-relaxed">{score.rationale}</p>
+        <div className="flex flex-wrap gap-x-4 gap-y-1 text-xs text-muted-foreground">
+          <span>
+            Model: <span className="font-mono">{score.modelVersion}</span>
+          </span>
+          <span>Scored {fmtDate(score.createdAt)}</span>
+        </div>
+      </CardContent>
+    </Card>
   );
 }


### PR DESCRIPTION
Closes #218

## Summary
- New server action `scoreFilingAction` (`src/app/actions/eviction.ts`) — role-gated, Sentry-instrumented, revalidates the detail page on success.
- Detail page fetches the latest score and passes it into `FilingDetail`.
- New `RiskScorePanel` sub-component:
  - shows the score (band-colored: green <40, amber 40-69, red 70+), rationale, model version, scored-at — when a score exists.
  - shows a "Score this case" button with `useTransition` pending state and inline error — when there's no score yet.

## Acceptance criteria
- [x] `/app/cases/filings/[id]` reads via `getLatestScore`
- [x] Existing score → big band-colored number + rationale + model_version + scored_at
- [x] No score → "Score this case" button calling `scoreFilingAction`, revalidates after success
- [x] Server action gated on `CaseFilingsRoles`
- [x] Loading state on the button while in flight
- [x] Error state on parse failure (logged to Sentry)

🤖 Generated with [Claude Code](https://claude.com/claude-code)