### PR TITLE
feat(EVDT-012): tenant response-packet generator (Claude API)

### DIFF
--- a/drizzle/migrations/0007_quiet_galactus.sql
+++ b/drizzle/migrations/0007_quiet_galactus.sql
@@ -1,0 +1,17 @@
+CREATE TYPE "public"."eviction_response_packet_status" AS ENUM('draft', 'approved', 'filed', 'rejected');--> statement-breakpoint
+CREATE TABLE "eviction_response_packets" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"filing_id" uuid NOT NULL,
+	"packet_md" text NOT NULL,
+	"prompt_version" text NOT NULL,
+	"generated_by_user_id" uuid,
+	"status" "eviction_response_packet_status" DEFAULT 'draft' NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "eviction_response_packets" ADD CONSTRAINT "eviction_response_packets_filing_id_eviction_filings_id_fk" FOREIGN KEY ("filing_id") REFERENCES "public"."eviction_filings"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "eviction_response_packets" ADD CONSTRAINT "eviction_response_packets_generated_by_user_id_users_id_fk" FOREIGN KEY ("generated_by_user_id") REFERENCES "public"."users"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+CREATE UNIQUE INDEX "response_packets_filing_version_idx" ON "eviction_response_packets" USING btree ("filing_id","prompt_version");--> statement-breakpoint
+CREATE INDEX "response_packets_filing_idx" ON "eviction_response_packets" USING btree ("filing_id");--> statement-breakpoint
+CREATE INDEX "response_packets_status_idx" ON "eviction_response_packets" USING btree ("status");

--- a/drizzle/migrations/meta/0007_snapshot.json
+++ b/drizzle/migrations/meta/0007_snapshot.json
@@ -1,0 +1,1064 @@
+{
+  "id": "c95f4d43-79ad-439b-abcc-395a936229a9",
+  "prevId": "f9095efa-7690-48c5-ae4a-b6b17256ba93",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.audit_log": {
+      "name": "audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_table": {
+          "name": "target_table",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "audit_log_actor_idx": {
+          "name": "audit_log_actor_idx",
+          "columns": [
+            {
+              "expression": "actor_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_log_action_idx": {
+          "name": "audit_log_action_idx",
+          "columns": [
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_log_created_at_idx": {
+          "name": "audit_log_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audit_log_actor_user_id_users_id_fk": {
+          "name": "audit_log_actor_user_id_users_id_fk",
+          "tableFrom": "audit_log",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.consents": {
+      "name": "consents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "subject_external_id": {
+          "name": "subject_external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consent_type": {
+          "name": "consent_type",
+          "type": "consent_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "granted_via": {
+          "name": "granted_via",
+          "type": "consent_channel",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "granted_at": {
+          "name": "granted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "consents_subject_idx": {
+          "name": "consents_subject_idx",
+          "columns": [
+            {
+              "expression": "subject_external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "consents_type_idx": {
+          "name": "consents_type_idx",
+          "columns": [
+            {
+              "expression": "consent_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.eviction_filing_risk_scores": {
+      "name": "eviction_filing_risk_scores",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "filing_id": {
+          "name": "filing_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rationale": {
+          "name": "rationale",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model_version": {
+          "name": "model_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "risk_scores_filing_version_idx": {
+          "name": "risk_scores_filing_version_idx",
+          "columns": [
+            {
+              "expression": "filing_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "model_version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "risk_scores_filing_idx": {
+          "name": "risk_scores_filing_idx",
+          "columns": [
+            {
+              "expression": "filing_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "risk_scores_score_idx": {
+          "name": "risk_scores_score_idx",
+          "columns": [
+            {
+              "expression": "score",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "eviction_filing_risk_scores_filing_id_eviction_filings_id_fk": {
+          "name": "eviction_filing_risk_scores_filing_id_eviction_filings_id_fk",
+          "tableFrom": "eviction_filing_risk_scores",
+          "tableTo": "eviction_filings",
+          "columnsFrom": [
+            "filing_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.eviction_filings": {
+      "name": "eviction_filings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "case_number": {
+          "name": "case_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filed_at": {
+          "name": "filed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "court_division": {
+          "name": "court_division",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plaintiff": {
+          "name": "plaintiff",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "defendant_first_name": {
+          "name": "defendant_first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "defendant_last_name": {
+          "name": "defendant_last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "defendant_address": {
+          "name": "defendant_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cause_type": {
+          "name": "cause_type",
+          "type": "eviction_cause_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_claimed_cents": {
+          "name": "amount_claimed_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "eviction_filing_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'filed'"
+        },
+        "source": {
+          "name": "source",
+          "type": "eviction_filing_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "raw_json": {
+          "name": "raw_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "eviction_filings_case_source_idx": {
+          "name": "eviction_filings_case_source_idx",
+          "columns": [
+            {
+              "expression": "case_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "eviction_filings_filed_at_idx": {
+          "name": "eviction_filings_filed_at_idx",
+          "columns": [
+            {
+              "expression": "filed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "eviction_filings_status_idx": {
+          "name": "eviction_filings_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.eviction_response_packets": {
+      "name": "eviction_response_packets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "filing_id": {
+          "name": "filing_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "packet_md": {
+          "name": "packet_md",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt_version": {
+          "name": "prompt_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "generated_by_user_id": {
+          "name": "generated_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "eviction_response_packet_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "response_packets_filing_version_idx": {
+          "name": "response_packets_filing_version_idx",
+          "columns": [
+            {
+              "expression": "filing_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "prompt_version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "response_packets_filing_idx": {
+          "name": "response_packets_filing_idx",
+          "columns": [
+            {
+              "expression": "filing_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "response_packets_status_idx": {
+          "name": "response_packets_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "eviction_response_packets_filing_id_eviction_filings_id_fk": {
+          "name": "eviction_response_packets_filing_id_eviction_filings_id_fk",
+          "tableFrom": "eviction_response_packets",
+          "tableTo": "eviction_filings",
+          "columnsFrom": [
+            "filing_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "eviction_response_packets_generated_by_user_id_users_id_fk": {
+          "name": "eviction_response_packets_generated_by_user_id_users_id_fk",
+          "tableFrom": "eviction_response_packets",
+          "tableTo": "users",
+          "columnsFrom": [
+            "generated_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.health_check": {
+      "name": "health_check",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_memberships": {
+      "name": "org_memberships",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "partner_org_id": {
+          "name": "partner_org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "org_memberships_user_org_idx": {
+          "name": "org_memberships_user_org_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "partner_org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "org_memberships_user_idx": {
+          "name": "org_memberships_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "org_memberships_partner_org_idx": {
+          "name": "org_memberships_partner_org_idx",
+          "columns": [
+            {
+              "expression": "partner_org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "org_memberships_user_id_users_id_fk": {
+          "name": "org_memberships_user_id_users_id_fk",
+          "tableFrom": "org_memberships",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "org_memberships_partner_org_id_partner_orgs_id_fk": {
+          "name": "org_memberships_partner_org_id_partner_orgs_id_fk",
+          "tableFrom": "org_memberships",
+          "tableTo": "partner_orgs",
+          "columnsFrom": [
+            "partner_org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.partner_orgs": {
+      "name": "partner_orgs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "partner_org_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_email": {
+          "name": "contact_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_phone": {
+          "name": "contact_phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "partner_orgs_slug_idx": {
+          "name": "partner_orgs_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "clerk_user_id": {
+          "name": "clerk_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "users_clerk_user_id_idx": {
+          "name": "users_clerk_user_id_idx",
+          "columns": [
+            {
+              "expression": "clerk_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.consent_channel": {
+      "name": "consent_channel",
+      "schema": "public",
+      "values": [
+        "sms",
+        "in_person",
+        "web_form",
+        "phone",
+        "paper"
+      ]
+    },
+    "public.consent_type": {
+      "name": "consent_type",
+      "schema": "public",
+      "values": [
+        "phi_share_within_coalition",
+        "sms_communication",
+        "data_for_program_eval"
+      ]
+    },
+    "public.eviction_cause_type": {
+      "name": "eviction_cause_type",
+      "schema": "public",
+      "values": [
+        "non_payment",
+        "lease_violation",
+        "holdover",
+        "other"
+      ]
+    },
+    "public.eviction_filing_source": {
+      "name": "eviction_filing_source",
+      "schema": "public",
+      "values": [
+        "courtnet",
+        "manual",
+        "synthetic"
+      ]
+    },
+    "public.eviction_filing_status": {
+      "name": "eviction_filing_status",
+      "schema": "public",
+      "values": [
+        "filed",
+        "served",
+        "judgment",
+        "dismissed",
+        "sealed"
+      ]
+    },
+    "public.eviction_response_packet_status": {
+      "name": "eviction_response_packet_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "approved",
+        "filed",
+        "rejected"
+      ]
+    },
+    "public.partner_org_type": {
+      "name": "partner_org_type",
+      "schema": "public",
+      "values": [
+        "hospital",
+        "legal_aid",
+        "shelter",
+        "community_org",
+        "government",
+        "other"
+      ]
+    },
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "pending",
+        "attorney",
+        "caseworker",
+        "ed_coordinator",
+        "shelter_staff",
+        "admin"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/migrations/meta/_journal.json
+++ b/drizzle/migrations/meta/_journal.json
@@ -50,6 +50,13 @@
       "when": 1777168170746,
       "tag": "0006_absent_speedball",
       "breakpoints": true
+    },
+    {
+      "idx": 7,
+      "version": "7",
+      "when": 1777173132993,
+      "tag": "0007_quiet_galactus",
+      "breakpoints": true
     }
   ]
 }

--- a/fixtures/response-packet-eval.json
+++ b/fixtures/response-packet-eval.json
@@ -1,0 +1,54 @@
+{
+  "filings": [
+    {
+      "case_number": "EVAL-26-CI-00101",
+      "court_division": "1st Division",
+      "plaintiff": "Riverbend Apartments, LLC",
+      "defendant_name": "Marcus Synthwell",
+      "cause_type": "non_payment",
+      "amount_claimed_cents": 145000,
+      "status": "filed",
+      "filed_at": "2026-04-22T09:00:00-05:00"
+    },
+    {
+      "case_number": "EVAL-26-CI-00102",
+      "court_division": "2nd Division",
+      "plaintiff": "Owensboro Housing Group",
+      "defendant_name": "Lina Fakeman",
+      "cause_type": "lease_violation",
+      "amount_claimed_cents": null,
+      "status": "served",
+      "filed_at": "2026-04-15T10:30:00-05:00"
+    },
+    {
+      "case_number": "EVAL-26-CI-00103",
+      "court_division": "1st Division",
+      "plaintiff": "Daviess Property Management",
+      "defendant_name": "Eli Mocksworth",
+      "cause_type": "holdover",
+      "amount_claimed_cents": null,
+      "status": "filed",
+      "filed_at": "2026-04-20T14:00:00-05:00"
+    },
+    {
+      "case_number": "EVAL-26-CI-00104",
+      "court_division": "3rd Division",
+      "plaintiff": "Westport Realty",
+      "defendant_name": "Priya Phantomson",
+      "cause_type": "non_payment",
+      "amount_claimed_cents": 285000,
+      "status": "judgment",
+      "filed_at": "2026-03-30T11:00:00-05:00"
+    },
+    {
+      "case_number": "EVAL-26-CI-00105",
+      "court_division": "2nd Division",
+      "plaintiff": "Bluegrass Holdings, LLC",
+      "defendant_name": "Tomas Imaginario",
+      "cause_type": "other",
+      "amount_claimed_cents": 50000,
+      "status": "filed",
+      "filed_at": "2026-04-23T08:45:00-05:00"
+    }
+  ]
+}

--- a/scripts/eval-response-packet.ts
+++ b/scripts/eval-response-packet.ts
@@ -141,7 +141,9 @@ async function main() {
   console.log(
     `\n[eval] overall: ${passedChecks}/${totalChecks} checks (${overallPct.toFixed(1)}%) — ${perfectPackets}/${data.filings.length} packets fully clean`,
   );
-  process.exit(0);
+  // Exit non-zero unless every packet passes every structural check, so
+  // CI / a manual run can spot regressions without reading the log.
+  process.exit(perfectPackets === data.filings.length ? 0 : 1);
 }
 
 main().catch((err) => {

--- a/scripts/eval-response-packet.ts
+++ b/scripts/eval-response-packet.ts
@@ -1,0 +1,150 @@
+#!/usr/bin/env tsx
+/**
+ * Eval harness for the EVDT-012 response-packet generator.
+ *
+ * Reads fixtures/response-packet-eval.json — 5 hand-curated synthetic
+ * filings. Calls Claude on each. Verifies the produced markdown contains
+ * the structural elements an attorney expects:
+ *
+ *   - Disclaimer prefix at the top
+ *   - Case caption (court name, plaintiff, defendant, case number)
+ *   - At least one numbered response paragraph
+ *   - Affirmative defenses checklist (header + at least 5 [ ] items)
+ *   - Signature block placeholder
+ *
+ * This is structural — semantic legal correctness is the attorney's job.
+ *
+ * Run: pnpm tsx scripts/eval-response-packet.ts
+ */
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import Anthropic from '@anthropic-ai/sdk';
+import { zodOutputFormat } from '@anthropic-ai/sdk/helpers/zod';
+import { config } from 'dotenv';
+import {
+  buildResponsePacketUserPrompt,
+  EVICTION_RESPONSE_PACKET_SYSTEM_PROMPT,
+  RESPONSE_PACKET_DISCLAIMER_PREFIX,
+  RESPONSE_PACKET_PROMPT_VERSION,
+  ResponsePacketSchema,
+} from '@/ai/prompts/eviction-response-packet';
+
+config({ path: ['.env.local', '.env'], override: true });
+
+if (!process.env.ANTHROPIC_API_KEY) {
+  console.error('ANTHROPIC_API_KEY is not set (check .env.local)');
+  process.exit(1);
+}
+
+type EvalRow = Parameters<typeof buildResponsePacketUserPrompt>[0];
+
+interface CheckResult {
+  name: string;
+  ok: boolean;
+  detail?: string;
+}
+
+function checkPacket(packet: string, row: EvalRow): CheckResult[] {
+  const checks: CheckResult[] = [];
+
+  checks.push({
+    name: 'disclaimer prefix present',
+    ok: packet.includes(RESPONSE_PACKET_DISCLAIMER_PREFIX),
+  });
+
+  checks.push({
+    name: 'case number in caption',
+    ok: packet.includes(row.case_number),
+  });
+
+  checks.push({
+    name: 'plaintiff in caption',
+    ok: packet.includes(row.plaintiff),
+  });
+
+  checks.push({
+    name: 'defendant in caption',
+    ok: packet.includes(row.defendant_name),
+  });
+
+  checks.push({
+    name: 'has numbered response paragraphs',
+    ok: /^\s*\d+\.\s/m.test(packet),
+  });
+
+  const checkboxCount = (packet.match(/\[\s*\]/g) ?? []).length;
+  checks.push({
+    name: 'affirmative defenses checklist (≥5 items)',
+    ok: checkboxCount >= 5,
+    detail: `found ${checkboxCount} unchecked boxes`,
+  });
+
+  checks.push({
+    name: 'signature block placeholder',
+    ok: /signature/i.test(packet) && /defendant/i.test(packet),
+  });
+
+  return checks;
+}
+
+async function main() {
+  const evalPath = resolve(process.cwd(), 'fixtures/response-packet-eval.json');
+  const data = JSON.parse(readFileSync(evalPath, 'utf8')) as { filings: EvalRow[] };
+  const client = new Anthropic();
+
+  console.log(
+    `[eval] running ${data.filings.length} filings against ${RESPONSE_PACKET_PROMPT_VERSION}`,
+  );
+
+  let totalChecks = 0;
+  let passedChecks = 0;
+  let perfectPackets = 0;
+
+  for (const row of data.filings) {
+    const r = await client.messages.parse({
+      model: 'claude-opus-4-7',
+      max_tokens: 16000,
+      thinking: { type: 'adaptive' },
+      output_config: {
+        effort: 'high',
+        format: zodOutputFormat(ResponsePacketSchema),
+      },
+      system: [
+        {
+          type: 'text',
+          text: EVICTION_RESPONSE_PACKET_SYSTEM_PROMPT,
+          cache_control: { type: 'ephemeral' },
+        },
+      ],
+      messages: [{ role: 'user', content: buildResponsePacketUserPrompt(row) }],
+    });
+
+    if (!r.parsed_output) {
+      console.error(`[eval] ${row.case_number}: no parsed output (stop_reason=${r.stop_reason})`);
+      continue;
+    }
+
+    const checks = checkPacket(r.parsed_output.packet_md, row);
+    const passed = checks.filter((c) => c.ok).length;
+    totalChecks += checks.length;
+    passedChecks += passed;
+    if (passed === checks.length) perfectPackets += 1;
+
+    const verdict = passed === checks.length ? '✓' : '✗';
+    console.log(`[eval] ${verdict} ${row.case_number}: ${passed}/${checks.length} checks`);
+    for (const c of checks.filter((c) => !c.ok)) {
+      console.log(`         ✗ ${c.name}${c.detail ? ` — ${c.detail}` : ''}`);
+    }
+  }
+
+  const overallPct = (passedChecks / totalChecks) * 100;
+  console.log(
+    `\n[eval] overall: ${passedChecks}/${totalChecks} checks (${overallPct.toFixed(1)}%) — ${perfectPackets}/${data.filings.length} packets fully clean`,
+  );
+  process.exit(0);
+}
+
+main().catch((err) => {
+  console.error('[eval] failed', err);
+  process.exit(1);
+});

--- a/src/ai/prompts/eviction-response-packet.ts
+++ b/src/ai/prompts/eviction-response-packet.ts
@@ -1,0 +1,165 @@
+import { z } from 'zod';
+
+/**
+ * Single source of truth for the tenant Answer-to-Forcible-Detainer-
+ * Complaint generator (EVDT-012). Produces a Kentucky-specific draft
+ * Answer in markdown that an attorney reviews, edits, and files.
+ *
+ * IMPORTANT — PHI / privacy fence:
+ * - Defendant ADDRESS is scrubbed from the prompt (the model never sees it).
+ * - Defendant NAME is included because it appears on the answer caption.
+ * - Plaintiff name + case number + court are public record on the filing.
+ *
+ * The disclaimer block at the top of every packet is non-negotiable —
+ * the prompt instructs the model to include it verbatim, and the service
+ * also asserts on it before returning.
+ */
+
+export const RESPONSE_PACKET_DISCLAIMER_PREFIX = 'AI-DRAFTED — REVIEW BY LICENSED ATTORNEY';
+
+export const EVICTION_RESPONSE_PACKET_SYSTEM_PROMPT = `You draft Answers to Forcible Detainer Complaints in Kentucky district
+court. Your output is reviewed by a licensed attorney at Kentucky Legal
+Aid (KLA) before being filed. You are NOT giving legal advice — you are
+producing a structured first draft.
+
+INPUT: facts from a public eviction filing (case number, plaintiff,
+defendant name, court division, cause of action, amount claimed,
+status, filing date).
+
+OUTPUT: a single markdown document in this exact shape:
+
+  1. Disclaimer block (verbatim, see below).
+  2. Caption (court name, case number, plaintiff vs defendant).
+  3. Numbered response paragraphs that mirror a typical Forcible Detainer
+     Complaint (1. Plaintiff allegation; 2. Defendant response; etc.).
+     Use one of: ADMITTED / DENIED / WITHOUT SUFFICIENT INFORMATION TO
+     ADMIT OR DENY. Default to WITHOUT SUFFICIENT INFORMATION when the
+     filing facts don't tell you. NEVER ADMIT a fact you weren't given.
+  4. Affirmative defenses checklist — every standard KY tenant defense
+     listed with [ ] checkboxes. The attorney ticks the ones that apply.
+     Include at minimum: improper notice, retaliation, warranty of
+     habitability, partial payment / accord & satisfaction, fair housing
+     / discrimination, prior dismissal of same complaint, lack of
+     standing.
+  5. Signature block placeholder (defendant name, address line, phone,
+     date).
+
+DISCLAIMER BLOCK — copy this text VERBATIM at the top of every packet.
+The {timestamp} and {model_version} placeholders will be filled by the
+caller; you write them as literal placeholder strings.
+
+> **${RESPONSE_PACKET_DISCLAIMER_PREFIX} REQUIRED BEFORE FILING.**
+> Generated {timestamp} model {model_version}.
+> This document is a machine-drafted first pass for attorney review. It
+> is not legal advice and may contain errors. Do not file without an
+> attorney's review and edits.
+
+Style:
+- Plain English, short paragraphs.
+- Match the formal register of a court filing in headings ("ANSWER",
+  "AFFIRMATIVE DEFENSES") but keep paragraph text readable.
+- Do NOT invent facts. If the filing doesn't tell you whether the rent
+  was paid, the response is WITHOUT SUFFICIENT INFORMATION — not DENIED.
+- Markdown only; no HTML.
+
+EXAMPLE — well-formed answer for a fictitious case:
+
+> **${RESPONSE_PACKET_DISCLAIMER_PREFIX} REQUIRED BEFORE FILING.**
+> Generated {timestamp} model {model_version}.
+> This document is a machine-drafted first pass for attorney review. It
+> is not legal advice and may contain errors. Do not file without an
+> attorney's review and edits.
+
+# IN THE DAVIESS DISTRICT COURT
+**COMMONWEALTH OF KENTUCKY**
+
+**Plaintiff:** Riverbend Apartments, LLC
+**v.**
+**Defendant:** John Q. Tenant
+
+**Case No.:** 26-C-00012
+**Division:** 1st Division
+
+# ANSWER TO FORCIBLE DETAINER COMPLAINT
+
+Defendant, John Q. Tenant, by and through counsel, responds to the
+Complaint as follows:
+
+1. **Paragraph 1 of Complaint (allegation that Plaintiff owns the
+   premises):** WITHOUT SUFFICIENT INFORMATION TO ADMIT OR DENY.
+
+2. **Paragraph 2 of Complaint (allegation that Defendant occupies the
+   premises under a lease):** ADMITTED that Defendant occupies the
+   premises; the terms of any written lease are matters as to which
+   Defendant currently has insufficient information.
+
+3. **Paragraph 3 of Complaint (allegation of non-payment of rent in the
+   amount of $1,250.00):** WITHOUT SUFFICIENT INFORMATION TO ADMIT OR
+   DENY the specific amount alleged. Defendant reserves the right to
+   produce payment records.
+
+4. **Paragraph 4 of Complaint (allegation of proper notice to vacate):**
+   DENIED. Defendant did not receive notice in compliance with KRS
+   383.660.
+
+# AFFIRMATIVE DEFENSES
+
+- [ ] **Improper notice** — notice did not comply with KRS 383.660 / 383.695.
+- [ ] **Retaliation** — Plaintiff filed in retaliation for tenant complaint to a code-enforcement or housing authority (KRS 383.705).
+- [ ] **Warranty of habitability** — premises were not in compliance with applicable housing codes; partial-rent withholding was justified.
+- [ ] **Partial payment / accord & satisfaction** — Plaintiff accepted partial rent after the alleged default.
+- [ ] **Fair housing / discrimination** — eviction is motivated by a protected-class characteristic (FHA, KRS 344).
+- [ ] **Prior dismissal** — same complaint between same parties was previously dismissed.
+- [ ] **Lack of standing** — Plaintiff is not the owner or duly authorized agent of the premises.
+
+# REQUEST FOR RELIEF
+
+Defendant respectfully requests that the Court (1) DISMISS the
+Complaint with prejudice; (2) award Defendant's costs; and (3) grant
+such other and further relief as the Court deems just and proper.
+
+---
+
+**Defendant signature:** ______________________________
+**Printed name:** John Q. Tenant
+**Address:** _________________________________________
+**Phone:** ___________________________________________
+**Date:** ____________________________________________
+
+(end of example)
+
+Now produce the same shape for the actual case below. Do not echo the
+example; do not include "(end of example)" or any meta-commentary.
+Output ONLY the JSON object specified in the schema.`;
+
+export const buildResponsePacketUserPrompt = (filing: {
+  case_number: string;
+  court_division: string | null;
+  plaintiff: string;
+  defendant_name: string;
+  cause_type: string;
+  amount_claimed_cents: number | null;
+  status: string;
+  filed_at: string;
+}) =>
+  `Draft the Answer for this case. Output JSON per the schema. The "packet_md"
+field must contain the full markdown document including the disclaimer
+header (with literal {timestamp} and {model_version} placeholders).
+
+Case ${filing.case_number}
+Court: ${filing.court_division ?? 'unspecified'}
+Plaintiff: ${filing.plaintiff}
+Defendant: ${filing.defendant_name}
+Cause: ${filing.cause_type}
+Amount claimed: ${filing.amount_claimed_cents != null ? `$${(filing.amount_claimed_cents / 100).toFixed(2)}` : 'unspecified'}
+Status: ${filing.status}
+Filed: ${filing.filed_at}`;
+
+export const ResponsePacketSchema = z.object({
+  packet_md: z.string().min(200),
+});
+
+export type ResponsePacketOutput = z.infer<typeof ResponsePacketSchema>;
+
+/** Bumped any time the prompt or schema changes. Used as the cache key. */
+export const RESPONSE_PACKET_PROMPT_VERSION = 'response-packet-v1@2026-04-26';

--- a/src/db/schema/enums.ts
+++ b/src/db/schema/enums.ts
@@ -66,3 +66,13 @@ export const evictionFilingSourceEnum = pgEnum('eviction_filing_source', [
 ]);
 
 export type EvictionFilingSource = (typeof evictionFilingSourceEnum.enumValues)[number];
+
+export const evictionResponsePacketStatusEnum = pgEnum('eviction_response_packet_status', [
+  'draft',
+  'approved',
+  'filed',
+  'rejected',
+]);
+
+export type EvictionResponsePacketStatus =
+  (typeof evictionResponsePacketStatusEnum.enumValues)[number];

--- a/src/db/schema/eviction-response-packets.ts
+++ b/src/db/schema/eviction-response-packets.ts
@@ -1,0 +1,44 @@
+import { index, pgTable, text, timestamp, uniqueIndex, uuid } from 'drizzle-orm/pg-core';
+import { evictionResponsePacketStatusEnum } from './enums';
+import { evictionFilings } from './eviction-filings';
+import { users } from './users';
+
+/**
+ * AI-drafted Answer to Forcible Detainer Complaint, generated from a
+ * filing by the EVDT-012 service. One row per (filing_id, prompt_version)
+ * — re-running the generator with the same prompt version no-ops via the
+ * unique index. Bumping prompt_version inserts a new draft alongside the
+ * old; an attorney can compare versions during prompt iteration.
+ *
+ * Status flow:
+ *   draft (default) -> approved -> filed
+ *                  \-> rejected
+ *
+ * `generated_by_user_id` is the attorney who triggered the generation;
+ * SET NULL on user delete so the packet survives staff turnover.
+ */
+export const evictionResponsePackets = pgTable(
+  'eviction_response_packets',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    filingId: uuid('filing_id')
+      .notNull()
+      .references(() => evictionFilings.id, { onDelete: 'cascade' }),
+    packetMd: text('packet_md').notNull(),
+    promptVersion: text('prompt_version').notNull(),
+    generatedByUserId: uuid('generated_by_user_id').references(() => users.id, {
+      onDelete: 'set null',
+    }),
+    status: evictionResponsePacketStatusEnum('status').notNull().default('draft'),
+    createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),
+  },
+  (t) => [
+    uniqueIndex('response_packets_filing_version_idx').on(t.filingId, t.promptVersion),
+    index('response_packets_filing_idx').on(t.filingId),
+    index('response_packets_status_idx').on(t.status),
+  ],
+);
+
+export type EvictionResponsePacket = typeof evictionResponsePackets.$inferSelect;
+export type NewEvictionResponsePacket = typeof evictionResponsePackets.$inferInsert;

--- a/src/db/schema/index.ts
+++ b/src/db/schema/index.ts
@@ -3,6 +3,7 @@ export * from './consents';
 export * from './enums';
 export * from './eviction-filing-risk-scores';
 export * from './eviction-filings';
+export * from './eviction-response-packets';
 export * from './health-check';
 export * from './org-memberships';
 export * from './partner-orgs';

--- a/src/lib/eviction/response-packet.ts
+++ b/src/lib/eviction/response-packet.ts
@@ -1,0 +1,151 @@
+import Anthropic from '@anthropic-ai/sdk';
+import { zodOutputFormat } from '@anthropic-ai/sdk/helpers/zod';
+import { and, eq } from 'drizzle-orm';
+import {
+  buildResponsePacketUserPrompt,
+  EVICTION_RESPONSE_PACKET_SYSTEM_PROMPT,
+  RESPONSE_PACKET_DISCLAIMER_PREFIX,
+  RESPONSE_PACKET_PROMPT_VERSION,
+  type ResponsePacketOutput,
+  ResponsePacketSchema,
+} from '@/ai/prompts/eviction-response-packet';
+import { db } from '@/db/client';
+import type { EvictionFiling } from '@/db/schema/eviction-filings';
+import {
+  type EvictionResponsePacket,
+  evictionResponsePackets,
+  type NewEvictionResponsePacket,
+} from '@/db/schema/eviction-response-packets';
+
+let _client: Anthropic | null = null;
+function client(): Anthropic {
+  if (!_client) _client = new Anthropic();
+  return _client;
+}
+
+/**
+ * Project a filing into the prompt input. Defendant ADDRESS is dropped
+ * (the model never sees it) — defendant NAME stays because it appears
+ * on the answer caption. CLAUDE.md PHI fence is satisfied by construction.
+ */
+function scrubForPrompt(filing: EvictionFiling) {
+  return {
+    case_number: filing.caseNumber,
+    court_division: filing.courtDivision,
+    plaintiff: filing.plaintiff,
+    defendant_name: `${filing.defendantFirstName} ${filing.defendantLastName}`.trim(),
+    cause_type: filing.causeType,
+    amount_claimed_cents: filing.amountClaimedCents,
+    status: filing.status,
+    filed_at: filing.filedAt.toISOString(),
+  };
+}
+
+function fillDisclaimer(packet: string, generatedAt: Date): string {
+  return packet
+    .replace(/\{timestamp\}/g, generatedAt.toISOString())
+    .replace(/\{model_version\}/g, RESPONSE_PACKET_PROMPT_VERSION);
+}
+
+/**
+ * Generate (or retrieve) the AI-drafted Answer for a filing. Idempotent:
+ * (filing_id, prompt_version) pairs return the cached row instead of
+ * re-calling Claude.
+ *
+ * `generatedByUserId` is the attorney who clicked the button — recorded
+ * for audit and so we can show "drafted on behalf of {name}" in the UI.
+ * Pass `null` for system-triggered generation (e.g. eval harness).
+ */
+export async function generateResponsePacket(
+  filing: EvictionFiling,
+  generatedByUserId: string | null,
+): Promise<EvictionResponsePacket> {
+  const cached = await db
+    .select()
+    .from(evictionResponsePackets)
+    .where(
+      and(
+        eq(evictionResponsePackets.filingId, filing.id),
+        eq(evictionResponsePackets.promptVersion, RESPONSE_PACKET_PROMPT_VERSION),
+      ),
+    )
+    .limit(1);
+  if (cached.length > 0) return cached[0];
+
+  const inputs = scrubForPrompt(filing);
+
+  const response = await client().messages.parse({
+    model: 'claude-opus-4-7',
+    max_tokens: 16000,
+    thinking: { type: 'adaptive' },
+    output_config: {
+      effort: 'high',
+      format: zodOutputFormat(ResponsePacketSchema),
+    },
+    system: [
+      {
+        type: 'text',
+        text: EVICTION_RESPONSE_PACKET_SYSTEM_PROMPT,
+        cache_control: { type: 'ephemeral' },
+      },
+    ],
+    messages: [{ role: 'user', content: buildResponsePacketUserPrompt(inputs) }],
+  });
+
+  if (!response.parsed_output) {
+    throw new Error(
+      `[response-packet] structured output parse failed; stop_reason=${response.stop_reason}`,
+    );
+  }
+  const parsed: ResponsePacketOutput = response.parsed_output;
+
+  if (!parsed.packet_md.includes(RESPONSE_PACKET_DISCLAIMER_PREFIX)) {
+    throw new Error('[response-packet] generated packet missing required disclaimer block');
+  }
+
+  const filledPacket = fillDisclaimer(parsed.packet_md, new Date());
+
+  const newRow: NewEvictionResponsePacket = {
+    filingId: filing.id,
+    packetMd: filledPacket,
+    promptVersion: RESPONSE_PACKET_PROMPT_VERSION,
+    generatedByUserId,
+    status: 'draft',
+  };
+
+  const [persisted] = await db
+    .insert(evictionResponsePackets)
+    .values(newRow)
+    .onConflictDoNothing({
+      target: [evictionResponsePackets.filingId, evictionResponsePackets.promptVersion],
+    })
+    .returning();
+  if (persisted) return persisted;
+
+  // Concurrent caller beat us — re-select the winner.
+  const [winner] = await db
+    .select()
+    .from(evictionResponsePackets)
+    .where(
+      and(
+        eq(evictionResponsePackets.filingId, filing.id),
+        eq(evictionResponsePackets.promptVersion, RESPONSE_PACKET_PROMPT_VERSION),
+      ),
+    )
+    .limit(1);
+  return winner;
+}
+
+export async function getResponsePacket(filingId: string): Promise<EvictionResponsePacket | null> {
+  const rows = await db
+    .select()
+    .from(evictionResponsePackets)
+    .where(
+      and(
+        eq(evictionResponsePackets.filingId, filingId),
+        eq(evictionResponsePackets.promptVersion, RESPONSE_PACKET_PROMPT_VERSION),
+      ),
+    )
+    .limit(1);
+  return rows[0] ?? null;
+}

--- a/src/lib/eviction/response-packet.ts
+++ b/src/lib/eviction/response-packet.ts
@@ -99,11 +99,31 @@ export async function generateResponsePacket(
   }
   const parsed: ResponsePacketOutput = response.parsed_output;
 
-  if (!parsed.packet_md.includes(RESPONSE_PACKET_DISCLAIMER_PREFIX)) {
-    throw new Error('[response-packet] generated packet missing required disclaimer block');
+  // Tighter than substring-prefix: require the full canonical disclaimer
+  // wording, both placeholders (so fillDisclaimer can substitute), and the
+  // attorney-review sentence. Catches malformed/abbreviated disclaimers
+  // that pass a loose prefix check.
+  const requiredDisclaimerFragments = [
+    `${RESPONSE_PACKET_DISCLAIMER_PREFIX} REQUIRED BEFORE FILING.`,
+    'Generated {timestamp} model {model_version}.',
+    'not legal advice',
+  ];
+  for (const fragment of requiredDisclaimerFragments) {
+    if (!parsed.packet_md.includes(fragment)) {
+      throw new Error(
+        `[response-packet] disclaimer missing required fragment: ${fragment.slice(0, 60)}…`,
+      );
+    }
   }
 
   const filledPacket = fillDisclaimer(parsed.packet_md, new Date());
+
+  // Belt-and-braces: after filling, both placeholders must be gone.
+  // If the model self-substituted a timestamp or version string, fill
+  // wouldn't fire and the packet would carry a misleading value.
+  if (filledPacket.includes('{timestamp}') || filledPacket.includes('{model_version}')) {
+    throw new Error('[response-packet] disclaimer placeholders still present after fill');
+  }
 
   const newRow: NewEvictionResponsePacket = {
     filingId: filing.id,


### PR DESCRIPTION
Closes #27

## Summary
\`generateResponsePacket(filing, generatedByUserId)\` produces a KY-specific draft Answer to a Forcible Detainer Complaint, gated by structured-output schema and a required disclaimer prefix, persisted in a new \`eviction_response_packets\` table.

- **Prompt** (\`src/ai/prompts/eviction-response-packet.ts\`): system text with the full KY-template 1-shot example, structured-output schema (\`{packet_md}\`), \`RESPONSE_PACKET_DISCLAIMER_PREFIX\` constant, and \`RESPONSE_PACKET_PROMPT_VERSION\` cache key.
- **Service** (\`src/lib/eviction/response-packet.ts\`): scrub → \`messages.parse()\` → assert disclaimer present → fill \`{timestamp}\` + \`{model_version}\` placeholders → upsert. Idempotent on \`(filing_id, prompt_version)\`. Uses \`claude-opus-4-7\`, adaptive thinking, \`effort: 'high'\`, ephemeral cache on the system block (per the claude-api skill).
- **Schema** (\`drizzle/migrations/0007_quiet_galactus.sql\`): \`eviction_response_packets\` with status enum \`draft|approved|filed|rejected\`, FKs to filing (cascade) and user (set null), unique on \`(filing_id, prompt_version)\`.
- **Eval** (\`scripts/eval-response-packet.ts\` + \`fixtures/response-packet-eval.json\`): 5 hand-curated synthetic filings, structural checklist (disclaimer, caption, response paragraphs, defenses checkbox count ≥ 5, signature block).

## PHI fence
Defendant **address** is dropped before the prompt; the model never sees it. Defendant **name** is included because it appears on the answer caption (per AC). Plaintiff/case-number/court are public record on the filing.

## Acceptance criteria
- [x] \`generateResponsePacket(filing): Promise<{packet_md, version}>\` (returns the persisted row which contains both)
- [x] Prompt at \`src/ai/prompts/eviction-response-packet.ts\` (no inline strings)
- [x] Markdown shape: caption, numbered response paragraphs, defenses checklist, signature block
- [x] Disclaimer block at top with timestamp + model version
- [x] 1-shot KY example in the system prompt
- [x] \`eviction_response_packets\` table with all required columns
- [x] Defendant address scrubbed; name kept
- [x] 5 fixtures + eval harness with element checklist
- [x] Idempotent on \`(filing_id, prompt_version)\`

## Notes for review
- Eval is structural, not semantic — legal correctness is the attorney's job per the AI-assisted-law disclaimer.
- I haven't run \`pnpm tsx scripts/eval-response-packet.ts\` yet (each call is real Claude API spend); happy to do a single eval run before merge if you want.
- No UI yet — that's a separate story (EVDT-013/014) once Bo signs off on packet quality.

🤖 Generated with [Claude Code](https://claude.com/claude-code)