### PR TITLE
feat(EVDT-010): listRankedDocket query + ranking comparator

### DIFF
--- a/src/db/queries/eviction-filings.ts
+++ b/src/db/queries/eviction-filings.ts
@@ -1,7 +1,10 @@
-import { desc, eq } from 'drizzle-orm';
+import { and, desc, eq, sql } from 'drizzle-orm';
+import { RISK_SCORE_MODEL_VERSION } from '@/ai/prompts/eviction-risk-score';
 import { db } from '@/db/client';
 import type { EvictionFilingSource } from '@/db/schema/enums';
+import { evictionFilingRiskScores } from '@/db/schema/eviction-filing-risk-scores';
 import { type EvictionFiling, evictionFilings } from '@/db/schema/eviction-filings';
+import type { RankedDocketRow } from '@/lib/eviction/docket-ranking';
 
 /**
  * Fetch the most recent N filings, ordered by filed_at desc.
@@ -21,4 +24,39 @@ export async function listRecentFilings(
 export async function getFilingById(id: string): Promise<EvictionFiling | null> {
   const rows = await db.select().from(evictionFilings).where(eq(evictionFilings.id, id)).limit(1);
   return rows[0] ?? null;
+}
+
+/**
+ * KLA daily docket: every filing joined to its risk score for the current
+ * model version, ordered by (score DESC, filed_at DESC). Unscored filings
+ * are included and rank last (COALESCE score = 0).
+ *
+ * Restricting the join to RISK_SCORE_MODEL_VERSION guarantees one score row
+ * per filing (model_version is part of the unique index), so no fan-out.
+ * When a new model_version ships, this query continues returning the
+ * current-version score; old-version rows are ignored — exactly the
+ * eval-comparison semantics described in the schema.
+ */
+export async function listRankedDocket(opts: { limit?: number } = {}): Promise<RankedDocketRow[]> {
+  const { limit = 50 } = opts;
+  const rows = await db
+    .select({
+      filing: evictionFilings,
+      score: evictionFilingRiskScores.score,
+      rationale: evictionFilingRiskScores.rationale,
+    })
+    .from(evictionFilings)
+    .leftJoin(
+      evictionFilingRiskScores,
+      and(
+        eq(evictionFilingRiskScores.filingId, evictionFilings.id),
+        eq(evictionFilingRiskScores.modelVersion, RISK_SCORE_MODEL_VERSION),
+      ),
+    )
+    .orderBy(
+      desc(sql`COALESCE(${evictionFilingRiskScores.score}, 0)`),
+      desc(evictionFilings.filedAt),
+    )
+    .limit(limit);
+  return rows;
 }

--- a/src/lib/eviction/docket-ranking.test.ts
+++ b/src/lib/eviction/docket-ranking.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest';
+import type { EvictionFiling } from '@/db/schema/eviction-filings';
+import { compareDocketRanking, type RankedDocketRow, rankDocketRows } from './docket-ranking';
+
+const baseFiling = (overrides: Partial<EvictionFiling> = {}): EvictionFiling => ({
+  id: '00000000-0000-0000-0000-000000000000',
+  caseNumber: 'SYN-26-CI-00000',
+  filedAt: new Date('2026-04-01T10:00:00-05:00'),
+  courtDivision: '1st Division',
+  plaintiff: 'Test LLC',
+  defendantFirstName: 'D',
+  defendantLastName: 'D',
+  defendantAddress: null,
+  causeType: 'non_payment',
+  amountClaimedCents: 100_000,
+  status: 'filed',
+  source: 'synthetic',
+  rawJson: null,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+  ...overrides,
+});
+
+const row = (
+  id: string,
+  filedAt: string,
+  score: number | null,
+  rationale: string | null = score == null ? null : 'because',
+): RankedDocketRow => ({
+  filing: baseFiling({ id, filedAt: new Date(filedAt) }),
+  score,
+  rationale,
+});
+
+describe('rankDocketRows', () => {
+  it('sorts 3 scored + 1 unscored: highest score first, unscored last', () => {
+    const a = row('a', '2026-04-10T10:00:00-05:00', 80);
+    const b = row('b', '2026-04-12T10:00:00-05:00', 55);
+    const c = row('c', '2026-04-08T10:00:00-05:00', 25);
+    const d = row('d', '2026-04-20T10:00:00-05:00', null);
+
+    const sorted = rankDocketRows([d, c, b, a]);
+    expect(sorted.map((r) => r.filing.id)).toEqual(['a', 'b', 'c', 'd']);
+  });
+
+  it('breaks ties on score by filed_at DESC (newer first)', () => {
+    const older = row('older', '2026-04-01T10:00:00-05:00', 50);
+    const newer = row('newer', '2026-04-15T10:00:00-05:00', 50);
+
+    const sorted = rankDocketRows([older, newer]);
+    expect(sorted.map((r) => r.filing.id)).toEqual(['newer', 'older']);
+  });
+
+  it('two unscored filings still order by filed_at DESC among themselves', () => {
+    const old = row('old', '2026-04-01T10:00:00-05:00', null);
+    const fresh = row('fresh', '2026-04-20T10:00:00-05:00', null);
+
+    const sorted = rankDocketRows([old, fresh]);
+    expect(sorted.map((r) => r.filing.id)).toEqual(['fresh', 'old']);
+  });
+
+  it('does not mutate the input array', () => {
+    const a = row('a', '2026-04-10T10:00:00-05:00', 90);
+    const b = row('b', '2026-04-11T10:00:00-05:00', 10);
+    const input = [b, a];
+    rankDocketRows(input);
+    expect(input.map((r) => r.filing.id)).toEqual(['b', 'a']);
+  });
+
+  it('treats null score identical to 0 for comparison', () => {
+    const zero = row('zero', '2026-04-15T10:00:00-05:00', 0);
+    const nullish = row('null', '2026-04-10T10:00:00-05:00', null);
+    // both effectively-zero — newer filed_at wins
+    expect(compareDocketRanking(zero, nullish)).toBeLessThan(0);
+  });
+});

--- a/src/lib/eviction/docket-ranking.ts
+++ b/src/lib/eviction/docket-ranking.ts
@@ -1,0 +1,30 @@
+import type { EvictionFiling } from '@/db/schema/eviction-filings';
+
+/**
+ * One row in the KLA daily docket — a filing plus the (optional) latest
+ * risk-score row for the current model version. Unscored filings are
+ * still included in the docket but rank last.
+ */
+export interface RankedDocketRow {
+  filing: EvictionFiling;
+  score: number | null;
+  rationale: string | null;
+}
+
+/**
+ * Pure comparator mirroring the SQL `ORDER BY COALESCE(score, 0) DESC,
+ * filed_at DESC` used by `listRankedDocket`. Exported so tests can verify
+ * the ranking semantics without a DB round-trip and so callers that build
+ * docket views from cached/in-memory rows sort identically to the DB.
+ */
+export function compareDocketRanking(a: RankedDocketRow, b: RankedDocketRow): number {
+  const aScore = a.score ?? 0;
+  const bScore = b.score ?? 0;
+  if (aScore !== bScore) return bScore - aScore;
+  return b.filing.filedAt.getTime() - a.filing.filedAt.getTime();
+}
+
+/** Convenience: stable sort of docket rows by the canonical ranking. */
+export function rankDocketRows(rows: RankedDocketRow[]): RankedDocketRow[] {
+  return [...rows].sort(compareDocketRanking);
+}


### PR DESCRIPTION
Closes #25

## Summary
- \`listRankedDocket(limit?)\` in \`src/db/queries/eviction-filings.ts\` — LEFT JOIN to risk scores filtered to the current model version, ordered by \`(COALESCE(score, 0) DESC, filed_at DESC)\`, returns \`RankedDocketRow[]\`.
- New \`src/lib/eviction/docket-ranking.ts\` with the pure \`compareDocketRanking\` comparator + \`rankDocketRows\` helper, mirroring the SQL order so in-memory sorts match the DB.
- 5 unit tests cover the AC's 3-scored + 1-unscored case, filed-at tiebreak, two-unscored ordering, no-mutate, and null-vs-0 equivalence.

## Acceptance criteria
- [x] \`listRankedDocket(limit?)\` joins filings to latest risk score, ordered score DESC then filed_at DESC
- [x] Filings without a score sort last (LEFT JOIN, COALESCE 0)
- [x] Returns \`{filing, score, rationale}\` rows
- [x] Indexes: existing \`risk_scores_score_idx\` + unique \`(filing_id, model_version)\` are sufficient for Phase 1
- [x] Unit test: 3 scored + 1 unscored returns 4 rows in correct order (plus 4 more cases)

## Notes for review
- Restricting the JOIN to \`RISK_SCORE_MODEL_VERSION\` guarantees one score row per filing (model_version is part of the unique index) — no fan-out, no \`DISTINCT ON\` needed. When a model version bumps, this query continues returning the current-version score; old rows are ignored, matching the eval-comparison semantics in the schema doc.
- Pure-comparator approach (vs DB integration test) was chosen because there's no DB test infrastructure yet and the ranking semantics are the interesting bit; the SQL ORDER BY mirrors the comparator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)