### PR TITLE
feat(EVDT-020): outcome metrics dashboard

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "react": "19.2.4",
     "react-dom": "19.2.4",
     "react-markdown": "^10.1.0",
+    "recharts": "^3.8.1",
     "resend": "^6.12.2",
     "shadcn": "^4.5.0",
     "svix": "^1.92.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -65,6 +65,9 @@ importers:
       react-markdown:
         specifier: ^10.1.0
         version: 10.1.0(@types/react@19.2.14)(react@19.2.4)
+      recharts:
+        specifier: ^3.8.1
+        version: 3.8.1(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react-is@19.2.5)(react@19.2.4)(redux@5.0.1)
       resend:
         specifier: ^6.12.2
         version: 6.12.2
@@ -1983,6 +1986,17 @@ packages:
   '@protobufjs/utf8@1.1.0':
     resolution: {integrity: sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==}
 
+  '@reduxjs/toolkit@2.11.2':
+    resolution: {integrity: sha512-Kd6kAHTA6/nUpp8mySPqj3en3dm0tdMIgbttnQ1xFMVpufoj+ADi8pXLBsd4xzTRHQa7t/Jv8W5UnCuW4kuWMQ==}
+    peerDependencies:
+      react: ^16.9.0 || ^17.0.0 || ^18 || ^19
+      react-redux: ^7.2.1 || ^8.1.3 || ^9.0.0
+    peerDependenciesMeta:
+      react:
+        optional: true
+      react-redux:
+        optional: true
+
   '@rolldown/binding-android-arm64@1.0.0-rc.17':
     resolution: {integrity: sha512-s70pVGhw4zqGeFnXWvAzJDlvxhlRollagdCCKRgOsgUOH3N1l0LIxf83AtGzmb5SiVM4Hjl5HyarMRfdfj3DaQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -2374,6 +2388,9 @@ packages:
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
+  '@standard-schema/utils@0.3.0':
+    resolution: {integrity: sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==}
+
   '@swc/helpers@0.5.15':
     resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
 
@@ -2494,6 +2511,33 @@ packages:
   '@types/connect@3.4.38':
     resolution: {integrity: sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==}
 
+  '@types/d3-array@3.2.2':
+    resolution: {integrity: sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==}
+
+  '@types/d3-color@3.1.3':
+    resolution: {integrity: sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==}
+
+  '@types/d3-ease@3.0.2':
+    resolution: {integrity: sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==}
+
+  '@types/d3-interpolate@3.0.4':
+    resolution: {integrity: sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==}
+
+  '@types/d3-path@3.1.1':
+    resolution: {integrity: sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==}
+
+  '@types/d3-scale@4.0.9':
+    resolution: {integrity: sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==}
+
+  '@types/d3-shape@3.1.8':
+    resolution: {integrity: sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==}
+
+  '@types/d3-time@3.0.4':
+    resolution: {integrity: sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==}
+
+  '@types/d3-timer@3.0.2':
+    resolution: {integrity: sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==}
+
   '@types/debug@4.1.13':
     resolution: {integrity: sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==}
 
@@ -2573,6 +2617,9 @@ packages:
 
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
+
+  '@types/use-sync-external-store@0.0.6':
+    resolution: {integrity: sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==}
 
   '@types/validate-npm-package-name@4.0.2':
     resolution: {integrity: sha512-lrpDziQipxCEeK5kWxvljWYhUvOiB2A9izZd9B2AFarYAkqZshb4lPbRs7zKEic6eGtH8V/2qJW+dPp9OtF6bw==}
@@ -2953,6 +3000,50 @@ packages:
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
+  d3-array@3.2.4:
+    resolution: {integrity: sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==}
+    engines: {node: '>=12'}
+
+  d3-color@3.1.0:
+    resolution: {integrity: sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==}
+    engines: {node: '>=12'}
+
+  d3-ease@3.0.1:
+    resolution: {integrity: sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==}
+    engines: {node: '>=12'}
+
+  d3-format@3.1.2:
+    resolution: {integrity: sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==}
+    engines: {node: '>=12'}
+
+  d3-interpolate@3.0.1:
+    resolution: {integrity: sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==}
+    engines: {node: '>=12'}
+
+  d3-path@3.1.0:
+    resolution: {integrity: sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==}
+    engines: {node: '>=12'}
+
+  d3-scale@4.0.2:
+    resolution: {integrity: sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==}
+    engines: {node: '>=12'}
+
+  d3-shape@3.2.0:
+    resolution: {integrity: sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==}
+    engines: {node: '>=12'}
+
+  d3-time-format@4.1.0:
+    resolution: {integrity: sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==}
+    engines: {node: '>=12'}
+
+  d3-time@3.1.0:
+    resolution: {integrity: sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==}
+    engines: {node: '>=12'}
+
+  d3-timer@3.0.1:
+    resolution: {integrity: sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==}
+    engines: {node: '>=12'}
+
   data-uri-to-buffer@4.0.1:
     resolution: {integrity: sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==}
     engines: {node: '>= 12'}
@@ -2965,6 +3056,9 @@ packages:
     peerDependenciesMeta:
       supports-color:
         optional: true
+
+  decimal.js-light@2.5.1:
+    resolution: {integrity: sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==}
 
   decode-named-character-reference@1.3.0:
     resolution: {integrity: sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==}
@@ -3172,6 +3266,9 @@ packages:
     resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
     engines: {node: '>= 0.4'}
 
+  es-toolkit@1.46.0:
+    resolution: {integrity: sha512-IToJ6ct9OLl5zz6WsC/1vZEwfSZ7Myil+ygl5Tf30Xjn9AEkzNB4kqp2G7VUJKF1DtTx/ra5M5KLlXvzOg51BA==}
+
   esbuild@0.18.20:
     resolution: {integrity: sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA==}
     engines: {node: '>=12'}
@@ -3227,6 +3324,9 @@ packages:
   etag@1.8.1:
     resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
     engines: {node: '>= 0.6'}
+
+  eventemitter3@5.0.4:
+    resolution: {integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==}
 
   events@3.3.0:
     resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
@@ -3483,6 +3583,12 @@ packages:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
     engines: {node: '>= 4'}
 
+  immer@10.2.0:
+    resolution: {integrity: sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==}
+
+  immer@11.1.4:
+    resolution: {integrity: sha512-XREFCPo6ksxVzP4E0ekD5aMdf8WMwmdNaz6vuvxgI40UaEiu6q3p8X52aU6GdyvLY3XXX/8R7JOTXStz/nBbRw==}
+
   import-fresh@3.3.1:
     resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
     engines: {node: '>=6'}
@@ -3542,6 +3648,10 @@ packages:
         optional: true
       typescript:
         optional: true
+
+  internmap@2.0.3:
+    resolution: {integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==}
+    engines: {node: '>=12'}
 
   ip-address@10.1.0:
     resolution: {integrity: sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==}
@@ -4315,11 +4425,26 @@ packages:
     peerDependencies:
       react: ^19.2.4
 
+  react-is@19.2.5:
+    resolution: {integrity: sha512-Dn0t8IQhCmeIT3wu+Apm1/YVsJXsGWi6k4sPdnBIdqMVtHtv0IGi6dcpNpNkNac0zB2uUAqNX3MHzN8c+z2rwQ==}
+
   react-markdown@10.1.0:
     resolution: {integrity: sha512-qKxVopLT/TyA6BX3Ue5NwabOsAzm0Q7kAPwq6L+wWDwisYs7R8vZ0nRXqq6rkueboxpkjvLGU9fWifiX/ZZFxQ==}
     peerDependencies:
       '@types/react': '>=18'
       react: '>=18'
+
+  react-redux@9.2.0:
+    resolution: {integrity: sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==}
+    peerDependencies:
+      '@types/react': ^18.2.25 || ^19
+      react: ^18.0 || ^19
+      redux: ^5.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      redux:
+        optional: true
 
   react@19.2.4:
     resolution: {integrity: sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==}
@@ -4328,6 +4453,22 @@ packages:
   recast@0.23.11:
     resolution: {integrity: sha512-YTUo+Flmw4ZXiWfQKGcwwc11KnoRAYgzAE2E7mXKCjSviTKShtxBsN6YUUBB2gtaBzKzeKunxhUwNHQuRryhWA==}
     engines: {node: '>= 4'}
+
+  recharts@3.8.1:
+    resolution: {integrity: sha512-mwzmO1s9sFL0TduUpwndxCUNoXsBw3u3E/0+A+cLcrSfQitSG62L32N69GhqUrrT5qKcAE3pCGVINC6pqkBBQg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-is: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  redux-thunk@3.1.0:
+    resolution: {integrity: sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==}
+    peerDependencies:
+      redux: ^5.0.0
+
+  redux@5.0.1:
+    resolution: {integrity: sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==}
 
   remark-parse@11.0.0:
     resolution: {integrity: sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==}
@@ -4809,6 +4950,9 @@ packages:
 
   vfile@6.0.3:
     resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
+
+  victory-vendor@37.3.6:
+    resolution: {integrity: sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==}
 
   vite@8.0.10:
     resolution: {integrity: sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw==}
@@ -6906,6 +7050,18 @@ snapshots:
 
   '@protobufjs/utf8@1.1.0': {}
 
+  '@reduxjs/toolkit@2.11.2(react-redux@9.2.0(@types/react@19.2.14)(react@19.2.4)(redux@5.0.1))(react@19.2.4)':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@standard-schema/utils': 0.3.0
+      immer: 11.1.4
+      redux: 5.0.1
+      redux-thunk: 3.1.0(redux@5.0.1)
+      reselect: 5.1.1
+    optionalDependencies:
+      react: 19.2.4
+      react-redux: 9.2.0(@types/react@19.2.14)(react@19.2.4)(redux@5.0.1)
+
   '@rolldown/binding-android-arm64@1.0.0-rc.17':
     optional: true
 
@@ -7250,6 +7406,8 @@ snapshots:
 
   '@standard-schema/spec@1.1.0': {}
 
+  '@standard-schema/utils@0.3.0': {}
+
   '@swc/helpers@0.5.15':
     dependencies:
       tslib: 2.8.1
@@ -7366,6 +7524,30 @@ snapshots:
     dependencies:
       '@types/node': 20.19.39
 
+  '@types/d3-array@3.2.2': {}
+
+  '@types/d3-color@3.1.3': {}
+
+  '@types/d3-ease@3.0.2': {}
+
+  '@types/d3-interpolate@3.0.4':
+    dependencies:
+      '@types/d3-color': 3.1.3
+
+  '@types/d3-path@3.1.1': {}
+
+  '@types/d3-scale@4.0.9':
+    dependencies:
+      '@types/d3-time': 3.0.4
+
+  '@types/d3-shape@3.1.8':
+    dependencies:
+      '@types/d3-path': 3.1.1
+
+  '@types/d3-time@3.0.4': {}
+
+  '@types/d3-timer@3.0.2': {}
+
   '@types/debug@4.1.13':
     dependencies:
       '@types/ms': 2.1.0
@@ -7458,6 +7640,8 @@ snapshots:
   '@types/unist@2.0.11': {}
 
   '@types/unist@3.0.3': {}
+
+  '@types/use-sync-external-store@0.0.6': {}
 
   '@types/validate-npm-package-name@4.0.2': {}
 
@@ -7824,11 +8008,51 @@ snapshots:
 
   csstype@3.2.3: {}
 
+  d3-array@3.2.4:
+    dependencies:
+      internmap: 2.0.3
+
+  d3-color@3.1.0: {}
+
+  d3-ease@3.0.1: {}
+
+  d3-format@3.1.2: {}
+
+  d3-interpolate@3.0.1:
+    dependencies:
+      d3-color: 3.1.0
+
+  d3-path@3.1.0: {}
+
+  d3-scale@4.0.2:
+    dependencies:
+      d3-array: 3.2.4
+      d3-format: 3.1.2
+      d3-interpolate: 3.0.1
+      d3-time: 3.1.0
+      d3-time-format: 4.1.0
+
+  d3-shape@3.2.0:
+    dependencies:
+      d3-path: 3.1.0
+
+  d3-time-format@4.1.0:
+    dependencies:
+      d3-time: 3.1.0
+
+  d3-time@3.1.0:
+    dependencies:
+      d3-array: 3.2.4
+
+  d3-timer@3.0.1: {}
+
   data-uri-to-buffer@4.0.1: {}
 
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
+
+  decimal.js-light@2.5.1: {}
 
   decode-named-character-reference@1.3.0:
     dependencies:
@@ -7925,6 +8149,8 @@ snapshots:
   es-object-atoms@1.1.1:
     dependencies:
       es-errors: 1.3.0
+
+  es-toolkit@1.46.0: {}
 
   esbuild@0.18.20:
     optionalDependencies:
@@ -8037,6 +8263,8 @@ snapshots:
       '@types/estree': 1.0.8
 
   etag@1.8.1: {}
+
+  eventemitter3@5.0.4: {}
 
   events@3.3.0: {}
 
@@ -8364,6 +8592,10 @@ snapshots:
 
   ignore@5.3.2: {}
 
+  immer@10.2.0: {}
+
+  immer@11.1.4: {}
+
   import-fresh@3.3.1:
     dependencies:
       parent-module: 1.0.1
@@ -8430,6 +8662,8 @@ snapshots:
       - '@opentelemetry/core'
       - encoding
       - supports-color
+
+  internmap@2.0.3: {}
 
   ip-address@10.1.0: {}
 
@@ -9263,6 +9497,8 @@ snapshots:
       react: 19.2.4
       scheduler: 0.27.0
 
+  react-is@19.2.5: {}
+
   react-markdown@10.1.0(@types/react@19.2.14)(react@19.2.4):
     dependencies:
       '@types/hast': 3.0.4
@@ -9281,6 +9517,15 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  react-redux@9.2.0(@types/react@19.2.14)(react@19.2.4)(redux@5.0.1):
+    dependencies:
+      '@types/use-sync-external-store': 0.0.6
+      react: 19.2.4
+      use-sync-external-store: 1.6.0(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      redux: 5.0.1
+
   react@19.2.4: {}
 
   recast@0.23.11:
@@ -9290,6 +9535,32 @@ snapshots:
       source-map: 0.6.1
       tiny-invariant: 1.3.3
       tslib: 2.8.1
+
+  recharts@3.8.1(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react-is@19.2.5)(react@19.2.4)(redux@5.0.1):
+    dependencies:
+      '@reduxjs/toolkit': 2.11.2(react-redux@9.2.0(@types/react@19.2.14)(react@19.2.4)(redux@5.0.1))(react@19.2.4)
+      clsx: 2.1.1
+      decimal.js-light: 2.5.1
+      es-toolkit: 1.46.0
+      eventemitter3: 5.0.4
+      immer: 10.2.0
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+      react-is: 19.2.5
+      react-redux: 9.2.0(@types/react@19.2.14)(react@19.2.4)(redux@5.0.1)
+      reselect: 5.1.1
+      tiny-invariant: 1.3.3
+      use-sync-external-store: 1.6.0(react@19.2.4)
+      victory-vendor: 37.3.6
+    transitivePeerDependencies:
+      - '@types/react'
+      - redux
+
+  redux-thunk@3.1.0(redux@5.0.1):
+    dependencies:
+      redux: 5.0.1
+
+  redux@5.0.1: {}
 
   remark-parse@11.0.0:
     dependencies:
@@ -9877,6 +10148,23 @@ snapshots:
     dependencies:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
+
+  victory-vendor@37.3.6:
+    dependencies:
+      '@types/d3-array': 3.2.2
+      '@types/d3-ease': 3.0.2
+      '@types/d3-interpolate': 3.0.4
+      '@types/d3-scale': 4.0.9
+      '@types/d3-shape': 3.1.8
+      '@types/d3-time': 3.0.4
+      '@types/d3-timer': 3.0.2
+      d3-array: 3.2.4
+      d3-ease: 3.0.1
+      d3-interpolate: 3.0.1
+      d3-scale: 4.0.2
+      d3-shape: 3.2.0
+      d3-time: 3.1.0
+      d3-timer: 3.0.1
 
   vite@8.0.10(@types/node@20.19.39)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3):
     dependencies:

--- a/src/app/app/metrics/page.tsx
+++ b/src/app/app/metrics/page.tsx
@@ -1,0 +1,115 @@
+import Link from 'next/link';
+import { DailyChart } from '@/components/metrics/daily-chart';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import {
+  type DailyPoint,
+  getDailySeries,
+  getMetricsKpis,
+  getMetricsRates,
+  type MetricsKpis,
+  type MetricsRates,
+} from '@/db/queries/metrics';
+import { requireRole } from '@/lib/auth';
+
+const WINDOW_DAYS = 30;
+
+const fmtPct = (v: number | null): string => (v == null ? '—' : `${(v * 100).toFixed(0)}%`);
+const fmtInt = (v: number): string => v.toLocaleString();
+
+function Kpi({ label, value, hint }: { label: string; value: string; hint?: string }) {
+  return (
+    <Card>
+      <CardHeader className="pb-2">
+        <p className="text-xs uppercase tracking-wide text-muted-foreground">{label}</p>
+      </CardHeader>
+      <CardContent>
+        <p className="font-mono text-3xl font-semibold tabular-nums">{value}</p>
+        {hint ? <p className="mt-1 text-xs text-muted-foreground">{hint}</p> : null}
+      </CardContent>
+    </Card>
+  );
+}
+
+export default async function MetricsPage() {
+  await requireRole(['attorney', 'admin']);
+
+  const [kpis, rates, series] = (await Promise.all([
+    getMetricsKpis(WINDOW_DAYS),
+    getMetricsRates(WINDOW_DAYS),
+    getDailySeries(WINDOW_DAYS),
+  ])) as [MetricsKpis, MetricsRates, DailyPoint[]];
+
+  const noOutcomes = kpis.outcomesRecorded === 0;
+
+  return (
+    <div className="mx-auto max-w-6xl space-y-4 p-6">
+      <header>
+        <h1 className="font-serif text-3xl font-bold text-primary">Outcomes</h1>
+        <p className="text-sm text-muted-foreground">
+          Eviction-defense metrics for the last {WINDOW_DAYS} days. Phase 1 cohort: KLA Owensboro.
+        </p>
+      </header>
+
+      <section className="grid grid-cols-2 gap-3 md:grid-cols-5">
+        <Kpi
+          label={`Filings (${WINDOW_DAYS}d)`}
+          value={fmtInt(kpis.filingsInWindow)}
+          hint="Ingested by the daily docket job"
+        />
+        <Kpi
+          label="With packet"
+          value={fmtInt(kpis.filingsWithPacket)}
+          hint="Filings with at least one AI-drafted answer"
+        />
+        <Kpi label="Packets approved" value={fmtInt(kpis.packetsApproved)} hint="Awaiting filing" />
+        <Kpi label="Packets filed" value={fmtInt(kpis.packetsFiled)} hint="Submitted to court" />
+        <Kpi label="Outcomes" value={fmtInt(kpis.outcomesRecorded)} hint="Court results recorded" />
+      </section>
+
+      <section className="grid grid-cols-1 gap-3 md:grid-cols-3">
+        <Kpi
+          label="Representation rate"
+          value={fmtPct(rates.representationRate)}
+          hint="Filings with at least one packet generated"
+        />
+        <Kpi
+          label="Default-judgment rate"
+          value={fmtPct(rates.defaultJudgmentRate)}
+          hint="Of cases with any recorded outcome"
+        />
+        <Kpi
+          label="Favorable outcomes"
+          value={fmtPct(rates.favorableOutcomeRate)}
+          hint="Dismissed, defendant judgment, or settled"
+        />
+      </section>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">
+            Daily filings vs. packets approved (last {WINDOW_DAYS} days)
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <DailyChart data={series} />
+        </CardContent>
+      </Card>
+
+      {noOutcomes ? (
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-base">No outcomes recorded yet</CardTitle>
+          </CardHeader>
+          <CardContent className="text-sm text-muted-foreground">
+            Outcomes (dismissed, judgment, settled, default) are recorded from the case-detail page
+            once the court rules. Open a case from the{' '}
+            <Link href="/app/cases/queue" className="underline hover:text-primary">
+              daily queue
+            </Link>{' '}
+            and use the &ldquo;Record outcome&rdquo; form to start populating this dashboard.
+          </CardContent>
+        </Card>
+      ) : null}
+    </div>
+  );
+}

--- a/src/app/app/metrics/page.tsx
+++ b/src/app/app/metrics/page.tsx
@@ -1,15 +1,9 @@
 import Link from 'next/link';
+import { notFound } from 'next/navigation';
 import { DailyChart } from '@/components/metrics/daily-chart';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import {
-  type DailyPoint,
-  getDailySeries,
-  getMetricsKpis,
-  getMetricsRates,
-  type MetricsKpis,
-  type MetricsRates,
-} from '@/db/queries/metrics';
-import { requireRole } from '@/lib/auth';
+import { getDailySeries, getMetricsKpis, getMetricsRates } from '@/db/queries/metrics';
+import { requireRole, userIsKlaAttorney } from '@/lib/auth';
 
 const WINDOW_DAYS = 30;
 
@@ -31,13 +25,19 @@ function Kpi({ label, value, hint }: { label: string; value: string; hint?: stri
 }
 
 export default async function MetricsPage() {
-  await requireRole(['attorney', 'admin']);
+  const me = await requireRole(['attorney', 'admin']);
+  // The page header / KPIs claim 'Phase-1 cohort: KLA Owensboro'. We
+  // can't enforce per-org scoping in the queries yet (single-org
+  // assumption — see TODO in src/db/queries/metrics.ts when multi-org
+  // lands), so at minimum gate attorney access on KLA membership so
+  // the label is true. Admins pass without the membership check.
+  if (me.role === 'attorney' && !(await userIsKlaAttorney(me))) notFound();
 
-  const [kpis, rates, series] = (await Promise.all([
+  const [kpis, rates, series] = await Promise.all([
     getMetricsKpis(WINDOW_DAYS),
     getMetricsRates(WINDOW_DAYS),
     getDailySeries(WINDOW_DAYS),
-  ])) as [MetricsKpis, MetricsRates, DailyPoint[]];
+  ]);
 
   const noOutcomes = kpis.outcomesRecorded === 0;
 
@@ -91,7 +91,31 @@ export default async function MetricsPage() {
           </CardTitle>
         </CardHeader>
         <CardContent>
-          <DailyChart data={series} />
+          <div
+            role="img"
+            aria-label={`Line chart, two series. Daily eviction filings and approved response packets over the last ${WINDOW_DAYS} days.`}
+          >
+            <DailyChart data={series} />
+          </div>
+          <table className="sr-only">
+            <caption>Daily filings and packets approved, last {WINDOW_DAYS} days.</caption>
+            <thead>
+              <tr>
+                <th>Day</th>
+                <th>Filings</th>
+                <th>Packets approved</th>
+              </tr>
+            </thead>
+            <tbody>
+              {series.map((p) => (
+                <tr key={p.day}>
+                  <td>{p.day}</td>
+                  <td>{p.filings}</td>
+                  <td>{p.packetsApproved}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
         </CardContent>
       </Card>
 

--- a/src/components/app-shell/nav-config.ts
+++ b/src/components/app-shell/nav-config.ts
@@ -35,6 +35,11 @@ export const NAV_ITEMS: NavItem[] = [
     href: '/app/clients',
     roles: ['caseworker', 'ed_coordinator', 'shelter_staff', 'admin'],
   },
+  {
+    label: 'Outcomes',
+    href: '/app/metrics',
+    roles: ['attorney', 'admin'],
+  },
   { label: 'Settings', href: '/app/settings', roles: 'all' },
   { label: 'Admin · Users', href: '/app/admin/users', roles: ['admin'] },
 ];

--- a/src/components/metrics/daily-chart.tsx
+++ b/src/components/metrics/daily-chart.tsx
@@ -1,0 +1,55 @@
+'use client';
+
+import {
+  CartesianGrid,
+  Legend,
+  Line,
+  LineChart,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from 'recharts';
+import type { DailyPoint } from '@/db/queries/metrics';
+
+const tickFmt = (day: string) => {
+  // YYYY-MM-DD -> M/D
+  const [, m, d] = day.split('-');
+  return `${Number(m)}/${Number(d)}`;
+};
+
+export function DailyChart({ data }: { data: DailyPoint[] }) {
+  return (
+    <div className="h-72 w-full">
+      <ResponsiveContainer width="100%" height="100%">
+        <LineChart data={data} margin={{ top: 8, right: 16, bottom: 8, left: 0 }}>
+          <CartesianGrid strokeDasharray="3 3" stroke="hsl(var(--border))" />
+          <XAxis dataKey="day" tickFormatter={tickFmt} fontSize={11} stroke="currentColor" />
+          <YAxis allowDecimals={false} fontSize={11} stroke="currentColor" />
+          <Tooltip
+            labelFormatter={(label) => label}
+            contentStyle={{ fontSize: 12 }}
+            cursor={{ stroke: 'hsl(var(--border))' }}
+          />
+          <Legend wrapperStyle={{ fontSize: 12 }} />
+          <Line
+            type="monotone"
+            dataKey="filings"
+            name="Filings"
+            stroke="hsl(var(--primary))"
+            strokeWidth={2}
+            dot={false}
+          />
+          <Line
+            type="monotone"
+            dataKey="packetsApproved"
+            name="Packets approved"
+            stroke="#10b981"
+            strokeWidth={2}
+            dot={false}
+          />
+        </LineChart>
+      </ResponsiveContainer>
+    </div>
+  );
+}

--- a/src/db/queries/metrics.ts
+++ b/src/db/queries/metrics.ts
@@ -1,0 +1,165 @@
+import { and, count, countDistinct, eq, gte, sql } from 'drizzle-orm';
+import { db } from '@/db/client';
+import { evictionCaseOutcomes } from '@/db/schema/eviction-case-outcomes';
+import { evictionFilings } from '@/db/schema/eviction-filings';
+import { evictionResponsePackets } from '@/db/schema/eviction-response-packets';
+
+export interface MetricsKpis {
+  /** Filings ingested in the last `windowDays` days. */
+  filingsInWindow: number;
+  /** Filings (in window) with at least one response packet generated. */
+  filingsWithPacket: number;
+  /** Packets currently in `approved` status (across all time). */
+  packetsApproved: number;
+  /** Packets currently in `filed` status (across all time). */
+  packetsFiled: number;
+  /** Total recorded outcome events (across all time). */
+  outcomesRecorded: number;
+}
+
+export interface MetricsRates {
+  /** Filings with a packet / total filings (in window). 0..1. */
+  representationRate: number | null;
+  /** Filings with outcome=default_judgment / filings with any outcome. */
+  defaultJudgmentRate: number | null;
+  /** Filings with outcome in {dismissed, judgment_for_defendant, settled} / filings with any outcome. */
+  favorableOutcomeRate: number | null;
+}
+
+export interface DailyPoint {
+  /** YYYY-MM-DD bucket (UTC date). */
+  day: string;
+  filings: number;
+  packetsApproved: number;
+}
+
+const FAVORABLE_OUTCOMES = ['dismissed', 'judgment_for_defendant', 'settled'] as const;
+
+const daysAgo = (days: number) => {
+  const d = new Date();
+  d.setUTCHours(0, 0, 0, 0);
+  d.setUTCDate(d.getUTCDate() - days);
+  return d;
+};
+
+export async function getMetricsKpis(windowDays = 30): Promise<MetricsKpis> {
+  const since = daysAgo(windowDays);
+
+  const [filingsRow] = await db
+    .select({ value: count() })
+    .from(evictionFilings)
+    .where(gte(evictionFilings.filedAt, since));
+
+  const [withPacketRow] = await db
+    .select({ value: countDistinct(evictionResponsePackets.filingId) })
+    .from(evictionResponsePackets)
+    .innerJoin(evictionFilings, eq(evictionFilings.id, evictionResponsePackets.filingId))
+    .where(gte(evictionFilings.filedAt, since));
+
+  const [approvedRow] = await db
+    .select({ value: count() })
+    .from(evictionResponsePackets)
+    .where(eq(evictionResponsePackets.status, 'approved'));
+
+  const [filedRow] = await db
+    .select({ value: count() })
+    .from(evictionResponsePackets)
+    .where(eq(evictionResponsePackets.status, 'filed'));
+
+  const [outcomesRow] = await db.select({ value: count() }).from(evictionCaseOutcomes);
+
+  return {
+    filingsInWindow: filingsRow.value,
+    filingsWithPacket: withPacketRow.value,
+    packetsApproved: approvedRow.value,
+    packetsFiled: filedRow.value,
+    outcomesRecorded: outcomesRow.value,
+  };
+}
+
+export async function getMetricsRates(windowDays = 30): Promise<MetricsRates> {
+  const since = daysAgo(windowDays);
+
+  const [filingsRow] = await db
+    .select({ value: count() })
+    .from(evictionFilings)
+    .where(gte(evictionFilings.filedAt, since));
+
+  const [withPacketRow] = await db
+    .select({ value: countDistinct(evictionResponsePackets.filingId) })
+    .from(evictionResponsePackets)
+    .innerJoin(evictionFilings, eq(evictionFilings.id, evictionResponsePackets.filingId))
+    .where(gte(evictionFilings.filedAt, since));
+
+  const [outcomeFilingsRow] = await db
+    .select({ value: countDistinct(evictionCaseOutcomes.filingId) })
+    .from(evictionCaseOutcomes);
+
+  const [defaultJudgmentRow] = await db
+    .select({ value: countDistinct(evictionCaseOutcomes.filingId) })
+    .from(evictionCaseOutcomes)
+    .where(eq(evictionCaseOutcomes.outcome, 'default_judgment'));
+
+  const [favorableRow] = await db
+    .select({ value: countDistinct(evictionCaseOutcomes.filingId) })
+    .from(evictionCaseOutcomes)
+    .where(
+      sql`${evictionCaseOutcomes.outcome} IN (${sql.join(
+        FAVORABLE_OUTCOMES.map((o) => sql`${o}`),
+        sql`, `,
+      )})`,
+    );
+
+  const safeRatio = (num: number, denom: number) => (denom === 0 ? null : num / denom);
+
+  return {
+    representationRate: safeRatio(withPacketRow.value, filingsRow.value),
+    defaultJudgmentRate: safeRatio(defaultJudgmentRow.value, outcomeFilingsRow.value),
+    favorableOutcomeRate: safeRatio(favorableRow.value, outcomeFilingsRow.value),
+  };
+}
+
+export async function getDailySeries(windowDays = 30): Promise<DailyPoint[]> {
+  const since = daysAgo(windowDays);
+
+  const filingsByDay = await db
+    .select({
+      day: sql<string>`to_char(${evictionFilings.filedAt} AT TIME ZONE 'UTC', 'YYYY-MM-DD')`,
+      value: count(),
+    })
+    .from(evictionFilings)
+    .where(gte(evictionFilings.filedAt, since))
+    .groupBy(sql`1`);
+
+  const approvedByDay = await db
+    .select({
+      day: sql<string>`to_char(${evictionResponsePackets.updatedAt} AT TIME ZONE 'UTC', 'YYYY-MM-DD')`,
+      value: count(),
+    })
+    .from(evictionResponsePackets)
+    .where(
+      and(
+        eq(evictionResponsePackets.status, 'approved'),
+        gte(evictionResponsePackets.updatedAt, since),
+      ),
+    )
+    .groupBy(sql`1`);
+
+  // Merge into a contiguous day list so a missing day is 0, not absent.
+  const map = new Map<string, DailyPoint>();
+  for (let i = 0; i <= windowDays; i++) {
+    const d = new Date(since);
+    d.setUTCDate(d.getUTCDate() + i);
+    const key = d.toISOString().slice(0, 10);
+    map.set(key, { day: key, filings: 0, packetsApproved: 0 });
+  }
+  for (const row of filingsByDay) {
+    const point = map.get(row.day);
+    if (point) point.filings = row.value;
+  }
+  for (const row of approvedByDay) {
+    const point = map.get(row.day);
+    if (point) point.packetsApproved = row.value;
+  }
+  return Array.from(map.values()).sort((a, b) => a.day.localeCompare(b.day));
+}

--- a/src/db/queries/metrics.ts
+++ b/src/db/queries/metrics.ts
@@ -4,6 +4,12 @@ import { evictionCaseOutcomes } from '@/db/schema/eviction-case-outcomes';
 import { evictionFilings } from '@/db/schema/eviction-filings';
 import { evictionResponsePackets } from '@/db/schema/eviction-response-packets';
 
+// TODO(multi-org): Phase 1 has a single legal-aid partner (KLA Owensboro),
+// so every filing in the system is implicitly that cohort's. When a
+// second partner org joins, every query in this file needs an explicit
+// JOIN to filter by partner_org. See docs/access-control.md for the
+// Phase-1 single-org assumption.
+
 export interface MetricsKpis {
   /** Filings ingested in the last `windowDays` days. */
   filingsInWindow: number;
@@ -50,6 +56,10 @@ export async function getMetricsKpis(windowDays = 30): Promise<MetricsKpis> {
     .from(evictionFilings)
     .where(gte(evictionFilings.filedAt, since));
 
+  // Note: window is on filing.filed_at, not packet.created_at. A packet
+  // generated this week for a 60-day-old filing does NOT count toward
+  // filingsWithPacket — the rate this feeds (representation rate) reads
+  // 'of filings ingested in this window, how many got a draft answer.'
   const [withPacketRow] = await db
     .select({ value: countDistinct(evictionResponsePackets.filingId) })
     .from(evictionResponsePackets)


### PR DESCRIPTION
Closes #35

## Summary
Demo's headline-number page. \`/app/metrics\`, gated to \`['attorney', 'admin']\`. 30-day rolling window scoped to the KLA-Owensboro Phase-1 cohort.

- **5 KPI cards (top row):** filings ingested in 30d, filings-with-packet, packets approved, packets filed, outcomes recorded.
- **3 rate cards:** representation rate, default-judgment rate, favorable-outcome rate. Each is null when the denominator is zero — renders as \`—\`.
- **Time-series chart** (recharts \`LineChart\`): daily filings + daily packets-approved over the last 30 days. Day buckets filled contiguously so zero days render as 0, not missing.
- **Empty state** when no outcomes recorded yet, with a link to the daily queue and a hint about where to record outcomes from.
- **Sidebar** gets an "Outcomes" nav item.

## Acceptance criteria
- [x] New page \`/app/metrics\` gated by \`requireRole(['attorney', 'admin'])\`
- [x] Cards: total filings (last 30d), filings with packet, packets approved, packets filed, outcomes recorded
- [x] Outcome breakdown: representation, default-judgment, favorable-outcome rates
- [x] Time-series chart: daily filing count + daily packets-approved count, last 30 days, lightweight chart lib (recharts)
- [x] All numbers scoped to current Phase-1 cohort (single-org today; the query shape generalizes when multi-org lands)
- [x] Empty state with link to outcome capture

## Notes for review
- \`getMetricsKpis\` and \`getMetricsRates\` overlap on \`filingsInWindow\` and \`filingsWithPacket\` — duplicated work for now since the page calls both via \`Promise.all\`. Could merge into one query if it shows up in profiling. Phase 1 row counts make this irrelevant.
- Day bucketing is UTC. Cental-time edge case: a filing recorded at 11pm Central on April 25th is bucketed as April 26th UTC. Acceptable for a 30-day rolling story; tighten if/when "yesterday" specifically becomes a metric.
- Chart colors hardcode \`#10b981\` (emerald) for the packets-approved line because Tailwind \`hsl(var(--*))\` isn't available to recharts at runtime. Cosmetic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)