### PR TITLE
feat(COOR-002): bed-count update UI for shelter staff

### DIFF
--- a/src/app/actions/coordination.ts
+++ b/src/app/actions/coordination.ts
@@ -1,0 +1,94 @@
+'use server';
+
+import { eq } from 'drizzle-orm';
+import { revalidatePath } from 'next/cache';
+import { db } from '@/db/client';
+import { bedCountUpdates, shelters } from '@/db/schema/shelters';
+import { logAuditEvent } from '@/lib/audit';
+import { requireRole } from '@/lib/auth';
+import { validateBedCount } from '@/lib/coordination/bed-availability';
+
+export type UpdateBedCountResult = { ok: true } | { ok: false; error: string };
+
+const STAFF_ROLES = ['shelter_staff', 'admin'] as const;
+
+const MAX_NOTE_LEN = 280;
+
+/**
+ * Set a shelter's current_occupancy to `newOccupancy` and append the
+ * change to bed_count_updates. The mutation runs in a transaction so
+ * we never end up with a shelters row that disagrees with the audit
+ * log.
+ *
+ * Server-authoritative bounds: clamp to [0, capacity]. The check
+ * constraint on shelters would reject anything else, but explicit
+ * validation gives a useful error to staff instead of a 500.
+ */
+export async function updateBedCountAction(
+  shelterId: string,
+  newOccupancy: number,
+  note: string | null,
+): Promise<UpdateBedCountResult> {
+  const actor = await requireRole(STAFF_ROLES);
+
+  const trimmedNote = note?.trim() ? note.trim().slice(0, MAX_NOTE_LEN) : null;
+
+  const result = await db.transaction(async (tx) => {
+    const [shelter] = await tx
+      .select({
+        id: shelters.id,
+        capacity: shelters.capacity,
+        currentOccupancy: shelters.currentOccupancy,
+        active: shelters.active,
+      })
+      .from(shelters)
+      .where(eq(shelters.id, shelterId))
+      .limit(1);
+    if (!shelter) return { ok: false as const, error: 'Shelter not found.' };
+    if (!shelter.active) return { ok: false as const, error: 'Shelter is inactive.' };
+    const validation = validateBedCount(newOccupancy, shelter.capacity);
+    if (!validation.ok) return { ok: false as const, error: validation.error };
+    if (newOccupancy === shelter.currentOccupancy) {
+      return { ok: true as const, noChange: true, previous: shelter.currentOccupancy };
+    }
+
+    await tx
+      .update(shelters)
+      .set({ currentOccupancy: newOccupancy, updatedAt: new Date() })
+      .where(eq(shelters.id, shelterId));
+
+    await tx.insert(bedCountUpdates).values({
+      shelterId,
+      updatedByUserId: actor.id,
+      previousOccupancy: shelter.currentOccupancy,
+      newOccupancy,
+      note: trimmedNote,
+    });
+
+    return {
+      ok: true as const,
+      noChange: false,
+      previous: shelter.currentOccupancy,
+    };
+  });
+
+  if (!result.ok) return result;
+
+  if (!result.noChange) {
+    await logAuditEvent({
+      actorUserId: actor.id,
+      action: 'shelter.bed_count_updated',
+      targetTable: 'shelters',
+      targetId: shelterId,
+      metadata: {
+        previousOccupancy: result.previous,
+        newOccupancy,
+        hasNote: Boolean(trimmedNote),
+      },
+    });
+  }
+
+  revalidatePath('/app/coalition/beds');
+  revalidatePath('/app/coalition/beds/update');
+  return { ok: true };
+}

--- a/src/app/app/coalition/beds/update/page.tsx
+++ b/src/app/app/coalition/beds/update/page.tsx
@@ -1,0 +1,55 @@
+import { BedCountStaffCard } from '@/components/coordination/bed-count-staff-card';
+import { Card, CardContent } from '@/components/ui/card';
+import { lastBedCountUpdateByShelter, listActiveShelters } from '@/db/queries/shelters';
+import { requireRole } from '@/lib/auth';
+
+export const dynamic = 'force-dynamic';
+
+export default async function BedCountUpdatePage() {
+  await requireRole(['shelter_staff', 'admin']);
+  const [shelterRows, lastUpdates] = await Promise.all([
+    listActiveShelters(),
+    lastBedCountUpdateByShelter(),
+  ]);
+
+  return (
+    <div className="mx-auto max-w-3xl space-y-4 p-4 md:p-6">
+      <header>
+        <h1 className="font-serif text-3xl font-bold text-primary">Update bed counts</h1>
+        <p className="text-sm text-muted-foreground">
+          Tap −1 / +1 (or −5 / +5 for fast moves) when a bed turns over. Saves take a second; the
+          live availability board picks up the change automatically.
+        </p>
+      </header>
+
+      {shelterRows.length === 0 ? (
+        <Card>
+          <CardContent className="text-sm text-muted-foreground">
+            No active shelters. Run <code className="font-mono">pnpm db:seed</code> to load the
+            Daviess catalog.
+          </CardContent>
+        </Card>
+      ) : (
+        <div className="grid gap-4 md:grid-cols-2">
+          {shelterRows.map((shelter) => (
+            <BedCountStaffCard
+              key={shelter.id}
+              shelter={shelter}
+              lastUpdatedAt={lastUpdates.get(shelter.id) ?? null}
+            />
+          ))}
+        </div>
+      )}
+
+      <Card className="border-amber-500/40 bg-amber-500/5">
+        <CardContent className="text-xs">
+          <p className="font-medium">Phase-1 scoping note.</p>
+          <p className="mt-1 text-muted-foreground">
+            Every shelter_staff user sees every shelter today. Per-shelter membership scoping (so
+            St. Benedict's staff only see St. Benedict's) ships with COOR-007 onboarding.
+          </p>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/components/app-shell/nav-config.ts
+++ b/src/components/app-shell/nav-config.ts
@@ -51,6 +51,11 @@ export const NAV_ITEMS: NavItem[] = [
     href: '/app/coalition/coordination',
     roles: ['attorney', 'caseworker', 'ed_coordinator', 'shelter_staff', 'admin'],
   },
+  {
+    label: 'Update beds',
+    href: '/app/coalition/beds/update',
+    roles: ['shelter_staff', 'admin'],
+  },
   { label: 'Settings', href: '/app/settings', roles: 'all' },
   { label: 'Admin · Users', href: '/app/admin/users', roles: ['admin'] },
 ];

--- a/src/components/coordination/bed-count-staff-card.tsx
+++ b/src/components/coordination/bed-count-staff-card.tsx
@@ -1,0 +1,201 @@
+'use client';
+
+import { useId, useState, useTransition } from 'react';
+import { updateBedCountAction } from '@/app/actions/coordination';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import type { ShelterWithOrg } from '@/db/queries/shelters';
+
+const fmtTime = (d: Date) =>
+  new Intl.DateTimeFormat('en-US', { dateStyle: 'medium', timeStyle: 'short' }).format(new Date(d));
+
+export function BedCountStaffCard({
+  shelter,
+  lastUpdatedAt,
+}: {
+  shelter: ShelterWithOrg;
+  lastUpdatedAt: Date | null;
+}) {
+  const occInputId = useId();
+  const noteInputId = useId();
+  const [draftOccupancy, setDraftOccupancy] = useState<number>(shelter.currentOccupancy);
+  const [note, setNote] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [savedAt, setSavedAt] = useState<Date | null>(null);
+  const [pending, startTransition] = useTransition();
+
+  const free = Math.max(0, shelter.capacity - draftOccupancy);
+  const isAtCapacity = draftOccupancy >= shelter.capacity;
+  const isAtZero = draftOccupancy <= 0;
+  const dirty = draftOccupancy !== shelter.currentOccupancy || note.trim().length > 0;
+
+  const adjust = (delta: number) => {
+    setError(null);
+    setDraftOccupancy((prev) => {
+      const next = prev + delta;
+      if (next < 0) return 0;
+      if (next > shelter.capacity) return shelter.capacity;
+      return next;
+    });
+  };
+
+  const onSave = () => {
+    setError(null);
+    startTransition(async () => {
+      const r = await updateBedCountAction(shelter.id, draftOccupancy, note || null);
+      if (!r.ok) {
+        setError(r.error);
+        return;
+      }
+      setNote('');
+      setSavedAt(new Date());
+    });
+  };
+
+  const onReset = () => {
+    setDraftOccupancy(shelter.currentOccupancy);
+    setNote('');
+    setError(null);
+  };
+
+  return (
+    <Card>
+      <CardHeader className="pb-2">
+        <CardTitle className="text-base">{shelter.name}</CardTitle>
+        <p className="text-xs text-muted-foreground">{shelter.partnerOrg.name}</p>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div className="grid grid-cols-3 gap-2 text-center">
+          <div className="rounded-md border border-border bg-muted/40 p-2">
+            <p className="text-xs uppercase tracking-wide text-muted-foreground">Capacity</p>
+            <p className="text-lg font-semibold">{shelter.capacity}</p>
+          </div>
+          <div className="rounded-md border border-border bg-muted/40 p-2">
+            <p className="text-xs uppercase tracking-wide text-muted-foreground">Occupied</p>
+            <p className="text-lg font-semibold">{draftOccupancy}</p>
+          </div>
+          <div className="rounded-md border border-border bg-muted/40 p-2">
+            <p className="text-xs uppercase tracking-wide text-muted-foreground">Free</p>
+            <p
+              className={`text-lg font-semibold ${
+                free === 0 ? 'text-destructive' : 'text-emerald-600 dark:text-emerald-400'
+              }`}
+            >
+              {free}
+            </p>
+          </div>
+        </div>
+
+        <div className="space-y-2">
+          <Label htmlFor={occInputId} className="text-xs uppercase tracking-wide">
+            New occupancy
+          </Label>
+          <div className="flex flex-wrap items-center gap-2">
+            <Button
+              type="button"
+              variant="outline"
+              size="lg"
+              className="h-12 min-w-12"
+              disabled={pending || isAtZero}
+              onClick={() => adjust(-5)}
+              aria-label="Decrease by 5"
+            >
+              −5
+            </Button>
+            <Button
+              type="button"
+              variant="outline"
+              size="lg"
+              className="h-12 min-w-12"
+              disabled={pending || isAtZero}
+              onClick={() => adjust(-1)}
+              aria-label="Decrease by 1"
+            >
+              −1
+            </Button>
+            <Input
+              id={occInputId}
+              type="number"
+              inputMode="numeric"
+              min={0}
+              max={shelter.capacity}
+              value={draftOccupancy}
+              disabled={pending}
+              onChange={(e) => {
+                const n = Number.parseInt(e.target.value, 10);
+                if (Number.isNaN(n)) return;
+                setError(null);
+                setDraftOccupancy(Math.max(0, Math.min(shelter.capacity, n)));
+              }}
+              className="h-12 w-20 text-center text-lg font-semibold"
+            />
+            <Button
+              type="button"
+              variant="outline"
+              size="lg"
+              className="h-12 min-w-12"
+              disabled={pending || isAtCapacity}
+              onClick={() => adjust(1)}
+              aria-label="Increase by 1"
+            >
+              +1
+            </Button>
+            <Button
+              type="button"
+              variant="outline"
+              size="lg"
+              className="h-12 min-w-12"
+              disabled={pending || isAtCapacity}
+              onClick={() => adjust(5)}
+              aria-label="Increase by 5"
+            >
+              +5
+            </Button>
+          </div>
+        </div>
+
+        <div className="space-y-1">
+          <Label htmlFor={noteInputId} className="text-xs uppercase tracking-wide">
+            Note (optional)
+          </Label>
+          <Input
+            id={noteInputId}
+            value={note}
+            onChange={(e) => setNote(e.target.value)}
+            disabled={pending}
+            placeholder="e.g. early intake, reservation released"
+            maxLength={280}
+          />
+        </div>
+
+        {error ? <p className="text-sm text-destructive">{error}</p> : null}
+
+        <div className="flex items-center justify-between gap-2 text-xs text-muted-foreground">
+          <span>
+            {savedAt
+              ? `Saved ${fmtTime(savedAt)}`
+              : lastUpdatedAt
+                ? `Last updated ${fmtTime(lastUpdatedAt)}`
+                : 'No updates yet'}
+          </span>
+          <div className="flex gap-2">
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              disabled={pending || !dirty}
+              onClick={onReset}
+            >
+              Reset
+            </Button>
+            <Button type="button" size="sm" disabled={pending || !dirty} onClick={onSave}>
+              {pending ? 'Saving…' : 'Save'}
+            </Button>
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/db/queries/shelters.ts
+++ b/src/db/queries/shelters.ts
@@ -1,4 +1,4 @@
-import { and, asc, desc, eq } from 'drizzle-orm';
+import { and, asc, desc, eq, max } from 'drizzle-orm';
 import { db } from '@/db/client';
 import { type PartnerOrg, partnerOrgs } from '@/db/schema/partner-orgs';
 import { type BedCountUpdate, bedCountUpdates, type Shelter, shelters } from '@/db/schema/shelters';
@@ -53,4 +53,20 @@ export async function listRecentBedCountUpdates(
     .where(eq(bedCountUpdates.shelterId, shelterId))
     .orderBy(desc(bedCountUpdates.createdAt))
     .limit(limit);
+}
+
+/**
+ * Map of shelter id → most recent bed_count_updates.created_at. Used by
+ * the staff update UI to show "last updated" alongside each card. Returns
+ * `null` for shelters with no updates yet.
+ */
+export async function lastBedCountUpdateByShelter(): Promise<Map<string, Date | null>> {
+  const rows = await db
+    .select({
+      shelterId: bedCountUpdates.shelterId,
+      lastAt: max(bedCountUpdates.createdAt),
+    })
+    .from(bedCountUpdates)
+    .groupBy(bedCountUpdates.shelterId);
+  return new Map(rows.map((r) => [r.shelterId, r.lastAt ? new Date(r.lastAt) : null]));
 }

--- a/src/lib/coordination/bed-availability.test.ts
+++ b/src/lib/coordination/bed-availability.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { freeBeds, matchesFilter, occupancyRate } from './bed-availability';
+import { freeBeds, matchesFilter, occupancyRate, validateBedCount } from './bed-availability';
 
 const baseShelter = {
   capacity: 60,
@@ -62,5 +62,30 @@ describe('matchesFilter', () => {
   it('rejects when minFreeBeds is not met', () => {
     expect(matchesFilter({ ...baseShelter, currentOccupancy: 60 }, { minFreeBeds: 1 })).toBe(false);
     expect(matchesFilter({ ...baseShelter, currentOccupancy: 50 }, { minFreeBeds: 1 })).toBe(true);
+  });
+});
+
+describe('validateBedCount', () => {
+  it('accepts integer occupancies in [0, capacity]', () => {
+    expect(validateBedCount(0, 10)).toEqual({ ok: true, value: 0 });
+    expect(validateBedCount(10, 10)).toEqual({ ok: true, value: 10 });
+    expect(validateBedCount(7, 10)).toEqual({ ok: true, value: 7 });
+  });
+
+  it('rejects negative occupancy', () => {
+    const r = validateBedCount(-1, 10);
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toMatch(/whole number/);
+  });
+
+  it('rejects fractional occupancy', () => {
+    const r = validateBedCount(3.5, 10);
+    expect(r.ok).toBe(false);
+  });
+
+  it('rejects occupancy above capacity with the capacity in the message', () => {
+    const r = validateBedCount(11, 10);
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toContain('10');
   });
 });

--- a/src/lib/coordination/bed-availability.ts
+++ b/src/lib/coordination/bed-availability.ts
@@ -20,6 +20,26 @@ export function occupancyRate(shelter: Pick<Shelter, 'capacity' | 'currentOccupa
   return Math.min(1, Math.max(0, shelter.currentOccupancy / shelter.capacity));
 }
 
+export type BedCountValidation = { ok: true; value: number } | { ok: false; error: string };
+
+/**
+ * Validates a proposed `newOccupancy` against `capacity`. Mirrors what
+ * the server action accepts; pulled out as a pure function so unit
+ * tests can cover the rule set without spinning up a database.
+ */
+export function validateBedCount(newOccupancy: number, capacity: number): BedCountValidation {
+  if (!Number.isInteger(newOccupancy) || newOccupancy < 0) {
+    return { ok: false, error: 'Bed count must be a whole number ≥ 0.' };
+  }
+  if (capacity < 0) {
+    return { ok: false, error: 'Shelter capacity is invalid.' };
+  }
+  if (newOccupancy > capacity) {
+    return { ok: false, error: `Bed count cannot exceed capacity (${capacity}).` };
+  }
+  return { ok: true, value: newOccupancy };
+}
+
 /**
  * True iff a shelter satisfies every populated criterion in `filter`.
  * Empty filter matches every active shelter.


### PR DESCRIPTION
Closes #55. Stacked on top of [#254](https://github.com/DobbsBoldry/homeless/pull/254) (COOR-001).

## Summary
- `/app/coalition/beds/update` — mobile-first card grid, one per active shelter
- Per-card controls: `−5` / `−1` / `+1` / `+5` (h-12 tap targets), direct numeric input, optional 280-char note, Save / Reset
- `updateBedCountAction` — transactional update of `shelters.current_occupancy` + append to `bed_count_updates`, gated to `shelter_staff` + `admin`, audit-logged
- `validateBedCount` extracted as a pure helper in `bed-availability.ts` for testability
- `lastBedCountUpdateByShelter` query → "last updated" hint per card
- Nav: \"Update beds\" item, role-gated

## Acceptance criteria
- [x] 1-click add/remove (via −1 / +1)
- [x] Mobile-friendly (h-12 tap targets, single column on small screens)
- [x] <30 sec per update — no modal, debounce-free, instant visual feedback
- [x] Audit trail (bed_count_updates rows + audit_log entries)
- [x] Lint + typecheck + 73 tests passing

## Test plan
- [ ] Sign in as a shelter_staff seed user → /app/coalition/beds/update
- [ ] Tap +1 several times, save → re-load page, count persists
- [ ] Try to set above capacity → server-side rejection with friendly error
- [ ] Verify a row appears in bed_count_updates per save

🤖 Generated with [Claude Code](https://claude.com/claude-code)