### PR TITLE
feat(EVDT-017): closed-loop case outcome tracking

### DIFF
--- a/drizzle/migrations/0009_nebulous_peter_quill.sql
+++ b/drizzle/migrations/0009_nebulous_peter_quill.sql
@@ -1,0 +1,15 @@
+CREATE TYPE "public"."eviction_case_outcome" AS ENUM('dismissed', 'judgment_for_plaintiff', 'judgment_for_defendant', 'settled', 'default_judgment', 'withdrawn');--> statement-breakpoint
+CREATE TABLE "eviction_case_outcomes" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"filing_id" uuid NOT NULL,
+	"outcome" "eviction_case_outcome" NOT NULL,
+	"notes" text,
+	"recorded_by_user_id" uuid,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "eviction_case_outcomes" ADD CONSTRAINT "eviction_case_outcomes_filing_id_eviction_filings_id_fk" FOREIGN KEY ("filing_id") REFERENCES "public"."eviction_filings"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "eviction_case_outcomes" ADD CONSTRAINT "eviction_case_outcomes_recorded_by_user_id_users_id_fk" FOREIGN KEY ("recorded_by_user_id") REFERENCES "public"."users"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "case_outcomes_filing_idx" ON "eviction_case_outcomes" USING btree ("filing_id");--> statement-breakpoint
+CREATE INDEX "case_outcomes_outcome_idx" ON "eviction_case_outcomes" USING btree ("outcome");--> statement-breakpoint
+CREATE INDEX "case_outcomes_created_at_idx" ON "eviction_case_outcomes" USING btree ("created_at");

--- a/drizzle/migrations/meta/0009_snapshot.json
+++ b/drizzle/migrations/meta/0009_snapshot.json
@@ -1,0 +1,1201 @@
+{
+  "id": "0bfccc81-2a8b-4521-a964-89b48c2dd58a",
+  "prevId": "1eb449a0-82e8-4489-b800-8319fbc4044f",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.audit_log": {
+      "name": "audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_table": {
+          "name": "target_table",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "audit_log_actor_idx": {
+          "name": "audit_log_actor_idx",
+          "columns": [
+            {
+              "expression": "actor_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_log_action_idx": {
+          "name": "audit_log_action_idx",
+          "columns": [
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_log_created_at_idx": {
+          "name": "audit_log_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audit_log_actor_user_id_users_id_fk": {
+          "name": "audit_log_actor_user_id_users_id_fk",
+          "tableFrom": "audit_log",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.consents": {
+      "name": "consents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "subject_external_id": {
+          "name": "subject_external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consent_type": {
+          "name": "consent_type",
+          "type": "consent_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "granted_via": {
+          "name": "granted_via",
+          "type": "consent_channel",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "granted_at": {
+          "name": "granted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "consents_subject_idx": {
+          "name": "consents_subject_idx",
+          "columns": [
+            {
+              "expression": "subject_external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "consents_type_idx": {
+          "name": "consents_type_idx",
+          "columns": [
+            {
+              "expression": "consent_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.eviction_case_outcomes": {
+      "name": "eviction_case_outcomes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "filing_id": {
+          "name": "filing_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "eviction_case_outcome",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recorded_by_user_id": {
+          "name": "recorded_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "case_outcomes_filing_idx": {
+          "name": "case_outcomes_filing_idx",
+          "columns": [
+            {
+              "expression": "filing_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "case_outcomes_outcome_idx": {
+          "name": "case_outcomes_outcome_idx",
+          "columns": [
+            {
+              "expression": "outcome",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "case_outcomes_created_at_idx": {
+          "name": "case_outcomes_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "eviction_case_outcomes_filing_id_eviction_filings_id_fk": {
+          "name": "eviction_case_outcomes_filing_id_eviction_filings_id_fk",
+          "tableFrom": "eviction_case_outcomes",
+          "tableTo": "eviction_filings",
+          "columnsFrom": [
+            "filing_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "eviction_case_outcomes_recorded_by_user_id_users_id_fk": {
+          "name": "eviction_case_outcomes_recorded_by_user_id_users_id_fk",
+          "tableFrom": "eviction_case_outcomes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "recorded_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.eviction_filing_risk_scores": {
+      "name": "eviction_filing_risk_scores",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "filing_id": {
+          "name": "filing_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rationale": {
+          "name": "rationale",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model_version": {
+          "name": "model_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "risk_scores_filing_version_idx": {
+          "name": "risk_scores_filing_version_idx",
+          "columns": [
+            {
+              "expression": "filing_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "model_version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "risk_scores_filing_idx": {
+          "name": "risk_scores_filing_idx",
+          "columns": [
+            {
+              "expression": "filing_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "risk_scores_score_idx": {
+          "name": "risk_scores_score_idx",
+          "columns": [
+            {
+              "expression": "score",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "eviction_filing_risk_scores_filing_id_eviction_filings_id_fk": {
+          "name": "eviction_filing_risk_scores_filing_id_eviction_filings_id_fk",
+          "tableFrom": "eviction_filing_risk_scores",
+          "tableTo": "eviction_filings",
+          "columnsFrom": [
+            "filing_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.eviction_filings": {
+      "name": "eviction_filings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "case_number": {
+          "name": "case_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filed_at": {
+          "name": "filed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "court_division": {
+          "name": "court_division",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plaintiff": {
+          "name": "plaintiff",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "defendant_first_name": {
+          "name": "defendant_first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "defendant_last_name": {
+          "name": "defendant_last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "defendant_address": {
+          "name": "defendant_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cause_type": {
+          "name": "cause_type",
+          "type": "eviction_cause_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_claimed_cents": {
+          "name": "amount_claimed_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "eviction_filing_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'filed'"
+        },
+        "source": {
+          "name": "source",
+          "type": "eviction_filing_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "raw_json": {
+          "name": "raw_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "eviction_filings_case_source_idx": {
+          "name": "eviction_filings_case_source_idx",
+          "columns": [
+            {
+              "expression": "case_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "eviction_filings_filed_at_idx": {
+          "name": "eviction_filings_filed_at_idx",
+          "columns": [
+            {
+              "expression": "filed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "eviction_filings_status_idx": {
+          "name": "eviction_filings_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.eviction_response_packets": {
+      "name": "eviction_response_packets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "filing_id": {
+          "name": "filing_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "packet_md": {
+          "name": "packet_md",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt_version": {
+          "name": "prompt_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "generated_by_user_id": {
+          "name": "generated_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "eviction_response_packet_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "response_packets_filing_version_idx": {
+          "name": "response_packets_filing_version_idx",
+          "columns": [
+            {
+              "expression": "filing_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "prompt_version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "response_packets_filing_idx": {
+          "name": "response_packets_filing_idx",
+          "columns": [
+            {
+              "expression": "filing_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "response_packets_status_idx": {
+          "name": "response_packets_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "eviction_response_packets_filing_id_eviction_filings_id_fk": {
+          "name": "eviction_response_packets_filing_id_eviction_filings_id_fk",
+          "tableFrom": "eviction_response_packets",
+          "tableTo": "eviction_filings",
+          "columnsFrom": [
+            "filing_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "eviction_response_packets_generated_by_user_id_users_id_fk": {
+          "name": "eviction_response_packets_generated_by_user_id_users_id_fk",
+          "tableFrom": "eviction_response_packets",
+          "tableTo": "users",
+          "columnsFrom": [
+            "generated_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.health_check": {
+      "name": "health_check",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_memberships": {
+      "name": "org_memberships",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "partner_org_id": {
+          "name": "partner_org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "org_memberships_user_org_idx": {
+          "name": "org_memberships_user_org_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "partner_org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "org_memberships_user_idx": {
+          "name": "org_memberships_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "org_memberships_partner_org_idx": {
+          "name": "org_memberships_partner_org_idx",
+          "columns": [
+            {
+              "expression": "partner_org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "org_memberships_user_id_users_id_fk": {
+          "name": "org_memberships_user_id_users_id_fk",
+          "tableFrom": "org_memberships",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "org_memberships_partner_org_id_partner_orgs_id_fk": {
+          "name": "org_memberships_partner_org_id_partner_orgs_id_fk",
+          "tableFrom": "org_memberships",
+          "tableTo": "partner_orgs",
+          "columnsFrom": [
+            "partner_org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.partner_orgs": {
+      "name": "partner_orgs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "partner_org_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_email": {
+          "name": "contact_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_phone": {
+          "name": "contact_phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "partner_orgs_slug_idx": {
+          "name": "partner_orgs_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "clerk_user_id": {
+          "name": "clerk_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "users_clerk_user_id_idx": {
+          "name": "users_clerk_user_id_idx",
+          "columns": [
+            {
+              "expression": "clerk_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.consent_channel": {
+      "name": "consent_channel",
+      "schema": "public",
+      "values": [
+        "sms",
+        "in_person",
+        "web_form",
+        "phone",
+        "paper"
+      ]
+    },
+    "public.consent_type": {
+      "name": "consent_type",
+      "schema": "public",
+      "values": [
+        "phi_share_within_coalition",
+        "sms_communication",
+        "data_for_program_eval"
+      ]
+    },
+    "public.eviction_case_outcome": {
+      "name": "eviction_case_outcome",
+      "schema": "public",
+      "values": [
+        "dismissed",
+        "judgment_for_plaintiff",
+        "judgment_for_defendant",
+        "settled",
+        "default_judgment",
+        "withdrawn"
+      ]
+    },
+    "public.eviction_cause_type": {
+      "name": "eviction_cause_type",
+      "schema": "public",
+      "values": [
+        "non_payment",
+        "lease_violation",
+        "holdover",
+        "other"
+      ]
+    },
+    "public.eviction_filing_source": {
+      "name": "eviction_filing_source",
+      "schema": "public",
+      "values": [
+        "courtnet",
+        "manual",
+        "synthetic"
+      ]
+    },
+    "public.eviction_filing_status": {
+      "name": "eviction_filing_status",
+      "schema": "public",
+      "values": [
+        "filed",
+        "served",
+        "judgment",
+        "dismissed",
+        "sealed"
+      ]
+    },
+    "public.eviction_response_packet_status": {
+      "name": "eviction_response_packet_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "approved",
+        "filed",
+        "rejected"
+      ]
+    },
+    "public.partner_org_type": {
+      "name": "partner_org_type",
+      "schema": "public",
+      "values": [
+        "hospital",
+        "legal_aid",
+        "shelter",
+        "community_org",
+        "government",
+        "other"
+      ]
+    },
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "pending",
+        "attorney",
+        "caseworker",
+        "ed_coordinator",
+        "shelter_staff",
+        "admin"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/migrations/meta/_journal.json
+++ b/drizzle/migrations/meta/_journal.json
@@ -64,6 +64,13 @@
       "when": 1777176000000,
       "tag": "0008_audit_log_append_only",
       "breakpoints": true
+    },
+    {
+      "idx": 9,
+      "version": "7",
+      "when": 1777176959605,
+      "tag": "0009_nebulous_peter_quill",
+      "breakpoints": true
     }
   ]
 }

--- a/src/app/actions/eviction.ts
+++ b/src/app/actions/eviction.ts
@@ -197,6 +197,9 @@ export async function recordCaseOutcomeAction(
   if (!filing) return { ok: false, error: 'Filing not found.' };
 
   const trimmed = notes?.trim();
+  if (trimmed && trimmed.length > 4000) {
+    return { ok: false, error: 'Notes too long (max 4000 characters).' };
+  }
   const [row] = await db
     .insert(evictionCaseOutcomes)
     .values({

--- a/src/app/actions/eviction.ts
+++ b/src/app/actions/eviction.ts
@@ -7,9 +7,12 @@ import { CaseFilingsRoles } from '@/components/eviction/case-filings-roles';
 import { db } from '@/db/client';
 import { getFilingById } from '@/db/queries/eviction-filings';
 import {
+  type EvictionCaseOutcome,
   type EvictionResponsePacketStatus,
+  evictionCaseOutcomeEnum,
   evictionResponsePacketStatusEnum,
 } from '@/db/schema/enums';
+import { evictionCaseOutcomes } from '@/db/schema/eviction-case-outcomes';
 import { evictionResponsePackets } from '@/db/schema/eviction-response-packets';
 import { logAuditEvent } from '@/lib/audit';
 import { requireKlaAttorney, requireRole } from '@/lib/auth';
@@ -176,4 +179,42 @@ export async function exportPacketPdfAction(packetId: string): Promise<ExportPac
     filename: `packet-${safeCase}-${packet.id.slice(0, 8)}.pdf`,
     base64: bytes.toString('base64'),
   };
+}
+
+export type RecordCaseOutcomeResult = { ok: true } | { ok: false; error: string };
+
+const OUTCOMES: readonly EvictionCaseOutcome[] = evictionCaseOutcomeEnum.enumValues;
+
+export async function recordCaseOutcomeAction(
+  filingId: string,
+  outcome: EvictionCaseOutcome,
+  notes?: string,
+): Promise<RecordCaseOutcomeResult> {
+  const user = await requireKlaAttorney();
+  if (!OUTCOMES.includes(outcome)) return { ok: false, error: 'Invalid outcome.' };
+
+  const filing = await getFilingById(filingId);
+  if (!filing) return { ok: false, error: 'Filing not found.' };
+
+  const trimmed = notes?.trim();
+  const [row] = await db
+    .insert(evictionCaseOutcomes)
+    .values({
+      filingId,
+      outcome,
+      notes: trimmed && trimmed.length > 0 ? trimmed : null,
+      recordedByUserId: user.id,
+    })
+    .returning();
+
+  await logAuditEvent({
+    actorUserId: user.id,
+    action: 'case.outcome_recorded',
+    targetTable: 'eviction_case_outcomes',
+    targetId: row.id,
+    metadata: { filingId, outcome, hasNotes: Boolean(trimmed) },
+  });
+
+  revalidatePath(`/app/cases/filings/${filingId}`);
+  return { ok: true };
 }

--- a/src/app/app/cases/filings/[id]/page.tsx
+++ b/src/app/app/cases/filings/[id]/page.tsx
@@ -1,15 +1,17 @@
 import Link from 'next/link';
 import { notFound } from 'next/navigation';
 import { CaseFilingsRoles } from '@/components/eviction/case-filings-roles';
+import { CaseOutcomePanel } from '@/components/eviction/case-outcome-panel';
 import { FilingDetail } from '@/components/eviction/filing-detail';
+import { listCaseOutcomes } from '@/db/queries/eviction-case-outcomes';
 import { getFilingById } from '@/db/queries/eviction-filings';
-import { requireRole } from '@/lib/auth';
+import { requireRole, userIsKlaAttorney } from '@/lib/auth';
 import { getLatestScore } from '@/lib/eviction/risk-score';
 
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
 export default async function FilingDetailPage({ params }: { params: Promise<{ id: string }> }) {
-  await requireRole(CaseFilingsRoles);
+  const me = await requireRole(CaseFilingsRoles);
   const { id } = await params;
 
   // Cheap shape check before hitting the DB — pg would 22P02 on a malformed UUID
@@ -18,7 +20,11 @@ export default async function FilingDetailPage({ params }: { params: Promise<{ i
   const filing = await getFilingById(id);
   if (!filing) notFound();
 
-  const score = await getLatestScore(filing.id);
+  const [score, outcomes, canRecord] = await Promise.all([
+    getLatestScore(filing.id),
+    listCaseOutcomes(filing.id),
+    userIsKlaAttorney(me),
+  ]);
 
   return (
     <div className="mx-auto max-w-4xl p-6 space-y-4">
@@ -41,6 +47,7 @@ export default async function FilingDetailPage({ params }: { params: Promise<{ i
           Open packet workspace →
         </Link>
       </div>
+      <CaseOutcomePanel filingId={filing.id} history={outcomes} canRecord={canRecord} />
     </div>
   );
 }

--- a/src/components/eviction/case-outcome-panel.tsx
+++ b/src/components/eviction/case-outcome-panel.tsx
@@ -1,0 +1,136 @@
+'use client';
+
+import { useState, useTransition } from 'react';
+import { recordCaseOutcomeAction } from '@/app/actions/eviction';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import type { CaseOutcomeWithActor } from '@/db/queries/eviction-case-outcomes';
+import type { EvictionCaseOutcome } from '@/db/schema/enums';
+
+const OUTCOMES: Array<{ value: EvictionCaseOutcome; label: string }> = [
+  { value: 'dismissed', label: 'Dismissed' },
+  { value: 'judgment_for_plaintiff', label: 'Judgment for plaintiff' },
+  { value: 'judgment_for_defendant', label: 'Judgment for defendant' },
+  { value: 'settled', label: 'Settled' },
+  { value: 'default_judgment', label: 'Default judgment' },
+  { value: 'withdrawn', label: 'Withdrawn' },
+];
+
+const outcomeLabel = (v: EvictionCaseOutcome): string =>
+  OUTCOMES.find((o) => o.value === v)?.label ?? v;
+
+const outcomeBadge: Record<EvictionCaseOutcome, string> = {
+  dismissed: 'bg-emerald-600/15 text-emerald-700 dark:text-emerald-400',
+  judgment_for_defendant: 'bg-emerald-600/15 text-emerald-700 dark:text-emerald-400',
+  settled: 'bg-secondary text-secondary-foreground',
+  withdrawn: 'bg-secondary text-secondary-foreground',
+  judgment_for_plaintiff: 'bg-destructive/15 text-destructive',
+  default_judgment: 'bg-destructive/15 text-destructive',
+};
+
+const fmtDate = (d: Date) =>
+  new Intl.DateTimeFormat('en-US', { dateStyle: 'medium', timeStyle: 'short' }).format(new Date(d));
+
+export function CaseOutcomePanel({
+  filingId,
+  history,
+  canRecord,
+}: {
+  filingId: string;
+  history: CaseOutcomeWithActor[];
+  canRecord: boolean;
+}) {
+  const [outcome, setOutcome] = useState<EvictionCaseOutcome>('settled');
+  const [notes, setNotes] = useState('');
+  const [pending, startTransition] = useTransition();
+  const [error, setError] = useState<string | null>(null);
+
+  const onSubmit = () => {
+    setError(null);
+    startTransition(async () => {
+      const r = await recordCaseOutcomeAction(filingId, outcome, notes);
+      if (!r.ok) {
+        setError(r.error);
+        return;
+      }
+      setNotes('');
+    });
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-base">Case outcomes</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4 text-sm">
+        {canRecord ? (
+          <div className="rounded-md border border-border bg-muted/30 p-3">
+            <p className="mb-2 text-xs font-medium uppercase tracking-wide text-muted-foreground">
+              Record outcome
+            </p>
+            <div className="flex flex-wrap items-end gap-2">
+              <label className="flex flex-col gap-1">
+                <span className="text-xs text-muted-foreground">Outcome</span>
+                <select
+                  value={outcome}
+                  onChange={(e) => setOutcome(e.target.value as EvictionCaseOutcome)}
+                  className="h-9 rounded-md border border-input bg-background px-3 text-sm"
+                >
+                  {OUTCOMES.map((o) => (
+                    <option key={o.value} value={o.value}>
+                      {o.label}
+                    </option>
+                  ))}
+                </select>
+              </label>
+              <label className="flex flex-1 flex-col gap-1">
+                <span className="text-xs text-muted-foreground">Notes (optional)</span>
+                <input
+                  type="text"
+                  value={notes}
+                  onChange={(e) => setNotes(e.target.value)}
+                  placeholder="Settlement terms, hearing notes…"
+                  className="h-9 rounded-md border border-input bg-background px-3 text-sm"
+                />
+              </label>
+              <Button size="sm" disabled={pending} onClick={onSubmit}>
+                {pending ? 'Recording…' : 'Record'}
+              </Button>
+            </div>
+            {error ? <p className="mt-2 text-xs text-destructive">{error}</p> : null}
+          </div>
+        ) : null}
+
+        {history.length === 0 ? (
+          <p className="text-muted-foreground">
+            No outcomes recorded yet. {canRecord ? null : 'Only KLA attorneys can record outcomes.'}
+          </p>
+        ) : (
+          <ul className="space-y-2">
+            {history.map((row) => (
+              <li
+                key={row.outcome.id}
+                className="rounded-md border border-border bg-card p-3 text-sm"
+              >
+                <div className="mb-1 flex items-center justify-between gap-2">
+                  <span
+                    className={`rounded px-2 py-0.5 text-xs font-medium ${outcomeBadge[row.outcome.outcome]}`}
+                  >
+                    {outcomeLabel(row.outcome.outcome)}
+                  </span>
+                  <span className="text-xs text-muted-foreground">
+                    {fmtDate(row.outcome.createdAt)}
+                  </span>
+                </div>
+                {row.outcome.notes ? <p className="text-sm">{row.outcome.notes}</p> : null}
+                <p className="mt-1 text-xs text-muted-foreground">
+                  Recorded by {row.actorName ?? row.actorEmail ?? '(deleted user)'}
+                </p>
+              </li>
+            ))}
+          </ul>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/db/queries/eviction-case-outcomes.ts
+++ b/src/db/queries/eviction-case-outcomes.ts
@@ -1,0 +1,38 @@
+import { desc, eq } from 'drizzle-orm';
+import { db } from '@/db/client';
+import {
+  type EvictionCaseOutcomeRow,
+  evictionCaseOutcomes,
+} from '@/db/schema/eviction-case-outcomes';
+import { users } from '@/db/schema/users';
+
+export interface CaseOutcomeWithActor {
+  outcome: EvictionCaseOutcomeRow;
+  actorEmail: string | null;
+  actorName: string | null;
+}
+
+/**
+ * Outcome history for a single filing, most recent first. The actor's
+ * email/name come from a LEFT JOIN so a row whose recorded_by_user_id
+ * was nulled out by user deletion still renders.
+ */
+export async function listCaseOutcomes(filingId: string): Promise<CaseOutcomeWithActor[]> {
+  const rows = await db
+    .select({
+      outcome: evictionCaseOutcomes,
+      actorEmail: users.email,
+      actorFirst: users.firstName,
+      actorLast: users.lastName,
+    })
+    .from(evictionCaseOutcomes)
+    .leftJoin(users, eq(users.id, evictionCaseOutcomes.recordedByUserId))
+    .where(eq(evictionCaseOutcomes.filingId, filingId))
+    .orderBy(desc(evictionCaseOutcomes.createdAt));
+
+  return rows.map((r) => ({
+    outcome: r.outcome,
+    actorEmail: r.actorEmail ?? null,
+    actorName: [r.actorFirst, r.actorLast].filter(Boolean).join(' ') || null,
+  }));
+}

--- a/src/db/schema/enums.ts
+++ b/src/db/schema/enums.ts
@@ -76,3 +76,14 @@ export const evictionResponsePacketStatusEnum = pgEnum('eviction_response_packet
 
 export type EvictionResponsePacketStatus =
   (typeof evictionResponsePacketStatusEnum.enumValues)[number];
+
+export const evictionCaseOutcomeEnum = pgEnum('eviction_case_outcome', [
+  'dismissed',
+  'judgment_for_plaintiff',
+  'judgment_for_defendant',
+  'settled',
+  'default_judgment',
+  'withdrawn',
+]);
+
+export type EvictionCaseOutcome = (typeof evictionCaseOutcomeEnum.enumValues)[number];

--- a/src/db/schema/eviction-case-outcomes.ts
+++ b/src/db/schema/eviction-case-outcomes.ts
@@ -1,0 +1,41 @@
+import { index, pgTable, text, timestamp, uuid } from 'drizzle-orm/pg-core';
+import { evictionCaseOutcomeEnum } from './enums';
+import { evictionFilings } from './eviction-filings';
+import { users } from './users';
+
+/**
+ * One row per recorded outcome event for a filing. A single filing can
+ * have multiple outcome rows (e.g. dismissed and re-filed; or recorded
+ * incorrectly and then corrected by another row) — we keep the full
+ * history, the outcomes UI shows the most recent first.
+ *
+ * Append-only by convention. The audit_log triggers (#198) protect
+ * audit_log itself; this table is more like a clinical chart — corrections
+ * happen by writing a new row, not editing the old one.
+ *
+ * recorded_by_user_id is set null on user delete so the outcome record
+ * survives staff turnover.
+ */
+export const evictionCaseOutcomes = pgTable(
+  'eviction_case_outcomes',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    filingId: uuid('filing_id')
+      .notNull()
+      .references(() => evictionFilings.id, { onDelete: 'cascade' }),
+    outcome: evictionCaseOutcomeEnum('outcome').notNull(),
+    notes: text('notes'),
+    recordedByUserId: uuid('recorded_by_user_id').references(() => users.id, {
+      onDelete: 'set null',
+    }),
+    createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+  },
+  (t) => [
+    index('case_outcomes_filing_idx').on(t.filingId),
+    index('case_outcomes_outcome_idx').on(t.outcome),
+    index('case_outcomes_created_at_idx').on(t.createdAt),
+  ],
+);
+
+export type EvictionCaseOutcomeRow = typeof evictionCaseOutcomes.$inferSelect;
+export type NewEvictionCaseOutcomeRow = typeof evictionCaseOutcomes.$inferInsert;

--- a/src/db/schema/index.ts
+++ b/src/db/schema/index.ts
@@ -1,6 +1,7 @@
 export * from './audit-log';
 export * from './consents';
 export * from './enums';
+export * from './eviction-case-outcomes';
 export * from './eviction-filing-risk-scores';
 export * from './eviction-filings';
 export * from './eviction-response-packets';

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -90,14 +90,23 @@ export async function requireRole(allowed: readonly UserRole[]): Promise<User> {
 export async function requireKlaAttorney(): Promise<User> {
   const user = await requireUser();
   if (user.role !== 'attorney') notFound();
+  if (!(await userIsKlaAttorney(user))) notFound();
+  return user;
+}
 
+/**
+ * Non-throwing variant: returns true iff `user` has role=attorney AND
+ * KLA membership. For server components that need to decide whether to
+ * render an attorney-only widget but can't 404 the whole page (e.g.,
+ * the case-detail page is visible to caseworkers and admins too).
+ */
+export async function userIsKlaAttorney(user: User): Promise<boolean> {
+  if (user.role !== 'attorney') return false;
   const [membership] = await db
     .select({ id: orgMemberships.id })
     .from(orgMemberships)
     .innerJoin(partnerOrgs, eq(orgMemberships.partnerOrgId, partnerOrgs.id))
     .where(and(eq(orgMemberships.userId, user.id), eq(partnerOrgs.slug, KLA_OWENSBORO_SLUG)))
     .limit(1);
-  if (!membership) notFound();
-
-  return user;
+  return Boolean(membership);
 }


### PR DESCRIPTION
Closes #32

## Summary
Captures the *court* outcome for an eviction case (dismissed, judgment_for_*, settled, default_judgment, withdrawn). Distinct from packet status (our workflow); together with EVDT-020 they let us measure 'represented cases vs default-judgment rate' — the headline Phase-1 success metric.

- **Schema:** new \`eviction_case_outcome\` enum + \`eviction_case_outcomes\` table. Append-only by convention — corrections write a new row, not edit the old one (similar pattern to audit log).
- **Migration 0009.**
- **\`recordCaseOutcomeAction\`** — KLA gate, enum allow-list, audit-logged as \`case.outcome_recorded\`.
- **\`listCaseOutcomes\`** — LEFT JOIN to users so deleted recorders still render with a \`(deleted user)\` fallback.
- **\`userIsKlaAttorney(user)\`** — non-throwing variant of \`requireKlaAttorney\` for server pages that need to render an attorney-only widget without 404'ing the whole page (case-detail is visible to caseworker/admin too).
- **\`CaseOutcomePanel\`** — outcome dropdown + notes input + Record button (only rendered when \`canRecord\`), then the history list with color-coded outcome badges (pro-defendant green, pro-plaintiff red).
- Case-detail page wires it via \`Promise.all\` alongside the existing score lookup.

## Acceptance criteria
- [x] Outcome enum on a new \`eviction_case_outcomes\` table (with notes, created_at, FK to filing + recording user)
- [x] Server action \`recordCaseOutcome(filingId, outcome, attorneyUserId, notes?)\` (signature simplified — actor pulled from \`requireKlaAttorney()\` rather than passed)
- [x] Outcome capture UI on case-detail page (visible only to KLA attorneys)
- [x] Outcome history table (most recent first, with timestamp + attorney name)
- [x] Audit-log every outcome via \`logAuditEvent\` (\`case.outcome_recorded\`)
- [x] Outcomes will appear in EVDT-020 metrics dashboard (next story in the sprint)

## Notes for review
- Multiple outcomes per filing are allowed — supports correction-by-append and the rare "dismissed then re-filed" case. UI shows full chronological history.
- Notes are stored verbatim and rendered as plain text (no markdown). They're not for legal analysis; they're for the attorney's reminder.
- Packet status \`filed\` is distinct from outcome \`default_judgment\` — both can be true simultaneously (we filed; the court still ruled against us). The two state machines don't constrain each other.

🤖 Generated with [Claude Code](https://claude.com/claude-code)