### PR TITLE
feat(COOR-003): live bed availability board

### DIFF
--- a/src/app/app/coalition/beds/page.tsx
+++ b/src/app/app/coalition/beds/page.tsx
@@ -1,0 +1,73 @@
+import { AutoRefresh } from '@/components/coordination/auto-refresh';
+import { BedBoardCard } from '@/components/coordination/bed-board-card';
+import { Card, CardContent } from '@/components/ui/card';
+import { lastBedCountUpdateByShelter, listActiveShelters } from '@/db/queries/shelters';
+import { requireRole } from '@/lib/auth';
+import { freeBeds } from '@/lib/coordination/bed-availability';
+
+export const dynamic = 'force-dynamic';
+
+export default async function BedAvailabilityBoardPage() {
+  await requireRole(['attorney', 'caseworker', 'ed_coordinator', 'shelter_staff', 'admin']);
+  const [shelterRows, lastUpdates] = await Promise.all([
+    listActiveShelters(),
+    lastBedCountUpdateByShelter(),
+  ]);
+
+  const totalCapacity = shelterRows.reduce((sum, s) => sum + s.capacity, 0);
+  const totalOccupied = shelterRows.reduce((sum, s) => sum + s.currentOccupancy, 0);
+  const totalFree = shelterRows.reduce((sum, s) => sum + freeBeds(s), 0);
+
+  return (
+    <div className="mx-auto max-w-6xl space-y-4 p-4 md:p-6">
+      <header className="flex flex-wrap items-baseline justify-between gap-2">
+        <div>
+          <h1 className="font-serif text-3xl font-bold text-primary">Bed availability</h1>
+          <p className="text-sm text-muted-foreground">
+            Live across {shelterRows.length} Daviess shelters. Numbers reflect what staff entered
+            most recently in the bed-count update view.
+          </p>
+        </div>
+        <AutoRefresh />
+      </header>
+
+      <Card>
+        <CardContent className="grid grid-cols-3 gap-3 text-center">
+          <div>
+            <p className="text-xs uppercase tracking-wide text-muted-foreground">Free beds</p>
+            <p className="text-2xl font-semibold text-emerald-600 dark:text-emerald-400">
+              {totalFree}
+            </p>
+          </div>
+          <div>
+            <p className="text-xs uppercase tracking-wide text-muted-foreground">Occupied</p>
+            <p className="text-2xl font-semibold">{totalOccupied}</p>
+          </div>
+          <div>
+            <p className="text-xs uppercase tracking-wide text-muted-foreground">Capacity</p>
+            <p className="text-2xl font-semibold">{totalCapacity}</p>
+          </div>
+        </CardContent>
+      </Card>
+
+      {shelterRows.length === 0 ? (
+        <Card>
+          <CardContent className="text-sm text-muted-foreground">
+            No active shelters. Run <code className="font-mono">pnpm db:seed</code> to load the
+            Daviess catalog.
+          </CardContent>
+        </Card>
+      ) : (
+        <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+          {shelterRows.map((shelter) => (
+            <BedBoardCard
+              key={shelter.id}
+              shelter={shelter}
+              lastUpdatedAt={lastUpdates.get(shelter.id) ?? null}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/app-shell/nav-config.ts
+++ b/src/components/app-shell/nav-config.ts
@@ -52,6 +52,11 @@ export const NAV_ITEMS: NavItem[] = [
     roles: ['attorney', 'caseworker', 'ed_coordinator', 'shelter_staff', 'admin'],
   },
   {
+    label: 'Bed availability',
+    href: '/app/coalition/beds',
+    roles: ['attorney', 'caseworker', 'ed_coordinator', 'shelter_staff', 'admin'],
+  },
+  {
     label: 'Update beds',
     href: '/app/coalition/beds/update',
     roles: ['shelter_staff', 'admin'],

--- a/src/components/coordination/auto-refresh.tsx
+++ b/src/components/coordination/auto-refresh.tsx
@@ -1,0 +1,33 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { useEffect, useState } from 'react';
+
+const fmtTime = (d: Date) => new Intl.DateTimeFormat('en-US', { timeStyle: 'medium' }).format(d);
+
+/**
+ * Polls `router.refresh()` every `intervalMs` so a server component
+ * page picks up the latest DB state without a manual reload. Pauses
+ * automatically when the tab is hidden — staff often park this on a
+ * back monitor and we don't want to hammer the DB for invisible tabs.
+ */
+export function AutoRefresh({ intervalMs = 60_000 }: { intervalMs?: number }) {
+  const router = useRouter();
+  const [lastRefreshed, setLastRefreshed] = useState<Date>(() => new Date());
+
+  useEffect(() => {
+    const tick = () => {
+      if (document.hidden) return;
+      router.refresh();
+      setLastRefreshed(new Date());
+    };
+    const id = window.setInterval(tick, intervalMs);
+    return () => window.clearInterval(id);
+  }, [router, intervalMs]);
+
+  return (
+    <span className="text-xs text-muted-foreground">
+      Auto-refreshing every {Math.round(intervalMs / 1000)}s · last {fmtTime(lastRefreshed)}
+    </span>
+  );
+}

--- a/src/components/coordination/bed-board-card.tsx
+++ b/src/components/coordination/bed-board-card.tsx
@@ -1,0 +1,100 @@
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import type { ShelterWithOrg } from '@/db/queries/shelters';
+import { freeBeds, occupancyRate } from '@/lib/coordination/bed-availability';
+
+const fmtTime = (d: Date) =>
+  new Intl.DateTimeFormat('en-US', { dateStyle: 'medium', timeStyle: 'short' }).format(new Date(d));
+
+function popChips(shelter: ShelterWithOrg): string[] {
+  const chips: string[] = [];
+  if (shelter.acceptsMen) chips.push('Men');
+  if (shelter.acceptsWomen) chips.push('Women');
+  if (shelter.acceptsFamilies) chips.push('Families');
+  if (shelter.petFriendly) chips.push('Pet-friendly');
+  if (shelter.sudFriendly) chips.push('SUD-OK');
+  return chips;
+}
+
+export function BedBoardCard({
+  shelter,
+  lastUpdatedAt,
+}: {
+  shelter: ShelterWithOrg;
+  lastUpdatedAt: Date | null;
+}) {
+  const free = freeBeds(shelter);
+  const rate = occupancyRate(shelter);
+  const isFull = free === 0;
+  const isTight = !isFull && rate >= 0.85;
+  const chips = popChips(shelter);
+
+  // Tailwind class lookup (avoid string-built classes that get tree-shaken).
+  const barColor = isFull ? 'bg-destructive' : isTight ? 'bg-amber-500' : 'bg-emerald-500';
+  const freeColor = isFull
+    ? 'text-destructive'
+    : isTight
+      ? 'text-amber-600 dark:text-amber-400'
+      : 'text-emerald-600 dark:text-emerald-400';
+
+  return (
+    <Card>
+      <CardHeader className="pb-2">
+        <CardTitle className="text-base">{shelter.name}</CardTitle>
+        <p className="text-xs text-muted-foreground">{shelter.partnerOrg.name}</p>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        <div className="flex items-baseline justify-between">
+          <div>
+            <p className="text-xs uppercase tracking-wide text-muted-foreground">Free</p>
+            <p className={`text-3xl font-semibold ${freeColor}`}>{free}</p>
+          </div>
+          <p className="text-sm text-muted-foreground">
+            {shelter.currentOccupancy} / {shelter.capacity} occupied
+          </p>
+        </div>
+
+        <div
+          role="progressbar"
+          aria-label={`${Math.round(rate * 100)}% full`}
+          aria-valuenow={Math.round(rate * 100)}
+          aria-valuemin={0}
+          aria-valuemax={100}
+          className="h-2 overflow-hidden rounded-full bg-muted"
+        >
+          <div
+            className={`h-full ${barColor} transition-all`}
+            style={{ width: `${Math.round(rate * 100)}%` }}
+          />
+        </div>
+
+        {chips.length > 0 ? (
+          <div className="flex flex-wrap gap-1">
+            {chips.map((c) => (
+              <span
+                key={c}
+                className="rounded bg-secondary px-2 py-0.5 text-xs text-secondary-foreground"
+              >
+                {c}
+              </span>
+            ))}
+          </div>
+        ) : null}
+
+        {shelter.contactPhone ? (
+          <p className="text-xs text-muted-foreground">
+            <a href={`tel:${shelter.contactPhone}`} className="hover:underline">
+              {shelter.contactPhone}
+            </a>
+            {shelter.city ? ` · ${shelter.city}` : null}
+          </p>
+        ) : shelter.city ? (
+          <p className="text-xs text-muted-foreground">{shelter.city}</p>
+        ) : null}
+
+        <p className="text-xs text-muted-foreground">
+          {lastUpdatedAt ? `Last update ${fmtTime(lastUpdatedAt)}` : 'No updates yet'}
+        </p>
+      </CardContent>
+    </Card>
+  );
+}


### PR DESCRIPTION
Closes #56. Stacked on [#255](https://github.com/DobbsBoldry/homeless/pull/255) (COOR-002) which is stacked on [#254](https://github.com/DobbsBoldry/homeless/pull/254) (COOR-001).

## Summary
- `/app/coalition/beds` — live, read-only board across all active shelters
- Card layout: free / occupied / capacity headline, occupancy bar (green → amber ≥ 85% → red at full), population chips, clickable phone, last-update timestamp
- Top summary row sums free / occupied / capacity coalition-wide
- `AutoRefresh` client component — `router.refresh()` every 60s, pauses when tab is hidden
- Nav: \"Bed availability\" item, visible to all coalition staff roles (attorney / caseworker / ed_coordinator / shelter_staff / admin)

## Acceptance criteria
- [x] Read-only view, refreshes every 60s
- [x] Card-per-shelter layout
- [x] Lint + typecheck + 73 tests + production build pass

## Test plan
- [ ] Sign in as any coalition role → /app/coalition/beds shows the 6 seeded shelters
- [ ] Open beds/update in a second tab; bump occupancy + Save; first tab updates within ~60s
- [ ] Verify tab-hidden behavior: switch away, occupancy shouldn't be hammered
- [ ] Resize to phone width: cards stack to single column

🤖 Generated with [Claude Code](https://claude.com/claude-code)