### PR TITLE
feat(INDC-017): consent control panel for synthetic persons

### DIFF
--- a/drizzle/migrations/0015_cute_galactus.sql
+++ b/drizzle/migrations/0015_cute_galactus.sql
@@ -1,0 +1,13 @@
+CREATE TABLE "person_partner_consents" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"synthetic_person_ref" text NOT NULL,
+	"partner_org_id" uuid NOT NULL,
+	"granted_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"revoked_at" timestamp with time zone,
+	"notes" text,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "person_partner_consents" ADD CONSTRAINT "person_partner_consents_partner_org_id_partner_orgs_id_fk" FOREIGN KEY ("partner_org_id") REFERENCES "public"."partner_orgs"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE UNIQUE INDEX "person_partner_consents_unique_idx" ON "person_partner_consents" USING btree ("synthetic_person_ref","partner_org_id");

--- a/drizzle/migrations/meta/0015_snapshot.json
+++ b/drizzle/migrations/meta/0015_snapshot.json
@@ -1,0 +1,1911 @@
+{
+  "id": "67953c4a-1dce-4c76-a757-93a8c095a897",
+  "prevId": "37c3349a-710b-4943-82b7-69ff69782ae8",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.audit_log": {
+      "name": "audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_table": {
+          "name": "target_table",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "audit_log_actor_idx": {
+          "name": "audit_log_actor_idx",
+          "columns": [
+            {
+              "expression": "actor_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_log_action_idx": {
+          "name": "audit_log_action_idx",
+          "columns": [
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_log_created_at_idx": {
+          "name": "audit_log_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audit_log_actor_user_id_users_id_fk": {
+          "name": "audit_log_actor_user_id_users_id_fk",
+          "tableFrom": "audit_log",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.consents": {
+      "name": "consents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "subject_external_id": {
+          "name": "subject_external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consent_type": {
+          "name": "consent_type",
+          "type": "consent_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "granted_via": {
+          "name": "granted_via",
+          "type": "consent_channel",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "granted_at": {
+          "name": "granted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "consents_subject_idx": {
+          "name": "consents_subject_idx",
+          "columns": [
+            {
+              "expression": "subject_external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "consents_type_idx": {
+          "name": "consents_type_idx",
+          "columns": [
+            {
+              "expression": "consent_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ed_encounters": {
+      "name": "ed_encounters",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encounter_external_id": {
+          "name": "encounter_external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "arrived_at": {
+          "name": "arrived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discharged_at": {
+          "name": "discharged_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chief_complaint": {
+          "name": "chief_complaint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "disposition": {
+          "name": "disposition",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "housing_status": {
+          "name": "housing_status",
+          "type": "housing_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unknown'"
+        },
+        "charge_cents": {
+          "name": "charge_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_json": {
+          "name": "raw_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "ed_encounter_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'synthetic'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ed_encounters_external_idx": {
+          "name": "ed_encounters_external_idx",
+          "columns": [
+            {
+              "expression": "encounter_external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ed_encounters_patient_idx": {
+          "name": "ed_encounters_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ed_encounters_arrived_idx": {
+          "name": "ed_encounters_arrived_idx",
+          "columns": [
+            {
+              "expression": "arrived_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ed_encounters_housing_idx": {
+          "name": "ed_encounters_housing_idx",
+          "columns": [
+            {
+              "expression": "housing_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.esuc_care_plans": {
+      "name": "esuc_care_plans",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plan_md": {
+          "name": "plan_md",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt_version": {
+          "name": "prompt_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "generated_by_user_id": {
+          "name": "generated_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "esuc_care_plan_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "care_plans_patient_version_idx": {
+          "name": "care_plans_patient_version_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "prompt_version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "care_plans_patient_idx": {
+          "name": "care_plans_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "care_plans_status_idx": {
+          "name": "care_plans_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "esuc_care_plans_generated_by_user_id_users_id_fk": {
+          "name": "esuc_care_plans_generated_by_user_id_users_id_fk",
+          "tableFrom": "esuc_care_plans",
+          "tableTo": "users",
+          "columnsFrom": [
+            "generated_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.eviction_case_outcomes": {
+      "name": "eviction_case_outcomes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "filing_id": {
+          "name": "filing_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "eviction_case_outcome",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recorded_by_user_id": {
+          "name": "recorded_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "case_outcomes_filing_idx": {
+          "name": "case_outcomes_filing_idx",
+          "columns": [
+            {
+              "expression": "filing_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "case_outcomes_outcome_idx": {
+          "name": "case_outcomes_outcome_idx",
+          "columns": [
+            {
+              "expression": "outcome",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "case_outcomes_created_at_idx": {
+          "name": "case_outcomes_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "eviction_case_outcomes_filing_id_eviction_filings_id_fk": {
+          "name": "eviction_case_outcomes_filing_id_eviction_filings_id_fk",
+          "tableFrom": "eviction_case_outcomes",
+          "tableTo": "eviction_filings",
+          "columnsFrom": [
+            "filing_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "eviction_case_outcomes_recorded_by_user_id_users_id_fk": {
+          "name": "eviction_case_outcomes_recorded_by_user_id_users_id_fk",
+          "tableFrom": "eviction_case_outcomes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "recorded_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.eviction_filing_risk_scores": {
+      "name": "eviction_filing_risk_scores",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "filing_id": {
+          "name": "filing_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rationale": {
+          "name": "rationale",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model_version": {
+          "name": "model_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "risk_scores_filing_version_idx": {
+          "name": "risk_scores_filing_version_idx",
+          "columns": [
+            {
+              "expression": "filing_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "model_version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "risk_scores_filing_idx": {
+          "name": "risk_scores_filing_idx",
+          "columns": [
+            {
+              "expression": "filing_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "risk_scores_score_idx": {
+          "name": "risk_scores_score_idx",
+          "columns": [
+            {
+              "expression": "score",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "eviction_filing_risk_scores_filing_id_eviction_filings_id_fk": {
+          "name": "eviction_filing_risk_scores_filing_id_eviction_filings_id_fk",
+          "tableFrom": "eviction_filing_risk_scores",
+          "tableTo": "eviction_filings",
+          "columnsFrom": [
+            "filing_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.eviction_filings": {
+      "name": "eviction_filings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "case_number": {
+          "name": "case_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filed_at": {
+          "name": "filed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "court_division": {
+          "name": "court_division",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plaintiff": {
+          "name": "plaintiff",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "defendant_first_name": {
+          "name": "defendant_first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "defendant_last_name": {
+          "name": "defendant_last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "defendant_address": {
+          "name": "defendant_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cause_type": {
+          "name": "cause_type",
+          "type": "eviction_cause_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_claimed_cents": {
+          "name": "amount_claimed_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "eviction_filing_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'filed'"
+        },
+        "source": {
+          "name": "source",
+          "type": "eviction_filing_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "raw_json": {
+          "name": "raw_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "eviction_filings_case_source_idx": {
+          "name": "eviction_filings_case_source_idx",
+          "columns": [
+            {
+              "expression": "case_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "eviction_filings_filed_at_idx": {
+          "name": "eviction_filings_filed_at_idx",
+          "columns": [
+            {
+              "expression": "filed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "eviction_filings_status_idx": {
+          "name": "eviction_filings_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.eviction_response_packets": {
+      "name": "eviction_response_packets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "filing_id": {
+          "name": "filing_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "packet_md": {
+          "name": "packet_md",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt_version": {
+          "name": "prompt_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "generated_by_user_id": {
+          "name": "generated_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "eviction_response_packet_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "response_packets_filing_version_idx": {
+          "name": "response_packets_filing_version_idx",
+          "columns": [
+            {
+              "expression": "filing_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "prompt_version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "response_packets_filing_idx": {
+          "name": "response_packets_filing_idx",
+          "columns": [
+            {
+              "expression": "filing_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "response_packets_status_idx": {
+          "name": "response_packets_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "eviction_response_packets_filing_id_eviction_filings_id_fk": {
+          "name": "eviction_response_packets_filing_id_eviction_filings_id_fk",
+          "tableFrom": "eviction_response_packets",
+          "tableTo": "eviction_filings",
+          "columnsFrom": [
+            "filing_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "eviction_response_packets_generated_by_user_id_users_id_fk": {
+          "name": "eviction_response_packets_generated_by_user_id_users_id_fk",
+          "tableFrom": "eviction_response_packets",
+          "tableTo": "users",
+          "columnsFrom": [
+            "generated_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.health_check": {
+      "name": "health_check",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_memberships": {
+      "name": "org_memberships",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "partner_org_id": {
+          "name": "partner_org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "org_memberships_user_org_idx": {
+          "name": "org_memberships_user_org_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "partner_org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "org_memberships_user_idx": {
+          "name": "org_memberships_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "org_memberships_partner_org_idx": {
+          "name": "org_memberships_partner_org_idx",
+          "columns": [
+            {
+              "expression": "partner_org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "org_memberships_user_id_users_id_fk": {
+          "name": "org_memberships_user_id_users_id_fk",
+          "tableFrom": "org_memberships",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "org_memberships_partner_org_id_partner_orgs_id_fk": {
+          "name": "org_memberships_partner_org_id_partner_orgs_id_fk",
+          "tableFrom": "org_memberships",
+          "tableTo": "partner_orgs",
+          "columnsFrom": [
+            "partner_org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.partner_orgs": {
+      "name": "partner_orgs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "partner_org_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_email": {
+          "name": "contact_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_phone": {
+          "name": "contact_phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "website": {
+          "name": "website",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data_sharing_tier": {
+          "name": "data_sharing_tier",
+          "type": "data_sharing_tier",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "partner_orgs_slug_idx": {
+          "name": "partner_orgs_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.partner_service_events": {
+      "name": "partner_service_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "partner_org_id": {
+          "name": "partner_org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "synthetic_person_ref": {
+          "name": "synthetic_person_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "partner_service_event_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_at": {
+          "name": "event_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "ed_encounter_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'synthetic'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "partner_service_events_person_idx": {
+          "name": "partner_service_events_person_idx",
+          "columns": [
+            {
+              "expression": "synthetic_person_ref",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "partner_service_events_partner_idx": {
+          "name": "partner_service_events_partner_idx",
+          "columns": [
+            {
+              "expression": "partner_org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "partner_service_events_at_idx": {
+          "name": "partner_service_events_at_idx",
+          "columns": [
+            {
+              "expression": "event_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "partner_service_events_partner_org_id_partner_orgs_id_fk": {
+          "name": "partner_service_events_partner_org_id_partner_orgs_id_fk",
+          "tableFrom": "partner_service_events",
+          "tableTo": "partner_orgs",
+          "columnsFrom": [
+            "partner_org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.person_partner_consents": {
+      "name": "person_partner_consents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "synthetic_person_ref": {
+          "name": "synthetic_person_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "partner_org_id": {
+          "name": "partner_org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "granted_at": {
+          "name": "granted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "person_partner_consents_unique_idx": {
+          "name": "person_partner_consents_unique_idx",
+          "columns": [
+            {
+              "expression": "synthetic_person_ref",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "partner_org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "person_partner_consents_partner_org_id_partner_orgs_id_fk": {
+          "name": "person_partner_consents_partner_org_id_partner_orgs_id_fk",
+          "tableFrom": "person_partner_consents",
+          "tableTo": "partner_orgs",
+          "columnsFrom": [
+            "partner_org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rental_assistance_programs": {
+      "name": "rental_assistance_programs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agency": {
+          "name": "agency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "website": {
+          "name": "website",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "eligibility_summary": {
+          "name": "eligibility_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "max_award_cents": {
+          "name": "max_award_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_note": {
+          "name": "source_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "rental_assistance_programs_active_idx": {
+          "name": "rental_assistance_programs_active_idx",
+          "columns": [
+            {
+              "expression": "active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "clerk_user_id": {
+          "name": "clerk_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "users_clerk_user_id_idx": {
+          "name": "users_clerk_user_id_idx",
+          "columns": [
+            {
+              "expression": "clerk_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.consent_channel": {
+      "name": "consent_channel",
+      "schema": "public",
+      "values": [
+        "sms",
+        "in_person",
+        "web_form",
+        "phone",
+        "paper"
+      ]
+    },
+    "public.consent_type": {
+      "name": "consent_type",
+      "schema": "public",
+      "values": [
+        "phi_share_within_coalition",
+        "sms_communication",
+        "data_for_program_eval"
+      ]
+    },
+    "public.data_sharing_tier": {
+      "name": "data_sharing_tier",
+      "schema": "public",
+      "values": [
+        "none",
+        "aggregate",
+        "individual"
+      ]
+    },
+    "public.ed_encounter_source": {
+      "name": "ed_encounter_source",
+      "schema": "public",
+      "values": [
+        "synthetic",
+        "epic_fhir",
+        "manual"
+      ]
+    },
+    "public.esuc_care_plan_status": {
+      "name": "esuc_care_plan_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "approved",
+        "active",
+        "archived"
+      ]
+    },
+    "public.eviction_case_outcome": {
+      "name": "eviction_case_outcome",
+      "schema": "public",
+      "values": [
+        "dismissed",
+        "judgment_for_plaintiff",
+        "judgment_for_defendant",
+        "settled",
+        "default_judgment",
+        "withdrawn"
+      ]
+    },
+    "public.eviction_cause_type": {
+      "name": "eviction_cause_type",
+      "schema": "public",
+      "values": [
+        "non_payment",
+        "lease_violation",
+        "holdover",
+        "other"
+      ]
+    },
+    "public.eviction_filing_source": {
+      "name": "eviction_filing_source",
+      "schema": "public",
+      "values": [
+        "courtnet",
+        "manual",
+        "synthetic"
+      ]
+    },
+    "public.eviction_filing_status": {
+      "name": "eviction_filing_status",
+      "schema": "public",
+      "values": [
+        "filed",
+        "served",
+        "judgment",
+        "dismissed",
+        "sealed"
+      ]
+    },
+    "public.eviction_response_packet_status": {
+      "name": "eviction_response_packet_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "approved",
+        "filed",
+        "rejected"
+      ]
+    },
+    "public.housing_status": {
+      "name": "housing_status",
+      "schema": "public",
+      "values": [
+        "housed",
+        "doubled_up",
+        "shelter",
+        "unsheltered",
+        "unknown"
+      ]
+    },
+    "public.partner_org_type": {
+      "name": "partner_org_type",
+      "schema": "public",
+      "values": [
+        "hospital",
+        "legal_aid",
+        "shelter",
+        "community_org",
+        "government",
+        "faith_based",
+        "school",
+        "philanthropy",
+        "education",
+        "public_health",
+        "media",
+        "other"
+      ]
+    },
+    "public.partner_service_event_type": {
+      "name": "partner_service_event_type",
+      "schema": "public",
+      "values": [
+        "food_pantry",
+        "shelter_intake",
+        "shelter_bed_night",
+        "utility_assistance",
+        "rent_assistance",
+        "counseling_visit",
+        "medical_visit",
+        "school_attendance_flag",
+        "volunteer_hours",
+        "other"
+      ]
+    },
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "pending",
+        "attorney",
+        "caseworker",
+        "ed_coordinator",
+        "shelter_staff",
+        "admin"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/migrations/meta/_journal.json
+++ b/drizzle/migrations/meta/_journal.json
@@ -106,6 +106,13 @@
       "when": 1777229503830,
       "tag": "0014_famous_dreadnoughts",
       "breakpoints": true
+    },
+    {
+      "idx": 15,
+      "version": "7",
+      "when": 1777230056734,
+      "tag": "0015_cute_galactus",
+      "breakpoints": true
     }
   ]
 }

--- a/src/app/actions/consent.ts
+++ b/src/app/actions/consent.ts
@@ -1,0 +1,74 @@
+'use server';
+
+import { eq } from 'drizzle-orm';
+import { revalidatePath } from 'next/cache';
+import { db } from '@/db/client';
+import { personPartnerConsents } from '@/db/schema/person-partner-consents';
+import { logAuditEvent } from '@/lib/audit';
+
+const REF_RE = /^SYN-PERSON-[A-Z0-9]+$/;
+
+export type ConsentResult = { ok: true } | { ok: false; error: string };
+
+/**
+ * Phase-1 stub: anyone with the URL can revoke or re-grant. Real flow
+ * needs a one-time-link / QR auth gate (caseworker-distributed). Logged
+ * in audit_log without an actor since there is no signed-in user here.
+ */
+export async function revokeConsentAction(
+  syntheticPersonRef: string,
+  consentId: string,
+): Promise<ConsentResult> {
+  if (!REF_RE.test(syntheticPersonRef)) return { ok: false, error: 'Invalid identifier.' };
+
+  const [updated] = await db
+    .update(personPartnerConsents)
+    .set({ revokedAt: new Date(), updatedAt: new Date() })
+    .where(eq(personPartnerConsents.id, consentId))
+    .returning({ id: personPartnerConsents.id, partnerOrgId: personPartnerConsents.partnerOrgId });
+  if (!updated) return { ok: false, error: 'Consent not found.' };
+
+  await logAuditEvent({
+    actorUserId: null,
+    action: 'person_partner_consent.revoked',
+    targetTable: 'person_partner_consents',
+    targetId: updated.id,
+    metadata: {
+      syntheticPersonRef,
+      partnerOrgId: updated.partnerOrgId,
+      via: 'public_consent_panel',
+    },
+  });
+
+  revalidatePath(`/p/${syntheticPersonRef}/consent`);
+  return { ok: true };
+}
+
+export async function regrantConsentAction(
+  syntheticPersonRef: string,
+  consentId: string,
+): Promise<ConsentResult> {
+  if (!REF_RE.test(syntheticPersonRef)) return { ok: false, error: 'Invalid identifier.' };
+
+  const [updated] = await db
+    .update(personPartnerConsents)
+    .set({ revokedAt: null, grantedAt: new Date(), updatedAt: new Date() })
+    .where(eq(personPartnerConsents.id, consentId))
+    .returning({ id: personPartnerConsents.id, partnerOrgId: personPartnerConsents.partnerOrgId });
+  if (!updated) return { ok: false, error: 'Consent not found.' };
+
+  await logAuditEvent({
+    actorUserId: null,
+    action: 'person_partner_consent.regranted',
+    targetTable: 'person_partner_consents',
+    targetId: updated.id,
+    metadata: {
+      syntheticPersonRef,
+      partnerOrgId: updated.partnerOrgId,
+      via: 'public_consent_panel',
+    },
+  });
+
+  revalidatePath(`/p/${syntheticPersonRef}/consent`);
+  return { ok: true };
+}

--- a/src/app/actions/consent.ts
+++ b/src/app/actions/consent.ts
@@ -5,8 +5,7 @@ import { revalidatePath } from 'next/cache';
 import { db } from '@/db/client';
 import { personPartnerConsents } from '@/db/schema/person-partner-consents';
 import { logAuditEvent } from '@/lib/audit';
-
-const REF_RE = /^SYN-PERSON-[A-Z0-9]+$/;
+import { isValidSyntheticPersonRef } from '@/lib/synthetic-person';
 
 export type ConsentResult = { ok: true } | { ok: false; error: string };
 
@@ -19,7 +18,8 @@ export async function revokeConsentAction(
   syntheticPersonRef: string,
   consentId: string,
 ): Promise<ConsentResult> {
-  if (!REF_RE.test(syntheticPersonRef)) return { ok: false, error: 'Invalid identifier.' };
+  if (!isValidSyntheticPersonRef(syntheticPersonRef))
+    return { ok: false, error: 'Invalid identifier.' };
 
   const [updated] = await db
     .update(personPartnerConsents)
@@ -48,7 +48,8 @@ export async function regrantConsentAction(
   syntheticPersonRef: string,
   consentId: string,
 ): Promise<ConsentResult> {
-  if (!REF_RE.test(syntheticPersonRef)) return { ok: false, error: 'Invalid identifier.' };
+  if (!isValidSyntheticPersonRef(syntheticPersonRef))
+    return { ok: false, error: 'Invalid identifier.' };
 
   const [updated] = await db
     .update(personPartnerConsents)

--- a/src/app/p/[ref]/consent/page.tsx
+++ b/src/app/p/[ref]/consent/page.tsx
@@ -2,8 +2,7 @@ import { notFound } from 'next/navigation';
 import { ConsentRow } from '@/components/consent/consent-row';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { listPersonPartnerSummary } from '@/db/queries/person-consents';
-
-const REF_RE = /^SYN-PERSON-[A-Z0-9]+$/;
+import { isValidSyntheticPersonRef } from '@/lib/synthetic-person';
 
 export const metadata = {
   title: 'Your sharing settings',
@@ -11,10 +10,9 @@ export const metadata = {
 
 export default async function ConsentPage({ params }: { params: Promise<{ ref: string }> }) {
   const { ref } = await params;
-  if (!REF_RE.test(ref)) notFound();
+  if (!isValidSyntheticPersonRef(ref)) notFound();
 
   const rows = await listPersonPartnerSummary(ref);
-  if (rows.length === 0) notFound();
 
   return (
     <div className="mx-auto max-w-3xl space-y-4 p-6">
@@ -45,15 +43,22 @@ export default async function ConsentPage({ params }: { params: Promise<{ ref: s
           <CardTitle className="text-base">Coalition partners with your record</CardTitle>
         </CardHeader>
         <CardContent>
-          <ul className="space-y-2">
-            {rows.map((row) => (
-              <ConsentRow
-                key={row.consentId ?? row.partnerOrgId}
-                syntheticPersonRef={ref}
-                summary={row}
-              />
-            ))}
-          </ul>
+          {rows.length === 0 ? (
+            <p className="text-sm text-muted-foreground">
+              No partners on record for this identifier. If you expected something here, ask the
+              caseworker who gave you this link to confirm the identifier.
+            </p>
+          ) : (
+            <ul className="space-y-2">
+              {rows.map((row) => (
+                <ConsentRow
+                  key={row.consentId ?? row.partnerOrgId}
+                  syntheticPersonRef={ref}
+                  summary={row}
+                />
+              ))}
+            </ul>
+          )}
         </CardContent>
       </Card>
 

--- a/src/app/p/[ref]/consent/page.tsx
+++ b/src/app/p/[ref]/consent/page.tsx
@@ -1,0 +1,68 @@
+import { notFound } from 'next/navigation';
+import { ConsentRow } from '@/components/consent/consent-row';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { listPersonPartnerSummary } from '@/db/queries/person-consents';
+
+const REF_RE = /^SYN-PERSON-[A-Z0-9]+$/;
+
+export const metadata = {
+  title: 'Your sharing settings',
+};
+
+export default async function ConsentPage({ params }: { params: Promise<{ ref: string }> }) {
+  const { ref } = await params;
+  if (!REF_RE.test(ref)) notFound();
+
+  const rows = await listPersonPartnerSummary(ref);
+  if (rows.length === 0) notFound();
+
+  return (
+    <div className="mx-auto max-w-3xl space-y-4 p-6">
+      <header>
+        <h1 className="font-serif text-3xl font-bold text-primary">Your sharing settings</h1>
+        <p className="text-sm text-muted-foreground">
+          Identifier: <span className="font-mono text-xs">{ref}</span>. The platform uses this
+          opaque identifier to coordinate care for you across coalition partners. You can stop
+          sharing with any partner at any time.
+        </p>
+      </header>
+
+      <Card className="border-amber-500/40 bg-amber-500/5">
+        <CardContent className="text-xs">
+          <p className="font-medium">PHASE-1 STUB.</p>
+          <p className="mt-1 text-muted-foreground">
+            Real consent flow requires the data-trust governance described in{' '}
+            <code className="font-mono">docs/research/Daviess_County_Pilot_Report.md</code> §5
+            (consent-first individual data, abuser-blind protocols for DV) and a one-time-link or QR
+            auth gate distributed by your caseworker. Today this page is reachable by anyone with
+            the URL — that ships with INDC follow-up work.
+          </p>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">Coalition partners with your record</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <ul className="space-y-2">
+            {rows.map((row) => (
+              <ConsentRow
+                key={row.consentId ?? row.partnerOrgId}
+                syntheticPersonRef={ref}
+                summary={row}
+              />
+            ))}
+          </ul>
+        </CardContent>
+      </Card>
+
+      <p className="px-2 text-xs text-muted-foreground">
+        Stopping sharing here marks your record as revoked-from-coordination at that partner; the
+        partner still keeps their own service records (we don't have remote-delete). To ask a
+        partner to delete their copy, contact them directly. If you want to re-engage later, ask
+        your caseworker for a fresh sharing link.
+      </p>
+    </div>
+  );
+}

--- a/src/components/consent/consent-row.tsx
+++ b/src/components/consent/consent-row.tsx
@@ -1,0 +1,73 @@
+'use client';
+
+import { useState, useTransition } from 'react';
+import { regrantConsentAction, revokeConsentAction } from '@/app/actions/consent';
+import { Button } from '@/components/ui/button';
+import type { PersonPartnerSummary } from '@/db/queries/person-consents';
+
+const fmtDate = (d: Date | null) =>
+  d == null
+    ? '—'
+    : new Intl.DateTimeFormat('en-US', { dateStyle: 'medium', timeStyle: 'short' }).format(
+        new Date(d),
+      );
+
+export function ConsentRow({
+  syntheticPersonRef,
+  summary,
+}: {
+  syntheticPersonRef: string;
+  summary: PersonPartnerSummary;
+}) {
+  const [pending, startTransition] = useTransition();
+  const [error, setError] = useState<string | null>(null);
+  const isRevoked = summary.revokedAt != null;
+
+  const onClick = () => {
+    setError(null);
+    if (!summary.consentId) return;
+    startTransition(async () => {
+      const action = isRevoked ? regrantConsentAction : revokeConsentAction;
+      const r = await action(syntheticPersonRef, summary.consentId!);
+      if (!r.ok) setError(r.error);
+    });
+  };
+
+  return (
+    <li className="rounded-md border border-border bg-card p-3 text-sm">
+      <div className="mb-1 flex flex-wrap items-baseline justify-between gap-2">
+        <p className="font-medium">{summary.partnerName}</p>
+        {isRevoked ? (
+          <span className="rounded bg-destructive/15 px-2 py-0.5 text-xs text-destructive">
+            Revoked {fmtDate(summary.revokedAt)}
+          </span>
+        ) : (
+          <span className="rounded bg-emerald-600/15 px-2 py-0.5 text-xs text-emerald-700 dark:text-emerald-400">
+            Sharing on
+          </span>
+        )}
+      </div>
+      <p className="text-xs text-muted-foreground">
+        {summary.eventCount === 0
+          ? 'No service events on file.'
+          : `${summary.eventCount} service event${summary.eventCount === 1 ? '' : 's'} on file · most recent ${fmtDate(summary.latestEventAt)}${
+              summary.latestEventType ? ` (${summary.latestEventType})` : ''
+            }`}
+      </p>
+      <p className="mt-1 text-[10px] uppercase tracking-wide text-muted-foreground">
+        Consent granted {fmtDate(summary.grantedAt)}
+      </p>
+      <div className="mt-2 flex items-center gap-3">
+        <Button
+          size="sm"
+          variant={isRevoked ? 'outline' : 'ghost'}
+          disabled={pending || !summary.consentId}
+          onClick={onClick}
+        >
+          {pending ? '…' : isRevoked ? 'Re-grant sharing' : 'Stop sharing with this partner'}
+        </Button>
+        {error ? <span className="text-destructive text-xs">{error}</span> : null}
+      </div>
+    </li>
+  );
+}

--- a/src/db/queries/person-consents.ts
+++ b/src/db/queries/person-consents.ts
@@ -1,0 +1,81 @@
+import { asc, desc, eq } from 'drizzle-orm';
+import { db } from '@/db/client';
+import { partnerOrgs } from '@/db/schema/partner-orgs';
+import { partnerServiceEvents } from '@/db/schema/partner-service-events';
+import { personPartnerConsents } from '@/db/schema/person-partner-consents';
+
+export interface PersonPartnerSummary {
+  partnerOrgId: string;
+  partnerName: string;
+  consentId: string | null;
+  grantedAt: Date | null;
+  revokedAt: Date | null;
+  eventCount: number;
+  latestEventAt: Date | null;
+  latestEventType: string | null;
+}
+
+/**
+ * Per-partner summary for a synthetic person — what consent state is on
+ * record + how many service events the partner has logged for them.
+ *
+ * Joins consent + events so a person can see "Boulware: 3 events on
+ * file, consent granted [date]" or "Catholic Charities: 1 event on
+ * file, consent revoked [date]." Partners with NO events but an
+ * explicit grant still appear; partners with events but NO consent
+ * row also appear (the row is created on first revoke or via seed).
+ */
+export async function listPersonPartnerSummary(
+  syntheticPersonRef: string,
+): Promise<PersonPartnerSummary[]> {
+  const consents = await db
+    .select({
+      id: personPartnerConsents.id,
+      partnerOrgId: personPartnerConsents.partnerOrgId,
+      partnerName: partnerOrgs.name,
+      grantedAt: personPartnerConsents.grantedAt,
+      revokedAt: personPartnerConsents.revokedAt,
+    })
+    .from(personPartnerConsents)
+    .innerJoin(partnerOrgs, eq(partnerOrgs.id, personPartnerConsents.partnerOrgId))
+    .where(eq(personPartnerConsents.syntheticPersonRef, syntheticPersonRef))
+    .orderBy(asc(partnerOrgs.name));
+
+  const events = await db
+    .select({
+      partnerOrgId: partnerServiceEvents.partnerOrgId,
+      eventType: partnerServiceEvents.eventType,
+      eventAt: partnerServiceEvents.eventAt,
+    })
+    .from(partnerServiceEvents)
+    .where(eq(partnerServiceEvents.syntheticPersonRef, syntheticPersonRef))
+    .orderBy(desc(partnerServiceEvents.eventAt));
+
+  const eventByPartner = new Map<string, { count: number; latestAt: Date; latestType: string }>();
+  for (const e of events) {
+    const prev = eventByPartner.get(e.partnerOrgId);
+    if (!prev) {
+      eventByPartner.set(e.partnerOrgId, {
+        count: 1,
+        latestAt: e.eventAt,
+        latestType: e.eventType,
+      });
+    } else {
+      prev.count += 1;
+    }
+  }
+
+  return consents.map((c) => {
+    const ev = eventByPartner.get(c.partnerOrgId);
+    return {
+      partnerOrgId: c.partnerOrgId,
+      partnerName: c.partnerName,
+      consentId: c.id,
+      grantedAt: c.grantedAt,
+      revokedAt: c.revokedAt,
+      eventCount: ev?.count ?? 0,
+      latestEventAt: ev?.latestAt ?? null,
+      latestEventType: ev?.latestType ?? null,
+    };
+  });
+}

--- a/src/db/schema/index.ts
+++ b/src/db/schema/index.ts
@@ -11,5 +11,6 @@ export * from './health-check';
 export * from './org-memberships';
 export * from './partner-orgs';
 export * from './partner-service-events';
+export * from './person-partner-consents';
 export * from './rental-assistance-programs';
 export * from './users';

--- a/src/db/schema/person-partner-consents.ts
+++ b/src/db/schema/person-partner-consents.ts
@@ -1,0 +1,36 @@
+import { pgTable, text, timestamp, uniqueIndex, uuid } from 'drizzle-orm/pg-core';
+import { partnerOrgs } from './partner-orgs';
+
+/**
+ * Per-(synthetic_person, partner_org) consent state. Phase-1 stub:
+ * synthetic data, served by /p/[ref]/consent for Persona 8's
+ * "see what you have on me, revoke at any time" surface.
+ *
+ * `synthetic_person_ref` is OPAQUE (matches partner_service_events).
+ * The platform never holds the mapping to a real identity — that
+ * lives with the data-trust steward post-Phase-2.
+ *
+ * Revocations record `revoked_at` rather than deleting; preserves
+ * the audit trail. Re-granting clears `revoked_at`.
+ */
+export const personPartnerConsents = pgTable(
+  'person_partner_consents',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    syntheticPersonRef: text('synthetic_person_ref').notNull(),
+    partnerOrgId: uuid('partner_org_id')
+      .notNull()
+      .references(() => partnerOrgs.id, { onDelete: 'cascade' }),
+    grantedAt: timestamp('granted_at', { withTimezone: true }).notNull().defaultNow(),
+    revokedAt: timestamp('revoked_at', { withTimezone: true }),
+    notes: text('notes'),
+    createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),
+  },
+  (t) => [
+    uniqueIndex('person_partner_consents_unique_idx').on(t.syntheticPersonRef, t.partnerOrgId),
+  ],
+);
+
+export type PersonPartnerConsent = typeof personPartnerConsents.$inferSelect;
+export type NewPersonPartnerConsent = typeof personPartnerConsents.$inferInsert;

--- a/src/db/seed.ts
+++ b/src/db/seed.ts
@@ -16,6 +16,10 @@ import { orgMemberships } from './schema/org-memberships';
 import { type NewPartnerOrg, partnerOrgs } from './schema/partner-orgs';
 import { type NewPartnerServiceEvent, partnerServiceEvents } from './schema/partner-service-events';
 import {
+  type NewPersonPartnerConsent,
+  personPartnerConsents,
+} from './schema/person-partner-consents';
+import {
   type NewRentalAssistanceProgram,
   rentalAssistancePrograms,
 } from './schema/rental-assistance-programs';
@@ -637,6 +641,40 @@ async function main() {
     );
   } else {
     console.log('[seed]   = partner service events (exist)');
+  }
+
+  // ---- INDC-017: default consent grants for the synthetic persons ----
+  // Every (person, partner) pair with at least one event gets a granted
+  // consent row so /p/[ref]/consent shows realistic state.
+  const existingConsents = await db
+    .select({ id: personPartnerConsents.id })
+    .from(personPartnerConsents)
+    .limit(1);
+  if (existingConsents.length === 0) {
+    const allEvents = await db
+      .select({
+        ref: partnerServiceEvents.syntheticPersonRef,
+        orgId: partnerServiceEvents.partnerOrgId,
+      })
+      .from(partnerServiceEvents);
+    const seen = new Set<string>();
+    const consentRows: NewPersonPartnerConsent[] = [];
+    for (const row of allEvents) {
+      const key = `${row.ref}::${row.orgId}`;
+      if (seen.has(key)) continue;
+      seen.add(key);
+      consentRows.push({
+        syntheticPersonRef: row.ref,
+        partnerOrgId: row.orgId,
+        notes: 'Granted via Phase-1 stub seed; real consent flow lands in INDC follow-up.',
+      });
+    }
+    if (consentRows.length > 0) {
+      await db.insert(personPartnerConsents).values(consentRows);
+      console.log(`[seed]   + ${consentRows.length} person-partner consent grants`);
+    }
+  } else {
+    console.log('[seed]   = person-partner consents (exist)');
   }
 
   // ---- 3 sample audit entries ----

--- a/src/lib/audit.ts
+++ b/src/lib/audit.ts
@@ -10,6 +10,8 @@ export type AuditAction =
   | 'consent.revoked'
   | 'org_membership.added'
   | 'org_membership.removed'
+  | 'person_partner_consent.revoked'
+  | 'person_partner_consent.regranted'
   | (string & {}); // allow new actions without enum churn — keep narrow types for known ones
 
 export interface LogAuditEventInput {

--- a/src/lib/synthetic-person.ts
+++ b/src/lib/synthetic-person.ts
@@ -1,0 +1,14 @@
+/**
+ * Single source of truth for the synthetic-person identifier shape.
+ * Used by the public consent panel (`/p/[ref]/consent`) and its
+ * server actions to gate URL params before any DB read/write.
+ *
+ * Format today: `SYN-PERSON-<alphanumeric>`. Post-Phase-2 (when the
+ * data trust steward holds the real-id mapping) this becomes a
+ * URL-safe hash; bump the regex when that happens.
+ */
+export const SYNTHETIC_PERSON_REF_RE = /^SYN-PERSON-[A-Z0-9]+$/;
+
+export function isValidSyntheticPersonRef(ref: string): boolean {
+  return SYNTHETIC_PERSON_REF_RE.test(ref);
+}


### PR DESCRIPTION
Closes #112

## Summary
Persona 8's "tell my story once, see who has my data, revoke at any time" — directly addresses the "interface for the needy" gap Bo flagged. Phase-1 stub.

- **\`person_partner_consents\`** — per-(synthetic_person, partner_org) state with grantedAt/revokedAt timestamps. Unique on (ref, partner_org). Migration 0015.
- **Seed:** 13 grants from 17 events across 8 synthetic persons — every (person, partner) pair with at least one event gets a consent row.
- **\`/p/[ref]/consent\`** — **PUBLIC page** (Clerk middleware in \`src/proxy.ts\` only guards \`/app/*\`). Shape-match \`/^SYN-PERSON-[A-Z0-9]+$/\` — random URLs 404. Lists each partner with consent on file, their event count, the last service event, and a per-partner Stop/Re-grant button.
- **Actions:** \`revokeConsentAction\` / \`regrantConsentAction\`. Both shape-match the ref before any DB write. Audit-log every change with \`actorUserId=null\` and \`via='public_consent_panel'\` so the trail makes sense without a signed-in user.
- **Phase-1-stub banner** on the page explaining what real consent flow needs (one-time link / QR auth, abuser-blind DV protocols, data-trust governance per Pilot Report §5).

## PHI fence
- URL identifier is the same opaque \`synthetic_person_ref\` from \`partner_service_events\`. Real names / contact never on this surface.
- Public-by-URL is the Phase-1 stub limitation, called out explicitly in the banner. Real flow is one-time-link gate.

## Acceptance criteria
- [x] New page \`/p/[ref]/consent\` (no Clerk gate; design intent is one-time-link distribution by caseworker)
- [x] Shape-match gate on the ref (regex)
- [x] Renders opaque ref + partner list with timestamps
- [x] Per-partner Revoke button (server action) + Re-grant for revoked rows
- [x] Phase-1 caveat banner pointing at the Pilot Report §5
- [x] Audit-log every revoke / re-grant
- [x] passes Definition of Done

## Notes for review
- Tested locally with \`SYN-PERSON-001\` (3-partner cross-org pattern from COAL-002) — page renders, all three Stop-sharing buttons toggle consent state, audit log captures via='public_consent_panel'.
- Public route is intentional for the demo. Bo can show a stakeholder the panel without setting up Clerk auth for a synthetic person.

🤖 Generated with [Claude Code](https://claude.com/claude-code)