### PR TITLE
feat(ESUC-011): AI care plan generator

### DIFF
--- a/drizzle/migrations/0012_common_darkstar.sql
+++ b/drizzle/migrations/0012_common_darkstar.sql
@@ -1,0 +1,16 @@
+CREATE TYPE "public"."esuc_care_plan_status" AS ENUM('draft', 'approved', 'active', 'archived');--> statement-breakpoint
+CREATE TABLE "esuc_care_plans" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"patient_id" text NOT NULL,
+	"plan_md" text NOT NULL,
+	"prompt_version" text NOT NULL,
+	"generated_by_user_id" uuid,
+	"status" "esuc_care_plan_status" DEFAULT 'draft' NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "esuc_care_plans" ADD CONSTRAINT "esuc_care_plans_generated_by_user_id_users_id_fk" FOREIGN KEY ("generated_by_user_id") REFERENCES "public"."users"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+CREATE UNIQUE INDEX "care_plans_patient_version_idx" ON "esuc_care_plans" USING btree ("patient_id","prompt_version");--> statement-breakpoint
+CREATE INDEX "care_plans_patient_idx" ON "esuc_care_plans" USING btree ("patient_id");--> statement-breakpoint
+CREATE INDEX "care_plans_status_idx" ON "esuc_care_plans" USING btree ("status");

--- a/drizzle/migrations/meta/0012_snapshot.json
+++ b/drizzle/migrations/meta/0012_snapshot.json
@@ -1,0 +1,1633 @@
+{
+  "id": "31baf5ab-36c8-466d-9677-6c511b70963a",
+  "prevId": "54fc8546-5886-4f35-88ed-8aae56a6c4e1",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.audit_log": {
+      "name": "audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_table": {
+          "name": "target_table",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "audit_log_actor_idx": {
+          "name": "audit_log_actor_idx",
+          "columns": [
+            {
+              "expression": "actor_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_log_action_idx": {
+          "name": "audit_log_action_idx",
+          "columns": [
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_log_created_at_idx": {
+          "name": "audit_log_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audit_log_actor_user_id_users_id_fk": {
+          "name": "audit_log_actor_user_id_users_id_fk",
+          "tableFrom": "audit_log",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.consents": {
+      "name": "consents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "subject_external_id": {
+          "name": "subject_external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consent_type": {
+          "name": "consent_type",
+          "type": "consent_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "granted_via": {
+          "name": "granted_via",
+          "type": "consent_channel",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "granted_at": {
+          "name": "granted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "consents_subject_idx": {
+          "name": "consents_subject_idx",
+          "columns": [
+            {
+              "expression": "subject_external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "consents_type_idx": {
+          "name": "consents_type_idx",
+          "columns": [
+            {
+              "expression": "consent_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ed_encounters": {
+      "name": "ed_encounters",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encounter_external_id": {
+          "name": "encounter_external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "arrived_at": {
+          "name": "arrived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discharged_at": {
+          "name": "discharged_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chief_complaint": {
+          "name": "chief_complaint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "disposition": {
+          "name": "disposition",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "housing_status": {
+          "name": "housing_status",
+          "type": "housing_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unknown'"
+        },
+        "charge_cents": {
+          "name": "charge_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_json": {
+          "name": "raw_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "ed_encounter_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'synthetic'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ed_encounters_external_idx": {
+          "name": "ed_encounters_external_idx",
+          "columns": [
+            {
+              "expression": "encounter_external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ed_encounters_patient_idx": {
+          "name": "ed_encounters_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ed_encounters_arrived_idx": {
+          "name": "ed_encounters_arrived_idx",
+          "columns": [
+            {
+              "expression": "arrived_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ed_encounters_housing_idx": {
+          "name": "ed_encounters_housing_idx",
+          "columns": [
+            {
+              "expression": "housing_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.esuc_care_plans": {
+      "name": "esuc_care_plans",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plan_md": {
+          "name": "plan_md",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt_version": {
+          "name": "prompt_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "generated_by_user_id": {
+          "name": "generated_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "esuc_care_plan_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "care_plans_patient_version_idx": {
+          "name": "care_plans_patient_version_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "prompt_version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "care_plans_patient_idx": {
+          "name": "care_plans_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "care_plans_status_idx": {
+          "name": "care_plans_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "esuc_care_plans_generated_by_user_id_users_id_fk": {
+          "name": "esuc_care_plans_generated_by_user_id_users_id_fk",
+          "tableFrom": "esuc_care_plans",
+          "tableTo": "users",
+          "columnsFrom": [
+            "generated_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.eviction_case_outcomes": {
+      "name": "eviction_case_outcomes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "filing_id": {
+          "name": "filing_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "eviction_case_outcome",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recorded_by_user_id": {
+          "name": "recorded_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "case_outcomes_filing_idx": {
+          "name": "case_outcomes_filing_idx",
+          "columns": [
+            {
+              "expression": "filing_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "case_outcomes_outcome_idx": {
+          "name": "case_outcomes_outcome_idx",
+          "columns": [
+            {
+              "expression": "outcome",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "case_outcomes_created_at_idx": {
+          "name": "case_outcomes_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "eviction_case_outcomes_filing_id_eviction_filings_id_fk": {
+          "name": "eviction_case_outcomes_filing_id_eviction_filings_id_fk",
+          "tableFrom": "eviction_case_outcomes",
+          "tableTo": "eviction_filings",
+          "columnsFrom": [
+            "filing_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "eviction_case_outcomes_recorded_by_user_id_users_id_fk": {
+          "name": "eviction_case_outcomes_recorded_by_user_id_users_id_fk",
+          "tableFrom": "eviction_case_outcomes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "recorded_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.eviction_filing_risk_scores": {
+      "name": "eviction_filing_risk_scores",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "filing_id": {
+          "name": "filing_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rationale": {
+          "name": "rationale",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model_version": {
+          "name": "model_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "risk_scores_filing_version_idx": {
+          "name": "risk_scores_filing_version_idx",
+          "columns": [
+            {
+              "expression": "filing_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "model_version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "risk_scores_filing_idx": {
+          "name": "risk_scores_filing_idx",
+          "columns": [
+            {
+              "expression": "filing_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "risk_scores_score_idx": {
+          "name": "risk_scores_score_idx",
+          "columns": [
+            {
+              "expression": "score",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "eviction_filing_risk_scores_filing_id_eviction_filings_id_fk": {
+          "name": "eviction_filing_risk_scores_filing_id_eviction_filings_id_fk",
+          "tableFrom": "eviction_filing_risk_scores",
+          "tableTo": "eviction_filings",
+          "columnsFrom": [
+            "filing_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.eviction_filings": {
+      "name": "eviction_filings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "case_number": {
+          "name": "case_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filed_at": {
+          "name": "filed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "court_division": {
+          "name": "court_division",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plaintiff": {
+          "name": "plaintiff",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "defendant_first_name": {
+          "name": "defendant_first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "defendant_last_name": {
+          "name": "defendant_last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "defendant_address": {
+          "name": "defendant_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cause_type": {
+          "name": "cause_type",
+          "type": "eviction_cause_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_claimed_cents": {
+          "name": "amount_claimed_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "eviction_filing_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'filed'"
+        },
+        "source": {
+          "name": "source",
+          "type": "eviction_filing_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "raw_json": {
+          "name": "raw_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "eviction_filings_case_source_idx": {
+          "name": "eviction_filings_case_source_idx",
+          "columns": [
+            {
+              "expression": "case_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "eviction_filings_filed_at_idx": {
+          "name": "eviction_filings_filed_at_idx",
+          "columns": [
+            {
+              "expression": "filed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "eviction_filings_status_idx": {
+          "name": "eviction_filings_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.eviction_response_packets": {
+      "name": "eviction_response_packets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "filing_id": {
+          "name": "filing_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "packet_md": {
+          "name": "packet_md",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt_version": {
+          "name": "prompt_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "generated_by_user_id": {
+          "name": "generated_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "eviction_response_packet_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "response_packets_filing_version_idx": {
+          "name": "response_packets_filing_version_idx",
+          "columns": [
+            {
+              "expression": "filing_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "prompt_version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "response_packets_filing_idx": {
+          "name": "response_packets_filing_idx",
+          "columns": [
+            {
+              "expression": "filing_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "response_packets_status_idx": {
+          "name": "response_packets_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "eviction_response_packets_filing_id_eviction_filings_id_fk": {
+          "name": "eviction_response_packets_filing_id_eviction_filings_id_fk",
+          "tableFrom": "eviction_response_packets",
+          "tableTo": "eviction_filings",
+          "columnsFrom": [
+            "filing_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "eviction_response_packets_generated_by_user_id_users_id_fk": {
+          "name": "eviction_response_packets_generated_by_user_id_users_id_fk",
+          "tableFrom": "eviction_response_packets",
+          "tableTo": "users",
+          "columnsFrom": [
+            "generated_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.health_check": {
+      "name": "health_check",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_memberships": {
+      "name": "org_memberships",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "partner_org_id": {
+          "name": "partner_org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "org_memberships_user_org_idx": {
+          "name": "org_memberships_user_org_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "partner_org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "org_memberships_user_idx": {
+          "name": "org_memberships_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "org_memberships_partner_org_idx": {
+          "name": "org_memberships_partner_org_idx",
+          "columns": [
+            {
+              "expression": "partner_org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "org_memberships_user_id_users_id_fk": {
+          "name": "org_memberships_user_id_users_id_fk",
+          "tableFrom": "org_memberships",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "org_memberships_partner_org_id_partner_orgs_id_fk": {
+          "name": "org_memberships_partner_org_id_partner_orgs_id_fk",
+          "tableFrom": "org_memberships",
+          "tableTo": "partner_orgs",
+          "columnsFrom": [
+            "partner_org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.partner_orgs": {
+      "name": "partner_orgs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "partner_org_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_email": {
+          "name": "contact_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_phone": {
+          "name": "contact_phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "partner_orgs_slug_idx": {
+          "name": "partner_orgs_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rental_assistance_programs": {
+      "name": "rental_assistance_programs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agency": {
+          "name": "agency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "website": {
+          "name": "website",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "eligibility_summary": {
+          "name": "eligibility_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "max_award_cents": {
+          "name": "max_award_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_note": {
+          "name": "source_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "rental_assistance_programs_active_idx": {
+          "name": "rental_assistance_programs_active_idx",
+          "columns": [
+            {
+              "expression": "active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "clerk_user_id": {
+          "name": "clerk_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "users_clerk_user_id_idx": {
+          "name": "users_clerk_user_id_idx",
+          "columns": [
+            {
+              "expression": "clerk_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.consent_channel": {
+      "name": "consent_channel",
+      "schema": "public",
+      "values": [
+        "sms",
+        "in_person",
+        "web_form",
+        "phone",
+        "paper"
+      ]
+    },
+    "public.consent_type": {
+      "name": "consent_type",
+      "schema": "public",
+      "values": [
+        "phi_share_within_coalition",
+        "sms_communication",
+        "data_for_program_eval"
+      ]
+    },
+    "public.ed_encounter_source": {
+      "name": "ed_encounter_source",
+      "schema": "public",
+      "values": [
+        "synthetic",
+        "epic_fhir",
+        "manual"
+      ]
+    },
+    "public.esuc_care_plan_status": {
+      "name": "esuc_care_plan_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "approved",
+        "active",
+        "archived"
+      ]
+    },
+    "public.eviction_case_outcome": {
+      "name": "eviction_case_outcome",
+      "schema": "public",
+      "values": [
+        "dismissed",
+        "judgment_for_plaintiff",
+        "judgment_for_defendant",
+        "settled",
+        "default_judgment",
+        "withdrawn"
+      ]
+    },
+    "public.eviction_cause_type": {
+      "name": "eviction_cause_type",
+      "schema": "public",
+      "values": [
+        "non_payment",
+        "lease_violation",
+        "holdover",
+        "other"
+      ]
+    },
+    "public.eviction_filing_source": {
+      "name": "eviction_filing_source",
+      "schema": "public",
+      "values": [
+        "courtnet",
+        "manual",
+        "synthetic"
+      ]
+    },
+    "public.eviction_filing_status": {
+      "name": "eviction_filing_status",
+      "schema": "public",
+      "values": [
+        "filed",
+        "served",
+        "judgment",
+        "dismissed",
+        "sealed"
+      ]
+    },
+    "public.eviction_response_packet_status": {
+      "name": "eviction_response_packet_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "approved",
+        "filed",
+        "rejected"
+      ]
+    },
+    "public.housing_status": {
+      "name": "housing_status",
+      "schema": "public",
+      "values": [
+        "housed",
+        "doubled_up",
+        "shelter",
+        "unsheltered",
+        "unknown"
+      ]
+    },
+    "public.partner_org_type": {
+      "name": "partner_org_type",
+      "schema": "public",
+      "values": [
+        "hospital",
+        "legal_aid",
+        "shelter",
+        "community_org",
+        "government",
+        "other"
+      ]
+    },
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "pending",
+        "attorney",
+        "caseworker",
+        "ed_coordinator",
+        "shelter_staff",
+        "admin"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/migrations/meta/_journal.json
+++ b/drizzle/migrations/meta/_journal.json
@@ -85,6 +85,13 @@
       "when": 1777213496658,
       "tag": "0011_ancient_ultimo",
       "breakpoints": true
+    },
+    {
+      "idx": 12,
+      "version": "7",
+      "when": 1777228050129,
+      "tag": "0012_common_darkstar",
+      "breakpoints": true
     }
   ]
 }

--- a/fixtures/care-plan-eval.json
+++ b/fixtures/care-plan-eval.json
@@ -1,0 +1,191 @@
+{
+  "patients": [
+    {
+      "patient_id": "SYN-PAT-100001",
+      "encounter_count": 4,
+      "window_days": 180,
+      "encounters": [
+        {
+          "arrived_at": "2026-04-22T03:14:00-05:00",
+          "chief_complaint": "alcohol withdrawal",
+          "disposition": "admitted",
+          "housing_status": "shelter",
+          "charge_cents": 720000,
+          "notes": "CIWA 24 on arrival; admitted for IV thiamine + benzodiazepine taper"
+        },
+        {
+          "arrived_at": "2026-03-30T22:01:00-05:00",
+          "chief_complaint": "acute alcohol intoxication",
+          "disposition": "discharged-home",
+          "housing_status": "shelter",
+          "charge_cents": 180000,
+          "notes": "BAL 0.32, observed to clinical sobriety, declined SUD referral"
+        },
+        {
+          "arrived_at": "2026-02-18T14:55:00-05:00",
+          "chief_complaint": "alcohol withdrawal",
+          "disposition": "ama",
+          "housing_status": "doubled_up",
+          "charge_cents": 95000,
+          "notes": "left AMA after CIWA initiated"
+        },
+        {
+          "arrived_at": "2026-01-04T11:32:00-05:00",
+          "chief_complaint": "fall, intoxication",
+          "disposition": "discharged-home",
+          "housing_status": "unknown",
+          "charge_cents": 145000,
+          "notes": "head laceration sutured, no LOC documented"
+        }
+      ]
+    },
+    {
+      "patient_id": "SYN-PAT-100002",
+      "encounter_count": 5,
+      "window_days": 180,
+      "encounters": [
+        {
+          "arrived_at": "2026-04-21T09:10:00-05:00",
+          "chief_complaint": "hypertensive urgency",
+          "disposition": "discharged-home",
+          "housing_status": "unsheltered",
+          "charge_cents": 220000,
+          "notes": "BP 198/112; lost antihypertensive prescription"
+        },
+        {
+          "arrived_at": "2026-04-02T16:42:00-05:00",
+          "chief_complaint": "diabetic ketoacidosis",
+          "disposition": "admitted",
+          "housing_status": "unsheltered",
+          "charge_cents": 1850000,
+          "notes": "blood glucose 612, anion gap 22; insulin drip"
+        },
+        {
+          "arrived_at": "2026-03-15T07:20:00-05:00",
+          "chief_complaint": "frostbite",
+          "disposition": "discharged-home",
+          "housing_status": "unsheltered",
+          "charge_cents": 95000,
+          "notes": "left toes; rewarming, no surgical eval needed"
+        },
+        {
+          "arrived_at": "2026-02-08T13:55:00-05:00",
+          "chief_complaint": "uncontrolled hyperglycemia",
+          "disposition": "discharged-home",
+          "housing_status": "unsheltered",
+          "charge_cents": 165000,
+          "notes": "out of insulin x 6 days"
+        },
+        {
+          "arrived_at": "2026-01-12T20:30:00-05:00",
+          "chief_complaint": "alcohol withdrawal",
+          "disposition": "ama",
+          "housing_status": "unsheltered",
+          "charge_cents": 80000,
+          "notes": "left before treatment initiated"
+        }
+      ]
+    },
+    {
+      "patient_id": "SYN-PAT-100003",
+      "encounter_count": 3,
+      "window_days": 180,
+      "encounters": [
+        {
+          "arrived_at": "2026-04-19T18:00:00-05:00",
+          "chief_complaint": "suicidal ideation",
+          "disposition": "transferred",
+          "housing_status": "doubled_up",
+          "charge_cents": 280000,
+          "notes": "transferred to inpatient psych; C-SSRS positive"
+        },
+        {
+          "arrived_at": "2026-03-04T11:15:00-05:00",
+          "chief_complaint": "anxiety, panic",
+          "disposition": "discharged-home",
+          "housing_status": "doubled_up",
+          "charge_cents": 110000,
+          "notes": "PRN ativan; outpatient psych follow-up encouraged"
+        },
+        {
+          "arrived_at": "2026-02-01T22:45:00-05:00",
+          "chief_complaint": "depression with passive ideation",
+          "disposition": "discharged-home",
+          "housing_status": "doubled_up",
+          "charge_cents": 130000,
+          "notes": "warm handoff to mental-health crisis line"
+        }
+      ]
+    },
+    {
+      "patient_id": "SYN-PAT-100004",
+      "encounter_count": 4,
+      "window_days": 180,
+      "encounters": [
+        {
+          "arrived_at": "2026-04-25T05:30:00-05:00",
+          "chief_complaint": "opioid overdose",
+          "disposition": "admitted",
+          "housing_status": "shelter",
+          "charge_cents": 920000,
+          "notes": "narcan x 2 by EMS; admitted for monitoring + MOUD induction discussion"
+        },
+        {
+          "arrived_at": "2026-04-08T19:11:00-05:00",
+          "chief_complaint": "skin abscess (likely IVDU)",
+          "disposition": "discharged-home",
+          "housing_status": "shelter",
+          "charge_cents": 220000,
+          "notes": "I&D, oral antibiotics, declined SUD referral"
+        },
+        {
+          "arrived_at": "2026-03-12T15:40:00-05:00",
+          "chief_complaint": "withdrawal, opioid",
+          "disposition": "ama",
+          "housing_status": "shelter",
+          "charge_cents": 75000,
+          "notes": "left AMA after fluids"
+        },
+        {
+          "arrived_at": "2026-02-21T08:20:00-05:00",
+          "chief_complaint": "altered mental status",
+          "disposition": "discharged-home",
+          "housing_status": "unknown",
+          "charge_cents": 140000,
+          "notes": "tox screen positive for opioids; tox screen positive for benzos"
+        }
+      ]
+    },
+    {
+      "patient_id": "SYN-PAT-100005",
+      "encounter_count": 3,
+      "window_days": 180,
+      "encounters": [
+        {
+          "arrived_at": "2026-04-15T10:05:00-05:00",
+          "chief_complaint": "chest pain",
+          "disposition": "discharged-home",
+          "housing_status": "doubled_up",
+          "charge_cents": 410000,
+          "notes": "troponin negative x2, EKG benign, GERD likely"
+        },
+        {
+          "arrived_at": "2026-03-22T17:30:00-05:00",
+          "chief_complaint": "back pain",
+          "disposition": "discharged-home",
+          "housing_status": "doubled_up",
+          "charge_cents": 95000,
+          "notes": "no red flags; PCP referral, NSAID"
+        },
+        {
+          "arrived_at": "2026-02-05T09:45:00-05:00",
+          "chief_complaint": "shortness of breath",
+          "disposition": "discharged-home",
+          "housing_status": "shelter",
+          "charge_cents": 230000,
+          "notes": "asthma exacerbation; albuterol response"
+        }
+      ]
+    }
+  ]
+}

--- a/scripts/eval-care-plan.ts
+++ b/scripts/eval-care-plan.ts
@@ -1,0 +1,169 @@
+#!/usr/bin/env tsx
+/**
+ * Eval harness for the ESUC-011 care plan generator. Mirror of
+ * eval-response-packet.ts.
+ *
+ * Reads fixtures/care-plan-eval.json — 5 hand-curated synthetic
+ * patients, each with their own encounter history. Calls Claude on
+ * each and verifies the rendered markdown contains the structural
+ * elements a care coordinator expects.
+ *
+ * Run: pnpm tsx scripts/eval-care-plan.ts
+ *
+ * Exits non-zero unless every plan passes every structural check, so
+ * a regression is visible without reading the log.
+ */
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import Anthropic from '@anthropic-ai/sdk';
+import { zodOutputFormat } from '@anthropic-ai/sdk/helpers/zod';
+import { config } from 'dotenv';
+import {
+  buildCarePlanUserPrompt,
+  CARE_PLAN_DISCLAIMER_PREFIX,
+  CARE_PLAN_PROMPT_VERSION,
+  CarePlanSchema,
+  ESUC_CARE_PLAN_SYSTEM_PROMPT,
+} from '@/ai/prompts/esuc-care-plan';
+
+config({ path: ['.env.local', '.env'], override: true });
+
+if (!process.env.ANTHROPIC_API_KEY) {
+  console.error('ANTHROPIC_API_KEY is not set (check .env.local)');
+  process.exit(1);
+}
+
+type EvalRow = Parameters<typeof buildCarePlanUserPrompt>[0];
+
+interface CheckResult {
+  name: string;
+  ok: boolean;
+  detail?: string;
+}
+
+const FORBIDDEN_NAME_PATTERNS = [
+  // First+last name patterns Claude might try to invent. Real Epic
+  // data should never reach this prompt anyway, but assert defense.
+  /\b[A-Z][a-z]{2,}\s+[A-Z][a-z]{2,}\b/, // "John Smith"-shaped
+];
+
+function checkPlan(plan: string, row: EvalRow): CheckResult[] {
+  const checks: CheckResult[] = [];
+
+  checks.push({
+    name: 'disclaimer prefix present',
+    ok: plan.includes(CARE_PLAN_DISCLAIMER_PREFIX),
+  });
+
+  checks.push({
+    name: 'opaque patient_id rendered',
+    ok: plan.includes(row.patient_id),
+  });
+
+  checks.push({
+    name: 'has Patient summary section',
+    ok: /^#\s+Patient summary/im.test(plan),
+  });
+
+  checks.push({
+    name: 'has Risk factors section',
+    ok: /^#\s+Risk factors/im.test(plan),
+  });
+
+  checks.push({
+    name: 'has Recommended interventions section',
+    ok: /^#\s+Recommended interventions/im.test(plan),
+  });
+
+  const checkboxCount = (plan.match(/\[\s*\]/g) ?? []).length;
+  checks.push({
+    name: 'interventions checklist (≥5 items)',
+    ok: checkboxCount >= 5,
+    detail: `found ${checkboxCount} unchecked boxes`,
+  });
+
+  checks.push({
+    name: 'has TEAMKY HRSN / Recuperative Care note',
+    ok: /TEAMKY|HRSN|Recuperative/i.test(plan),
+  });
+
+  // Defense in depth: a plan should NOT contain anything that looks
+  // like an invented patient name. The forbidden pattern matches the
+  // example we put IN the prompt, so we strip the example before
+  // checking — but the example case-id (SYN-PAT-009104) won't be
+  // in the actual outputs unless Claude copied it.
+  const planMinusExample = plan.replace(
+    /SYN-PAT-009104[\s\S]*?(end of example\)|# Patient summary)/g,
+    '',
+  );
+  const nameLikely = FORBIDDEN_NAME_PATTERNS.some((re) => re.test(planMinusExample));
+  checks.push({
+    name: 'no invented name-like strings',
+    ok: !nameLikely,
+    detail: nameLikely ? 'matched name-shaped pattern' : undefined,
+  });
+
+  return checks;
+}
+
+async function main() {
+  const evalPath = resolve(process.cwd(), 'fixtures/care-plan-eval.json');
+  const data = JSON.parse(readFileSync(evalPath, 'utf8')) as { patients: EvalRow[] };
+  const client = new Anthropic();
+
+  console.log(
+    `[eval] running ${data.patients.length} care plans against ${CARE_PLAN_PROMPT_VERSION}`,
+  );
+
+  let totalChecks = 0;
+  let passedChecks = 0;
+  let perfectPlans = 0;
+
+  for (const row of data.patients) {
+    const r = await client.messages.parse({
+      model: 'claude-opus-4-7',
+      max_tokens: 16000,
+      thinking: { type: 'adaptive' },
+      output_config: {
+        effort: 'high',
+        format: zodOutputFormat(CarePlanSchema),
+      },
+      system: [
+        {
+          type: 'text',
+          text: ESUC_CARE_PLAN_SYSTEM_PROMPT,
+          cache_control: { type: 'ephemeral' },
+        },
+      ],
+      messages: [{ role: 'user', content: buildCarePlanUserPrompt(row) }],
+    });
+
+    if (!r.parsed_output) {
+      console.error(`[eval] ${row.patient_id}: no parsed output (stop=${r.stop_reason})`);
+      continue;
+    }
+
+    const checks = checkPlan(r.parsed_output.plan_md, row);
+    const passed = checks.filter((c) => c.ok).length;
+    totalChecks += checks.length;
+    passedChecks += passed;
+    if (passed === checks.length) perfectPlans += 1;
+
+    const verdict = passed === checks.length ? '✓' : '✗';
+    console.log(`[eval] ${verdict} ${row.patient_id}: ${passed}/${checks.length} checks`);
+    for (const c of checks.filter((c) => !c.ok)) {
+      console.log(`         ✗ ${c.name}${c.detail ? ` — ${c.detail}` : ''}`);
+    }
+  }
+
+  const overallPct = (passedChecks / totalChecks) * 100;
+  console.log(
+    `\n[eval] overall: ${passedChecks}/${totalChecks} checks (${overallPct.toFixed(1)}%) — ${perfectPlans}/${data.patients.length} plans fully clean`,
+  );
+  process.exit(perfectPlans === data.patients.length ? 0 : 1);
+}
+
+main().catch((err) => {
+  console.error('[eval] failed', err);
+  process.exit(1);
+});

--- a/scripts/eval-care-plan.ts
+++ b/scripts/eval-care-plan.ts
@@ -41,10 +41,14 @@ interface CheckResult {
   detail?: string;
 }
 
+// Strict patterns that an invented patient name would match. We
+// avoid the bare "[A-Z][a-z]+ [A-Z][a-z]+" shape because legitimate
+// partner-org and section-header phrases ("Catholic Charities",
+// "Boulware Mission", "Owensboro Health", "Patient Summary",
+// "Risk Factors") match it and produce false failures. The honorific
+// + name shape is much higher-signal for actual PII leakage.
 const FORBIDDEN_NAME_PATTERNS = [
-  // First+last name patterns Claude might try to invent. Real Epic
-  // data should never reach this prompt anyway, but assert defense.
-  /\b[A-Z][a-z]{2,}\s+[A-Z][a-z]{2,}\b/, // "John Smith"-shaped
+  /\b(Mr|Mrs|Ms|Dr|Mr\.|Mrs\.|Ms\.|Dr\.)\s+[A-Z][a-z]+(?:\s+[A-Z][a-z]+)?\b/,
 ];
 
 function checkPlan(plan: string, row: EvalRow): CheckResult[] {
@@ -88,15 +92,11 @@ function checkPlan(plan: string, row: EvalRow): CheckResult[] {
   });
 
   // Defense in depth: a plan should NOT contain anything that looks
-  // like an invented patient name. The forbidden pattern matches the
-  // example we put IN the prompt, so we strip the example before
-  // checking — but the example case-id (SYN-PAT-009104) won't be
-  // in the actual outputs unless Claude copied it.
-  const planMinusExample = plan.replace(
-    /SYN-PAT-009104[\s\S]*?(end of example\)|# Patient summary)/g,
-    '',
-  );
-  const nameLikely = FORBIDDEN_NAME_PATTERNS.some((re) => re.test(planMinusExample));
+  // like an invented patient name (honorific + name shape). The
+  // generic two-titlecase-words pattern produces false positives on
+  // legitimate partner-org and section-header phrases — see the
+  // FORBIDDEN_NAME_PATTERNS comment above.
+  const nameLikely = FORBIDDEN_NAME_PATTERNS.some((re) => re.test(plan));
   checks.push({
     name: 'no invented name-like strings',
     ok: !nameLikely,

--- a/src/ai/prompts/esuc-care-plan.ts
+++ b/src/ai/prompts/esuc-care-plan.ts
@@ -1,0 +1,171 @@
+import { z } from 'zod';
+
+/**
+ * Single source of truth for the AI care plan prompt (ESUC-011).
+ * Mirror of eviction-response-packet.ts. The output is a structured
+ * markdown care plan that an Owensboro Health care coordinator reviews
+ * and edits before activating.
+ *
+ * IMPORTANT — PHI / opaque-id fence:
+ * - patient_id is opaque on the way in (SYN-PAT-* today, hashed
+ *   post-BAA). NEVER ask the model to invent a real name; the model
+ *   sees only the encounter facts (chief complaint, disposition,
+ *   housing status, charge, notes).
+ * - The disclaimer at the top of every plan is non-negotiable. The
+ *   service asserts it before persisting; the save action asserts it
+ *   on attorney edits.
+ */
+
+export const CARE_PLAN_DISCLAIMER_PREFIX = 'AI-DRAFTED — REQUIRES CARE COORDINATOR REVIEW';
+
+export const ESUC_CARE_PLAN_SYSTEM_PROMPT = `You draft care plans for ED super-utilizers under Owensboro Health's
+care-coordination program. Your output is reviewed by a licensed care
+coordinator before activation. You are NOT delivering care or making
+treatment decisions — you are producing a structured first draft.
+
+INPUT: an opaque patient identifier (NEVER a name) and a list of recent
+ED encounters with chief complaint, disposition, housing status, charge,
+and any free-text notes.
+
+OUTPUT: a single markdown document in this exact shape:
+
+  1. Disclaimer block (verbatim, see below).
+  2. # Patient summary  — opaque id, encounter count, time window,
+     dominant chief-complaint themes, housing status of latest visit.
+  3. # Risk factors — bulleted list grounded in the facts. NEVER invent
+     a diagnosis the encounter data doesn't support. Acceptable risk
+     factors: housing instability, substance-use signals (chief
+     complaint = alcohol withdrawal, opioid overdose, etc.), repeat
+     mental-health presentations, untreated chronic disease (repeat
+     hypertensive urgency, diabetic ketoacidosis), social isolation
+     (frequent self-discharge, AMA), polypharmacy concerns from notes.
+  4. # Recommended interventions — checkbox list of concrete next
+     steps the coordinator can act on. Use \`- [ ]\` syntax. Examples:
+     'Verify housing status with HMIS via KHC consent', 'Refer to
+     Catholic Charities for shelter coordination', 'Engage
+     Owensboro Health behavioral-health team for SUD assessment',
+     'Confirm primary care assignment', 'Pharmacy reconciliation',
+     'Recuperative Care eligibility verification'. 5-10 items.
+  5. # Care-coordinator next steps — short numbered list of immediate
+     workflow actions (call patient, schedule warm handoff, document
+     in Epic).
+  6. # TEAMKY HRSN / Recuperative Care eligibility note — 2-3 sentences
+     on which Kentucky 1115 waiver components might apply (HRSN housing
+     supports for housing-unstable Medicaid beneficiaries; Recuperative
+     Care for post-discharge respite). Hedge appropriately — eligibility
+     is determined by the OH Medicaid team, not by this draft.
+
+DISCLAIMER BLOCK — copy verbatim at the top. {timestamp} and
+{model_version} are literal placeholders the caller fills in.
+
+> **${CARE_PLAN_DISCLAIMER_PREFIX}.**
+> Generated {timestamp} model {model_version}.
+> Patient identifiers are opaque; verify in Epic before clinical action.
+> This is a machine-drafted first pass for care-coordinator review. It
+> is not a treatment plan, not a clinical recommendation, and may
+> contain errors. Do not act on it without coordinator review.
+
+Style:
+- Plain English. Care coordinators are clinical but not medical
+  decision-makers; write to that audience.
+- Short paragraphs. Bullets and checklists over prose.
+- Do NOT invent encounters or diagnoses. If the data doesn't support
+  a risk factor, don't list it.
+- NO patient names, addresses, contact info, or other PII. The
+  opaque identifier is the only patient reference.
+- Markdown only; no HTML.
+
+EXAMPLE — well-formed plan for a fictitious patient:
+
+> **${CARE_PLAN_DISCLAIMER_PREFIX}.**
+> Generated {timestamp} model {model_version}.
+> Patient identifiers are opaque; verify in Epic before clinical action.
+> This is a machine-drafted first pass for care-coordinator review. It
+> is not a treatment plan, not a clinical recommendation, and may
+> contain errors. Do not act on it without coordinator review.
+
+# Patient summary
+
+Patient SYN-PAT-009104 has had 3 ED encounters in the last 75 days
+(2026-02-10 through 2026-04-25). Chief complaints cluster around
+alcohol-related presentations (acute intoxication, withdrawal). Latest
+encounter housing status: shelter. Two encounters were left AMA;
+one resulted in admission for IV thiamine + benzodiazepine taper.
+
+# Risk factors
+
+- Housing instability (latest housing status: shelter; previous: doubled_up)
+- Recurrent alcohol-related ED presentations consistent with active
+  alcohol-use disorder
+- Pattern of leaving AMA (2 of 3 encounters)
+- Charge totals over the window (~$18,000) suggest avoidable
+  utilization that better outpatient coordination could reduce
+
+# Recommended interventions
+
+- [ ] Verify HMIS enrollment and current shelter assignment via KHC consent
+- [ ] Engage Owensboro Health behavioral-health team for SUD warm handoff
+- [ ] Refer to Boulware Mission for sustained shelter placement
+- [ ] Confirm primary-care assignment; schedule post-discharge follow-up
+- [ ] Pharmacy reconciliation focused on benzo-taper continuity
+- [ ] Recuperative Care eligibility verification with OH Medicaid team
+
+# Care-coordinator next steps
+
+1. Outreach call to patient (caseworker, not platform) to confirm
+   willingness to engage
+2. Document conversation outcome in Epic care-management section
+3. Coordinate with shelter intake at Boulware or CrossRoads
+4. Schedule warm handoff to behavioral-health team within 7 days
+
+# TEAMKY HRSN / Recuperative Care eligibility note
+
+Patient appears to meet HRSN housing-support criteria (Medicaid +
+documented housing instability) and may be eligible for Recuperative
+Care services post-future inpatient stays. Eligibility determination
+sits with the OH Medicaid team; this note is a flag, not an approval.
+
+(end of example)
+
+Now produce the same shape for the actual patient below. Do not echo
+the example. Output ONLY the JSON object specified in the schema.`;
+
+export const buildCarePlanUserPrompt = (input: {
+  patient_id: string;
+  encounter_count: number;
+  window_days: number;
+  encounters: Array<{
+    arrived_at: string;
+    chief_complaint: string;
+    disposition: string;
+    housing_status: string;
+    charge_cents: number | null;
+    notes: string | null;
+  }>;
+}) =>
+  `Draft the care plan. Output JSON per the schema. The "plan_md" field
+must contain the full markdown document including the disclaimer header
+(with literal {timestamp} and {model_version} placeholders).
+
+Patient: ${input.patient_id}
+Encounter count in window: ${input.encounter_count}
+Window: last ${input.window_days} days
+
+Encounters (most recent first):
+${input.encounters
+  .map(
+    (e) =>
+      `- ${e.arrived_at} — chief complaint: ${e.chief_complaint}; disposition: ${e.disposition}; housing: ${e.housing_status}${
+        e.charge_cents != null ? `; charge: $${(e.charge_cents / 100).toFixed(0)}` : ''
+      }${e.notes ? `; notes: ${e.notes}` : ''}`,
+  )
+  .join('\n')}`;
+
+export const CarePlanSchema = z.object({
+  plan_md: z.string().min(300),
+});
+
+export type CarePlanOutput = z.infer<typeof CarePlanSchema>;
+
+/** Bumped any time the prompt or schema changes. Used as the cache key. */
+export const CARE_PLAN_PROMPT_VERSION = 'care-plan-v1@2026-04-26';

--- a/src/app/actions/care.ts
+++ b/src/app/actions/care.ts
@@ -1,0 +1,106 @@
+'use server';
+
+import * as Sentry from '@sentry/nextjs';
+import { eq } from 'drizzle-orm';
+import { revalidatePath } from 'next/cache';
+import { db } from '@/db/client';
+import { type EsucCarePlanStatus, esucCarePlanStatusEnum } from '@/db/schema/enums';
+import { esucCarePlans } from '@/db/schema/esuc-care-plans';
+import { logAuditEvent } from '@/lib/audit';
+import { requireRole } from '@/lib/auth';
+import { generateCarePlan, validateCarePlanDisclaimer } from '@/lib/esuc/care-plan';
+
+export type GenerateCarePlanResult = { ok: true } | { ok: false; error: string };
+
+const CARE_ROLES = ['ed_coordinator', 'admin'] as const;
+
+export async function generateCarePlanAction(patientId: string): Promise<GenerateCarePlanResult> {
+  const user = await requireRole(CARE_ROLES);
+
+  try {
+    await generateCarePlan(patientId, user.id);
+  } catch (err) {
+    Sentry.captureException(err, { tags: { action: 'generateCarePlanAction', patientId } });
+    return { ok: false, error: 'Care plan generation failed.' };
+  }
+
+  revalidatePath(`/app/care/patients/${patientId}`);
+  return { ok: true };
+}
+
+export type SaveCarePlanResult = { ok: true } | { ok: false; error: string };
+
+export async function saveCarePlanAction(
+  planId: string,
+  planMd: string,
+): Promise<SaveCarePlanResult> {
+  await requireRole(CARE_ROLES);
+  if (planMd.trim().length < 300) {
+    return { ok: false, error: 'Care plan must be at least 300 characters.' };
+  }
+  const dCheck = validateCarePlanDisclaimer(planMd, 'edit');
+  if (!dCheck.ok) return { ok: false, error: dCheck.error };
+
+  await db
+    .update(esucCarePlans)
+    .set({ planMd, updatedAt: new Date() })
+    .where(eq(esucCarePlans.id, planId));
+  revalidatePath('/app/care');
+  return { ok: true };
+}
+
+export type ChangeCarePlanStatusResult = { ok: true } | { ok: false; error: string };
+
+const STATUSES: readonly EsucCarePlanStatus[] = esucCarePlanStatusEnum.enumValues;
+
+/**
+ * Allowed transitions per current status. Server-authoritative.
+ * 'archived' is terminal — re-engaging a patient creates a new plan
+ * (bump prompt_version, or after this draft re-iteration, run the
+ * generator again with the new version key).
+ */
+const ALLOWED_TRANSITIONS: Record<EsucCarePlanStatus, readonly EsucCarePlanStatus[]> = {
+  draft: ['approved', 'archived'],
+  approved: ['active', 'draft', 'archived'],
+  active: ['archived', 'approved'],
+  archived: [],
+};
+
+export async function changeCarePlanStatusAction(
+  planId: string,
+  patientId: string,
+  newStatus: EsucCarePlanStatus,
+): Promise<ChangeCarePlanStatusResult> {
+  const user = await requireRole(CARE_ROLES);
+  if (!STATUSES.includes(newStatus)) return { ok: false, error: 'Invalid status.' };
+
+  const [previous] = await db
+    .select({ status: esucCarePlans.status })
+    .from(esucCarePlans)
+    .where(eq(esucCarePlans.id, planId))
+    .limit(1);
+  if (!previous) return { ok: false, error: 'Care plan not found.' };
+
+  if (!ALLOWED_TRANSITIONS[previous.status].includes(newStatus)) {
+    return {
+      ok: false,
+      error: `Status transition ${previous.status} → ${newStatus} is not allowed.`,
+    };
+  }
+
+  await db
+    .update(esucCarePlans)
+    .set({ status: newStatus, updatedAt: new Date() })
+    .where(eq(esucCarePlans.id, planId));
+
+  await logAuditEvent({
+    actorUserId: user.id,
+    action: 'care_plan.status_changed',
+    targetTable: 'esuc_care_plans',
+    targetId: planId,
+    metadata: { from: previous.status, to: newStatus, patientId },
+  });
+
+  revalidatePath(`/app/care/patients/${patientId}`);
+  return { ok: true };
+}

--- a/src/app/actions/care.ts
+++ b/src/app/actions/care.ts
@@ -58,11 +58,15 @@ const STATUSES: readonly EsucCarePlanStatus[] = esucCarePlanStatusEnum.enumValue
  * 'archived' is terminal — re-engaging a patient creates a new plan
  * (bump prompt_version, or after this draft re-iteration, run the
  * generator again with the new version key).
+ *
+ * 'active' (plan in effect) does NOT go back to 'approved'. Once a
+ * plan is in effect the legitimate moves are stay active or archive;
+ * to re-edit, push back to 'draft' for re-approval.
  */
 const ALLOWED_TRANSITIONS: Record<EsucCarePlanStatus, readonly EsucCarePlanStatus[]> = {
   draft: ['approved', 'archived'],
   approved: ['active', 'draft', 'archived'],
-  active: ['archived', 'approved'],
+  active: ['draft', 'archived'],
   archived: [],
 };
 

--- a/src/app/app/care/patients/[id]/page.tsx
+++ b/src/app/app/care/patients/[id]/page.tsx
@@ -1,8 +1,10 @@
 import Link from 'next/link';
 import { notFound } from 'next/navigation';
+import { CarePlanPanel } from '@/components/esuc/care-plan-panel';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { listEncountersForPatient } from '@/db/queries/ed-encounters';
 import { requireRole } from '@/lib/auth';
+import { getCarePlanByPatient } from '@/lib/esuc/care-plan';
 
 const fmtDate = (d: Date) =>
   new Intl.DateTimeFormat('en-US', { dateStyle: 'medium', timeStyle: 'short' }).format(new Date(d));
@@ -15,7 +17,10 @@ export default async function PatientDetailPage({ params }: { params: Promise<{ 
   // a hashed value. Either way they should be ≥ 6 chars of safe characters.
   if (!/^[A-Za-z0-9_-]{6,}$/.test(patientId)) notFound();
 
-  const encounters = await listEncountersForPatient(patientId);
+  const [encounters, carePlan] = await Promise.all([
+    listEncountersForPatient(patientId),
+    getCarePlanByPatient(patientId),
+  ]);
   if (encounters.length === 0) notFound();
 
   return (
@@ -57,14 +62,7 @@ export default async function PatientDetailPage({ params }: { params: Promise<{ 
         </CardContent>
       </Card>
 
-      <Card>
-        <CardHeader>
-          <CardTitle className="text-base">Care plan</CardTitle>
-        </CardHeader>
-        <CardContent className="text-sm text-muted-foreground">
-          AI-assisted care plan generation lands in ESUC-011.
-        </CardContent>
-      </Card>
+      <CarePlanPanel patientId={patientId} plan={carePlan} />
     </div>
   );
 }

--- a/src/components/esuc/care-plan-panel.tsx
+++ b/src/components/esuc/care-plan-panel.tsx
@@ -1,0 +1,197 @@
+'use client';
+
+import { useState, useTransition } from 'react';
+import ReactMarkdown from 'react-markdown';
+import {
+  changeCarePlanStatusAction,
+  generateCarePlanAction,
+  saveCarePlanAction,
+} from '@/app/actions/care';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import type { EsucCarePlan } from '@/db/schema/esuc-care-plans';
+
+const fmtDate = (d: Date) =>
+  new Intl.DateTimeFormat('en-US', { dateStyle: 'medium', timeStyle: 'short' }).format(new Date(d));
+
+const statusBadge: Record<EsucCarePlan['status'], string> = {
+  draft: 'bg-secondary text-secondary-foreground',
+  approved: 'bg-emerald-600/15 text-emerald-700 dark:text-emerald-400',
+  active: 'bg-primary text-primary-foreground',
+  archived: 'bg-muted text-muted-foreground',
+};
+
+export function CarePlanPanel({
+  patientId,
+  plan,
+}: {
+  patientId: string;
+  plan: EsucCarePlan | null;
+}) {
+  if (!plan) return <NoPlan patientId={patientId} />;
+  return <HasPlan plan={plan} patientId={patientId} />;
+}
+
+function NoPlan({ patientId }: { patientId: string }) {
+  const [pending, startTransition] = useTransition();
+  const [error, setError] = useState<string | null>(null);
+
+  const onClick = () => {
+    setError(null);
+    startTransition(async () => {
+      const r = await generateCarePlanAction(patientId);
+      if (!r.ok) setError(r.error);
+    });
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-base">No care plan drafted yet</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-3 text-sm">
+        <p className="text-muted-foreground">
+          Generate an AI-drafted care plan from the patient's encounter history. The draft will need
+          coordinator review before activation.
+        </p>
+        <div className="flex items-center gap-3">
+          <Button onClick={onClick} disabled={pending}>
+            {pending ? 'Generating…' : 'Generate care plan'}
+          </Button>
+          {error ? <span className="text-destructive text-xs">{error}</span> : null}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+function HasPlan({ plan, patientId }: { plan: EsucCarePlan; patientId: string }) {
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState(plan.planMd);
+  const [saved, setSaved] = useState(plan.planMd);
+  const [pending, startTransition] = useTransition();
+  const [error, setError] = useState<string | null>(null);
+
+  const onSave = () => {
+    setError(null);
+    startTransition(async () => {
+      const r = await saveCarePlanAction(plan.id, draft);
+      if (!r.ok) {
+        setError(r.error);
+        return;
+      }
+      setSaved(draft);
+      setEditing(false);
+    });
+  };
+
+  const onDiscard = () => {
+    setDraft(saved);
+    setEditing(false);
+    setError(null);
+  };
+
+  const onChangeStatus = (next: EsucCarePlan['status']) => {
+    setError(null);
+    startTransition(async () => {
+      const r = await changeCarePlanStatusAction(plan.id, patientId, next);
+      if (!r.ok) setError(r.error);
+    });
+  };
+
+  return (
+    <div className="space-y-4">
+      <Card>
+        <CardHeader>
+          <div className="flex items-center justify-between gap-3">
+            <div className="space-y-1">
+              <CardTitle className="text-base">Care plan status</CardTitle>
+              <p className="text-xs text-muted-foreground">
+                Generated {fmtDate(plan.createdAt)} · Last updated {fmtDate(plan.updatedAt)}
+              </p>
+            </div>
+            <span className={`rounded px-2 py-1 text-xs font-medium ${statusBadge[plan.status]}`}>
+              {plan.status}
+            </span>
+          </div>
+        </CardHeader>
+        <CardContent className="flex flex-wrap gap-2">
+          {plan.status === 'archived' ? (
+            <p className="text-xs text-muted-foreground">
+              Plan archived — generate a new plan to re-engage this patient.
+            </p>
+          ) : (
+            <>
+              <Button
+                size="sm"
+                variant="outline"
+                disabled={pending || plan.status !== 'draft'}
+                onClick={() => onChangeStatus('approved')}
+              >
+                Approve
+              </Button>
+              <Button
+                size="sm"
+                variant="outline"
+                disabled={pending || plan.status !== 'approved'}
+                onClick={() => onChangeStatus('active')}
+              >
+                Activate
+              </Button>
+              <Button
+                size="sm"
+                variant="ghost"
+                disabled={pending}
+                onClick={() => onChangeStatus('archived')}
+              >
+                Archive
+              </Button>
+            </>
+          )}
+          {error ? <span className="text-destructive text-xs">{error}</span> : null}
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <div className="flex items-center justify-between gap-3">
+            <CardTitle className="text-base">Plan</CardTitle>
+            {editing ? (
+              <div className="flex gap-2">
+                <Button size="sm" variant="ghost" disabled={pending} onClick={onDiscard}>
+                  Discard
+                </Button>
+                <Button size="sm" disabled={pending} onClick={onSave}>
+                  {pending ? 'Saving…' : 'Save'}
+                </Button>
+              </div>
+            ) : (
+              <Button
+                size="sm"
+                variant="outline"
+                disabled={plan.status === 'archived'}
+                onClick={() => setEditing(true)}
+              >
+                Edit
+              </Button>
+            )}
+          </div>
+        </CardHeader>
+        <CardContent>
+          {editing ? (
+            <textarea
+              value={draft}
+              onChange={(e) => setDraft(e.target.value)}
+              className="font-mono min-h-[36rem] w-full rounded-md border border-input bg-background p-3 text-sm"
+              spellCheck
+            />
+          ) : (
+            <div className="prose prose-sm dark:prose-invert max-w-none">
+              <ReactMarkdown>{saved}</ReactMarkdown>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/db/schema/enums.ts
+++ b/src/db/schema/enums.ts
@@ -105,3 +105,12 @@ export const edEncounterSourceEnum = pgEnum('ed_encounter_source', [
 ]);
 
 export type EdEncounterSource = (typeof edEncounterSourceEnum.enumValues)[number];
+
+export const esucCarePlanStatusEnum = pgEnum('esuc_care_plan_status', [
+  'draft',
+  'approved',
+  'active',
+  'archived',
+]);
+
+export type EsucCarePlanStatus = (typeof esucCarePlanStatusEnum.enumValues)[number];

--- a/src/db/schema/esuc-care-plans.ts
+++ b/src/db/schema/esuc-care-plans.ts
@@ -1,0 +1,48 @@
+import { index, pgTable, text, timestamp, uniqueIndex, uuid } from 'drizzle-orm/pg-core';
+import { esucCarePlanStatusEnum } from './enums';
+import { users } from './users';
+
+/**
+ * AI-drafted care plan for an ED super-utilizer, generated from the
+ * patient's encounter history by the ESUC-011 service. One row per
+ * (patient_id, prompt_version) — re-running the generator with the
+ * same prompt version no-ops via the unique index. Bumping the prompt
+ * version inserts a new draft alongside the old; a coordinator can
+ * compare plans during prompt iteration.
+ *
+ * Status flow:
+ *   draft (default) -> approved -> active -> archived
+ *                                \-> archived
+ *
+ * `patient_id` is the SAME opaque identifier used in `ed_encounters`
+ * (SYN-PAT-* synthetic, hashed real id post-BAA). We never store the
+ * real Epic name on the plan, by design. The cross-reference happens
+ * inside Epic for the care coordinator, not on this platform.
+ *
+ * `generated_by_user_id` is the care coordinator who triggered the
+ * generation; SET NULL on user delete so the plan survives staff turnover.
+ */
+export const esucCarePlans = pgTable(
+  'esuc_care_plans',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    /** Opaque — synthetic prefix today, hash post-BAA. Never a real name. */
+    patientId: text('patient_id').notNull(),
+    planMd: text('plan_md').notNull(),
+    promptVersion: text('prompt_version').notNull(),
+    generatedByUserId: uuid('generated_by_user_id').references(() => users.id, {
+      onDelete: 'set null',
+    }),
+    status: esucCarePlanStatusEnum('status').notNull().default('draft'),
+    createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),
+  },
+  (t) => [
+    uniqueIndex('care_plans_patient_version_idx').on(t.patientId, t.promptVersion),
+    index('care_plans_patient_idx').on(t.patientId),
+    index('care_plans_status_idx').on(t.status),
+  ],
+);
+
+export type EsucCarePlan = typeof esucCarePlans.$inferSelect;
+export type NewEsucCarePlan = typeof esucCarePlans.$inferInsert;

--- a/src/db/schema/index.ts
+++ b/src/db/schema/index.ts
@@ -2,6 +2,7 @@ export * from './audit-log';
 export * from './consents';
 export * from './ed-encounters';
 export * from './enums';
+export * from './esuc-care-plans';
 export * from './eviction-case-outcomes';
 export * from './eviction-filing-risk-scores';
 export * from './eviction-filings';

--- a/src/lib/esuc/care-plan.ts
+++ b/src/lib/esuc/care-plan.ts
@@ -69,15 +69,20 @@ export function validateCarePlanDisclaimer(
  */
 function scrubClinicalNote(s: string | null): string | null {
   if (!s) return s;
-  return s
-    // Phone numbers (US-shaped)
-    .replace(/\+?1?[\s-]?\(?\d{3}\)?[\s-]?\d{3}[\s-]?\d{4}/g, '[REDACTED-PHONE]')
-    // Email-shaped
-    .replace(/[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}/g, '[REDACTED-EMAIL]')
-    // SSN-shaped
-    .replace(/\b\d{3}-\d{2}-\d{4}\b/g, '[REDACTED-SSN]')
-    // Honorifics + name
-    .replace(/\b(Mr|Mrs|Ms|Dr|Mr\.|Mrs\.|Ms\.|Dr\.)\s+[A-Z][a-z]+(?:\s+[A-Z][a-z]+)?/g, '[REDACTED-NAME]');
+  return (
+    s
+      // Phone numbers (US-shaped)
+      .replace(/\+?1?[\s-]?\(?\d{3}\)?[\s-]?\d{3}[\s-]?\d{4}/g, '[REDACTED-PHONE]')
+      // Email-shaped
+      .replace(/[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}/g, '[REDACTED-EMAIL]')
+      // SSN-shaped
+      .replace(/\b\d{3}-\d{2}-\d{4}\b/g, '[REDACTED-SSN]')
+      // Honorifics + name
+      .replace(
+        /\b(Mr|Mrs|Ms|Dr|Mr\.|Mrs\.|Ms\.|Dr\.)\s+[A-Z][a-z]+(?:\s+[A-Z][a-z]+)?/g,
+        '[REDACTED-NAME]',
+      )
+  );
 }
 
 function fillDisclaimer(planMd: string, generatedAt: Date): string {

--- a/src/lib/esuc/care-plan.ts
+++ b/src/lib/esuc/care-plan.ts
@@ -56,6 +56,30 @@ export function validateCarePlanDisclaimer(
   return { ok: true };
 }
 
+/**
+ * Defensive scrub of an encounter `notes` field before it enters the
+ * Claude prompt. Phase 1: synthetic data, this is mostly a no-op
+ * stub. **TODO(ESUC-002):** when Epic FHIR data flows post-BAA,
+ * replace with a proper de-identification pipeline (Microsoft Presidio
+ * or equivalent — name/address/phone/MRN/email recognition + redaction).
+ *
+ * Today's stub catches the most blatant patterns so a developer who
+ * accidentally pastes a real name into a synthetic fixture gets
+ * a "[REDACTED]" in the prompt rather than passing it through.
+ */
+function scrubClinicalNote(s: string | null): string | null {
+  if (!s) return s;
+  return s
+    // Phone numbers (US-shaped)
+    .replace(/\+?1?[\s-]?\(?\d{3}\)?[\s-]?\d{3}[\s-]?\d{4}/g, '[REDACTED-PHONE]')
+    // Email-shaped
+    .replace(/[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}/g, '[REDACTED-EMAIL]')
+    // SSN-shaped
+    .replace(/\b\d{3}-\d{2}-\d{4}\b/g, '[REDACTED-SSN]')
+    // Honorifics + name
+    .replace(/\b(Mr|Mrs|Ms|Dr|Mr\.|Mrs\.|Ms\.|Dr\.)\s+[A-Z][a-z]+(?:\s+[A-Z][a-z]+)?/g, '[REDACTED-NAME]');
+}
+
 function fillDisclaimer(planMd: string, generatedAt: Date): string {
   return planMd
     .replace(/\{timestamp\}/g, generatedAt.toISOString())
@@ -102,7 +126,7 @@ export async function generateCarePlan(
       disposition: e.disposition,
       housing_status: e.housingStatus,
       charge_cents: e.chargeCents,
-      notes: e.notes,
+      notes: scrubClinicalNote(e.notes),
     })),
   };
 

--- a/src/lib/esuc/care-plan.ts
+++ b/src/lib/esuc/care-plan.ts
@@ -1,0 +1,188 @@
+import Anthropic from '@anthropic-ai/sdk';
+import { zodOutputFormat } from '@anthropic-ai/sdk/helpers/zod';
+import { and, eq } from 'drizzle-orm';
+import {
+  buildCarePlanUserPrompt,
+  CARE_PLAN_DISCLAIMER_PREFIX,
+  CARE_PLAN_PROMPT_VERSION,
+  type CarePlanOutput,
+  CarePlanSchema,
+  ESUC_CARE_PLAN_SYSTEM_PROMPT,
+} from '@/ai/prompts/esuc-care-plan';
+import { db } from '@/db/client';
+import { listEncountersForPatient } from '@/db/queries/ed-encounters';
+import {
+  type EsucCarePlan,
+  esucCarePlans,
+  type NewEsucCarePlan,
+} from '@/db/schema/esuc-care-plans';
+
+let _client: Anthropic | null = null;
+function client(): Anthropic {
+  if (!_client) _client = new Anthropic();
+  return _client;
+}
+
+const WINDOW_DAYS = 180;
+
+/**
+ * Single source of truth for the care-plan disclaimer contract. Used
+ * after generation (placeholder form) and on coordinator save (filled
+ * form). Same shape as response-packet.ts validateDisclaimer.
+ */
+export function validateCarePlanDisclaimer(
+  planMd: string,
+  phase: 'generation' | 'edit',
+): { ok: true } | { ok: false; error: string } {
+  const required = [
+    `${CARE_PLAN_DISCLAIMER_PREFIX}.`,
+    'not a treatment plan',
+    'not a clinical recommendation',
+  ];
+  if (phase === 'generation') {
+    required.push('Generated {timestamp} model {model_version}.');
+  } else {
+    required.push('Generated ');
+    required.push(' model ');
+  }
+  for (const fragment of required) {
+    if (!planMd.includes(fragment)) {
+      return {
+        ok: false,
+        error: `Care-plan disclaimer missing required fragment: "${fragment.slice(0, 60)}${fragment.length > 60 ? '…' : ''}"`,
+      };
+    }
+  }
+  return { ok: true };
+}
+
+function fillDisclaimer(planMd: string, generatedAt: Date): string {
+  return planMd
+    .replace(/\{timestamp\}/g, generatedAt.toISOString())
+    .replace(/\{model_version\}/g, CARE_PLAN_PROMPT_VERSION);
+}
+
+/**
+ * Generate (or retrieve) the AI-drafted care plan for a patient.
+ * Idempotent: (patient_id, prompt_version) pairs return the cached row
+ * instead of re-calling Claude.
+ *
+ * `generatedByUserId` is the care coordinator who clicked the button —
+ * recorded for audit and so we can show "drafted on behalf of {name}"
+ * in the UI. Pass `null` for system-triggered generation (eval harness).
+ */
+export async function generateCarePlan(
+  patientId: string,
+  generatedByUserId: string | null,
+): Promise<EsucCarePlan> {
+  const cached = await db
+    .select()
+    .from(esucCarePlans)
+    .where(
+      and(
+        eq(esucCarePlans.patientId, patientId),
+        eq(esucCarePlans.promptVersion, CARE_PLAN_PROMPT_VERSION),
+      ),
+    )
+    .limit(1);
+  if (cached.length > 0) return cached[0];
+
+  const encounters = await listEncountersForPatient(patientId);
+  if (encounters.length === 0) {
+    throw new Error(`[care-plan] no encounters for patient ${patientId}; refusing to draft`);
+  }
+
+  const promptInput = {
+    patient_id: patientId,
+    encounter_count: encounters.length,
+    window_days: WINDOW_DAYS,
+    encounters: encounters.map((e) => ({
+      arrived_at: e.arrivedAt.toISOString(),
+      chief_complaint: e.chiefComplaint,
+      disposition: e.disposition,
+      housing_status: e.housingStatus,
+      charge_cents: e.chargeCents,
+      notes: e.notes,
+    })),
+  };
+
+  const response = await client().messages.parse({
+    model: 'claude-opus-4-7',
+    max_tokens: 16000,
+    thinking: { type: 'adaptive' },
+    output_config: {
+      effort: 'high',
+      format: zodOutputFormat(CarePlanSchema),
+    },
+    system: [
+      {
+        type: 'text',
+        text: ESUC_CARE_PLAN_SYSTEM_PROMPT,
+        cache_control: { type: 'ephemeral' },
+      },
+    ],
+    messages: [{ role: 'user', content: buildCarePlanUserPrompt(promptInput) }],
+  });
+
+  if (!response.parsed_output) {
+    throw new Error(
+      `[care-plan] structured output parse failed; stop_reason=${response.stop_reason}`,
+    );
+  }
+  const parsed: CarePlanOutput = response.parsed_output;
+
+  const generationCheck = validateCarePlanDisclaimer(parsed.plan_md, 'generation');
+  if (!generationCheck.ok) {
+    throw new Error(`[care-plan] ${generationCheck.error}`);
+  }
+
+  const filled = fillDisclaimer(parsed.plan_md, new Date());
+
+  if (filled.includes('{timestamp}') || filled.includes('{model_version}')) {
+    throw new Error('[care-plan] disclaimer placeholders still present after fill');
+  }
+
+  const newRow: NewEsucCarePlan = {
+    patientId,
+    planMd: filled,
+    promptVersion: CARE_PLAN_PROMPT_VERSION,
+    generatedByUserId,
+    status: 'draft',
+  };
+
+  const [persisted] = await db
+    .insert(esucCarePlans)
+    .values(newRow)
+    .onConflictDoNothing({
+      target: [esucCarePlans.patientId, esucCarePlans.promptVersion],
+    })
+    .returning();
+  if (persisted) return persisted;
+
+  // Concurrent caller beat us — re-select the winner.
+  const [winner] = await db
+    .select()
+    .from(esucCarePlans)
+    .where(
+      and(
+        eq(esucCarePlans.patientId, patientId),
+        eq(esucCarePlans.promptVersion, CARE_PLAN_PROMPT_VERSION),
+      ),
+    )
+    .limit(1);
+  return winner;
+}
+
+export async function getCarePlanByPatient(patientId: string): Promise<EsucCarePlan | null> {
+  const rows = await db
+    .select()
+    .from(esucCarePlans)
+    .where(
+      and(
+        eq(esucCarePlans.patientId, patientId),
+        eq(esucCarePlans.promptVersion, CARE_PLAN_PROMPT_VERSION),
+      ),
+    )
+    .limit(1);
+  return rows[0] ?? null;
+}


### PR DESCRIPTION
Closes #81

## Summary
Mirror of EVDT-012 for the ED super-utilizer care-coordination flow. Patient encounter history → Claude Opus 4.7 → structured markdown care plan that an Owensboro Health care coordinator reviews, edits, approves, and activates.

- **Schema:** \`esuc_care_plans\` table with opaque \`patient_id\`, status enum (\`draft|approved|active|archived\`), idempotency on \`(patient_id, prompt_version)\`. Migration 0012.
- **Prompt** (\`src/ai/prompts/esuc-care-plan.ts\`) — system prompt with worked example, 6-section output (disclaimer / Patient summary / Risk factors / Recommended interventions checklist / Care-coordinator next steps / TEAMKY HRSN note), zod schema.
- **Service** (\`src/lib/esuc/care-plan.ts\`) — same idempotency / disclaimer-validator / fillDisclaimer / belt-and-braces post-fill check pattern as response-packet.ts.
- **Server actions** — generate / save / changeStatus, server-side \`ALLOWED_TRANSITIONS\` map, audit-logged. Roles: \`ed_coordinator\`, \`admin\`.
- **UI:** \`CarePlanPanel\` (NoPlan → Generate button; HasPlan → status pills + Edit / Save / Discard with markdown preview ↔ textarea swap). Wired into the patient-detail page.
- **Eval harness** + 5 hand-curated synthetic patient histories. 8 structural checks per plan (disclaimer / opaque id / all 4 required sections / ≥5 checkboxes / TEAMKY ref / no-name-pattern). Non-zero exit unless every plan clean.

## PHI fence
- \`patient_id\` opaque on every surface and inside the prompt.
- Encounter history is facts-only (chief complaint, disposition, housing status, charge, notes). Real Epic data shouldn't carry names in those fields — eval harness asserts no name-shaped strings appear in output.
- claude-opus-4-7 + adaptive thinking + effort:'high' + ephemeral cache on system block (per claude-api skill).

## Acceptance criteria
- [x] \`generateCarePlan(patientId, userId)\` in \`src/lib/esuc/care-plan.ts\`, idempotent on \`(patient_id, prompt_version)\`
- [x] Prompt at \`src/ai/prompts/esuc-care-plan.ts\` (no inline strings)
- [x] Output: structured markdown with all 5 sections + disclaimer
- [x] Required disclaimer at top with both placeholders
- [x] Disclaimer-validator pattern shared with response-packet (parallel impl, same shape)
- [x] New table \`esuc_care_plans\` with status enum
- [x] Patient ID stays opaque in the prompt
- [x] AI care-plan card on \`/app/care/patients/[id]\` (replaces placeholder)
- [x] Eval harness: 5 synthetic patients + structural checklist
- [x] Idempotent on \`(patient_id, prompt_version)\`

## Notes for review
- I haven't run the eval yet against the live API — each run is ~5 × Opus calls with effort=high (~$2-3 in spend). Bo can run it post-merge.
- Disclaimer validator is a near-duplicate of response-packet's. Could be extracted into a generic \`validateRequiredFragments\` helper but the contracts differ enough (different prefix, different required wording, different post-fill anchors) that the abstraction would obscure rather than simplify. Worth revisiting if a third generator lands.
- CarePlanPanel is a near-duplicate of PacketReviewPanel. Same call here — they share shape but the workflows diverge (status flows different, generate-with-encounter-history vs generate-with-filing); abstracting into a generic AI-doc-review primitive is a Phase 2 cleanup if we have 3+ such surfaces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)