### PR TITLE
feat(EVDT-015): KLA daily docket dashboard

### DIFF
--- a/src/app/app/cases/queue/page.tsx
+++ b/src/app/app/cases/queue/page.tsx
@@ -1,0 +1,77 @@
+import Link from 'next/link';
+import { DocketFilters, type DocketFilterValues } from '@/components/eviction/docket-filters';
+import { DocketTable } from '@/components/eviction/docket-table';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { listRankedDocket } from '@/db/queries/eviction-filings';
+import type { EvictionCauseType, EvictionFilingStatus } from '@/db/schema/enums';
+import { requireKlaAttorney } from '@/lib/auth';
+
+const ALLOWED_STATUSES: EvictionFilingStatus[] = [
+  'filed',
+  'served',
+  'judgment',
+  'dismissed',
+  'sealed',
+];
+const ALLOWED_CAUSES: EvictionCauseType[] = ['non_payment', 'lease_violation', 'holdover', 'other'];
+
+const parseMinScore = (raw: string | undefined): number | undefined => {
+  if (raw === undefined || raw === '') return undefined;
+  const n = Number(raw);
+  if (!Number.isFinite(n)) return undefined;
+  return Math.max(0, Math.min(100, Math.trunc(n)));
+};
+
+export default async function DocketQueuePage({
+  searchParams,
+}: {
+  searchParams: Promise<{
+    search?: string;
+    status?: string;
+    cause?: string;
+    min_score?: string;
+  }>;
+}) {
+  await requireKlaAttorney();
+
+  const params = await searchParams;
+  const status = ALLOWED_STATUSES.find((s) => s === params.status);
+  const cause = ALLOWED_CAUSES.find((c) => c === params.cause);
+  const minScore = parseMinScore(params.min_score);
+  const search = params.search?.trim() || undefined;
+
+  const values: DocketFilterValues = { search, status, cause, minScore };
+
+  const rows = await listRankedDocket({ limit: 50, status, cause, minScore, search });
+
+  return (
+    <div className="mx-auto max-w-6xl p-6 space-y-4">
+      <header>
+        <h1 className="font-serif text-3xl font-bold text-primary">Daily queue</h1>
+        <p className="text-sm text-muted-foreground">
+          Top {rows.length} eviction filings ranked by Claude risk score. Newest filings break ties.
+        </p>
+      </header>
+
+      <DocketFilters values={values} />
+
+      {rows.length === 0 ? (
+        <Card>
+          <CardHeader>
+            <CardTitle>No filings match these filters</CardTitle>
+            <CardDescription>
+              No filings ingested yet — see{' '}
+              <Link href="/app/cases/filings" className="underline hover:text-primary">
+                Filings
+              </Link>{' '}
+              page, or relax the filter criteria above.
+            </CardDescription>
+          </CardHeader>
+          <CardContent />
+        </Card>
+      ) : (
+        <DocketTable rows={rows} />
+      )}
+    </div>
+  );
+}

--- a/src/app/app/cases/queue/page.tsx
+++ b/src/app/app/cases/queue/page.tsx
@@ -41,6 +41,7 @@ export default async function DocketQueuePage({
   const search = params.search?.trim() || undefined;
 
   const values: DocketFilterValues = { search, status, cause, minScore };
+  const filtersActive = Boolean(search || status || cause || typeof minScore === 'number');
 
   const rows = await listRankedDocket({ limit: 50, status, cause, minScore, search });
 
@@ -58,14 +59,23 @@ export default async function DocketQueuePage({
       {rows.length === 0 ? (
         <Card>
           <CardHeader>
-            <CardTitle>No filings match these filters</CardTitle>
-            <CardDescription>
-              No filings ingested yet — see{' '}
-              <Link href="/app/cases/filings" className="underline hover:text-primary">
-                Filings
-              </Link>{' '}
-              page, or relax the filter criteria above.
-            </CardDescription>
+            {filtersActive ? (
+              <>
+                <CardTitle>No filings match these filters</CardTitle>
+                <CardDescription>Relax the filter criteria above and try again.</CardDescription>
+              </>
+            ) : (
+              <>
+                <CardTitle>No filings ingested yet</CardTitle>
+                <CardDescription>
+                  See the{' '}
+                  <Link href="/app/cases/filings" className="underline hover:text-primary">
+                    Filings page
+                  </Link>{' '}
+                  to load synthetic data, or wait for the daily scraper to populate.
+                </CardDescription>
+              </>
+            )}
           </CardHeader>
           <CardContent />
         </Card>

--- a/src/components/app-shell/nav-config.ts
+++ b/src/components/app-shell/nav-config.ts
@@ -14,6 +14,13 @@ export type NavItem = {
 export const NAV_ITEMS: NavItem[] = [
   { label: 'Dashboard', href: '/app/dashboard', roles: 'all' },
   {
+    label: 'Daily queue',
+    href: '/app/cases/queue',
+    // KLA-only by membership; the page itself enforces requireKlaAttorney().
+    // Sidebar shows it to all attorneys; non-KLA attorneys would 404 on click.
+    roles: ['attorney'],
+  },
+  {
     label: 'Filings',
     href: '/app/cases/filings',
     roles: ['attorney', 'caseworker', 'admin'],

--- a/src/components/eviction/docket-filters.tsx
+++ b/src/components/eviction/docket-filters.tsx
@@ -4,6 +4,14 @@ import type { EvictionCauseType, EvictionFilingStatus } from '@/db/schema/enums'
 const STATUSES: EvictionFilingStatus[] = ['filed', 'served', 'judgment', 'dismissed', 'sealed'];
 const CAUSES: EvictionCauseType[] = ['non_payment', 'lease_violation', 'holdover', 'other'];
 
+const statusLabel: Record<EvictionFilingStatus, string> = {
+  filed: 'Filed',
+  served: 'Served',
+  judgment: 'Judgment',
+  dismissed: 'Dismissed',
+  sealed: 'Sealed',
+};
+
 const causeLabel: Record<EvictionCauseType, string> = {
   non_payment: 'Non-payment',
   lease_violation: 'Lease violation',
@@ -51,7 +59,7 @@ export function DocketFilters({ values }: { values: DocketFilterValues }) {
           <option value="">Any</option>
           {STATUSES.map((s) => (
             <option key={s} value={s}>
-              {s}
+              {statusLabel[s]}
             </option>
           ))}
         </select>

--- a/src/components/eviction/docket-filters.tsx
+++ b/src/components/eviction/docket-filters.tsx
@@ -1,0 +1,104 @@
+import Link from 'next/link';
+import type { EvictionCauseType, EvictionFilingStatus } from '@/db/schema/enums';
+
+const STATUSES: EvictionFilingStatus[] = ['filed', 'served', 'judgment', 'dismissed', 'sealed'];
+const CAUSES: EvictionCauseType[] = ['non_payment', 'lease_violation', 'holdover', 'other'];
+
+const causeLabel: Record<EvictionCauseType, string> = {
+  non_payment: 'Non-payment',
+  lease_violation: 'Lease violation',
+  holdover: 'Holdover',
+  other: 'Other',
+};
+
+export interface DocketFilterValues {
+  search?: string;
+  status?: EvictionFilingStatus;
+  cause?: EvictionCauseType;
+  minScore?: number;
+}
+
+const isFiltered = (v: DocketFilterValues) =>
+  Boolean(v.search || v.status || v.cause || typeof v.minScore === 'number');
+
+export function DocketFilters({ values }: { values: DocketFilterValues }) {
+  return (
+    <form
+      action="/app/cases/queue"
+      method="get"
+      className="flex flex-wrap items-end gap-3 rounded-md border border-border bg-card p-3 text-sm"
+      aria-label="Filter docket"
+    >
+      <label className="flex flex-col gap-1">
+        <span className="text-xs uppercase tracking-wide text-muted-foreground">Search</span>
+        <input
+          name="search"
+          type="search"
+          defaultValue={values.search ?? ''}
+          placeholder="Case # or plaintiff…"
+          className="h-9 rounded-md border border-input bg-background px-3 text-sm"
+          aria-label="Search by case number or plaintiff"
+        />
+      </label>
+
+      <label className="flex flex-col gap-1">
+        <span className="text-xs uppercase tracking-wide text-muted-foreground">Status</span>
+        <select
+          name="status"
+          defaultValue={values.status ?? ''}
+          className="h-9 rounded-md border border-input bg-background px-3 text-sm"
+        >
+          <option value="">Any</option>
+          {STATUSES.map((s) => (
+            <option key={s} value={s}>
+              {s}
+            </option>
+          ))}
+        </select>
+      </label>
+
+      <label className="flex flex-col gap-1">
+        <span className="text-xs uppercase tracking-wide text-muted-foreground">Cause</span>
+        <select
+          name="cause"
+          defaultValue={values.cause ?? ''}
+          className="h-9 rounded-md border border-input bg-background px-3 text-sm"
+        >
+          <option value="">Any</option>
+          {CAUSES.map((c) => (
+            <option key={c} value={c}>
+              {causeLabel[c]}
+            </option>
+          ))}
+        </select>
+      </label>
+
+      <label className="flex flex-col gap-1">
+        <span className="text-xs uppercase tracking-wide text-muted-foreground">Min score</span>
+        <input
+          name="min_score"
+          type="number"
+          min={0}
+          max={100}
+          defaultValue={values.minScore ?? ''}
+          placeholder="0–100"
+          className="h-9 w-24 rounded-md border border-input bg-background px-3 text-sm"
+        />
+      </label>
+
+      <div className="flex items-center gap-2">
+        <button
+          type="submit"
+          className="h-9 rounded-md bg-primary px-4 text-sm text-primary-foreground hover:bg-primary/90"
+        >
+          Apply
+        </button>
+        {isFiltered(values) ? (
+          <Link href="/app/cases/queue" className="text-xs text-muted-foreground hover:underline">
+            Reset
+          </Link>
+        ) : null}
+      </div>
+    </form>
+  );
+}

--- a/src/components/eviction/docket-table.tsx
+++ b/src/components/eviction/docket-table.tsx
@@ -1,0 +1,99 @@
+import Link from 'next/link';
+import type { EvictionFiling } from '@/db/schema/eviction-filings';
+import type { RankedDocketRow } from '@/lib/eviction/docket-ranking';
+import { riskBandClass } from '@/lib/eviction/risk-band';
+
+const fmtDate = (d: Date) =>
+  new Intl.DateTimeFormat('en-US', { dateStyle: 'medium' }).format(new Date(d));
+
+const initials = (first: string, last: string) =>
+  `${first.charAt(0).toUpperCase()}.${last.charAt(0).toUpperCase()}.`;
+
+const causeLabel: Record<EvictionFiling['causeType'], string> = {
+  non_payment: 'Non-payment',
+  lease_violation: 'Lease violation',
+  holdover: 'Holdover',
+  other: 'Other',
+};
+
+const statusClass: Record<EvictionFiling['status'], string> = {
+  filed: 'bg-secondary text-secondary-foreground',
+  served: 'bg-accent text-accent-foreground',
+  judgment: 'bg-destructive/15 text-destructive',
+  dismissed: 'bg-muted text-muted-foreground',
+  sealed: 'bg-muted text-muted-foreground italic',
+};
+
+export function DocketTable({ rows }: { rows: RankedDocketRow[] }) {
+  return (
+    <div className="overflow-x-auto rounded-md border border-border">
+      <table className="w-full text-sm">
+        <thead className="bg-muted/40 text-left text-xs uppercase tracking-wide text-muted-foreground">
+          <tr>
+            <th scope="col" className="px-3 py-2 text-right">
+              #
+            </th>
+            <th scope="col" className="px-3 py-2 text-right">
+              Score
+            </th>
+            <th scope="col" className="px-3 py-2">
+              Case #
+            </th>
+            <th scope="col" className="px-3 py-2">
+              Defendant
+            </th>
+            <th scope="col" className="px-3 py-2">
+              Plaintiff
+            </th>
+            <th scope="col" className="px-3 py-2">
+              Cause
+            </th>
+            <th scope="col" className="px-3 py-2">
+              Status
+            </th>
+            <th scope="col" className="px-3 py-2 whitespace-nowrap">
+              Filed
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((row, idx) => {
+            const f = row.filing;
+            return (
+              <tr key={f.id} className="border-t border-border align-top">
+                <td className="px-3 py-2 text-right font-mono text-xs text-muted-foreground">
+                  {idx + 1}
+                </td>
+                <td className="px-3 py-2 text-right">
+                  {row.score == null ? (
+                    <span className="text-xs text-muted-foreground">—</span>
+                  ) : (
+                    <span
+                      className={`font-mono font-semibold tabular-nums ${riskBandClass(row.score)}`}
+                    >
+                      {row.score}
+                    </span>
+                  )}
+                </td>
+                <td className="px-3 py-2 font-mono text-xs">
+                  <Link href={`/app/cases/filings/${f.id}`} className="hover:underline">
+                    {f.caseNumber}
+                  </Link>
+                </td>
+                <td className="px-3 py-2">{initials(f.defendantFirstName, f.defendantLastName)}</td>
+                <td className="px-3 py-2">{f.plaintiff}</td>
+                <td className="px-3 py-2">{causeLabel[f.causeType]}</td>
+                <td className="px-3 py-2">
+                  <span className={`rounded px-2 py-0.5 text-xs ${statusClass[f.status]}`}>
+                    {f.status}
+                  </span>
+                </td>
+                <td className="px-3 py-2 whitespace-nowrap">{fmtDate(f.filedAt)}</td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/src/components/eviction/filing-detail.tsx
+++ b/src/components/eviction/filing-detail.tsx
@@ -6,6 +6,7 @@ import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import type { EvictionFilingRiskScore } from '@/db/schema/eviction-filing-risk-scores';
 import type { EvictionFiling } from '@/db/schema/eviction-filings';
+import { riskBandClass, riskBandLabel } from '@/lib/eviction/risk-band';
 
 const fmtDate = (d: Date) =>
   new Intl.DateTimeFormat('en-US', { dateStyle: 'long', timeStyle: 'short' }).format(new Date(d));
@@ -132,18 +133,6 @@ export function FilingDetail({
   );
 }
 
-const scoreBandClass = (score: number) => {
-  if (score >= 70) return 'text-destructive';
-  if (score >= 40) return 'text-amber-600 dark:text-amber-400';
-  return 'text-emerald-600 dark:text-emerald-400';
-};
-
-const scoreBandLabel = (score: number) => {
-  if (score >= 70) return 'High risk';
-  if (score >= 40) return 'Moderate risk';
-  return 'Lower risk';
-};
-
 function RiskScorePanel({
   filing,
   score,
@@ -191,11 +180,11 @@ function RiskScorePanel({
       </CardHeader>
       <CardContent className="space-y-3">
         <div className="flex items-baseline gap-3">
-          <span className={`text-5xl font-semibold tabular-nums ${scoreBandClass(score.score)}`}>
+          <span className={`text-5xl font-semibold tabular-nums ${riskBandClass(score.score)}`}>
             {score.score}
           </span>
-          <span className={`text-sm font-medium ${scoreBandClass(score.score)}`}>
-            {scoreBandLabel(score.score)}
+          <span className={`text-sm font-medium ${riskBandClass(score.score)}`}>
+            {riskBandLabel(score.score)}
           </span>
         </div>
         <p className="text-sm leading-relaxed">{score.rationale}</p>

--- a/src/db/queries/eviction-filings.ts
+++ b/src/db/queries/eviction-filings.ts
@@ -1,7 +1,11 @@
-import { and, desc, eq, sql } from 'drizzle-orm';
+import { and, desc, eq, gte, ilike, or, type SQL, sql } from 'drizzle-orm';
 import { RISK_SCORE_MODEL_VERSION } from '@/ai/prompts/eviction-risk-score';
 import { db } from '@/db/client';
-import type { EvictionFilingSource } from '@/db/schema/enums';
+import type {
+  EvictionCauseType,
+  EvictionFilingSource,
+  EvictionFilingStatus,
+} from '@/db/schema/enums';
 import { evictionFilingRiskScores } from '@/db/schema/eviction-filing-risk-scores';
 import { type EvictionFiling, evictionFilings } from '@/db/schema/eviction-filings';
 import type { RankedDocketRow } from '@/lib/eviction/docket-ranking';
@@ -37,9 +41,35 @@ export async function getFilingById(id: string): Promise<EvictionFiling | null> 
  * current-version score; old-version rows are ignored — exactly the
  * eval-comparison semantics described in the schema.
  */
-export async function listRankedDocket(opts: { limit?: number } = {}): Promise<RankedDocketRow[]> {
-  const { limit = 50 } = opts;
-  const rows = await db
+export interface ListRankedDocketOpts {
+  limit?: number;
+  status?: EvictionFilingStatus;
+  cause?: EvictionCauseType;
+  /** Inclusive lower bound on score. Filings without a score are excluded when set. */
+  minScore?: number;
+  /** Substring match (case-insensitive) on case_number OR plaintiff. */
+  search?: string;
+}
+
+export async function listRankedDocket(
+  opts: ListRankedDocketOpts = {},
+): Promise<RankedDocketRow[]> {
+  const { limit = 50, status, cause, minScore, search } = opts;
+
+  const where: SQL[] = [];
+  if (status) where.push(eq(evictionFilings.status, status));
+  if (cause) where.push(eq(evictionFilings.causeType, cause));
+  if (typeof minScore === 'number') where.push(gte(evictionFilingRiskScores.score, minScore));
+  if (search && search.trim().length > 0) {
+    const pattern = `%${search.trim()}%`;
+    const orClause = or(
+      ilike(evictionFilings.caseNumber, pattern),
+      ilike(evictionFilings.plaintiff, pattern),
+    );
+    if (orClause) where.push(orClause);
+  }
+
+  const query = db
     .select({
       filing: evictionFilings,
       score: evictionFilingRiskScores.score,
@@ -52,11 +82,13 @@ export async function listRankedDocket(opts: { limit?: number } = {}): Promise<R
         eq(evictionFilingRiskScores.filingId, evictionFilings.id),
         eq(evictionFilingRiskScores.modelVersion, RISK_SCORE_MODEL_VERSION),
       ),
-    )
+    );
+  const filtered = where.length > 0 ? query.where(and(...where)) : query;
+
+  return await filtered
     .orderBy(
       desc(sql`COALESCE(${evictionFilingRiskScores.score}, 0)`),
       desc(evictionFilings.filedAt),
     )
     .limit(limit);
-  return rows;
 }

--- a/src/lib/eviction/risk-band.ts
+++ b/src/lib/eviction/risk-band.ts
@@ -1,0 +1,23 @@
+/**
+ * Color/label band for a Claude-produced risk score (0-100).
+ * Single source of truth so the case-detail panel and the daily-queue
+ * table render the same bands consistently.
+ *
+ *   < 40  → lower risk (emerald)
+ *  40-69  → moderate risk (amber)
+ *   70+   → high risk (destructive/red)
+ */
+export const RISK_BAND_LOWER_MAX = 40;
+export const RISK_BAND_HIGH_MIN = 70;
+
+export function riskBandClass(score: number): string {
+  if (score >= RISK_BAND_HIGH_MIN) return 'text-destructive';
+  if (score >= RISK_BAND_LOWER_MAX) return 'text-amber-600 dark:text-amber-400';
+  return 'text-emerald-600 dark:text-emerald-400';
+}
+
+export function riskBandLabel(score: number): string {
+  if (score >= RISK_BAND_HIGH_MIN) return 'High risk';
+  if (score >= RISK_BAND_LOWER_MAX) return 'Moderate risk';
+  return 'Lower risk';
+}


### PR DESCRIPTION
Closes #30

## Summary
- New \`/app/cases/queue\` page — KLA attorney's ranked daily docket.
- \`requireKlaAttorney()\` gate (from EVDT-018) — non-attorneys and non-KLA attorneys 404.
- Server-rendered \`DocketTable\` from the new filter-aware \`listRankedDocket\`.
- \`DocketFilters\` is a plain HTML \`<form method="get">\` (no JS needed) — search box, status select, cause select, min_score numeric input, Reset link when filtered.
- Sidebar gets a "Daily queue" link (attorney role only — page is the authoritative gate).
- Small refactor: \`riskBandClass\` / \`riskBandLabel\` extracted to \`src/lib/eviction/risk-band.ts\` so the case-detail score panel (EVDT-009a) and the queue table render the same bands.

## Acceptance criteria
- [x] New page at \`/app/cases/queue\`
- [x] Sidebar: 'Daily queue' under Cases-area links (flat nav, no group concept yet)
- [x] \`requireKlaAttorney()\` gate
- [x] Server-rendered table from \`listRankedDocket(limit=50)\`
- [x] Columns: rank #, score (color-banded), case#, defendant initials, plaintiff, cause, status, filed
- [x] Filters as URL params: \`?status=\`, \`?cause=\`, \`?min_score=\` (form is a GET so they appear in the URL)
- [x] Search box: case# OR plaintiff substring (ILIKE)
- [x] Empty state: "No filings match these filters" + link back to Filings page
- [x] Each row links to \`/app/cases/filings/[id]\`
- [x] \`pnpm build\` clean (route appears in build manifest)

## Notes for review
- \`min_score\` filters at the *score row* (\`risk_scores.score >= n\`), so any filing without a score is excluded when this filter is set. Behavior matches the natural meaning of "show me only filings scored ≥ X."
- Filter form is intentionally JS-free — submit reloads the page with new query params, so search results survive browser back/forward and bookmarks. This is the cheapest way to deliver all the URL-param ACs cleanly.
- I did NOT manually browser-test against staging — \`pnpm build\` is green and the components are server-rendered; verification deferred to staging deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)