### PR TITLE
feat(EVDT-013): packet review/edit UI

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "posthog-node": "^5.30.4",
     "react": "19.2.4",
     "react-dom": "19.2.4",
+    "react-markdown": "^10.1.0",
     "resend": "^6.12.2",
     "shadcn": "^4.5.0",
     "svix": "^1.92.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,6 +56,9 @@ importers:
       react-dom:
         specifier: 19.2.4
         version: 19.2.4(react@19.2.4)
+      react-markdown:
+        specifier: ^10.1.0
+        version: 10.1.0(@types/react@19.2.14)(react@19.2.4)
       resend:
         specifier: ^6.12.2
         version: 6.12.2
@@ -2427,11 +2430,20 @@ packages:
   '@types/eslint@9.6.1':
     resolution: {integrity: sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==}
 
+  '@types/estree-jsx@1.0.5':
+    resolution: {integrity: sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==}
+
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
+  '@types/hast@3.0.4':
+    resolution: {integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==}
+
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
+
+  '@types/mdast@4.0.4':
+    resolution: {integrity: sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==}
 
   '@types/memcached@2.2.10':
     resolution: {integrity: sha512-AM9smvZN55Gzs2wRrqeMHVP7KE8KWgCJO/XL5yCly2xF6EKa4YlbpK+cLSAH4NG/Ah64HrlegmGqW8kYws7Vxg==}
@@ -2477,8 +2489,17 @@ packages:
   '@types/trusted-types@2.0.7':
     resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
 
+  '@types/unist@2.0.11':
+    resolution: {integrity: sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==}
+
+  '@types/unist@3.0.3':
+    resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
+
   '@types/validate-npm-package-name@4.0.2':
     resolution: {integrity: sha512-lrpDziQipxCEeK5kWxvljWYhUvOiB2A9izZd9B2AFarYAkqZshb4lPbRs7zKEic6eGtH8V/2qJW+dPp9OtF6bw==}
+
+  '@ungap/structured-clone@1.3.0':
+    resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
 
   '@vitest/expect@4.1.5':
     resolution: {integrity: sha512-PWBaRY5JoKuRnHlUHfpV/KohFylaDZTupcXN1H9vYryNLOnitSw60Mw9IAE2r67NbwwzBw/Cc/8q9BK3kIX8Kw==}
@@ -2635,6 +2656,9 @@ packages:
     resolution: {integrity: sha512-6t10qk83GOG8p0vKmaCr8eiilZwO171AvbROMtvvNiwrTly62t+7XkA8RdIIVbpMhCASAsxgAzdRSwh6nw/5Dg==}
     engines: {node: '>=4'}
 
+  bail@2.0.2:
+    resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
+
   balanced-match@4.0.4:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
@@ -2693,6 +2717,9 @@ packages:
   canonicalize@1.0.8:
     resolution: {integrity: sha512-0CNTVCLZggSh7bc5VkX5WWPWO+cyZbNd07IHIsSXLia/eAq+r836hgk+8BKoEh7949Mda87VUOitx5OddVj64A==}
 
+  ccount@2.0.1:
+    resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
+
   chai@6.2.2:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
     engines: {node: '>=18'}
@@ -2700,6 +2727,18 @@ packages:
   chalk@5.6.2:
     resolution: {integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==}
     engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
+
+  character-entities-html4@2.1.0:
+    resolution: {integrity: sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==}
+
+  character-entities-legacy@3.0.0:
+    resolution: {integrity: sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==}
+
+  character-entities@2.0.2:
+    resolution: {integrity: sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==}
+
+  character-reference-invalid@2.0.1:
+    resolution: {integrity: sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==}
 
   chrome-trace-event@1.0.4:
     resolution: {integrity: sha512-rNjApaLzuwaOTjCiT8lSDdGN1APCiqkChLMJxJPWLunPAt5fy8xgU9/jNOchV84wfIxrA0lRQB7oCT8jrn/wrQ==}
@@ -2746,6 +2785,9 @@ packages:
 
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+
+  comma-separated-tokens@2.0.3:
+    resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
 
   commander@11.1.0:
     resolution: {integrity: sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==}
@@ -2828,6 +2870,9 @@ packages:
       supports-color:
         optional: true
 
+  decode-named-character-reference@1.3.0:
+    resolution: {integrity: sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==}
+
   dedent@1.7.2:
     resolution: {integrity: sha512-WzMx3mW98SN+zn3hgemf4OzdmyNhhhKz5Ay0pUfQiMQ3e1g+xmTJWp/pKdwKVXhdSkAEGIIzqeuWrL3mV/AXbA==}
     peerDependencies:
@@ -2863,6 +2908,9 @@ packages:
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
+
+  devlop@1.1.0:
+    resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
 
   diff@8.0.4:
     resolution: {integrity: sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==}
@@ -3067,6 +3115,9 @@ packages:
   estraverse@5.3.0:
     resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
     engines: {node: '>=4.0'}
+
+  estree-util-is-identifier-name@3.0.0:
+    resolution: {integrity: sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg==}
 
   estree-walker@2.0.2:
     resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
@@ -3286,12 +3337,21 @@ packages:
     resolution: {integrity: sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==}
     engines: {node: '>= 0.4'}
 
+  hast-util-to-jsx-runtime@2.3.6:
+    resolution: {integrity: sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==}
+
+  hast-util-whitespace@3.0.0:
+    resolution: {integrity: sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==}
+
   headers-polyfill@5.0.1:
     resolution: {integrity: sha512-1TJ6Fih/b8h5TIcv+1+Hw0PDQWJTKDKzFZzcKOiW1wJza3XoAQlkCuXLbymPYB8+ZQyw8mHvdw560e8zVFIWyA==}
 
   hono@4.12.15:
     resolution: {integrity: sha512-qM0jDhFEaCBb4TxoW7f53Qrpv9RBiayUHo0S52JudprkhvpjIrGoU1mnnr29Fvd1U335ZFPZQY1wlkqgfGXyLg==}
     engines: {node: '>=16.9.0'}
+
+  html-url-attributes@3.0.1:
+    resolution: {integrity: sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==}
 
   http-errors@2.0.1:
     resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
@@ -3337,6 +3397,9 @@ packages:
 
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+
+  inline-style-parser@0.2.7:
+    resolution: {integrity: sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==}
 
   inngest@4.2.4:
     resolution: {integrity: sha512-MBFcRhhQ+dcGHLYCbIcMYxiAZCxzfAx0+3b/euYQKc7MK3rOnNHaNHuF2e0WsT13oWJiGzjuC3T4Nocggmh5WQ==}
@@ -3386,12 +3449,21 @@ packages:
     resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
     engines: {node: '>= 0.10'}
 
+  is-alphabetical@2.0.1:
+    resolution: {integrity: sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==}
+
+  is-alphanumerical@2.0.1:
+    resolution: {integrity: sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==}
+
   is-arrayish@0.2.1:
     resolution: {integrity: sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==}
 
   is-core-module@2.16.1:
     resolution: {integrity: sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==}
     engines: {node: '>= 0.4'}
+
+  is-decimal@2.0.1:
+    resolution: {integrity: sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==}
 
   is-docker@3.0.0:
     resolution: {integrity: sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==}
@@ -3409,6 +3481,9 @@ packages:
   is-glob@4.0.3:
     resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
     engines: {node: '>=0.10.0'}
+
+  is-hexadecimal@2.0.1:
+    resolution: {integrity: sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==}
 
   is-in-ssh@1.0.0:
     resolution: {integrity: sha512-jYa6Q9rH90kR1vKB6NM7qqd1mge3Fx4Dhw5TVlK1MUBqhEOuCagrEHMevNuCcbECmXZ0ThXkRm+Ymr51HwEPAw==}
@@ -3628,6 +3703,9 @@ packages:
   long@5.3.2:
     resolution: {integrity: sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==}
 
+  longest-streak@3.1.0:
+    resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
+
   lru-cache@11.3.5:
     resolution: {integrity: sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==}
     engines: {node: 20 || >=22}
@@ -3647,6 +3725,30 @@ packages:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
 
+  mdast-util-from-markdown@2.0.3:
+    resolution: {integrity: sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==}
+
+  mdast-util-mdx-expression@2.0.1:
+    resolution: {integrity: sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ==}
+
+  mdast-util-mdx-jsx@3.2.0:
+    resolution: {integrity: sha512-lj/z8v0r6ZtsN/cGNNtemmmfoLAFZnjMbNyLzBafjzikOM+glrjNHPlf6lQDOTccj9n5b0PPihEBbhneMyGs1Q==}
+
+  mdast-util-mdxjs-esm@2.0.1:
+    resolution: {integrity: sha512-EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg==}
+
+  mdast-util-phrasing@4.1.0:
+    resolution: {integrity: sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==}
+
+  mdast-util-to-hast@13.2.1:
+    resolution: {integrity: sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==}
+
+  mdast-util-to-markdown@2.1.2:
+    resolution: {integrity: sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==}
+
+  mdast-util-to-string@4.0.0:
+    resolution: {integrity: sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==}
+
   media-typer@1.1.0:
     resolution: {integrity: sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==}
     engines: {node: '>= 0.8'}
@@ -3661,6 +3763,69 @@ packages:
   merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
     engines: {node: '>= 8'}
+
+  micromark-core-commonmark@2.0.3:
+    resolution: {integrity: sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==}
+
+  micromark-factory-destination@2.0.1:
+    resolution: {integrity: sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==}
+
+  micromark-factory-label@2.0.1:
+    resolution: {integrity: sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==}
+
+  micromark-factory-space@2.0.1:
+    resolution: {integrity: sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==}
+
+  micromark-factory-title@2.0.1:
+    resolution: {integrity: sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==}
+
+  micromark-factory-whitespace@2.0.1:
+    resolution: {integrity: sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==}
+
+  micromark-util-character@2.1.1:
+    resolution: {integrity: sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==}
+
+  micromark-util-chunked@2.0.1:
+    resolution: {integrity: sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==}
+
+  micromark-util-classify-character@2.0.1:
+    resolution: {integrity: sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==}
+
+  micromark-util-combine-extensions@2.0.1:
+    resolution: {integrity: sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==}
+
+  micromark-util-decode-numeric-character-reference@2.0.2:
+    resolution: {integrity: sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==}
+
+  micromark-util-decode-string@2.0.1:
+    resolution: {integrity: sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==}
+
+  micromark-util-encode@2.0.1:
+    resolution: {integrity: sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==}
+
+  micromark-util-html-tag-name@2.0.1:
+    resolution: {integrity: sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==}
+
+  micromark-util-normalize-identifier@2.0.1:
+    resolution: {integrity: sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==}
+
+  micromark-util-resolve-all@2.0.1:
+    resolution: {integrity: sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==}
+
+  micromark-util-sanitize-uri@2.0.1:
+    resolution: {integrity: sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==}
+
+  micromark-util-subtokenize@2.1.0:
+    resolution: {integrity: sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==}
+
+  micromark-util-symbol@2.0.1:
+    resolution: {integrity: sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==}
+
+  micromark-util-types@2.0.2:
+    resolution: {integrity: sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==}
+
+  micromark@4.0.2:
+    resolution: {integrity: sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==}
 
   micromatch@4.0.8:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
@@ -3837,6 +4002,9 @@ packages:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
     engines: {node: '>=6'}
 
+  parse-entities@4.0.2:
+    resolution: {integrity: sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==}
+
   parse-json@5.2.0:
     resolution: {integrity: sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==}
     engines: {node: '>=8'}
@@ -3972,6 +4140,9 @@ packages:
     resolution: {integrity: sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==}
     engines: {node: '>= 6'}
 
+  property-information@7.1.0:
+    resolution: {integrity: sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==}
+
   protobufjs@7.5.5:
     resolution: {integrity: sha512-3wY1AxV+VBNW8Yypfd1yQY9pXnqTAN+KwQxL8iYm3/BjKYMNg4i0owhEe26PWDOMaIrzeeF98Lqd5NGz4omiIg==}
     engines: {node: '>=12.0.0'}
@@ -4010,6 +4181,12 @@ packages:
     peerDependencies:
       react: ^19.2.4
 
+  react-markdown@10.1.0:
+    resolution: {integrity: sha512-qKxVopLT/TyA6BX3Ue5NwabOsAzm0Q7kAPwq6L+wWDwisYs7R8vZ0nRXqq6rkueboxpkjvLGU9fWifiX/ZZFxQ==}
+    peerDependencies:
+      '@types/react': '>=18'
+      react: '>=18'
+
   react@19.2.4:
     resolution: {integrity: sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==}
     engines: {node: '>=0.10.0'}
@@ -4017,6 +4194,12 @@ packages:
   recast@0.23.11:
     resolution: {integrity: sha512-YTUo+Flmw4ZXiWfQKGcwwc11KnoRAYgzAE2E7mXKCjSviTKShtxBsN6YUUBB2gtaBzKzeKunxhUwNHQuRryhWA==}
     engines: {node: '>= 4'}
+
+  remark-parse@11.0.0:
+    resolution: {integrity: sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==}
+
+  remark-rehype@11.1.2:
+    resolution: {integrity: sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==}
 
   require-directory@2.1.1:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
@@ -4186,6 +4369,9 @@ packages:
     resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
     engines: {node: '>=0.10.0'}
 
+  space-separated-tokens@2.0.2:
+    resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
+
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
 
@@ -4221,6 +4407,9 @@ packages:
     resolution: {integrity: sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==}
     engines: {node: '>=18'}
 
+  stringify-entities@4.0.4:
+    resolution: {integrity: sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==}
+
   stringify-object@5.0.0:
     resolution: {integrity: sha512-zaJYxz2FtcMb4f+g60KsRNFOpVMUyuJgA51Zi5Z1DOTC3S59+OQiVOzE9GZt0x72uBGWKsQIuBKeF9iusmKFsg==}
     engines: {node: '>=14.16'}
@@ -4244,6 +4433,12 @@ packages:
   strip-final-newline@4.0.0:
     resolution: {integrity: sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw==}
     engines: {node: '>=18'}
+
+  style-to-js@1.1.21:
+    resolution: {integrity: sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ==}
+
+  style-to-object@1.0.14:
+    resolution: {integrity: sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==}
 
   styled-jsx@5.1.6:
     resolution: {integrity: sha512-qSVyDTeMotdvQYoHWLNGwRFJHC+i+ZvdBRYosOFgC+Wg1vx4frN2/RG/NA7SYqqvKNLf39P2LSRA2pu6n0XYZA==}
@@ -4353,6 +4548,12 @@ packages:
   tr46@0.0.3:
     resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
 
+  trim-lines@3.0.1:
+    resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
+
+  trough@2.2.0:
+    resolution: {integrity: sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==}
+
   ts-algebra@2.0.0:
     resolution: {integrity: sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==}
 
@@ -4402,6 +4603,24 @@ packages:
     resolution: {integrity: sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==}
     engines: {node: '>=18'}
 
+  unified@11.0.5:
+    resolution: {integrity: sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==}
+
+  unist-util-is@6.0.1:
+    resolution: {integrity: sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==}
+
+  unist-util-position@5.0.0:
+    resolution: {integrity: sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==}
+
+  unist-util-stringify-position@4.0.0:
+    resolution: {integrity: sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==}
+
+  unist-util-visit-parents@6.0.2:
+    resolution: {integrity: sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==}
+
+  unist-util-visit@5.1.0:
+    resolution: {integrity: sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==}
+
   universalify@2.0.1:
     resolution: {integrity: sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==}
     engines: {node: '>= 10.0.0'}
@@ -4438,6 +4657,12 @@ packages:
   vary@1.1.2:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
+
+  vfile-message@4.0.3:
+    resolution: {integrity: sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==}
+
+  vfile@6.0.3:
+    resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
 
   vite@8.0.10:
     resolution: {integrity: sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw==}
@@ -4626,6 +4851,9 @@ packages:
 
   zod@4.3.6:
     resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
+
+  zwitch@2.0.4:
+    resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
 snapshots:
 
@@ -6965,9 +7193,21 @@ snapshots:
       '@types/estree': 1.0.8
       '@types/json-schema': 7.0.15
 
+  '@types/estree-jsx@1.0.5':
+    dependencies:
+      '@types/estree': 1.0.8
+
   '@types/estree@1.0.8': {}
 
+  '@types/hast@3.0.4':
+    dependencies:
+      '@types/unist': 3.0.3
+
   '@types/json-schema@7.0.15': {}
+
+  '@types/mdast@4.0.4':
+    dependencies:
+      '@types/unist': 3.0.3
 
   '@types/memcached@2.2.10':
     dependencies:
@@ -7022,7 +7262,13 @@ snapshots:
   '@types/trusted-types@2.0.7':
     optional: true
 
+  '@types/unist@2.0.11': {}
+
+  '@types/unist@3.0.3': {}
+
   '@types/validate-npm-package-name@4.0.2': {}
+
+  '@ungap/structured-clone@1.3.0': {}
 
   '@vitest/expect@4.1.5':
     dependencies:
@@ -7205,6 +7451,8 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
+  bail@2.0.2: {}
+
   balanced-match@4.0.4: {}
 
   baseline-browser-mapping@2.10.22: {}
@@ -7265,9 +7513,19 @@ snapshots:
 
   canonicalize@1.0.8: {}
 
+  ccount@2.0.1: {}
+
   chai@6.2.2: {}
 
   chalk@5.6.2: {}
+
+  character-entities-html4@2.1.0: {}
+
+  character-entities-legacy@3.0.0: {}
+
+  character-entities@2.0.2: {}
+
+  character-reference-invalid@2.0.1: {}
 
   chrome-trace-event@1.0.4: {}
 
@@ -7304,6 +7562,8 @@ snapshots:
       color-name: 1.1.4
 
   color-name@1.1.4: {}
+
+  comma-separated-tokens@2.0.3: {}
 
   commander@11.1.0: {}
 
@@ -7363,6 +7623,10 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
+  decode-named-character-reference@1.3.0:
+    dependencies:
+      character-entities: 2.0.2
+
   dedent@1.7.2: {}
 
   deepmerge@4.3.1: {}
@@ -7381,6 +7645,10 @@ snapshots:
   dequal@2.0.3: {}
 
   detect-libc@2.1.2: {}
+
+  devlop@1.1.0:
+    dependencies:
+      dequal: 2.0.3
 
   diff@8.0.4: {}
 
@@ -7550,6 +7818,8 @@ snapshots:
   estraverse@4.3.0: {}
 
   estraverse@5.3.0: {}
+
+  estree-util-is-identifier-name@3.0.0: {}
 
   estree-walker@2.0.2: {}
 
@@ -7808,12 +8078,38 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
+  hast-util-to-jsx-runtime@2.3.6:
+    dependencies:
+      '@types/estree': 1.0.8
+      '@types/hast': 3.0.4
+      '@types/unist': 3.0.3
+      comma-separated-tokens: 2.0.3
+      devlop: 1.1.0
+      estree-util-is-identifier-name: 3.0.0
+      hast-util-whitespace: 3.0.0
+      mdast-util-mdx-expression: 2.0.1
+      mdast-util-mdx-jsx: 3.2.0
+      mdast-util-mdxjs-esm: 2.0.1
+      property-information: 7.1.0
+      space-separated-tokens: 2.0.2
+      style-to-js: 1.1.21
+      unist-util-position: 5.0.0
+      vfile-message: 4.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  hast-util-whitespace@3.0.0:
+    dependencies:
+      '@types/hast': 3.0.4
+
   headers-polyfill@5.0.1:
     dependencies:
       '@types/set-cookie-parser': 2.4.10
       set-cookie-parser: 3.1.0
 
   hono@4.12.15: {}
+
+  html-url-attributes@3.0.1: {}
 
   http-errors@2.0.1:
     dependencies:
@@ -7875,6 +8171,8 @@ snapshots:
 
   inherits@2.0.4: {}
 
+  inline-style-parser@0.2.7: {}
+
   inngest@4.2.4(@opentelemetry/core@2.7.0(@opentelemetry/api@1.9.1))(express@5.2.1)(hono@4.12.15)(next@16.2.4(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(zod@4.3.6):
     dependencies:
       '@bufbuild/protobuf': 2.12.0
@@ -7916,11 +8214,20 @@ snapshots:
 
   ipaddr.js@1.9.1: {}
 
+  is-alphabetical@2.0.1: {}
+
+  is-alphanumerical@2.0.1:
+    dependencies:
+      is-alphabetical: 2.0.1
+      is-decimal: 2.0.1
+
   is-arrayish@0.2.1: {}
 
   is-core-module@2.16.1:
     dependencies:
       hasown: 2.0.3
+
+  is-decimal@2.0.1: {}
 
   is-docker@3.0.0: {}
 
@@ -7931,6 +8238,8 @@ snapshots:
   is-glob@4.0.3:
     dependencies:
       is-extglob: 2.1.1
+
+  is-hexadecimal@2.0.1: {}
 
   is-in-ssh@1.0.0: {}
 
@@ -8087,6 +8396,8 @@ snapshots:
 
   long@5.3.2: {}
 
+  longest-streak@3.1.0: {}
+
   lru-cache@11.3.5: {}
 
   lru-cache@5.1.1:
@@ -8103,6 +8414,95 @@ snapshots:
 
   math-intrinsics@1.1.0: {}
 
+  mdast-util-from-markdown@2.0.3:
+    dependencies:
+      '@types/mdast': 4.0.4
+      '@types/unist': 3.0.3
+      decode-named-character-reference: 1.3.0
+      devlop: 1.1.0
+      mdast-util-to-string: 4.0.0
+      micromark: 4.0.2
+      micromark-util-decode-numeric-character-reference: 2.0.2
+      micromark-util-decode-string: 2.0.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+      unist-util-stringify-position: 4.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-mdx-expression@2.0.1:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-mdx-jsx@3.2.0:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      '@types/unist': 3.0.3
+      ccount: 2.0.1
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+      parse-entities: 4.0.2
+      stringify-entities: 4.0.4
+      unist-util-stringify-position: 4.0.0
+      vfile-message: 4.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-mdxjs-esm@2.0.1:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-phrasing@4.1.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      unist-util-is: 6.0.1
+
+  mdast-util-to-hast@13.2.1:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      '@ungap/structured-clone': 1.3.0
+      devlop: 1.1.0
+      micromark-util-sanitize-uri: 2.0.1
+      trim-lines: 3.0.1
+      unist-util-position: 5.0.0
+      unist-util-visit: 5.1.0
+      vfile: 6.0.3
+
+  mdast-util-to-markdown@2.1.2:
+    dependencies:
+      '@types/mdast': 4.0.4
+      '@types/unist': 3.0.3
+      longest-streak: 3.1.0
+      mdast-util-phrasing: 4.1.0
+      mdast-util-to-string: 4.0.0
+      micromark-util-classify-character: 2.0.1
+      micromark-util-decode-string: 2.0.1
+      unist-util-visit: 5.1.0
+      zwitch: 2.0.4
+
+  mdast-util-to-string@4.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+
   media-typer@1.1.0: {}
 
   merge-descriptors@2.0.0: {}
@@ -8110,6 +8510,139 @@ snapshots:
   merge-stream@2.0.0: {}
 
   merge2@1.4.1: {}
+
+  micromark-core-commonmark@2.0.3:
+    dependencies:
+      decode-named-character-reference: 1.3.0
+      devlop: 1.1.0
+      micromark-factory-destination: 2.0.1
+      micromark-factory-label: 2.0.1
+      micromark-factory-space: 2.0.1
+      micromark-factory-title: 2.0.1
+      micromark-factory-whitespace: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-chunked: 2.0.1
+      micromark-util-classify-character: 2.0.1
+      micromark-util-html-tag-name: 2.0.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-resolve-all: 2.0.1
+      micromark-util-subtokenize: 2.1.0
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-destination@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-label@2.0.1:
+    dependencies:
+      devlop: 1.1.0
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-space@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-title@2.0.1:
+    dependencies:
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-whitespace@2.0.1:
+    dependencies:
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-character@2.1.1:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-chunked@2.0.1:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-classify-character@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-combine-extensions@2.0.1:
+    dependencies:
+      micromark-util-chunked: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-decode-numeric-character-reference@2.0.2:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-decode-string@2.0.1:
+    dependencies:
+      decode-named-character-reference: 1.3.0
+      micromark-util-character: 2.1.1
+      micromark-util-decode-numeric-character-reference: 2.0.2
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-encode@2.0.1: {}
+
+  micromark-util-html-tag-name@2.0.1: {}
+
+  micromark-util-normalize-identifier@2.0.1:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-resolve-all@2.0.1:
+    dependencies:
+      micromark-util-types: 2.0.2
+
+  micromark-util-sanitize-uri@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-encode: 2.0.1
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-subtokenize@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-util-chunked: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-symbol@2.0.1: {}
+
+  micromark-util-types@2.0.2: {}
+
+  micromark@4.0.2:
+    dependencies:
+      '@types/debug': 4.1.13
+      debug: 4.4.3
+      decode-named-character-reference: 1.3.0
+      devlop: 1.1.0
+      micromark-core-commonmark: 2.0.3
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-chunked: 2.0.1
+      micromark-util-combine-extensions: 2.0.1
+      micromark-util-decode-numeric-character-reference: 2.0.2
+      micromark-util-encode: 2.0.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-resolve-all: 2.0.1
+      micromark-util-sanitize-uri: 2.0.1
+      micromark-util-subtokenize: 2.1.0
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
 
   micromatch@4.0.8:
     dependencies:
@@ -8285,6 +8818,16 @@ snapshots:
     dependencies:
       callsites: 3.1.0
 
+  parse-entities@4.0.2:
+    dependencies:
+      '@types/unist': 2.0.11
+      character-entities-legacy: 3.0.0
+      character-reference-invalid: 2.0.1
+      decode-named-character-reference: 1.3.0
+      is-alphanumerical: 2.0.1
+      is-decimal: 2.0.1
+      is-hexadecimal: 2.0.1
+
   parse-json@5.2.0:
     dependencies:
       '@babel/code-frame': 7.29.0
@@ -8403,6 +8946,8 @@ snapshots:
       kleur: 3.0.3
       sisteransi: 1.0.5
 
+  property-information@7.1.0: {}
+
   protobufjs@7.5.5:
     dependencies:
       '@protobufjs/aspromise': 1.1.2
@@ -8462,6 +9007,24 @@ snapshots:
       react: 19.2.4
       scheduler: 0.27.0
 
+  react-markdown@10.1.0(@types/react@19.2.14)(react@19.2.4):
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      '@types/react': 19.2.14
+      devlop: 1.1.0
+      hast-util-to-jsx-runtime: 2.3.6
+      html-url-attributes: 3.0.1
+      mdast-util-to-hast: 13.2.1
+      react: 19.2.4
+      remark-parse: 11.0.0
+      remark-rehype: 11.1.2
+      unified: 11.0.5
+      unist-util-visit: 5.1.0
+      vfile: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
+
   react@19.2.4: {}
 
   recast@0.23.11:
@@ -8471,6 +9034,23 @@ snapshots:
       source-map: 0.6.1
       tiny-invariant: 1.3.3
       tslib: 2.8.1
+
+  remark-parse@11.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-from-markdown: 2.0.3
+      micromark-util-types: 2.0.2
+      unified: 11.0.5
+    transitivePeerDependencies:
+      - supports-color
+
+  remark-rehype@11.1.2:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      mdast-util-to-hast: 13.2.1
+      unified: 11.0.5
+      vfile: 6.0.3
 
   require-directory@2.1.1: {}
 
@@ -8761,6 +9341,8 @@ snapshots:
 
   source-map@0.6.1: {}
 
+  space-separated-tokens@2.0.2: {}
+
   stackback@0.0.2: {}
 
   stacktrace-parser@0.1.11:
@@ -8794,6 +9376,11 @@ snapshots:
       get-east-asian-width: 1.5.0
       strip-ansi: 7.2.0
 
+  stringify-entities@4.0.4:
+    dependencies:
+      character-entities-html4: 2.1.0
+      character-entities-legacy: 3.0.0
+
   stringify-object@5.0.0:
     dependencies:
       get-own-enumerable-keys: 1.0.0
@@ -8813,6 +9400,14 @@ snapshots:
   strip-final-newline@2.0.0: {}
 
   strip-final-newline@4.0.0: {}
+
+  style-to-js@1.1.21:
+    dependencies:
+      style-to-object: 1.0.14
+
+  style-to-object@1.0.14:
+    dependencies:
+      inline-style-parser: 0.2.7
 
   styled-jsx@5.1.6(@babel/core@7.29.0)(react@19.2.4):
     dependencies:
@@ -8898,6 +9493,10 @@ snapshots:
 
   tr46@0.0.3: {}
 
+  trim-lines@3.0.1: {}
+
+  trough@2.2.0: {}
+
   ts-algebra@2.0.0: {}
 
   ts-morph@26.0.0:
@@ -8942,6 +9541,39 @@ snapshots:
 
   unicorn-magic@0.3.0: {}
 
+  unified@11.0.5:
+    dependencies:
+      '@types/unist': 3.0.3
+      bail: 2.0.2
+      devlop: 1.1.0
+      extend: 3.0.2
+      is-plain-obj: 4.1.0
+      trough: 2.2.0
+      vfile: 6.0.3
+
+  unist-util-is@6.0.1:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-position@5.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-stringify-position@4.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-visit-parents@6.0.2:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-is: 6.0.1
+
+  unist-util-visit@5.1.0:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-is: 6.0.1
+      unist-util-visit-parents: 6.0.2
+
   universalify@2.0.1: {}
 
   unpipe@1.0.0: {}
@@ -8965,6 +9597,16 @@ snapshots:
   validate-npm-package-name@7.0.2: {}
 
   vary@1.1.2: {}
+
+  vfile-message@4.0.3:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-stringify-position: 4.0.0
+
+  vfile@6.0.3:
+    dependencies:
+      '@types/unist': 3.0.3
+      vfile-message: 4.0.3
 
   vite@8.0.10(@types/node@20.19.39)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3):
     dependencies:
@@ -9120,3 +9762,5 @@ snapshots:
   zod@3.25.76: {}
 
   zod@4.3.6: {}
+
+  zwitch@2.0.4: {}

--- a/scripts/seed-acceptance-criteria-sprint5.py
+++ b/scripts/seed-acceptance-criteria-sprint5.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+"""Update Sprint 5 GitHub issues with concrete acceptance criteria.
+
+Sprint 5 goal: ship a stakeholder-ready demo. Build axis weighted toward
+making the eviction-defense pipeline usable end-to-end so Bo can get the
+first KLA partner on board.
+"""
+import json
+import re
+import subprocess
+
+REPO = "DobbsBoldry/homeless"
+
+CRITERIA = {
+    "EVDT-013": [
+        "New page `/app/cases/filings/[id]/packet` (or a panel on the case-detail page) gated by `requireKlaAttorney()`",
+        "Loads the latest packet via `getResponsePacket(filing.id)`; if none exists, shows a 'Generate packet' button that calls the EVDT-012 service",
+        "Markdown rendered to HTML for review (use `react-markdown` or equivalent — keep it simple, no rich text editor in v1)",
+        "Inline editing via a textarea swap on the packet markdown; save persists `packet_md` and bumps `updated_at`",
+        "Status transitions: 'Approve' button (draft -> approved), 'Mark filed' (approved -> filed), 'Reject' (any -> rejected)",
+        "All status changes write an audit_log entry via logAuditEvent (action: `response_packet.status_changed`)",
+        "Disclaimer banner is always visible; cannot be edited away in the textarea",
+        "Defendant full name visible on this page (attorney needs it for the answer caption); explicit click-through warning that this view contains the unredacted name",
+    ],
+    "EVDT-014": [
+        "New table `rental_assistance_programs`: id, name, agency, phone, eligibility_summary, max_award_cents, active",
+        "Static seed of 5-10 KY rental-assistance programs (KHC, KY HEALTH, Audubon Area, ER Brown grant, etc.) — synthetic OK if real eligibility text isn't easy to source",
+        "Query `matchAssistancePrograms(filing): Promise<Program[]>` — for v1 returns ALL active programs (matching logic comes when we have real eligibility data)",
+        "Display: a card on the case-detail page listing matching programs with name, phone, brief eligibility, max award",
+        "Caveat banner: 'Eligibility depends on household specifics not in the filing — verify with the agency before referring.'",
+    ],
+    "EVDT-017": [
+        "Status enum already exists on eviction_response_packets (draft|approved|filed|rejected). Add `outcome` enum on a new `eviction_case_outcomes` table: dismissed, judgment_for_plaintiff, judgment_for_defendant, settled, default_judgment, withdrawn",
+        "Server action `recordCaseOutcome(filingId, outcome, attorneyUserId, notes?)` — writes one row per filing per outcome event",
+        "Outcome capture UI on the case-detail page: dropdown + optional notes textarea + 'Record outcome' button (visible only to KLA attorneys)",
+        "Outcome history table on the case-detail page: shows all recorded outcomes with timestamp + attorney name (for the audit trail)",
+        "Outcomes appear in the EVDT-020 metrics dashboard",
+        "Audit-log every outcome via logAuditEvent (action: `case.outcome_recorded`)",
+    ],
+    "EVDT-020": [
+        "New page `/app/metrics` gated by `requireRole(['attorney', 'admin'])`",
+        "Cards for: total filings ingested (last 30 days), filings with packet generated, packets approved, packets filed, outcomes recorded",
+        "Outcome breakdown: representation rate (% of filings with at least one packet), default-judgment rate (% of filings with outcome=default_judgment), favorable-outcome rate (% with judgment_for_defendant or settled)",
+        "Time-series chart: daily filing count + daily packets-approved count, last 30 days (use a lightweight chart lib — recharts or visx)",
+        "All numbers are scoped to the current Phase 1 cohort (KLA Owensboro); when multi-org lands later this scopes per org",
+        "Empty state: 'No outcomes recorded yet' with a link to the case-detail outcome capture",
+    ],
+    "EVDT-021": [
+        "Server action `exportPacketPdf(packetId): Promise<{filename, bytes}>` returns a downloadable PDF",
+        "Use a markdown -> PDF library (md-to-pdf, marked + puppeteer, or react-pdf) — keep it server-side; no browser deps in the client bundle",
+        "PDF preserves the full disclaimer header, caption, response paragraphs, defenses checklist (rendered as filled or empty boxes), signature block",
+        "Filename: `packet-{caseNumber}-{packetId}.pdf`",
+        "Download button on the EVDT-013 packet review page; only enabled when status >= approved",
+        "Audit-log every export via logAuditEvent (action: `response_packet.exported`)",
+        "PDF generation is deterministic for the same packet_md (no timestamps in the body beyond the disclaimer)",
+    ],
+    "EVDT-022": [
+        "**SLIM:** single-page handout / leave-behind, NOT a full manual",
+        "Lives at `docs/kla-demo-handout.md` (Markdown) — convert to PDF via the EVDT-021 pipeline or pandoc",
+        "1 page, 4 sections: (1) what the system does in 3 sentences, (2) the 5-step daily workflow with screenshots, (3) what's AI-drafted vs human-reviewed (the disclaimer story), (4) what we measure / what success looks like",
+        "Owner: Bo writes content; engineering provides the screenshots from staging once Sprint 5 ships",
+    ],
+    "DEMO-001": [
+        "(see issue body)",
+    ],
+    "ADMIN-001": [
+        "(see issue body)",
+    ],
+}
+
+
+def get_issue(story_id):
+    r = subprocess.run(
+        ["gh", "issue", "list", "--repo", REPO, "--state", "open",
+         "--search", f"{story_id} in:title", "--json", "number,title,body", "--limit", "5"],
+        check=True, capture_output=True, text=True,
+    )
+    issues = json.loads(r.stdout)
+    for i in issues:
+        if f"[{story_id}]" in i["title"]:
+            return i
+    return None
+
+
+def update_body(num, new_body):
+    subprocess.run(
+        ["gh", "issue", "edit", str(num), "--repo", REPO, "--body", new_body],
+        check=True, capture_output=True,
+    )
+
+
+def main():
+    for story_id, criteria in CRITERIA.items():
+        issue = get_issue(story_id)
+        if not issue:
+            print(f"  {story_id}: NOT FOUND")
+            continue
+        # DEMO-001 and ADMIN-001 already have full bodies; skip.
+        if criteria == ["(see issue body)"]:
+            print(f"  {story_id} (#{issue['number']}): kept (issue body has ACs)")
+            continue
+        body = issue["body"]
+        new_ac = "## Acceptance criteria\n\n" + \
+                 "\n".join(f"- [ ] {c}" for c in criteria) + \
+                 "\n- [ ] passes Definition of Done (see CLAUDE.md)\n"
+        if "## Acceptance criteria" in body:
+            new_body = re.sub(
+                r"## Acceptance criteria\n\n.*?(?=\n---|$)",
+                new_ac.rstrip() + "\n",
+                body,
+                flags=re.DOTALL,
+            )
+        else:
+            new_body = body.rstrip() + "\n\n" + new_ac
+        update_body(issue["number"], new_body)
+        print(f"  {story_id} (#{issue['number']}): {len(criteria)} criteria")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/app/actions/eviction.ts
+++ b/src/app/actions/eviction.ts
@@ -3,7 +3,6 @@
 import * as Sentry from '@sentry/nextjs';
 import { eq } from 'drizzle-orm';
 import { revalidatePath } from 'next/cache';
-import { RESPONSE_PACKET_DISCLAIMER_PREFIX } from '@/ai/prompts/eviction-response-packet';
 import { CaseFilingsRoles } from '@/components/eviction/case-filings-roles';
 import { db } from '@/db/client';
 import { getFilingById } from '@/db/queries/eviction-filings';
@@ -14,7 +13,7 @@ import {
 import { evictionResponsePackets } from '@/db/schema/eviction-response-packets';
 import { logAuditEvent } from '@/lib/audit';
 import { requireKlaAttorney, requireRole } from '@/lib/auth';
-import { generateResponsePacket } from '@/lib/eviction/response-packet';
+import { generateResponsePacket, validateDisclaimer } from '@/lib/eviction/response-packet';
 import { scoreFiling } from '@/lib/eviction/risk-score';
 
 export type ScoreFilingResult = { ok: true } | { ok: false; error: string };
@@ -64,17 +63,10 @@ export async function savePacketAction(
   if (packetMd.trim().length < 200) {
     return { ok: false, error: 'Packet must be at least 200 characters.' };
   }
-  // The disclaimer is non-negotiable — refuse to save a packet that has
-  // had it stripped or substantially edited away.
-  if (
-    !packetMd.includes(RESPONSE_PACKET_DISCLAIMER_PREFIX) ||
-    !packetMd.includes('not legal advice')
-  ) {
-    return {
-      ok: false,
-      error: 'Disclaimer block must be preserved verbatim — restore it before saving.',
-    };
-  }
+  // The disclaimer is non-negotiable — same fragments enforced post-
+  // generation in response-packet.ts. Single source of truth.
+  const dCheck = validateDisclaimer(packetMd, 'edit');
+  if (!dCheck.ok) return { ok: false, error: dCheck.error };
   await db
     .update(evictionResponsePackets)
     .set({ packetMd, updatedAt: new Date() })
@@ -87,6 +79,22 @@ export type ChangePacketStatusResult = { ok: true } | { ok: false; error: string
 
 const STATUSES: readonly EvictionResponsePacketStatus[] =
   evictionResponsePacketStatusEnum.enumValues;
+
+/**
+ * Allowed transitions per current status. Server-authoritative — don't
+ * trust the client's `disabled` rules. `filed` is terminal: once a
+ * packet has been filed in court, our DB shouldn't pretend it can be
+ * un-filed; correcting a misfile happens out-of-band.
+ */
+const ALLOWED_TRANSITIONS: Record<
+  EvictionResponsePacketStatus,
+  readonly EvictionResponsePacketStatus[]
+> = {
+  draft: ['approved', 'rejected'],
+  approved: ['filed', 'rejected', 'draft'],
+  filed: [],
+  rejected: ['draft'],
+};
 
 export async function changePacketStatusAction(
   packetId: string,
@@ -102,6 +110,13 @@ export async function changePacketStatusAction(
     .where(eq(evictionResponsePackets.id, packetId))
     .limit(1);
   if (!previous) return { ok: false, error: 'Packet not found.' };
+
+  if (!ALLOWED_TRANSITIONS[previous.status].includes(newStatus)) {
+    return {
+      ok: false,
+      error: `Status transition ${previous.status} → ${newStatus} is not allowed.`,
+    };
+  }
 
   await db
     .update(evictionResponsePackets)

--- a/src/app/actions/eviction.ts
+++ b/src/app/actions/eviction.ts
@@ -1,10 +1,20 @@
 'use server';
 
 import * as Sentry from '@sentry/nextjs';
+import { eq } from 'drizzle-orm';
 import { revalidatePath } from 'next/cache';
+import { RESPONSE_PACKET_DISCLAIMER_PREFIX } from '@/ai/prompts/eviction-response-packet';
 import { CaseFilingsRoles } from '@/components/eviction/case-filings-roles';
+import { db } from '@/db/client';
 import { getFilingById } from '@/db/queries/eviction-filings';
-import { requireRole } from '@/lib/auth';
+import {
+  type EvictionResponsePacketStatus,
+  evictionResponsePacketStatusEnum,
+} from '@/db/schema/enums';
+import { evictionResponsePackets } from '@/db/schema/eviction-response-packets';
+import { logAuditEvent } from '@/lib/audit';
+import { requireKlaAttorney, requireRole } from '@/lib/auth';
+import { generateResponsePacket } from '@/lib/eviction/response-packet';
 import { scoreFiling } from '@/lib/eviction/risk-score';
 
 export type ScoreFilingResult = { ok: true } | { ok: false; error: string };
@@ -23,5 +33,89 @@ export async function scoreFilingAction(filingId: string): Promise<ScoreFilingRe
   }
 
   revalidatePath(`/app/cases/filings/${filingId}`);
+  return { ok: true };
+}
+
+export type GeneratePacketResult = { ok: true } | { ok: false; error: string };
+
+export async function generatePacketAction(filingId: string): Promise<GeneratePacketResult> {
+  const user = await requireKlaAttorney();
+  const filing = await getFilingById(filingId);
+  if (!filing) return { ok: false, error: 'Filing not found.' };
+
+  try {
+    await generateResponsePacket(filing, user.id);
+  } catch (err) {
+    Sentry.captureException(err, { tags: { action: 'generatePacketAction', filingId } });
+    return { ok: false, error: 'Packet generation failed. Please try again.' };
+  }
+
+  revalidatePath(`/app/cases/filings/${filingId}/packet`);
+  return { ok: true };
+}
+
+export type SavePacketResult = { ok: true } | { ok: false; error: string };
+
+export async function savePacketAction(
+  packetId: string,
+  packetMd: string,
+): Promise<SavePacketResult> {
+  await requireKlaAttorney();
+  if (packetMd.trim().length < 200) {
+    return { ok: false, error: 'Packet must be at least 200 characters.' };
+  }
+  // The disclaimer is non-negotiable — refuse to save a packet that has
+  // had it stripped or substantially edited away.
+  if (
+    !packetMd.includes(RESPONSE_PACKET_DISCLAIMER_PREFIX) ||
+    !packetMd.includes('not legal advice')
+  ) {
+    return {
+      ok: false,
+      error: 'Disclaimer block must be preserved verbatim — restore it before saving.',
+    };
+  }
+  await db
+    .update(evictionResponsePackets)
+    .set({ packetMd, updatedAt: new Date() })
+    .where(eq(evictionResponsePackets.id, packetId));
+  revalidatePath('/app/cases/filings');
+  return { ok: true };
+}
+
+export type ChangePacketStatusResult = { ok: true } | { ok: false; error: string };
+
+const STATUSES: readonly EvictionResponsePacketStatus[] =
+  evictionResponsePacketStatusEnum.enumValues;
+
+export async function changePacketStatusAction(
+  packetId: string,
+  filingId: string,
+  newStatus: EvictionResponsePacketStatus,
+): Promise<ChangePacketStatusResult> {
+  const user = await requireKlaAttorney();
+  if (!STATUSES.includes(newStatus)) return { ok: false, error: 'Invalid status.' };
+
+  const [previous] = await db
+    .select({ status: evictionResponsePackets.status })
+    .from(evictionResponsePackets)
+    .where(eq(evictionResponsePackets.id, packetId))
+    .limit(1);
+  if (!previous) return { ok: false, error: 'Packet not found.' };
+
+  await db
+    .update(evictionResponsePackets)
+    .set({ status: newStatus, updatedAt: new Date() })
+    .where(eq(evictionResponsePackets.id, packetId));
+
+  await logAuditEvent({
+    actorUserId: user.id,
+    action: 'response_packet.status_changed',
+    targetTable: 'eviction_response_packets',
+    targetId: packetId,
+    metadata: { from: previous.status, to: newStatus, filingId },
+  });
+
+  revalidatePath(`/app/cases/filings/${filingId}/packet`);
   return { ok: true };
 }

--- a/src/app/app/cases/filings/[id]/packet/page.tsx
+++ b/src/app/app/cases/filings/[id]/packet/page.tsx
@@ -1,0 +1,37 @@
+import Link from 'next/link';
+import { notFound } from 'next/navigation';
+import { PacketReviewPanel } from '@/components/eviction/packet-review-panel';
+import { getFilingById } from '@/db/queries/eviction-filings';
+import { requireKlaAttorney } from '@/lib/auth';
+import { getResponsePacket } from '@/lib/eviction/response-packet';
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export default async function PacketPage({ params }: { params: Promise<{ id: string }> }) {
+  await requireKlaAttorney();
+  const { id } = await params;
+  if (!UUID_RE.test(id)) notFound();
+
+  const filing = await getFilingById(id);
+  if (!filing) notFound();
+
+  const packet = await getResponsePacket(filing.id);
+
+  return (
+    <div className="mx-auto max-w-4xl space-y-4 p-6">
+      <div className="text-xs">
+        <Link href={`/app/cases/filings/${id}`} className="text-muted-foreground hover:underline">
+          ← Back to case detail
+        </Link>
+      </div>
+      <header>
+        <h1 className="font-serif text-3xl font-bold text-primary">Response packet</h1>
+        <p className="text-sm text-muted-foreground">
+          Case <span className="font-mono">{filing.caseNumber}</span> · {filing.plaintiff} v.{' '}
+          {filing.defendantFirstName} {filing.defendantLastName}
+        </p>
+      </header>
+      <PacketReviewPanel filing={filing} packet={packet} />
+    </div>
+  );
+}

--- a/src/app/app/cases/filings/[id]/page.tsx
+++ b/src/app/app/cases/filings/[id]/page.tsx
@@ -28,6 +28,19 @@ export default async function FilingDetailPage({ params }: { params: Promise<{ i
         </Link>
       </div>
       <FilingDetail filing={filing} score={score} />
+      <div className="rounded-md border border-border bg-card p-4 text-sm">
+        <p className="mb-2 font-medium">Response packet</p>
+        <p className="mb-3 text-xs text-muted-foreground">
+          Draft, review, and approve the AI-generated Answer to Forcible Detainer Complaint (KLA
+          attorneys only).
+        </p>
+        <Link
+          href={`/app/cases/filings/${id}/packet`}
+          className="inline-flex h-9 items-center rounded-md bg-primary px-4 text-sm text-primary-foreground hover:bg-primary/90"
+        >
+          Open packet workspace →
+        </Link>
+      </div>
     </div>
   );
 }

--- a/src/components/eviction/packet-review-panel.tsx
+++ b/src/components/eviction/packet-review-panel.tsx
@@ -117,30 +117,48 @@ function HasPacket({ packet, filing }: { packet: EvictionResponsePacket; filing:
           </div>
         </CardHeader>
         <CardContent className="flex flex-wrap gap-2">
-          <Button
-            size="sm"
-            variant="outline"
-            disabled={pending || packet.status === 'approved'}
-            onClick={() => onChangeStatus('approved')}
-          >
-            Approve
-          </Button>
-          <Button
-            size="sm"
-            variant="outline"
-            disabled={pending || packet.status !== 'approved'}
-            onClick={() => onChangeStatus('filed')}
-          >
-            Mark filed
-          </Button>
-          <Button
-            size="sm"
-            variant="outline"
-            disabled={pending || packet.status === 'rejected'}
-            onClick={() => onChangeStatus('rejected')}
-          >
-            Reject
-          </Button>
+          {packet.status === 'filed' ? (
+            <p className="text-xs text-muted-foreground">
+              Packet has been filed in court — no further status changes from this UI.
+            </p>
+          ) : (
+            <>
+              <Button
+                size="sm"
+                variant="outline"
+                disabled={pending || packet.status !== 'draft'}
+                onClick={() => onChangeStatus('approved')}
+              >
+                Approve
+              </Button>
+              <Button
+                size="sm"
+                variant="outline"
+                disabled={pending || packet.status !== 'approved'}
+                onClick={() => onChangeStatus('filed')}
+              >
+                Mark filed
+              </Button>
+              <Button
+                size="sm"
+                variant="outline"
+                disabled={pending || packet.status === 'rejected'}
+                onClick={() => onChangeStatus('rejected')}
+              >
+                Reject
+              </Button>
+              {packet.status === 'rejected' ? (
+                <Button
+                  size="sm"
+                  variant="ghost"
+                  disabled={pending}
+                  onClick={() => onChangeStatus('draft')}
+                >
+                  Re-open as draft
+                </Button>
+              ) : null}
+            </>
+          )}
           {error ? <span className="text-destructive text-xs">{error}</span> : null}
         </CardContent>
       </Card>

--- a/src/components/eviction/packet-review-panel.tsx
+++ b/src/components/eviction/packet-review-panel.tsx
@@ -1,0 +1,200 @@
+'use client';
+
+import { useState, useTransition } from 'react';
+import ReactMarkdown from 'react-markdown';
+import {
+  changePacketStatusAction,
+  generatePacketAction,
+  savePacketAction,
+} from '@/app/actions/eviction';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import type { EvictionFiling } from '@/db/schema/eviction-filings';
+import type { EvictionResponsePacket } from '@/db/schema/eviction-response-packets';
+
+interface Props {
+  filing: EvictionFiling;
+  packet: EvictionResponsePacket | null;
+}
+
+const fmtDate = (d: Date) =>
+  new Intl.DateTimeFormat('en-US', { dateStyle: 'medium', timeStyle: 'short' }).format(new Date(d));
+
+const statusBadge: Record<EvictionResponsePacket['status'], string> = {
+  draft: 'bg-secondary text-secondary-foreground',
+  approved: 'bg-emerald-600/15 text-emerald-700 dark:text-emerald-400',
+  filed: 'bg-primary text-primary-foreground',
+  rejected: 'bg-destructive/15 text-destructive',
+};
+
+export function PacketReviewPanel({ filing, packet }: Props) {
+  if (!packet) return <NoPacket filing={filing} />;
+  return <HasPacket packet={packet} filing={filing} />;
+}
+
+function NoPacket({ filing }: { filing: EvictionFiling }) {
+  const [pending, startTransition] = useTransition();
+  const [error, setError] = useState<string | null>(null);
+
+  const onClick = () => {
+    setError(null);
+    startTransition(async () => {
+      const r = await generatePacketAction(filing.id);
+      if (!r.ok) setError(r.error);
+    });
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-base">No packet drafted yet</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-3 text-sm">
+        <p className="text-muted-foreground">
+          Generate an AI-drafted Answer to Forcible Detainer Complaint for this case. The draft will
+          need attorney review and edits before filing — review carefully.
+        </p>
+        <div className="flex items-center gap-3">
+          <Button onClick={onClick} disabled={pending}>
+            {pending ? 'Generating…' : 'Generate packet'}
+          </Button>
+          {error ? <span className="text-destructive text-xs">{error}</span> : null}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+function HasPacket({ packet, filing }: { packet: EvictionResponsePacket; filing: EvictionFiling }) {
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState(packet.packetMd);
+  const [saved, setSaved] = useState(packet.packetMd);
+  const [pending, startTransition] = useTransition();
+  const [error, setError] = useState<string | null>(null);
+  const [showDefendantWarn, setShowDefendantWarn] = useState(true);
+
+  const onSave = () => {
+    setError(null);
+    startTransition(async () => {
+      const r = await savePacketAction(packet.id, draft);
+      if (!r.ok) {
+        setError(r.error);
+        return;
+      }
+      setSaved(draft);
+      setEditing(false);
+    });
+  };
+
+  const onDiscard = () => {
+    setDraft(saved);
+    setEditing(false);
+    setError(null);
+  };
+
+  const onChangeStatus = (next: EvictionResponsePacket['status']) => {
+    setError(null);
+    startTransition(async () => {
+      const r = await changePacketStatusAction(packet.id, filing.id, next);
+      if (!r.ok) setError(r.error);
+    });
+  };
+
+  return (
+    <div className="space-y-4">
+      <Card>
+        <CardHeader>
+          <div className="flex items-center justify-between gap-3">
+            <div className="space-y-1">
+              <CardTitle className="text-base">Status</CardTitle>
+              <p className="text-xs text-muted-foreground">
+                Generated {fmtDate(packet.createdAt)} · Last updated {fmtDate(packet.updatedAt)}
+              </p>
+            </div>
+            <span className={`rounded px-2 py-1 text-xs font-medium ${statusBadge[packet.status]}`}>
+              {packet.status}
+            </span>
+          </div>
+        </CardHeader>
+        <CardContent className="flex flex-wrap gap-2">
+          <Button
+            size="sm"
+            variant="outline"
+            disabled={pending || packet.status === 'approved'}
+            onClick={() => onChangeStatus('approved')}
+          >
+            Approve
+          </Button>
+          <Button
+            size="sm"
+            variant="outline"
+            disabled={pending || packet.status !== 'approved'}
+            onClick={() => onChangeStatus('filed')}
+          >
+            Mark filed
+          </Button>
+          <Button
+            size="sm"
+            variant="outline"
+            disabled={pending || packet.status === 'rejected'}
+            onClick={() => onChangeStatus('rejected')}
+          >
+            Reject
+          </Button>
+          {error ? <span className="text-destructive text-xs">{error}</span> : null}
+        </CardContent>
+      </Card>
+
+      {showDefendantWarn ? (
+        <Card className="border-amber-500/40 bg-amber-500/5">
+          <CardContent className="flex items-start justify-between gap-3 pt-4 text-sm">
+            <p>
+              <strong>Heads up:</strong> this view shows the defendant's full name in the packet
+              caption ({filing.defendantFirstName} {filing.defendantLastName}). The case-detail and
+              queue views only show initials.
+            </p>
+            <Button variant="ghost" size="sm" onClick={() => setShowDefendantWarn(false)}>
+              Got it
+            </Button>
+          </CardContent>
+        </Card>
+      ) : null}
+
+      <Card>
+        <CardHeader>
+          <div className="flex items-center justify-between gap-3">
+            <CardTitle className="text-base">Packet</CardTitle>
+            {editing ? (
+              <div className="flex gap-2">
+                <Button size="sm" variant="ghost" disabled={pending} onClick={onDiscard}>
+                  Discard
+                </Button>
+                <Button size="sm" disabled={pending} onClick={onSave}>
+                  {pending ? 'Saving…' : 'Save'}
+                </Button>
+              </div>
+            ) : (
+              <Button size="sm" variant="outline" onClick={() => setEditing(true)}>
+                Edit
+              </Button>
+            )}
+          </div>
+        </CardHeader>
+        <CardContent>
+          {editing ? (
+            <textarea
+              value={draft}
+              onChange={(e) => setDraft(e.target.value)}
+              className="font-mono min-h-[40rem] w-full rounded-md border border-input bg-background p-3 text-sm"
+              spellCheck
+            />
+          ) : (
+            <div className="prose prose-sm dark:prose-invert max-w-none">
+              <ReactMarkdown>{saved}</ReactMarkdown>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/lib/eviction/response-packet.ts
+++ b/src/lib/eviction/response-packet.ts
@@ -48,6 +48,42 @@ function fillDisclaimer(packet: string, generatedAt: Date): string {
 }
 
 /**
+ * Single source of truth for the disclaimer-block contract. Used both
+ * after generation (placeholder form, before fill) and on attorney save
+ * (filled form). Pass `phase` so the right post-fill fragment is checked.
+ *
+ * Returns ok+error rather than throwing so server actions can surface
+ * the message to the user; the generator wraps in throw().
+ */
+export function validateDisclaimer(
+  packetMd: string,
+  phase: 'generation' | 'edit',
+): { ok: true } | { ok: false; error: string } {
+  const required = [
+    `${RESPONSE_PACKET_DISCLAIMER_PREFIX} REQUIRED BEFORE FILING.`,
+    'not legal advice',
+  ];
+  if (phase === 'generation') {
+    required.push('Generated {timestamp} model {model_version}.');
+  } else {
+    // After fillDisclaimer the placeholders are gone but the literal
+    // 'Generated ' + ' model ' anchors must remain so the attorney can
+    // see when/with-what the draft was produced.
+    required.push('Generated ');
+    required.push(' model ');
+  }
+  for (const fragment of required) {
+    if (!packetMd.includes(fragment)) {
+      return {
+        ok: false,
+        error: `Disclaimer missing required fragment: "${fragment.slice(0, 60)}${fragment.length > 60 ? '…' : ''}"`,
+      };
+    }
+  }
+  return { ok: true };
+}
+
+/**
  * Generate (or retrieve) the AI-drafted Answer for a filing. Idempotent:
  * (filing_id, prompt_version) pairs return the cached row instead of
  * re-calling Claude.
@@ -99,21 +135,9 @@ export async function generateResponsePacket(
   }
   const parsed: ResponsePacketOutput = response.parsed_output;
 
-  // Tighter than substring-prefix: require the full canonical disclaimer
-  // wording, both placeholders (so fillDisclaimer can substitute), and the
-  // attorney-review sentence. Catches malformed/abbreviated disclaimers
-  // that pass a loose prefix check.
-  const requiredDisclaimerFragments = [
-    `${RESPONSE_PACKET_DISCLAIMER_PREFIX} REQUIRED BEFORE FILING.`,
-    'Generated {timestamp} model {model_version}.',
-    'not legal advice',
-  ];
-  for (const fragment of requiredDisclaimerFragments) {
-    if (!parsed.packet_md.includes(fragment)) {
-      throw new Error(
-        `[response-packet] disclaimer missing required fragment: ${fragment.slice(0, 60)}…`,
-      );
-    }
+  const generationCheck = validateDisclaimer(parsed.packet_md, 'generation');
+  if (!generationCheck.ok) {
+    throw new Error(`[response-packet] ${generationCheck.error}`);
   }
 
   const filledPacket = fillDisclaimer(parsed.packet_md, new Date());


### PR DESCRIPTION
Closes #28

## Summary
Closes the demo dead-end. Response packets from EVDT-012 are no longer trapped in a DB row — KLA attorneys can now review, edit, change status, and (after EVDT-021) export.

- **New page** \`/app/cases/filings/[id]/packet\` gated by \`requireKlaAttorney()\`.
- **\`PacketReviewPanel\`** — \`NoPacket\` shows a \"Generate packet\" button; \`HasPacket\` renders the markdown, swaps to a textarea on edit, shows the status pill, and exposes Approve / Mark filed / Reject status transitions.
- **3 new server actions** in \`src/app/actions/eviction.ts\`:
  - \`generatePacketAction\` — KLA gate + EVDT-012 service call
  - \`savePacketAction\` — refuses edits that strip the disclaimer (must contain the AI-DRAFTED prefix AND 'not legal advice')
  - \`changePacketStatusAction\` — validates against the enum, audit-logs from→to with filing id
- **Case-detail page** now links to the packet workspace.
- **Sprint 5 ACs** seeded on the 6 existing eviction issues (script in \`scripts/seed-acceptance-criteria-sprint5.py\`).
- **New dep:** \`react-markdown@10\`.

## Acceptance criteria
- [x] New page \`/app/cases/filings/[id]/packet\` gated by \`requireKlaAttorney()\`
- [x] Loads via \`getResponsePacket\`; if none exists, \"Generate packet\" button calls EVDT-012
- [x] Markdown rendered to HTML (react-markdown)
- [x] Inline edit via textarea swap; save persists \`packet_md\` and bumps \`updated_at\`
- [x] Status transitions wired (Approve, Mark filed, Reject)
- [x] All status changes write \`audit_log\` via \`logAuditEvent\`
- [x] Disclaimer banner can't be edited away (save-action enforces)
- [x] Defendant full name visible with explicit warning banner

## Notes for review
- Save-action also enforces \`packet_md.length >= 200\` (matches the schema validation in EVDT-012).
- The defendant-warning banner is dismissable per session — once attorneys are familiar with the model, the warning becomes noise. Audit log captures who viewed when via the existing audit pattern.
- The textarea is intentionally minimal (no rich-text editor) per AC \"keep it simple, no rich text editor in v1\".

🤖 Generated with [Claude Code](https://claude.com/claude-code)