### PR TITLE
feat(ADMIN-001): admin user-management UI (promote-to-attorney)

### DIFF
--- a/src/app/actions/admin.ts
+++ b/src/app/actions/admin.ts
@@ -1,6 +1,6 @@
 'use server';
 
-import { eq } from 'drizzle-orm';
+import { count, eq } from 'drizzle-orm';
 import { revalidatePath } from 'next/cache';
 import { db } from '@/db/client';
 import { orgMemberships } from '@/db/schema/org-memberships';
@@ -41,17 +41,22 @@ export async function promoteToKlaAttorneyAction(
     };
   }
 
-  await db
-    .update(users)
-    .set({ role: 'attorney', updatedAt: new Date() })
-    .where(eq(users.id, target.id));
-
-  await db
-    .insert(orgMemberships)
-    .values({ userId: target.id, partnerOrgId: klaOrg.id, role: 'attorney' })
-    .onConflictDoNothing({
-      target: [orgMemberships.userId, orgMemberships.partnerOrgId],
-    });
+  // Wrap role-flip + membership in a transaction so an interrupted
+  // promote doesn't leave a user as `attorney` with no KLA membership.
+  // Re-running the action self-heals either way (idempotent), but the
+  // transaction closes the failure window without relying on retry.
+  await db.transaction(async (tx) => {
+    await tx
+      .update(users)
+      .set({ role: 'attorney', updatedAt: new Date() })
+      .where(eq(users.id, target.id));
+    await tx
+      .insert(orgMemberships)
+      .values({ userId: target.id, partnerOrgId: klaOrg.id, role: 'attorney' })
+      .onConflictDoNothing({
+        target: [orgMemberships.userId, orgMemberships.partnerOrgId],
+      });
+  });
 
   await logAuditEvent({
     actorUserId: actor.id,
@@ -81,6 +86,19 @@ export async function demoteUserAction(targetUserId: string): Promise<AdminUserA
   if (!target) return { ok: false, error: 'User not found.' };
   if (target.id === actor.id) {
     return { ok: false, error: 'You cannot demote yourself.' };
+  }
+
+  // Last-admin lockout: never let the admin role count drop to zero,
+  // even if the actor is somehow demoting another admin (only possible
+  // when there are >= 2 admins).
+  if (target.role === 'admin') {
+    const [{ value: adminCount }] = await db
+      .select({ value: count() })
+      .from(users)
+      .where(eq(users.role, 'admin'));
+    if (adminCount <= 1) {
+      return { ok: false, error: 'Cannot demote the last admin in the system.' };
+    }
   }
 
   await db

--- a/src/app/actions/admin.ts
+++ b/src/app/actions/admin.ts
@@ -1,0 +1,101 @@
+'use server';
+
+import { eq } from 'drizzle-orm';
+import { revalidatePath } from 'next/cache';
+import { db } from '@/db/client';
+import { orgMemberships } from '@/db/schema/org-memberships';
+import { partnerOrgs } from '@/db/schema/partner-orgs';
+import { users } from '@/db/schema/users';
+import { logAuditEvent } from '@/lib/audit';
+import { KLA_OWENSBORO_SLUG, requireRole } from '@/lib/auth';
+
+export type AdminUserActionResult = { ok: true } | { ok: false; error: string };
+
+/**
+ * Promote a user to KLA attorney: set role=attorney AND add membership
+ * in the kla-owensboro partner org. Both writes happen unconditionally
+ * so the action is also a self-heal — if the user is already an attorney
+ * but missing membership (or vice versa), they end up correct.
+ */
+export async function promoteToKlaAttorneyAction(
+  targetUserId: string,
+): Promise<AdminUserActionResult> {
+  const actor = await requireRole(['admin']);
+
+  const [target] = await db
+    .select({ id: users.id, email: users.email, role: users.role })
+    .from(users)
+    .where(eq(users.id, targetUserId))
+    .limit(1);
+  if (!target) return { ok: false, error: 'User not found.' };
+
+  const [klaOrg] = await db
+    .select({ id: partnerOrgs.id })
+    .from(partnerOrgs)
+    .where(eq(partnerOrgs.slug, KLA_OWENSBORO_SLUG))
+    .limit(1);
+  if (!klaOrg) {
+    return {
+      ok: false,
+      error: `Partner org '${KLA_OWENSBORO_SLUG}' not found — run pnpm db:seed.`,
+    };
+  }
+
+  await db
+    .update(users)
+    .set({ role: 'attorney', updatedAt: new Date() })
+    .where(eq(users.id, target.id));
+
+  await db
+    .insert(orgMemberships)
+    .values({ userId: target.id, partnerOrgId: klaOrg.id, role: 'attorney' })
+    .onConflictDoNothing({
+      target: [orgMemberships.userId, orgMemberships.partnerOrgId],
+    });
+
+  await logAuditEvent({
+    actorUserId: actor.id,
+    action: 'user.promoted_to_kla_attorney',
+    targetTable: 'users',
+    targetId: target.id,
+    metadata: { previousRole: target.role, targetEmail: target.email },
+  });
+
+  revalidatePath('/app/admin/users');
+  return { ok: true };
+}
+
+/**
+ * Demote a user back to 'pending'. Membership rows are left in place
+ * for audit; the role check is what gates access. Re-promotion via
+ * promoteToKlaAttorneyAction will hit the unique index and no-op.
+ */
+export async function demoteUserAction(targetUserId: string): Promise<AdminUserActionResult> {
+  const actor = await requireRole(['admin']);
+
+  const [target] = await db
+    .select({ id: users.id, email: users.email, role: users.role })
+    .from(users)
+    .where(eq(users.id, targetUserId))
+    .limit(1);
+  if (!target) return { ok: false, error: 'User not found.' };
+  if (target.id === actor.id) {
+    return { ok: false, error: 'You cannot demote yourself.' };
+  }
+
+  await db
+    .update(users)
+    .set({ role: 'pending', updatedAt: new Date() })
+    .where(eq(users.id, target.id));
+
+  await logAuditEvent({
+    actorUserId: actor.id,
+    action: 'user.demoted',
+    targetTable: 'users',
+    targetId: target.id,
+    metadata: { previousRole: target.role, targetEmail: target.email },
+  });
+
+  revalidatePath('/app/admin/users');
+  return { ok: true };
+}

--- a/src/app/app/admin/users/page.tsx
+++ b/src/app/app/admin/users/page.tsx
@@ -1,0 +1,21 @@
+import { UsersTable } from '@/components/admin/users-table';
+import { listUsersForAdmin } from '@/db/queries/users';
+import { requireRole } from '@/lib/auth';
+
+export default async function AdminUsersPage() {
+  const me = await requireRole(['admin']);
+  const rows = await listUsersForAdmin();
+
+  return (
+    <div className="mx-auto max-w-6xl space-y-4 p-6">
+      <header>
+        <h1 className="font-serif text-3xl font-bold text-primary">Users</h1>
+        <p className="text-sm text-muted-foreground">
+          Promote a user to KLA attorney (sets role + adds membership in one step) or demote back to
+          pending. Every change is recorded in the audit log.
+        </p>
+      </header>
+      <UsersTable rows={rows} currentUserId={me.id} />
+    </div>
+  );
+}

--- a/src/components/admin/users-table.tsx
+++ b/src/components/admin/users-table.tsx
@@ -1,0 +1,121 @@
+'use client';
+
+import { useState, useTransition } from 'react';
+import { demoteUserAction, promoteToKlaAttorneyAction } from '@/app/actions/admin';
+import { Button } from '@/components/ui/button';
+import type { UserAdminRow } from '@/db/queries/users';
+
+const fmtDate = (d: Date) =>
+  new Intl.DateTimeFormat('en-US', { dateStyle: 'medium' }).format(new Date(d));
+
+const roleBadge: Record<string, string> = {
+  pending: 'bg-muted text-muted-foreground',
+  attorney: 'bg-primary text-primary-foreground',
+  caseworker: 'bg-secondary text-secondary-foreground',
+  ed_coordinator: 'bg-secondary text-secondary-foreground',
+  shelter_staff: 'bg-secondary text-secondary-foreground',
+  admin: 'bg-emerald-600/15 text-emerald-700 dark:text-emerald-400',
+};
+
+export function UsersTable({
+  rows,
+  currentUserId,
+}: {
+  rows: UserAdminRow[];
+  currentUserId: string;
+}) {
+  const [pending, startTransition] = useTransition();
+  const [error, setError] = useState<string | null>(null);
+
+  const onPromote = (id: string) => {
+    setError(null);
+    startTransition(async () => {
+      const r = await promoteToKlaAttorneyAction(id);
+      if (!r.ok) setError(r.error);
+    });
+  };
+
+  const onDemote = (id: string) => {
+    setError(null);
+    startTransition(async () => {
+      const r = await demoteUserAction(id);
+      if (!r.ok) setError(r.error);
+    });
+  };
+
+  return (
+    <div className="space-y-2">
+      {error ? <p className="text-destructive text-sm">{error}</p> : null}
+      <div className="overflow-x-auto rounded-md border border-border">
+        <table className="w-full text-sm">
+          <thead className="bg-muted/40 text-left text-xs uppercase tracking-wide text-muted-foreground">
+            <tr>
+              <th className="px-3 py-2">Email</th>
+              <th className="px-3 py-2">Name</th>
+              <th className="px-3 py-2">Role</th>
+              <th className="px-3 py-2">KLA member</th>
+              <th className="px-3 py-2">Created</th>
+              <th className="px-3 py-2 text-right">Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map(({ user, isKlaMember }) => {
+              const isSelf = user.id === currentUserId;
+              const canPromote = !(user.role === 'attorney' && isKlaMember);
+              const canDemote = user.role !== 'pending' && !isSelf;
+              return (
+                <tr key={user.id} className="border-t border-border align-top">
+                  <td className="px-3 py-2 font-mono text-xs">{user.email}</td>
+                  <td className="px-3 py-2">
+                    {[user.firstName, user.lastName].filter(Boolean).join(' ') || (
+                      <span className="text-muted-foreground">—</span>
+                    )}
+                  </td>
+                  <td className="px-3 py-2">
+                    <span
+                      className={`rounded px-2 py-0.5 text-xs ${roleBadge[user.role] ?? 'bg-muted'}`}
+                    >
+                      {user.role}
+                    </span>
+                  </td>
+                  <td className="px-3 py-2">
+                    {isKlaMember ? (
+                      <span className="text-emerald-600 dark:text-emerald-400">✓</span>
+                    ) : (
+                      <span className="text-muted-foreground">—</span>
+                    )}
+                  </td>
+                  <td className="px-3 py-2 whitespace-nowrap text-xs text-muted-foreground">
+                    {fmtDate(user.createdAt)}
+                  </td>
+                  <td className="px-3 py-2">
+                    <div className="flex justify-end gap-2">
+                      <Button
+                        size="sm"
+                        variant="outline"
+                        disabled={pending || !canPromote}
+                        onClick={() => onPromote(user.id)}
+                        title={canPromote ? 'Promote to KLA attorney' : 'Already KLA attorney'}
+                      >
+                        Promote
+                      </Button>
+                      <Button
+                        size="sm"
+                        variant="ghost"
+                        disabled={pending || !canDemote}
+                        onClick={() => onDemote(user.id)}
+                        title={isSelf ? "Can't demote yourself" : 'Demote to pending'}
+                      >
+                        Demote
+                      </Button>
+                    </div>
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/src/components/app-shell/nav-config.ts
+++ b/src/components/app-shell/nav-config.ts
@@ -36,6 +36,7 @@ export const NAV_ITEMS: NavItem[] = [
     roles: ['caseworker', 'ed_coordinator', 'shelter_staff', 'admin'],
   },
   { label: 'Settings', href: '/app/settings', roles: 'all' },
+  { label: 'Admin · Users', href: '/app/admin/users', roles: ['admin'] },
 ];
 
 export function navItemsForRole(role: UserRole): NavItem[] {

--- a/src/db/queries/users.ts
+++ b/src/db/queries/users.ts
@@ -1,4 +1,4 @@
-import { and, eq } from 'drizzle-orm';
+import { and, asc, eq, sql } from 'drizzle-orm';
 import { db } from '@/db/client';
 import { KLA_OWENSBORO_SLUG } from '@/lib/auth';
 import { orgMemberships } from '../schema/org-memberships';
@@ -26,4 +26,31 @@ export async function listKlaAttorneys(): Promise<User[]> {
     .innerJoin(orgMemberships, eq(orgMemberships.userId, users.id))
     .innerJoin(partnerOrgs, eq(orgMemberships.partnerOrgId, partnerOrgs.id))
     .where(and(eq(users.role, 'attorney'), eq(partnerOrgs.slug, KLA_OWENSBORO_SLUG)));
+}
+
+export interface UserAdminRow {
+  user: User;
+  isKlaMember: boolean;
+}
+
+/**
+ * Every user in the system, with a flag for KLA membership. Used by the
+ * admin user-management surface (ADMIN-001). Sorted by created_at DESC
+ * so newly-signed-up users appear first.
+ */
+export async function listUsersForAdmin(): Promise<UserAdminRow[]> {
+  // LEFT JOIN to a derived KLA membership existence so we get one row
+  // per user even for users without any membership rows.
+  const rows = await db
+    .select({
+      user: users,
+      isKlaMember: sql<boolean>`bool_or(${partnerOrgs.slug} = ${KLA_OWENSBORO_SLUG})`,
+    })
+    .from(users)
+    .leftJoin(orgMemberships, eq(orgMemberships.userId, users.id))
+    .leftJoin(partnerOrgs, eq(orgMemberships.partnerOrgId, partnerOrgs.id))
+    .groupBy(users.id)
+    .orderBy(asc(users.createdAt));
+
+  return rows.map((r) => ({ user: r.user, isKlaMember: Boolean(r.isKlaMember) }));
 }


### PR DESCRIPTION
Closes #230

## Summary
Replaces \"SSH into Supabase mid-demo\" with a real surface. New page \`/app/admin/users\` gated by \`requireRole(['admin'])\`, lists every user with role + KLA membership flag, per-row Promote / Demote.

- **\`listUsersForAdmin()\`** — LEFT JOIN \`org_memberships\` + \`partner_orgs\`, GROUP BY \`users.id\` with \`bool_or(slug = kla-owensboro)\` so we get one row per user with a clean \`isKlaMember\` boolean.
- **\`promoteToKlaAttorneyAction\`** — admin gate → set \`role=attorney\` + insert KLA membership (onConflictDoNothing). Self-heal: works even if the user was already attorney without membership or vice versa. Audit-logged with \`previousRole\` + \`targetEmail\`.
- **\`demoteUserAction\`** — sets role back to \`pending\`. **Refuses to demote yourself** (admin lockout protection). Membership rows are left in place for audit; the role check is what gates access. Audit-logged.
- **\`UsersTable\`** client component: per-row buttons disabled appropriately (Promote off when already KLA attorney; Demote off for self or for already-pending users). Color-coded role badges.
- **Sidebar:** new \"Admin · Users\" item, role: \`['admin']\`.

## Acceptance criteria
- [x] New page \`/app/admin/users\` gated by \`requireRole(['admin'])\`
- [x] Lists all users with current role + KLA membership status
- [x] Per-row 'Promote to KLA attorney' button — server action sets role + inserts membership in one operation
- [x] Per-row 'Demote' button — sets role back to 'pending', leaves membership rows alone (audit trail)
- [x] Sidebar nav: 'Admin · Users' item, role: \`['admin']\`
- [x] Audit-log every promotion/demotion via existing \`logAuditEvent\`
- [x] \`pnpm build\` clean

## Notes for review
- Self-demote protection is server-side (\`target.id === actor.id\` check) AND client-side (Demote button disabled when row is current user). Both layers because client-only would be trivially bypassable.
- Promote is intentionally Promote-to-KLA-attorney specifically. We don't have multi-org membership UI yet (Phase-1 single-legal-aid-partner assumption per docs/access-control.md). When a second legal-aid org joins, this page generalizes to a partner-org dropdown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)