### PR TITLE
feat(EVDT-018): KLA attorney role + partner_org membership

### DIFF
--- a/docs/access-control.md
+++ b/docs/access-control.md
@@ -1,0 +1,62 @@
+# Access control — role + org-membership model
+
+This doc explains how the platform decides "can this signed-in user see/do this." It's the mental model for engineers wiring new pages and server actions.
+
+## Two layers
+
+We have two complementary checks. Most routes use just the first; KLA-only routes use both.
+
+### Layer 1 — Global role (`users.role`)
+
+Every user has a single primary role assigned at provisioning time:
+
+| Role            | Who                                               |
+|-----------------|---------------------------------------------------|
+| `pending`       | Brand-new sign-up; can't see PHI or case data yet |
+| `attorney`      | A licensed attorney working evictions             |
+| `caseworker`    | A non-clinical case worker (shelter, community)   |
+| `ed_coordinator`| ED super-utilizer care coordinator                |
+| `shelter_staff` | Shelter intake / bed management staff             |
+| `admin`         | Platform admin (us, until partners are onboarded) |
+
+The role gate is `requireRole(allowed: readonly UserRole[])` in [src/lib/auth.ts](../src/lib/auth.ts). Use it as the **first line** of any role-gated server component or server action. It calls `notFound()` if the user's role isn't in the allow-list — we 404 rather than 403 so we don't leak which routes exist for which roles.
+
+### Layer 2 — Partner-org membership (`org_memberships`)
+
+A user can belong to one or more partner orgs (`partner_orgs`), with a possibly different scoped role per org. This lets us say "Ada is a global `attorney`, AND a member of the KLA Owensboro org" — needed when multiple legal-aid partners join the platform and we want to scope what each org's staff can see.
+
+The first concrete partner-scoped helper is `requireKlaAttorney()` (also in [src/lib/auth.ts](../src/lib/auth.ts)):
+
+- Returns the user only if `user.role === 'attorney'` AND they are a member of the partner org with slug `kla-owensboro`.
+- Otherwise `notFound()`.
+
+## Phase 1 assumption: KLA is the only legal-aid partner
+
+For Phase 1 (pilot), Kentucky Legal Aid - Owensboro (`slug: kla-owensboro`, `type: legal_aid`) is the only legal-aid partner. The KLA-only views — daily docket, response-packet generator, etc. — gate on `requireKlaAttorney()` rather than a generic `requireRole(['attorney'])`.
+
+This matters because as the network grows, an "attorney" role check alone would let a future partner attorney see KLA's queue. Membership-scoped gating prevents that by construction.
+
+When a second legal-aid partner joins, generalize to a `requirePartnerOrgRole(slug, role)` helper rather than fan out per-org helpers.
+
+## When to use which
+
+| Route / action                        | Gate                                        |
+|---------------------------------------|---------------------------------------------|
+| Filings dashboard (`/app/cases/filings`) | `requireRole(CaseFilingsRoles)` (multi-role) |
+| Case detail (`/app/cases/filings/[id]`)  | `requireRole(CaseFilingsRoles)`              |
+| KLA daily queue (`/app/cases/queue`)     | `requireKlaAttorney()`                       |
+| Response-packet generator                | `requireKlaAttorney()`                       |
+| Audit log viewer                          | `requireRole(['admin'])`                     |
+
+## Sidebar visibility ≠ access control
+
+`navItemsForRole` controls which sidebar links a user sees, but it is **presentation only**. The server-side `requireRole` / `requireKlaAttorney` call inside each page (and each server action) is the authoritative gate. Never trust the sidebar to hide routes for security purposes.
+
+## Seeding
+
+`pnpm db:seed` creates one user per global role plus the two partner orgs (Audubon Area and KLA Owensboro). The seed `attorney` user (Ada Attorney) is a member of both orgs so a developer signed in as Ada can access KLA-only routes locally.
+
+## Open questions / future work
+
+- Add `member_of_org(slug)` column-level helpers for queries that need to scope DB reads by org membership (e.g. an attorney from a different legal-aid partner viewing only their org's filings).
+- Decide whether `admin` should pass `requireKlaAttorney()` for support/troubleshooting or stay strictly excluded. Phase 1: strictly excluded.

--- a/src/db/seed.ts
+++ b/src/db/seed.ts
@@ -21,7 +21,7 @@ config({ path: ['.env.local', '.env'] });
 async function main() {
   console.log('[seed] starting…');
 
-  // ---- 1 partner org ----
+  // ---- partner orgs ----
   const orgSlug = 'audubon-area-community-services';
   let [org] = await db.select().from(partnerOrgs).where(eq(partnerOrgs.slug, orgSlug)).limit(1);
   if (!org) {
@@ -38,6 +38,26 @@ async function main() {
     console.log('[seed]   + partner org', org.slug);
   } else {
     console.log('[seed]   = partner org', org.slug, '(exists)');
+  }
+
+  // KLA Owensboro — legal aid partner. Membership in this org gates
+  // the attorney-only views (see requireKlaAttorney in src/lib/auth.ts).
+  const klaSlug = 'kla-owensboro';
+  let [klaOrg] = await db.select().from(partnerOrgs).where(eq(partnerOrgs.slug, klaSlug)).limit(1);
+  if (!klaOrg) {
+    [klaOrg] = await db
+      .insert(partnerOrgs)
+      .values({
+        name: 'Kentucky Legal Aid - Owensboro',
+        slug: klaSlug,
+        type: 'legal_aid',
+        contactEmail: 'owensboro@klaid.example',
+        contactPhone: '+1-270-555-0200',
+      })
+      .returning();
+    console.log('[seed]   + partner org', klaOrg.slug);
+  } else {
+    console.log('[seed]   = partner org', klaOrg.slug, '(exists)');
   }
 
   // ---- 5 users, one per role ----
@@ -94,17 +114,23 @@ async function main() {
       console.log('[seed]   = user', u.role, user.email, '(exists)');
     }
 
-    // Org membership for each.
-    const [hasMembership] = await db
-      .select()
-      .from(orgMemberships)
-      .where(eq(orgMemberships.userId, user.id))
-      .limit(1);
-    if (!hasMembership) {
+    // Org membership in the default community org for every seed user.
+    await db
+      .insert(orgMemberships)
+      .values({ userId: user.id, partnerOrgId: org.id, role: u.role })
+      .onConflictDoNothing({
+        target: [orgMemberships.userId, orgMemberships.partnerOrgId],
+      });
+
+    // Attorneys also get KLA Owensboro membership so they can access the
+    // KLA-only views (requireKlaAttorney).
+    if (u.role === 'attorney') {
       await db
         .insert(orgMemberships)
-        .values({ userId: user.id, partnerOrgId: org.id, role: u.role })
-        .onConflictDoNothing();
+        .values({ userId: user.id, partnerOrgId: klaOrg.id, role: 'attorney' })
+        .onConflictDoNothing({
+          target: [orgMemberships.userId, orgMemberships.partnerOrgId],
+        });
     }
   }
 

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,10 +1,14 @@
 import { auth, clerkClient } from '@clerk/nextjs/server';
-import { eq } from 'drizzle-orm';
+import { and, eq } from 'drizzle-orm';
 import { notFound, redirect } from 'next/navigation';
 import { db } from '@/db/client';
 import type { UserRole } from '@/db/schema/enums';
+import { orgMemberships } from '@/db/schema/org-memberships';
+import { partnerOrgs } from '@/db/schema/partner-orgs';
 import { type User, users } from '@/db/schema/users';
 import { logAuditEvent } from './audit';
+
+export const KLA_OWENSBORO_SLUG = 'kla-owensboro';
 
 /**
  * Server-only helper: returns the current user from our DB, lazy-creating
@@ -72,5 +76,28 @@ export async function requireUser(): Promise<User> {
 export async function requireRole(allowed: readonly UserRole[]): Promise<User> {
   const user = await requireUser();
   if (!allowed.includes(user.role)) notFound();
+  return user;
+}
+
+/**
+ * Server-only: returns the current user only if they are an attorney AND
+ * a member of the Kentucky Legal Aid - Owensboro partner org. Otherwise
+ * 404s (don't leak the existence of attorney-only routes).
+ *
+ * Phase 1 assumption: KLA Owensboro is the single legal-aid partner. When
+ * a second attorney org joins, generalize to `requirePartnerOrgRole(slug, role)`.
+ */
+export async function requireKlaAttorney(): Promise<User> {
+  const user = await requireUser();
+  if (user.role !== 'attorney') notFound();
+
+  const [membership] = await db
+    .select({ id: orgMemberships.id })
+    .from(orgMemberships)
+    .innerJoin(partnerOrgs, eq(orgMemberships.partnerOrgId, partnerOrgs.id))
+    .where(and(eq(orgMemberships.userId, user.id), eq(partnerOrgs.slug, KLA_OWENSBORO_SLUG)))
+    .limit(1);
+  if (!membership) notFound();
+
   return user;
 }


### PR DESCRIPTION
Closes #33

## Summary
- **Seed**: adds Kentucky Legal Aid - Owensboro partner org (\`slug: kla-owensboro\`, \`type: legal_aid\`). Seed attorney is now a member of both Audubon Area and KLA so a developer signed in as Ada can hit KLA-only routes locally.
- **\`requireKlaAttorney()\`** helper in \`src/lib/auth.ts\` — gates on \`role=attorney\` AND membership in the \`kla-owensboro\` org. \`notFound()\` otherwise (don't leak existence of attorney-only routes).
- **\`docs/access-control.md\`** explains the two-layer (role + partner-org membership) gating model and the Phase-1 single-legal-aid-partner assumption.

## Acceptance criteria
- [x] Seed script creates KLA partner_org (slug \`kla-owensboro\`, type \`legal_aid\`) and assigns the seed attorney via \`org_memberships\`
- [x] \`requireKlaAttorney()\` returns user only if role=attorney AND member of \`kla-owensboro\`; otherwise \`notFound()\`
- [x] Role mental model documented in \`docs/access-control.md\`
- [x] Typecheck + lint + tests green

## Notes for review
- Membership upsert switched to \`onConflictDoNothing\` keyed on \`(user_id, partner_org_id)\` so re-running the seed after KLA was added cleanly extends Ada with the new membership instead of skipping her entirely.
- KLA slug exported as \`KLA_OWENSBORO_SLUG\` constant so future callers don't re-type the string.

🤖 Generated with [Claude Code](https://claude.com/claude-code)