### PR TITLE
chore: apply pending migrations on Railway start

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build",
-    "start": "next start",
+    "start": "node scripts/migrate-prod.mjs && next start",
     "lint": "biome check .",
     "lint:fix": "biome check --write .",
     "format": "biome format --write .",

--- a/scripts/migrate-prod.mjs
+++ b/scripts/migrate-prod.mjs
@@ -1,0 +1,31 @@
+// Production migration runner. Used by the `start` script on Railway
+// so every deploy applies any pending migrations before the app accepts
+// traffic. Stays in plain .mjs so it runs without tsx / drizzle-kit
+// (both devDeps).
+//
+// Idempotent — drizzle-orm's migrator records applied migrations in
+// `__drizzle_migrations` and skips them on subsequent runs.
+
+import { drizzle } from 'drizzle-orm/postgres-js';
+import { migrate } from 'drizzle-orm/postgres-js/migrator';
+import postgres from 'postgres';
+
+const url = process.env.DATABASE_URL;
+if (!url) {
+  console.error('[migrate-prod] DATABASE_URL is not set');
+  process.exit(1);
+}
+
+const sql = postgres(url, { max: 1, prepare: false });
+const db = drizzle(sql);
+
+try {
+  console.log('[migrate-prod] applying migrations…');
+  await migrate(db, { migrationsFolder: './drizzle/migrations' });
+  console.log('[migrate-prod] done');
+} catch (err) {
+  console.error('[migrate-prod] failed:', err);
+  process.exit(1);
+} finally {
+  await sql.end({ timeout: 5 });
+}


### PR DESCRIPTION
## Summary
Railway deploys run \`pnpm install && pnpm build && pnpm start\`. Until now neither \`db:migrate\` nor \`db:seed\` ran on deploy, so migrations landed in main but didn't apply to staging until you ran them manually. (The KLA queue 404 a couple sessions back was the visible symptom.)

- **New \`scripts/migrate-prod.mjs\`** — tiny runtime migrator using \`drizzle-orm/postgres-js/migrator\` (already in deps; no drizzle-kit / tsx required at runtime). Records applied migrations in \`__drizzle_migrations\` so it's idempotent across deploys.
- **\`start\` script** chains the migration before \`next start\`. If migration fails, the deploy fails — desired behavior (don't serve traffic against a stale schema).
- Verified locally: applies 0011-0015 cleanly against the existing DB, exits 0.

## What this does NOT do
**Seeds are not run on deploy.** The seed is for first-run demo state, not every-restart state. Run \`pnpm db:seed\` once per environment via Railway's run-command UI when you want to populate the coalition / rental-assistance / partner-events catalog. (Idempotent — safe to re-run when you add new orgs.)

## Notes for review
- \`migrate-prod.mjs\` is plain \`.mjs\` so it runs from production node without tsx loader. Avoids moving \`drizzle-kit\` and \`dotenv\` from devDeps to deps.
- \`max: 1, prepare: false\` matches the production client config (Supabase Transaction Pooler).
- \`sql.end({ timeout: 5 })\` in finally so the script always exits cleanly even if Railway's process timing is fast.

🤖 Generated with [Claude Code](https://claude.com/claude-code)