### PR TITLE
feat(EVDT-019): daily attorney email digest via Resend

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -46,3 +46,16 @@ EVICTION_SOURCE=mock
 
 # ---- AI (Anthropic / Claude) ----
 ANTHROPIC_API_KEY=sk-ant-xxx
+
+# ---- Email (Resend) ----
+# Sign up at https://resend.com — free tier covers staging.
+# Required by the daily-attorney-digest Inngest cron (EVDT-019).
+RESEND_API_KEY=re_xxx
+# Optional sender override. Default uses Resend's onboarding@resend.dev
+# which works without DNS verification — switch to a verified domain
+# (Daviess Coalition <noreply@daviess-coalition.org>) once DNS is set.
+# RESEND_FROM=Daviess Coalition <onboarding@resend.dev>
+# Dev override: route the daily digest to a single test address rather
+# than to KLA attorneys looked up from the DB. Useful before real
+# attorneys are seeded.
+# EVDT_DIGEST_TEST_EMAIL=you@example.com

--- a/README.md
+++ b/README.md
@@ -38,6 +38,21 @@ await inngest.send({ name: 'user.signed_up', data: { clerkUserId: 'test_123' } }
 The scheduled `daily-health-ping` (cron `0 9 * * *` UTC) can be invoked
 on-demand from the dev UI without waiting for the cron.
 
+### Daily attorney email digest (EVDT-019)
+
+The `daily-attorney-digest` Inngest cron (12:00 UTC weekdays = 7am Central)
+sends each KLA attorney the top-10 ranked eviction filings via Resend.
+
+Set `RESEND_API_KEY` in `.env.local` (free tier from
+[resend.com](https://resend.com) is enough for staging). Optionally set
+`RESEND_FROM` to a verified-domain sender — defaults to Resend's
+`onboarding@resend.dev` which works without DNS.
+
+While iterating in dev, set `EVDT_DIGEST_TEST_EMAIL=you@example.com` to
+route the digest to a single recipient instead of doing the DB lookup;
+that lets you trigger the cron from the Inngest dev UI without seeding
+real attorneys.
+
 ### Generating synthetic test data
 
 We never use real PHI or real eviction-defendant data in development. The

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "posthog-node": "^5.30.4",
     "react": "19.2.4",
     "react-dom": "19.2.4",
+    "resend": "^6.12.2",
     "shadcn": "^4.5.0",
     "svix": "^1.92.2",
     "tailwind-merge": "^3.5.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,6 +56,9 @@ importers:
       react-dom:
         specifier: 19.2.4
         version: 19.2.4(react@19.2.4)
+      resend:
+        specifier: ^6.12.2
+        version: 6.12.2
       shadcn:
         specifier: ^4.5.0
         version: 4.5.0(@types/node@20.19.39)(typescript@5.9.3)
@@ -3903,6 +3906,9 @@ packages:
     resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
     engines: {node: '>=16.20.0'}
 
+  postal-mime@2.7.4:
+    resolution: {integrity: sha512-0WdnFQYUrPGGTFu1uOqD2s7omwua8xaeYGdO6rb88oD5yJ/4pPHDA4sdWqfD8wQVfCny563n/HQS7zTFft+f/g==}
+
   postcss-selector-parser@7.1.1:
     resolution: {integrity: sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==}
     engines: {node: '>=4'}
@@ -4030,6 +4036,15 @@ packages:
 
   reselect@5.1.1:
     resolution: {integrity: sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==}
+
+  resend@6.12.2:
+    resolution: {integrity: sha512-xwgmU4b0OqoabJsIoK/x0Whk0Fcs3bpbK4i/DEWPiE5hYJHyHl0TbB6QbI3gIr+bLdLUJ1GYm/fe41aVFuHXgw==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      '@react-email/render': '*'
+    peerDependenciesMeta:
+      '@react-email/render':
+        optional: true
 
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
@@ -4251,6 +4266,9 @@ packages:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
 
+  svix@1.90.0:
+    resolution: {integrity: sha512-ljkZuyy2+IBEoESkIpn8sLM+sxJHQcPxlZFxU+nVDhltNfUMisMBzWX/UR8SjEnzoI28ZjCzMbmYAPwSTucoMw==}
+
   svix@1.92.2:
     resolution: {integrity: sha512-ZmuA3UVvlnF9EgxlzmPtF7CKjQb64Z6OFlyfdDfU0sdcC7dJa+3aOYX5B9mA+RS6ch1AxBa4UP/l6KmqfGtWBQ==}
 
@@ -4408,6 +4426,10 @@ packages:
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+
+  uuid@10.0.0:
+    resolution: {integrity: sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==}
+    hasBin: true
 
   validate-npm-package-name@7.0.2:
     resolution: {integrity: sha512-hVDIBwsRruT73PbK7uP5ebUt+ezEtCmzZz3F59BSr2F6OVFnJ/6h8liuvdLrQ88Xmnk6/+xGGuq+pG9WwTuy3A==}
@@ -8315,6 +8337,8 @@ snapshots:
 
   pkce-challenge@5.0.1: {}
 
+  postal-mime@2.7.4: {}
+
   postcss-selector-parser@7.1.1:
     dependencies:
       cssesc: 3.0.0
@@ -8468,6 +8492,11 @@ snapshots:
       - supports-color
 
   reselect@5.1.1: {}
+
+  resend@6.12.2:
+    dependencies:
+      postal-mime: 2.7.4
+      svix: 1.90.0
 
   resolve-from@4.0.0: {}
 
@@ -8798,6 +8827,11 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
+  svix@1.90.0:
+    dependencies:
+      standardwebhooks: 1.0.0
+      uuid: 10.0.0
+
   svix@1.92.2:
     dependencies:
       standardwebhooks: 1.0.0
@@ -8925,6 +8959,8 @@ snapshots:
       react: 19.2.4
 
   util-deprecate@1.0.2: {}
+
+  uuid@10.0.0: {}
 
   validate-npm-package-name@7.0.2: {}
 

--- a/src/db/queries/users.ts
+++ b/src/db/queries/users.ts
@@ -1,0 +1,29 @@
+import { and, eq } from 'drizzle-orm';
+import { db } from '@/db/client';
+import { KLA_OWENSBORO_SLUG } from '@/lib/auth';
+import { orgMemberships } from '../schema/org-memberships';
+import { partnerOrgs } from '../schema/partner-orgs';
+import { type User, users } from '../schema/users';
+
+/**
+ * Every user with role=attorney AND a membership in the KLA Owensboro
+ * partner org. Used by the daily digest cron and any future broadcast
+ * surface targeting KLA staff.
+ */
+export async function listKlaAttorneys(): Promise<User[]> {
+  return await db
+    .select({
+      id: users.id,
+      clerkUserId: users.clerkUserId,
+      email: users.email,
+      firstName: users.firstName,
+      lastName: users.lastName,
+      role: users.role,
+      createdAt: users.createdAt,
+      updatedAt: users.updatedAt,
+    })
+    .from(users)
+    .innerJoin(orgMemberships, eq(orgMemberships.userId, users.id))
+    .innerJoin(partnerOrgs, eq(orgMemberships.partnerOrgId, partnerOrgs.id))
+    .where(and(eq(users.role, 'attorney'), eq(partnerOrgs.slug, KLA_OWENSBORO_SLUG)));
+}

--- a/src/inngest/functions/daily-attorney-digest.ts
+++ b/src/inngest/functions/daily-attorney-digest.ts
@@ -1,0 +1,95 @@
+import * as Sentry from '@sentry/nextjs';
+import { listRankedDocket } from '@/db/queries/eviction-filings';
+import { listKlaAttorneys } from '@/db/queries/users';
+import type { User } from '@/db/schema/users';
+import { DEFAULT_FROM, resendClient } from '@/lib/email/client';
+import { type DigestPayload, digestHtml, digestMarkdown, digestSubject } from '@/lib/email/digest';
+import { inngest } from '../client';
+
+const TOP_N = 10;
+
+const appUrl = () =>
+  process.env.NEXT_PUBLIC_APP_URL ?? 'https://homeless-production.up.railway.app';
+
+interface SendOutcome {
+  to: string;
+  ok: boolean;
+  error?: string;
+}
+
+async function sendDigestTo(recipient: string, payload: DigestPayload): Promise<SendOutcome> {
+  try {
+    const result = await resendClient().emails.send({
+      from: DEFAULT_FROM,
+      to: recipient,
+      subject: digestSubject(payload.date, payload.rows.length),
+      html: digestHtml(payload),
+      text: digestMarkdown(payload),
+    });
+    if (result.error) {
+      Sentry.captureMessage('[digest] resend returned error', {
+        level: 'warning',
+        tags: { recipient },
+        extra: { resendError: result.error },
+      });
+      return { to: recipient, ok: false, error: result.error.message };
+    }
+    return { to: recipient, ok: true };
+  } catch (err) {
+    Sentry.captureException(err, { tags: { recipient, source: 'daily-attorney-digest' } });
+    return { to: recipient, ok: false, error: err instanceof Error ? err.message : String(err) };
+  }
+}
+
+/**
+ * Daily 6am Central (12:00 UTC) cron, weekdays only — sends each KLA
+ * attorney the top-10 ranked eviction filings as an email digest.
+ *
+ * EVDT_DIGEST_TEST_EMAIL overrides the recipient list with a single address
+ * for development before real attorneys are seeded — the cron still runs the
+ * query, just sends to one place.
+ */
+export const dailyAttorneyDigest = inngest.createFunction(
+  {
+    id: 'daily-attorney-digest',
+    retries: 0,
+    triggers: [{ cron: '0 12 * * 1-5' }],
+  },
+  async ({ step }) => {
+    const recipients = await step.run('resolve-recipients', async (): Promise<string[]> => {
+      const override = process.env.EVDT_DIGEST_TEST_EMAIL?.trim();
+      if (override) return [override];
+      const attorneys: User[] = await listKlaAttorneys();
+      return attorneys.map((a) => a.email).filter((e) => e.length > 0);
+    });
+
+    if (recipients.length === 0) {
+      return {
+        skipped: true,
+        reason: 'no recipients (no KLA attorneys seeded and no EVDT_DIGEST_TEST_EMAIL override)',
+      };
+    }
+
+    // Single step that does fetch + render + send so Date doesn't have to
+    // round-trip across an Inngest step boundary (Inngest JSON-serializes
+    // each step's return). Send failures are captured per-recipient and
+    // summarized in the return — not re-thrown — so one bad address
+    // doesn't fail the whole cron.
+    const result = await step.run('compose-and-send', async () => {
+      const date = new Date();
+      const rows = await listRankedDocket({ limit: TOP_N });
+      const payload: DigestPayload = { date, rows, appUrl: appUrl() };
+      const outcomes = await Promise.all(recipients.map((to) => sendDigestTo(to, payload)));
+      const sent = outcomes.filter((o) => o.ok).length;
+      return { sent, failed: outcomes.length - sent, rows: rows.length, outcomes };
+    });
+
+    Sentry.addBreadcrumb({
+      category: 'digest',
+      level: result.failed > 0 ? 'warning' : 'info',
+      message: `attorney digest: sent=${result.sent} failed=${result.failed} rows=${result.rows}`,
+    });
+
+    return result;
+  },
+);

--- a/src/inngest/functions/index.ts
+++ b/src/inngest/functions/index.ts
@@ -1,5 +1,6 @@
+import { dailyAttorneyDigest } from './daily-attorney-digest';
 import { dailyCourtnetScrape } from './daily-courtnet-scrape';
 import { dailyHealthPing } from './daily-health-ping';
 import { userSignedUp } from './user-signed-up';
 
-export const functions = [dailyHealthPing, userSignedUp, dailyCourtnetScrape];
+export const functions = [dailyHealthPing, userSignedUp, dailyCourtnetScrape, dailyAttorneyDigest];

--- a/src/lib/email/client.ts
+++ b/src/lib/email/client.ts
@@ -1,0 +1,22 @@
+import { Resend } from 'resend';
+
+let _client: Resend | null = null;
+
+/**
+ * Lazy Resend client. Construction is deferred until first use so importing
+ * this module in tests/dev doesn't require RESEND_API_KEY to be set.
+ */
+export function resendClient(): Resend {
+  if (!_client) {
+    const key = process.env.RESEND_API_KEY;
+    if (!key) throw new Error('RESEND_API_KEY is not set');
+    _client = new Resend(key);
+  }
+  return _client;
+}
+
+/**
+ * Default sender. Resend lets you send from `onboarding@resend.dev` without
+ * domain verification; use that until DNS for a custom domain is configured.
+ */
+export const DEFAULT_FROM = process.env.RESEND_FROM ?? 'Daviess Coalition <onboarding@resend.dev>';

--- a/src/lib/email/digest.ts
+++ b/src/lib/email/digest.ts
@@ -1,0 +1,154 @@
+import type { RankedDocketRow } from '@/lib/eviction/docket-ranking';
+import { riskBandLabel } from '@/lib/eviction/risk-band';
+
+const fmtDate = (d: Date) =>
+  new Intl.DateTimeFormat('en-US', { dateStyle: 'long' }).format(new Date(d));
+
+const fmtMoney = (cents: number | null) =>
+  cents == null
+    ? '—'
+    : new Intl.NumberFormat('en-US', {
+        style: 'currency',
+        currency: 'USD',
+        maximumFractionDigits: 0,
+      }).format(cents / 100);
+
+const initials = (first: string, last: string) =>
+  `${first.charAt(0).toUpperCase()}.${last.charAt(0).toUpperCase()}.`;
+
+const causeLabel: Record<string, string> = {
+  non_payment: 'Non-payment',
+  lease_violation: 'Lease violation',
+  holdover: 'Holdover',
+  other: 'Other',
+};
+
+export interface DigestPayload {
+  date: Date;
+  rows: RankedDocketRow[];
+  appUrl: string;
+}
+
+export function digestSubject(date: Date, count: number): string {
+  return `[Daviess Daily] ${count} high-risk eviction case${count === 1 ? '' : 's'} for ${fmtDate(date)}`;
+}
+
+/**
+ * Markdown body for the email. Resend renders markdown if you pass it in the
+ * `text` field as plain text — but since we want HTML and a plaintext alt,
+ * we render both ourselves: the HTML is a basic styled table, the text is
+ * the markdown source.
+ */
+export function digestMarkdown(payload: DigestPayload): string {
+  const { date, rows, appUrl } = payload;
+  if (rows.length === 0) {
+    return [
+      `# Daviess Daily — ${fmtDate(date)}`,
+      '',
+      'No new high-risk eviction filings to review today.',
+      '',
+      `Open the queue: ${appUrl}/app/cases/queue`,
+    ].join('\n');
+  }
+
+  const header = '| # | Score | Band | Case # | Defendant | Plaintiff | Cause | Amount | Filed |';
+  const sep = '|---:|---:|---|---|---|---|---|---:|---|';
+  const lines = rows.map((row, idx) => {
+    const f = row.filing;
+    return [
+      `| ${idx + 1}`,
+      ` | ${row.score ?? '—'}`,
+      ` | ${row.score == null ? '—' : riskBandLabel(row.score)}`,
+      ` | [${f.caseNumber}](${appUrl}/app/cases/filings/${f.id})`,
+      ` | ${initials(f.defendantFirstName, f.defendantLastName)}`,
+      ` | ${f.plaintiff}`,
+      ` | ${causeLabel[f.causeType] ?? f.causeType}`,
+      ` | ${fmtMoney(f.amountClaimedCents)}`,
+      ` | ${fmtDate(f.filedAt)} |`,
+    ].join('');
+  });
+
+  return [
+    `# Daviess Daily — ${fmtDate(date)}`,
+    '',
+    `Top ${rows.length} eviction cases by risk score. Defendant initials only — open a case for the full record.`,
+    '',
+    header,
+    sep,
+    ...lines,
+    '',
+    `Open the full ranked queue: ${appUrl}/app/cases/queue`,
+  ].join('\n');
+}
+
+/**
+ * Lightweight HTML rendering (no template engine) — table mirrors the
+ * markdown so the email reads the same in HTML or text-only clients.
+ */
+export function digestHtml(payload: DigestPayload): string {
+  const { date, rows, appUrl } = payload;
+  const queueLink = `${appUrl}/app/cases/queue`;
+
+  if (rows.length === 0) {
+    return wrap(
+      `<h1>Daviess Daily — ${fmtDate(date)}</h1>
+       <p>No new high-risk eviction filings to review today.</p>
+       <p><a href="${queueLink}">Open the queue</a></p>`,
+    );
+  }
+
+  const trs = rows
+    .map((row, idx) => {
+      const f = row.filing;
+      const score = row.score == null ? '—' : String(row.score);
+      const band = row.score == null ? '—' : riskBandLabel(row.score);
+      const url = `${appUrl}/app/cases/filings/${f.id}`;
+      return `<tr>
+        <td style="text-align:right;padding:6px 10px;">${idx + 1}</td>
+        <td style="text-align:right;padding:6px 10px;font-weight:600;">${score}</td>
+        <td style="padding:6px 10px;">${band}</td>
+        <td style="padding:6px 10px;font-family:ui-monospace,monospace;font-size:13px;"><a href="${url}">${escapeHtml(f.caseNumber)}</a></td>
+        <td style="padding:6px 10px;">${initials(f.defendantFirstName, f.defendantLastName)}</td>
+        <td style="padding:6px 10px;">${escapeHtml(f.plaintiff)}</td>
+        <td style="padding:6px 10px;">${escapeHtml(causeLabel[f.causeType] ?? f.causeType)}</td>
+        <td style="text-align:right;padding:6px 10px;font-family:ui-monospace,monospace;">${fmtMoney(f.amountClaimedCents)}</td>
+        <td style="padding:6px 10px;white-space:nowrap;">${fmtDate(f.filedAt)}</td>
+      </tr>`;
+    })
+    .join('');
+
+  return wrap(
+    `<h1>Daviess Daily — ${fmtDate(date)}</h1>
+     <p>Top ${rows.length} eviction cases by risk score. Defendant initials only — open a case for the full record.</p>
+     <table style="border-collapse:collapse;width:100%;font-size:14px;">
+       <thead>
+         <tr style="text-align:left;background:#f5f5f5;">
+           <th style="padding:6px 10px;text-align:right;">#</th>
+           <th style="padding:6px 10px;text-align:right;">Score</th>
+           <th style="padding:6px 10px;">Band</th>
+           <th style="padding:6px 10px;">Case #</th>
+           <th style="padding:6px 10px;">Defendant</th>
+           <th style="padding:6px 10px;">Plaintiff</th>
+           <th style="padding:6px 10px;">Cause</th>
+           <th style="padding:6px 10px;text-align:right;">Amount</th>
+           <th style="padding:6px 10px;">Filed</th>
+         </tr>
+       </thead>
+       <tbody>${trs}</tbody>
+     </table>
+     <p style="margin-top:18px;"><a href="${queueLink}">Open the full ranked queue</a></p>`,
+  );
+}
+
+function wrap(inner: string): string {
+  return `<!DOCTYPE html><html><body style="font-family:system-ui,-apple-system,sans-serif;color:#111;max-width:900px;margin:0 auto;padding:18px;">${inner}</body></html>`;
+}
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}


### PR DESCRIPTION
Closes #34

## Summary
New \`daily-attorney-digest\` Inngest cron — fires at 12:00 UTC weekdays (7am Central), sends each KLA attorney an email with the top-10 ranked eviction filings.

- New \`listKlaAttorneys()\` query (attorney role + KLA org membership).
- \`src/lib/email/{client,digest}.ts\` — lazy Resend client, markdown + inline-styled HTML rendering. Defendant initials only.
- \`EVDT_DIGEST_TEST_EMAIL\` dev override skips DB lookup and sends to a single recipient — lets you trigger the cron from the Inngest dev UI before real attorneys are seeded.
- Per-recipient send failures are Sentry-captured but don't fail the cron; outcomes are returned in the function summary.

## Acceptance criteria
- [x] Inngest function \`daily-attorney-digest\` (cron \`0 12 * * 1-5\` UTC)
- [x] One Resend send per KLA attorney looked up via \`listKlaAttorneys()\`
- [x] Body: top-10 from \`listRankedDocket\`, markdown table (and styled HTML)
- [x] Subject: \`[Daviess Daily] N high-risk eviction case(s) for {date}\`
- [x] Plain-text fallback (markdown source) + defendant initials only
- [x] \`RESEND_API_KEY\` in \`.env.example\` + README
- [x] \`EVDT_DIGEST_TEST_EMAIL\` override
- [x] Sentry captures send failures; doesn't break the cron
- [x] \`pnpm build\` clean

## Notes for review
- Compose + send are in a single Inngest step so \`Date\` doesn't round-trip the JSON-serialized step boundary (typecheck caught this — Inngest's \`step.run\` returns \`JsonifyObject<T>\`, which strings dates).
- Default sender is \`onboarding@resend.dev\` (no DNS verification needed). Once a custom domain is set up, override via \`RESEND_FROM\`.
- I did not run the cron end-to-end against staging — verifying Resend deliverability post-deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)