### PR TITLE
feat(COAL-001): partner directory + multi-org seed

### DIFF
--- a/drizzle/migrations/0013_blue_tinkerer.sql
+++ b/drizzle/migrations/0013_blue_tinkerer.sql
@@ -1,0 +1,10 @@
+CREATE TYPE "public"."data_sharing_tier" AS ENUM('none', 'aggregate', 'individual');--> statement-breakpoint
+ALTER TYPE "public"."partner_org_type" ADD VALUE 'faith_based' BEFORE 'other';--> statement-breakpoint
+ALTER TYPE "public"."partner_org_type" ADD VALUE 'school' BEFORE 'other';--> statement-breakpoint
+ALTER TYPE "public"."partner_org_type" ADD VALUE 'philanthropy' BEFORE 'other';--> statement-breakpoint
+ALTER TYPE "public"."partner_org_type" ADD VALUE 'education' BEFORE 'other';--> statement-breakpoint
+ALTER TYPE "public"."partner_org_type" ADD VALUE 'public_health' BEFORE 'other';--> statement-breakpoint
+ALTER TYPE "public"."partner_org_type" ADD VALUE 'media' BEFORE 'other';--> statement-breakpoint
+ALTER TABLE "partner_orgs" ADD COLUMN "website" text;--> statement-breakpoint
+ALTER TABLE "partner_orgs" ADD COLUMN "description" text;--> statement-breakpoint
+ALTER TABLE "partner_orgs" ADD COLUMN "data_sharing_tier" "data_sharing_tier" DEFAULT 'none' NOT NULL;

--- a/drizzle/migrations/meta/0013_snapshot.json
+++ b/drizzle/migrations/meta/0013_snapshot.json
@@ -1,0 +1,1668 @@
+{
+  "id": "1cc890a6-aacf-49da-a924-fe6a6b10e4a7",
+  "prevId": "31baf5ab-36c8-466d-9677-6c511b70963a",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.audit_log": {
+      "name": "audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_table": {
+          "name": "target_table",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "audit_log_actor_idx": {
+          "name": "audit_log_actor_idx",
+          "columns": [
+            {
+              "expression": "actor_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_log_action_idx": {
+          "name": "audit_log_action_idx",
+          "columns": [
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_log_created_at_idx": {
+          "name": "audit_log_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audit_log_actor_user_id_users_id_fk": {
+          "name": "audit_log_actor_user_id_users_id_fk",
+          "tableFrom": "audit_log",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.consents": {
+      "name": "consents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "subject_external_id": {
+          "name": "subject_external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consent_type": {
+          "name": "consent_type",
+          "type": "consent_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "granted_via": {
+          "name": "granted_via",
+          "type": "consent_channel",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "granted_at": {
+          "name": "granted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "consents_subject_idx": {
+          "name": "consents_subject_idx",
+          "columns": [
+            {
+              "expression": "subject_external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "consents_type_idx": {
+          "name": "consents_type_idx",
+          "columns": [
+            {
+              "expression": "consent_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ed_encounters": {
+      "name": "ed_encounters",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encounter_external_id": {
+          "name": "encounter_external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "arrived_at": {
+          "name": "arrived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discharged_at": {
+          "name": "discharged_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chief_complaint": {
+          "name": "chief_complaint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "disposition": {
+          "name": "disposition",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "housing_status": {
+          "name": "housing_status",
+          "type": "housing_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unknown'"
+        },
+        "charge_cents": {
+          "name": "charge_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_json": {
+          "name": "raw_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "ed_encounter_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'synthetic'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ed_encounters_external_idx": {
+          "name": "ed_encounters_external_idx",
+          "columns": [
+            {
+              "expression": "encounter_external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ed_encounters_patient_idx": {
+          "name": "ed_encounters_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ed_encounters_arrived_idx": {
+          "name": "ed_encounters_arrived_idx",
+          "columns": [
+            {
+              "expression": "arrived_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ed_encounters_housing_idx": {
+          "name": "ed_encounters_housing_idx",
+          "columns": [
+            {
+              "expression": "housing_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.esuc_care_plans": {
+      "name": "esuc_care_plans",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plan_md": {
+          "name": "plan_md",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt_version": {
+          "name": "prompt_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "generated_by_user_id": {
+          "name": "generated_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "esuc_care_plan_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "care_plans_patient_version_idx": {
+          "name": "care_plans_patient_version_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "prompt_version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "care_plans_patient_idx": {
+          "name": "care_plans_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "care_plans_status_idx": {
+          "name": "care_plans_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "esuc_care_plans_generated_by_user_id_users_id_fk": {
+          "name": "esuc_care_plans_generated_by_user_id_users_id_fk",
+          "tableFrom": "esuc_care_plans",
+          "tableTo": "users",
+          "columnsFrom": [
+            "generated_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.eviction_case_outcomes": {
+      "name": "eviction_case_outcomes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "filing_id": {
+          "name": "filing_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "eviction_case_outcome",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recorded_by_user_id": {
+          "name": "recorded_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "case_outcomes_filing_idx": {
+          "name": "case_outcomes_filing_idx",
+          "columns": [
+            {
+              "expression": "filing_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "case_outcomes_outcome_idx": {
+          "name": "case_outcomes_outcome_idx",
+          "columns": [
+            {
+              "expression": "outcome",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "case_outcomes_created_at_idx": {
+          "name": "case_outcomes_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "eviction_case_outcomes_filing_id_eviction_filings_id_fk": {
+          "name": "eviction_case_outcomes_filing_id_eviction_filings_id_fk",
+          "tableFrom": "eviction_case_outcomes",
+          "tableTo": "eviction_filings",
+          "columnsFrom": [
+            "filing_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "eviction_case_outcomes_recorded_by_user_id_users_id_fk": {
+          "name": "eviction_case_outcomes_recorded_by_user_id_users_id_fk",
+          "tableFrom": "eviction_case_outcomes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "recorded_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.eviction_filing_risk_scores": {
+      "name": "eviction_filing_risk_scores",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "filing_id": {
+          "name": "filing_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rationale": {
+          "name": "rationale",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model_version": {
+          "name": "model_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "risk_scores_filing_version_idx": {
+          "name": "risk_scores_filing_version_idx",
+          "columns": [
+            {
+              "expression": "filing_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "model_version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "risk_scores_filing_idx": {
+          "name": "risk_scores_filing_idx",
+          "columns": [
+            {
+              "expression": "filing_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "risk_scores_score_idx": {
+          "name": "risk_scores_score_idx",
+          "columns": [
+            {
+              "expression": "score",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "eviction_filing_risk_scores_filing_id_eviction_filings_id_fk": {
+          "name": "eviction_filing_risk_scores_filing_id_eviction_filings_id_fk",
+          "tableFrom": "eviction_filing_risk_scores",
+          "tableTo": "eviction_filings",
+          "columnsFrom": [
+            "filing_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.eviction_filings": {
+      "name": "eviction_filings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "case_number": {
+          "name": "case_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filed_at": {
+          "name": "filed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "court_division": {
+          "name": "court_division",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plaintiff": {
+          "name": "plaintiff",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "defendant_first_name": {
+          "name": "defendant_first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "defendant_last_name": {
+          "name": "defendant_last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "defendant_address": {
+          "name": "defendant_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cause_type": {
+          "name": "cause_type",
+          "type": "eviction_cause_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_claimed_cents": {
+          "name": "amount_claimed_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "eviction_filing_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'filed'"
+        },
+        "source": {
+          "name": "source",
+          "type": "eviction_filing_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "raw_json": {
+          "name": "raw_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "eviction_filings_case_source_idx": {
+          "name": "eviction_filings_case_source_idx",
+          "columns": [
+            {
+              "expression": "case_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "eviction_filings_filed_at_idx": {
+          "name": "eviction_filings_filed_at_idx",
+          "columns": [
+            {
+              "expression": "filed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "eviction_filings_status_idx": {
+          "name": "eviction_filings_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.eviction_response_packets": {
+      "name": "eviction_response_packets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "filing_id": {
+          "name": "filing_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "packet_md": {
+          "name": "packet_md",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt_version": {
+          "name": "prompt_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "generated_by_user_id": {
+          "name": "generated_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "eviction_response_packet_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "response_packets_filing_version_idx": {
+          "name": "response_packets_filing_version_idx",
+          "columns": [
+            {
+              "expression": "filing_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "prompt_version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "response_packets_filing_idx": {
+          "name": "response_packets_filing_idx",
+          "columns": [
+            {
+              "expression": "filing_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "response_packets_status_idx": {
+          "name": "response_packets_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "eviction_response_packets_filing_id_eviction_filings_id_fk": {
+          "name": "eviction_response_packets_filing_id_eviction_filings_id_fk",
+          "tableFrom": "eviction_response_packets",
+          "tableTo": "eviction_filings",
+          "columnsFrom": [
+            "filing_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "eviction_response_packets_generated_by_user_id_users_id_fk": {
+          "name": "eviction_response_packets_generated_by_user_id_users_id_fk",
+          "tableFrom": "eviction_response_packets",
+          "tableTo": "users",
+          "columnsFrom": [
+            "generated_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.health_check": {
+      "name": "health_check",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_memberships": {
+      "name": "org_memberships",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "partner_org_id": {
+          "name": "partner_org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "org_memberships_user_org_idx": {
+          "name": "org_memberships_user_org_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "partner_org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "org_memberships_user_idx": {
+          "name": "org_memberships_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "org_memberships_partner_org_idx": {
+          "name": "org_memberships_partner_org_idx",
+          "columns": [
+            {
+              "expression": "partner_org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "org_memberships_user_id_users_id_fk": {
+          "name": "org_memberships_user_id_users_id_fk",
+          "tableFrom": "org_memberships",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "org_memberships_partner_org_id_partner_orgs_id_fk": {
+          "name": "org_memberships_partner_org_id_partner_orgs_id_fk",
+          "tableFrom": "org_memberships",
+          "tableTo": "partner_orgs",
+          "columnsFrom": [
+            "partner_org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.partner_orgs": {
+      "name": "partner_orgs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "partner_org_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_email": {
+          "name": "contact_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_phone": {
+          "name": "contact_phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "website": {
+          "name": "website",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data_sharing_tier": {
+          "name": "data_sharing_tier",
+          "type": "data_sharing_tier",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "partner_orgs_slug_idx": {
+          "name": "partner_orgs_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rental_assistance_programs": {
+      "name": "rental_assistance_programs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agency": {
+          "name": "agency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "website": {
+          "name": "website",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "eligibility_summary": {
+          "name": "eligibility_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "max_award_cents": {
+          "name": "max_award_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_note": {
+          "name": "source_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "rental_assistance_programs_active_idx": {
+          "name": "rental_assistance_programs_active_idx",
+          "columns": [
+            {
+              "expression": "active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "clerk_user_id": {
+          "name": "clerk_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "users_clerk_user_id_idx": {
+          "name": "users_clerk_user_id_idx",
+          "columns": [
+            {
+              "expression": "clerk_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.consent_channel": {
+      "name": "consent_channel",
+      "schema": "public",
+      "values": [
+        "sms",
+        "in_person",
+        "web_form",
+        "phone",
+        "paper"
+      ]
+    },
+    "public.consent_type": {
+      "name": "consent_type",
+      "schema": "public",
+      "values": [
+        "phi_share_within_coalition",
+        "sms_communication",
+        "data_for_program_eval"
+      ]
+    },
+    "public.data_sharing_tier": {
+      "name": "data_sharing_tier",
+      "schema": "public",
+      "values": [
+        "none",
+        "aggregate",
+        "individual"
+      ]
+    },
+    "public.ed_encounter_source": {
+      "name": "ed_encounter_source",
+      "schema": "public",
+      "values": [
+        "synthetic",
+        "epic_fhir",
+        "manual"
+      ]
+    },
+    "public.esuc_care_plan_status": {
+      "name": "esuc_care_plan_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "approved",
+        "active",
+        "archived"
+      ]
+    },
+    "public.eviction_case_outcome": {
+      "name": "eviction_case_outcome",
+      "schema": "public",
+      "values": [
+        "dismissed",
+        "judgment_for_plaintiff",
+        "judgment_for_defendant",
+        "settled",
+        "default_judgment",
+        "withdrawn"
+      ]
+    },
+    "public.eviction_cause_type": {
+      "name": "eviction_cause_type",
+      "schema": "public",
+      "values": [
+        "non_payment",
+        "lease_violation",
+        "holdover",
+        "other"
+      ]
+    },
+    "public.eviction_filing_source": {
+      "name": "eviction_filing_source",
+      "schema": "public",
+      "values": [
+        "courtnet",
+        "manual",
+        "synthetic"
+      ]
+    },
+    "public.eviction_filing_status": {
+      "name": "eviction_filing_status",
+      "schema": "public",
+      "values": [
+        "filed",
+        "served",
+        "judgment",
+        "dismissed",
+        "sealed"
+      ]
+    },
+    "public.eviction_response_packet_status": {
+      "name": "eviction_response_packet_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "approved",
+        "filed",
+        "rejected"
+      ]
+    },
+    "public.housing_status": {
+      "name": "housing_status",
+      "schema": "public",
+      "values": [
+        "housed",
+        "doubled_up",
+        "shelter",
+        "unsheltered",
+        "unknown"
+      ]
+    },
+    "public.partner_org_type": {
+      "name": "partner_org_type",
+      "schema": "public",
+      "values": [
+        "hospital",
+        "legal_aid",
+        "shelter",
+        "community_org",
+        "government",
+        "faith_based",
+        "school",
+        "philanthropy",
+        "education",
+        "public_health",
+        "media",
+        "other"
+      ]
+    },
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "pending",
+        "attorney",
+        "caseworker",
+        "ed_coordinator",
+        "shelter_staff",
+        "admin"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/migrations/meta/_journal.json
+++ b/drizzle/migrations/meta/_journal.json
@@ -92,6 +92,13 @@
       "when": 1777228050129,
       "tag": "0012_common_darkstar",
       "breakpoints": true
+    },
+    {
+      "idx": 13,
+      "version": "7",
+      "when": 1777229074412,
+      "tag": "0013_blue_tinkerer",
+      "breakpoints": true
     }
   ]
 }

--- a/src/app/app/coalition/page.tsx
+++ b/src/app/app/coalition/page.tsx
@@ -1,0 +1,23 @@
+import { PartnerDirectory } from '@/components/coalition/partner-directory';
+import { listPartnerOrgs } from '@/db/queries/coalition';
+import { requireUser } from '@/lib/auth';
+
+export default async function CoalitionPage() {
+  await requireUser();
+  const orgs = await listPartnerOrgs();
+  const aggregateCount = orgs.filter((o) => o.dataSharingTier !== 'none').length;
+
+  return (
+    <div className="mx-auto max-w-6xl space-y-4 p-6">
+      <header>
+        <h1 className="font-serif text-3xl font-bold text-primary">Coalition</h1>
+        <p className="text-sm text-muted-foreground">
+          Daviess County homelessness-response stakeholders catalogued in the pilot report.
+          {orgs.length} organizations · {aggregateCount} actively contributing data ·{' '}
+          {orgs.length - aggregateCount} not yet on the data trust.
+        </p>
+      </header>
+      <PartnerDirectory orgs={orgs} />
+    </div>
+  );
+}

--- a/src/components/app-shell/nav-config.ts
+++ b/src/components/app-shell/nav-config.ts
@@ -45,6 +45,7 @@ export const NAV_ITEMS: NavItem[] = [
     href: '/app/metrics',
     roles: ['attorney', 'admin'],
   },
+  { label: 'Coalition', href: '/app/coalition', roles: 'all' },
   { label: 'Settings', href: '/app/settings', roles: 'all' },
   { label: 'Admin · Users', href: '/app/admin/users', roles: ['admin'] },
 ];

--- a/src/components/coalition/partner-directory.tsx
+++ b/src/components/coalition/partner-directory.tsx
@@ -1,0 +1,111 @@
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import type { DataSharingTier, PartnerOrgType } from '@/db/schema/enums';
+import type { PartnerOrg } from '@/db/schema/partner-orgs';
+
+const TYPE_LABEL: Record<PartnerOrgType, string> = {
+  hospital: 'Healthcare',
+  legal_aid: 'Legal aid',
+  shelter: 'Shelter providers',
+  community_org: 'Community organizations',
+  government: 'Government',
+  faith_based: 'Faith-based',
+  school: 'Schools',
+  philanthropy: 'Philanthropy',
+  education: 'Higher education',
+  public_health: 'Public health',
+  media: 'Media',
+  other: 'Other',
+};
+
+const TIER_LABEL: Record<DataSharingTier, string> = {
+  none: 'No data flow yet',
+  aggregate: 'Aggregate counts',
+  individual: 'Individual (consented)',
+};
+
+const TIER_BADGE: Record<DataSharingTier, string> = {
+  none: 'bg-muted text-muted-foreground',
+  aggregate: 'bg-amber-500/15 text-amber-700 dark:text-amber-400',
+  individual: 'bg-emerald-600/15 text-emerald-700 dark:text-emerald-400',
+};
+
+export function PartnerDirectory({ orgs }: { orgs: PartnerOrg[] }) {
+  // Group by type, preserving alphabetical order within each group.
+  const grouped = orgs.reduce<Map<PartnerOrgType, PartnerOrg[]>>((acc, org) => {
+    const list = acc.get(org.type) ?? [];
+    list.push(org);
+    acc.set(org.type, list);
+    return acc;
+  }, new Map());
+
+  return (
+    <div className="space-y-4">
+      <Card className="border-amber-500/40 bg-amber-500/5">
+        <CardContent className="text-xs">
+          <p className="font-medium">Phase-1 placeholder.</p>
+          <p className="mt-1 text-muted-foreground">
+            This directory lists every coalition stakeholder catalogued in the Daviess Pilot Report.
+            Data-sharing tiers default to "none" — they raise to "aggregate" or "individual" only
+            after a signed coalition data-trust agreement (see{' '}
+            <code className="font-mono">docs/research/Daviess_County_Pilot_Report.md</code> §5).
+            Contact info is intentionally minimal: names + websites are public; phone numbers and
+            emails are added per partner conversation, not seeded.
+          </p>
+        </CardContent>
+      </Card>
+
+      {Array.from(grouped.entries()).map(([type, list]) => (
+        <Card key={type}>
+          <CardHeader>
+            <CardTitle className="text-base">
+              {TYPE_LABEL[type]}{' '}
+              <span className="text-xs font-normal text-muted-foreground">({list.length})</span>
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <ul className="space-y-2">
+              {list.map((org) => (
+                <li key={org.id} className="rounded-md border border-border bg-card p-3">
+                  <div className="mb-1 flex flex-wrap items-baseline justify-between gap-2">
+                    <p className="font-medium">{org.name}</p>
+                    <span
+                      className={`rounded px-2 py-0.5 text-xs ${TIER_BADGE[org.dataSharingTier]}`}
+                      title="Phase-1 data-sharing tier"
+                    >
+                      {TIER_LABEL[org.dataSharingTier]}
+                    </span>
+                  </div>
+                  {org.description ? (
+                    <p className="text-sm text-muted-foreground">{org.description}</p>
+                  ) : null}
+                  <div className="mt-1 flex flex-wrap gap-3 text-xs">
+                    {org.website ? (
+                      <a
+                        href={org.website}
+                        target="_blank"
+                        rel="noreferrer noopener"
+                        className="hover:underline"
+                      >
+                        website ↗
+                      </a>
+                    ) : null}
+                    {org.contactPhone ? (
+                      <a className="font-mono hover:underline" href={`tel:${org.contactPhone}`}>
+                        {org.contactPhone}
+                      </a>
+                    ) : null}
+                    {org.contactEmail ? (
+                      <a className="hover:underline" href={`mailto:${org.contactEmail}`}>
+                        {org.contactEmail}
+                      </a>
+                    ) : null}
+                  </div>
+                </li>
+              ))}
+            </ul>
+          </CardContent>
+        </Card>
+      ))}
+    </div>
+  );
+}

--- a/src/components/coalition/partner-directory.tsx
+++ b/src/components/coalition/partner-directory.tsx
@@ -23,10 +23,15 @@ const TIER_LABEL: Record<DataSharingTier, string> = {
   individual: 'Individual (consented)',
 };
 
+// Color signals data-sensitivity, not workflow-success. `individual`
+// is the most-sensitive tier (consent-gated PHI flow); it gets the
+// most-intense badge so a directory reviewer's eye lands there.
+// `aggregate` is anonymized public-ish counts; muted info-color.
+// `none` is the default "no agreement yet" state; quiet grey.
 const TIER_BADGE: Record<DataSharingTier, string> = {
   none: 'bg-muted text-muted-foreground',
-  aggregate: 'bg-amber-500/15 text-amber-700 dark:text-amber-400',
-  individual: 'bg-emerald-600/15 text-emerald-700 dark:text-emerald-400',
+  aggregate: 'bg-secondary text-secondary-foreground',
+  individual: 'bg-amber-500/15 text-amber-700 dark:text-amber-400',
 };
 
 export function PartnerDirectory({ orgs }: { orgs: PartnerOrg[] }) {

--- a/src/db/queries/coalition.ts
+++ b/src/db/queries/coalition.ts
@@ -1,0 +1,12 @@
+import { asc, eq } from 'drizzle-orm';
+import { db } from '@/db/client';
+import { type PartnerOrg, partnerOrgs } from '@/db/schema/partner-orgs';
+
+/** All active partner orgs, sorted by type then name. */
+export async function listPartnerOrgs(): Promise<PartnerOrg[]> {
+  return await db
+    .select()
+    .from(partnerOrgs)
+    .where(eq(partnerOrgs.active, true))
+    .orderBy(asc(partnerOrgs.type), asc(partnerOrgs.name));
+}

--- a/src/db/schema/enums.ts
+++ b/src/db/schema/enums.ts
@@ -17,6 +17,12 @@ export const partnerOrgTypeEnum = pgEnum('partner_org_type', [
   'shelter',
   'community_org',
   'government',
+  'faith_based',
+  'school',
+  'philanthropy',
+  'education',
+  'public_health',
+  'media',
   'other',
 ]);
 
@@ -114,3 +120,7 @@ export const esucCarePlanStatusEnum = pgEnum('esuc_care_plan_status', [
 ]);
 
 export type EsucCarePlanStatus = (typeof esucCarePlanStatusEnum.enumValues)[number];
+
+export const dataSharingTierEnum = pgEnum('data_sharing_tier', ['none', 'aggregate', 'individual']);
+
+export type DataSharingTier = (typeof dataSharingTierEnum.enumValues)[number];

--- a/src/db/schema/partner-orgs.ts
+++ b/src/db/schema/partner-orgs.ts
@@ -1,5 +1,5 @@
 import { boolean, pgTable, text, timestamp, uniqueIndex, uuid } from 'drizzle-orm/pg-core';
-import { partnerOrgTypeEnum } from './enums';
+import { dataSharingTierEnum, partnerOrgTypeEnum } from './enums';
 
 export const partnerOrgs = pgTable(
   'partner_orgs',
@@ -10,6 +10,16 @@ export const partnerOrgs = pgTable(
     type: partnerOrgTypeEnum('type').notNull(),
     contactEmail: text('contact_email'),
     contactPhone: text('contact_phone'),
+    website: text('website'),
+    /** 1-2 sentence summary for the coalition directory page. */
+    description: text('description'),
+    /**
+     * Phase-1 placeholder for the coalition data-trust governance.
+     * Defaults to 'none' (no data flowing yet); coalition agreements
+     * raise this to 'aggregate' (anonymized service counts) or
+     * 'individual' (consent-gated per-person data).
+     */
+    dataSharingTier: dataSharingTierEnum('data_sharing_tier').notNull().default('none'),
     active: boolean('active').notNull().default(true),
     createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
     updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),

--- a/src/db/seed.ts
+++ b/src/db/seed.ts
@@ -13,7 +13,7 @@ import { db } from './client';
 import { auditLog } from './schema/audit-log';
 import type { UserRole } from './schema/enums';
 import { orgMemberships } from './schema/org-memberships';
-import { partnerOrgs } from './schema/partner-orgs';
+import { type NewPartnerOrg, partnerOrgs } from './schema/partner-orgs';
 import {
   type NewRentalAssistanceProgram,
   rentalAssistancePrograms,
@@ -57,12 +57,250 @@ async function main() {
         type: 'legal_aid',
         contactEmail: 'owensboro@klaid.example',
         contactPhone: '+1-270-555-0200',
+        website: 'https://www.kyjustice.org/county/daviess',
+        description:
+          'Civil legal aid for low-income Daviess residents. Phase-1 pilot partner for the eviction-defense triage workflow.',
+        dataSharingTier: 'individual',
       })
       .returning();
     console.log('[seed]   + partner org', klaOrg.slug);
   } else {
     console.log('[seed]   = partner org', klaOrg.slug, '(exists)');
   }
+
+  // ---- coalition catalog (COAL-001) ----
+  // Stakeholders catalogued in docs/research/Daviess_County_Pilot_Report.md.
+  // Names + websites are real (public sources); we deliberately omit
+  // phone numbers unless verified. data_sharing_tier defaults to 'none'
+  // until coalition agreements raise it.
+  const coalitionOrgs: NewPartnerOrg[] = [
+    // Shelter providers
+    {
+      name: 'Boulware Mission, Inc.',
+      slug: 'boulware-mission',
+      type: 'shelter',
+      website: 'https://www.boulwaremission.org',
+      description:
+        'Emergency and long-term shelter for homeless men and women across the seven-county Green River region.',
+      dataSharingTier: 'none',
+    },
+    {
+      name: "St. Benedict's Homeless Shelter",
+      slug: 'st-benedicts-shelter',
+      type: 'shelter',
+      website: 'https://stbenedictsowensboro.org',
+      description:
+        'Christian-mission 24/7 shelter for 64 men nightly + day shelter for ~40 women and families. ~500 served annually.',
+      dataSharingTier: 'none',
+    },
+    {
+      name: 'Daniel Pitino Shelter',
+      slug: 'daniel-pitino-shelter',
+      type: 'shelter',
+      website: 'https://pitinoshelter.org',
+      description:
+        '22,000 sq ft emergency and transitional housing for women, women with children, and families.',
+      dataSharingTier: 'none',
+    },
+    {
+      name: 'OASIS Shelter',
+      slug: 'oasis-shelter',
+      type: 'shelter',
+      description:
+        "Domestic-violence program AND licensed women's substance-use treatment. Location-confidential by design — coalition data design uses abuser-blind protocols here.",
+      dataSharingTier: 'none',
+    },
+    {
+      name: 'CrossRoads to Hope',
+      slug: 'crossroads-to-hope',
+      type: 'shelter',
+      website: 'https://crossroadsowensboro.org',
+      description:
+        'The only walk-in emergency overnight shelter for women and children in Daviess County.',
+      dataSharingTier: 'none',
+    },
+    {
+      name: 'St. Joseph Peace Mission for Children',
+      slug: 'st-joseph-peace-mission',
+      type: 'shelter',
+      description: 'Licensed emergency shelter for children. Designated Safe Place site.',
+      dataSharingTier: 'none',
+    },
+    // Faith-based ecosystem
+    {
+      name: 'Catholic Charities of the Diocese of Owensboro',
+      slug: 'catholic-charities-owensboro',
+      type: 'faith_based',
+      website: 'https://owensborodiocese.org/catholic-charities',
+      description:
+        'Coordinates parish-level social services across 32 western-KY counties. Operates Feeding Our Friends, Gerard Life Home, immigration legal services, disaster relief.',
+      dataSharingTier: 'none',
+    },
+    {
+      name: 'Aid the Homeless, Inc.',
+      slug: 'aid-the-homeless',
+      type: 'faith_based',
+      website: 'https://aidthehomeless.org',
+      description: 'Umbrella organization supporting multiple Owensboro shelters.',
+      dataSharingTier: 'none',
+    },
+    {
+      name: 'Volunteer Owensboro',
+      slug: 'volunteer-owensboro',
+      type: 'community_org',
+      description: 'Volunteer mobilization infrastructure across Daviess-area nonprofits.',
+      dataSharingTier: 'none',
+    },
+    // Healthcare
+    {
+      name: 'Owensboro Health',
+      slug: 'owensboro-health',
+      type: 'hospital',
+      website: 'https://www.owensborohealth.org',
+      description:
+        'Dominant regional health system. Phase-1 pilot partner for ED super-utilizer care coordination via TEAMKY HRSN reimbursement.',
+      dataSharingTier: 'none',
+    },
+    {
+      name: 'Green River District Health Department',
+      slug: 'green-river-health-dept',
+      type: 'public_health',
+      description:
+        'County/regional public health authority. Under-leveraged data + coordination partner.',
+      dataSharingTier: 'none',
+    },
+    // Government
+    {
+      name: 'Daviess County Fiscal Court',
+      slug: 'daviess-fiscal-court',
+      type: 'government',
+      website: 'https://www.daviessky.org/elected-officials/fiscal-court',
+      description:
+        'County government. Judge-Executive Charlie Castlen + 3 commissioners. Controls county appropriations.',
+      dataSharingTier: 'none',
+    },
+    {
+      name: 'City of Owensboro',
+      slug: 'city-of-owensboro',
+      type: 'government',
+      description:
+        'Municipal government. Housing-code enforcement, zoning, public-safety partnerships with homeless outreach.',
+      dataSharingTier: 'none',
+    },
+    {
+      name: 'Green River Area Development District (GRADD)',
+      slug: 'gradd',
+      type: 'government',
+      description:
+        'Regional planning entity covering Daviess + 6 neighboring counties. Path to multi-county scale-out.',
+      dataSharingTier: 'none',
+    },
+    {
+      name: 'Kentucky Housing Corporation (KHC)',
+      slug: 'khc',
+      type: 'government',
+      website: 'https://www.kyhousing.org',
+      description:
+        'State-level Balance-of-State CoC administrator. Runs HMIS for Daviess providers; sets state data standards.',
+      dataSharingTier: 'none',
+    },
+    {
+      name: 'Daviess District Court',
+      slug: 'daviess-district-court',
+      type: 'government',
+      description:
+        'Handles forcible-detainer (eviction) proceedings AND HB 5 unlawful-camping citations. Data source for the eviction-defense triage flow.',
+      dataSharingTier: 'aggregate',
+    },
+    // Schools
+    {
+      name: 'Daviess County Public Schools',
+      slug: 'daviess-county-public-schools',
+      type: 'school',
+      description:
+        'Maintains a federally-funded McKinney-Vento homeless-student liaison. Earliest-warning data source for family instability.',
+      dataSharingTier: 'none',
+    },
+    {
+      name: 'Owensboro Independent Schools',
+      slug: 'owensboro-independent-schools',
+      type: 'school',
+      description:
+        'Independent district covering city of Owensboro. McKinney-Vento liaison; same Phase-2 data-flow as Daviess County Public Schools.',
+      dataSharingTier: 'none',
+    },
+    // Education
+    {
+      name: 'Brescia University',
+      slug: 'brescia-university',
+      type: 'education',
+      description:
+        'Small Catholic (Ursuline) university with a strong social-work program. Candidate neutral steward for the data trust.',
+      dataSharingTier: 'none',
+    },
+    {
+      name: 'Kentucky Wesleyan College',
+      slug: 'kentucky-wesleyan',
+      type: 'education',
+      description: 'Liberal arts college in Owensboro.',
+      dataSharingTier: 'none',
+    },
+    {
+      name: 'Owensboro Community & Technical College (OCTC)',
+      slug: 'octc',
+      type: 'education',
+      description: 'Workforce-development partner. Candidate host for a neutral data intermediary.',
+      dataSharingTier: 'none',
+    },
+    // Philanthropy
+    {
+      name: 'Public Life Foundation of Owensboro (PLFO)',
+      slug: 'plfo',
+      type: 'philanthropy',
+      website: 'http://www.plfo.org',
+      description:
+        'Civic-convening foundation. Recommended Phase-0 convener / fiscal sponsor for the coalition.',
+      dataSharingTier: 'none',
+    },
+    {
+      name: 'Owensboro Health Community Health Investments',
+      slug: 'oh-community-health-investments',
+      type: 'philanthropy',
+      website: 'https://www.owensborohealth.org/about/grants',
+      description:
+        "Owensboro Health's grantmaking arm. Mini-grants up to $2,500 across an 18-county region; SDOH-strategy framing.",
+      dataSharingTier: 'none',
+    },
+    // Media
+    {
+      name: 'Messenger-Inquirer',
+      slug: 'messenger-inquirer',
+      type: 'media',
+      description:
+        'Daily newspaper of record for Owensboro. Coalition narrative + visibility channel.',
+      dataSharingTier: 'none',
+    },
+    {
+      name: 'Owensboro Times',
+      slug: 'owensboro-times',
+      type: 'media',
+      description: 'Digital-native local news; covers civic and nonprofit stories.',
+      dataSharingTier: 'none',
+    },
+  ];
+
+  for (const candidate of coalitionOrgs) {
+    const [existing] = await db
+      .select({ slug: partnerOrgs.slug })
+      .from(partnerOrgs)
+      .where(eq(partnerOrgs.slug, candidate.slug))
+      .limit(1);
+    if (!existing) {
+      await db.insert(partnerOrgs).values(candidate);
+      console.log('[seed]   + coalition org', candidate.slug);
+    }
+  }
+  console.log(`[seed]   = ${coalitionOrgs.length} coalition orgs verified`);
 
   // ---- 5 users, one per role ----
   const sampleUsers: Array<{ role: UserRole; email: string; firstName: string; lastName: string }> =


### PR DESCRIPTION
Closes #241

## Summary
Lists every coalition stakeholder catalogued in the Daviess Pilot Report (25 orgs). Directly addresses the "cross-coordination of ministries and NGOs" gap — until now the platform had one \`partner_org\` (KLA), so the coalition narrative was unsubstantiated.

- **\`partner_org_type\` enum** extended: \`faith_based\`, \`school\`, \`philanthropy\`, \`education\`, \`public_health\`, \`media\`. Migration 0013.
- **\`partner_orgs\` schema** gains \`website\`, \`description\`, \`data_sharing_tier\` (\`none | aggregate | individual\`). Tier defaults to \`none\`; raised by signed coalition agreement, not by code.
- **23 new partner orgs** in the seed: Boulware, St. Benedict's, Daniel Pitino, OASIS, CrossRoads, St. Joseph Peace Mission, Catholic Charities, Aid the Homeless, Volunteer Owensboro, Owensboro Health, Green River District Health Dept, Daviess Fiscal Court, City of Owensboro, GRADD, KHC, Daviess District Court, Daviess County Public Schools, Owensboro Independent Schools, Brescia, Kentucky Wesleyan, OCTC, PLFO, OH Community Health Investments, Messenger-Inquirer, Owensboro Times.
- **\`/app/coalition\`** server-rendered directory grouped by type. Phase-1-placeholder banner explaining the tier semantics. Per-row tier badge + website / phone / email links (only the ones we have).
- **Sidebar:** "Coalition" nav item, \`roles: 'all'\` — every signed-in user can see who's in the coalition.

## Acceptance criteria
- [x] Seed extended with the partner orgs from the Pilot Report
- [x] \`partner_org_type\` enum covers school, philanthropy, faith_based, public_health, education, media
- [x] \`/app/coalition\` page (sidebar 'Coalition', roles 'all')
- [x] Server-rendered list grouped by type, with name + (where available) contact info + 1-line description
- [x] Each row shows data-sharing tier as a Phase-1 placeholder field
- [x] passes Definition of Done

## Notes for review
- **Phone numbers / emails omitted** unless I had high confidence they were verified. Bo verifies per partner conversation; the EVDT-014 \`[SAMPLE]\`-prefix lesson applies. Listing names + websites is safe; listing wrong phone numbers is the risk.
- **Daviess District Court is tier=aggregate** — the eviction docket is genuinely public record, so the platform consuming it doesn't need a signed agreement. Other government orgs default to \`none\`.
- KLA Owensboro existing seed bumped to \`tier=individual\` since the Phase-1 eviction-defense workflow already runs full per-case data on its membership.

🤖 Generated with [Claude Code](https://claude.com/claude-code)