### PR TITLE
feat(COOR-004): filters and search on bed board

### DIFF
--- a/src/app/app/coalition/beds/page.tsx
+++ b/src/app/app/coalition/beds/page.tsx
@@ -1,22 +1,40 @@
 import { AutoRefresh } from '@/components/coordination/auto-refresh';
 import { BedBoardCard } from '@/components/coordination/bed-board-card';
+import { BedBoardFilters } from '@/components/coordination/bed-board-filters';
 import { Card, CardContent } from '@/components/ui/card';
 import { lastBedCountUpdateByShelter, listActiveShelters } from '@/db/queries/shelters';
 import { requireRole } from '@/lib/auth';
-import { freeBeds } from '@/lib/coordination/bed-availability';
+import {
+  freeBeds,
+  hasActiveFilter,
+  matchesFilter,
+  parseBedFilterParams,
+} from '@/lib/coordination/bed-availability';
 
 export const dynamic = 'force-dynamic';
 
-export default async function BedAvailabilityBoardPage() {
+export default async function BedAvailabilityBoardPage({
+  searchParams,
+}: {
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+}) {
   await requireRole(['attorney', 'caseworker', 'ed_coordinator', 'shelter_staff', 'admin']);
-  const [shelterRows, lastUpdates] = await Promise.all([
+  const params = await searchParams;
+  const filter = parseBedFilterParams(params);
+
+  const [allShelters, lastUpdates] = await Promise.all([
     listActiveShelters(),
     lastBedCountUpdateByShelter(),
   ]);
 
-  const totalCapacity = shelterRows.reduce((sum, s) => sum + s.capacity, 0);
-  const totalOccupied = shelterRows.reduce((sum, s) => sum + s.currentOccupancy, 0);
-  const totalFree = shelterRows.reduce((sum, s) => sum + freeBeds(s), 0);
+  const filtered = allShelters.filter((s) =>
+    matchesFilter(s, filter, `${s.name} ${s.partnerOrg.name}`),
+  );
+
+  const totalCapacity = filtered.reduce((sum, s) => sum + s.capacity, 0);
+  const totalOccupied = filtered.reduce((sum, s) => sum + s.currentOccupancy, 0);
+  const totalFree = filtered.reduce((sum, s) => sum + freeBeds(s), 0);
+  const filterActive = hasActiveFilter(filter);
 
   return (
     <div className="mx-auto max-w-6xl space-y-4 p-4 md:p-6">
@@ -24,17 +42,21 @@ export default async function BedAvailabilityBoardPage() {
         <div>
           <h1 className="font-serif text-3xl font-bold text-primary">Bed availability</h1>
           <p className="text-sm text-muted-foreground">
-            Live across {shelterRows.length} Daviess shelters. Numbers reflect what staff entered
+            Live across {allShelters.length} Daviess shelters. Numbers reflect what staff entered
             most recently in the bed-count update view.
           </p>
         </div>
         <AutoRefresh />
       </header>
 
+      <BedBoardFilters />
+
       <Card>
         <CardContent className="grid grid-cols-3 gap-3 text-center">
           <div>
-            <p className="text-xs uppercase tracking-wide text-muted-foreground">Free beds</p>
+            <p className="text-xs uppercase tracking-wide text-muted-foreground">
+              Free {filterActive ? '(filtered)' : ''}
+            </p>
             <p className="text-2xl font-semibold text-emerald-600 dark:text-emerald-400">
               {totalFree}
             </p>
@@ -50,16 +72,22 @@ export default async function BedAvailabilityBoardPage() {
         </CardContent>
       </Card>
 
-      {shelterRows.length === 0 ? (
+      {allShelters.length === 0 ? (
         <Card>
           <CardContent className="text-sm text-muted-foreground">
             No active shelters. Run <code className="font-mono">pnpm db:seed</code> to load the
             Daviess catalog.
           </CardContent>
         </Card>
+      ) : filtered.length === 0 ? (
+        <Card>
+          <CardContent className="text-sm text-muted-foreground">
+            No shelters match the current filters. Try a different preset or clear filters.
+          </CardContent>
+        </Card>
       ) : (
         <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
-          {shelterRows.map((shelter) => (
+          {filtered.map((shelter) => (
             <BedBoardCard
               key={shelter.id}
               shelter={shelter}

--- a/src/components/coordination/bed-board-filters.tsx
+++ b/src/components/coordination/bed-board-filters.tsx
@@ -1,0 +1,112 @@
+'use client';
+
+import { useRouter, useSearchParams } from 'next/navigation';
+import { useId, useTransition } from 'react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+
+type Preset = { label: string; params: Record<string, string> };
+
+const PRESETS: Preset[] = [
+  { label: 'Open beds now', params: { minFree: '1' } },
+  { label: 'Men', params: { population: 'men' } },
+  { label: 'Women', params: { population: 'women' } },
+  { label: 'Families', params: { population: 'families' } },
+  { label: 'Pet-friendly + family', params: { population: 'families', pet: '1' } },
+  { label: 'SUD-OK', params: { sud: '1' } },
+];
+
+export function BedBoardFilters() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const [pending, startTransition] = useTransition();
+  const queryId = useId();
+
+  const setParams = (next: Record<string, string | null>) => {
+    const usp = new URLSearchParams(searchParams.toString());
+    for (const [k, v] of Object.entries(next)) {
+      if (v === null || v === '') usp.delete(k);
+      else usp.set(k, v);
+    }
+    const qs = usp.toString();
+    startTransition(() => {
+      router.push(qs ? `/app/coalition/beds?${qs}` : '/app/coalition/beds');
+    });
+  };
+
+  const applyPreset = (preset: Preset) => {
+    // Clear existing scoped params, then set the preset's.
+    setParams({
+      population: null,
+      pet: null,
+      sud: null,
+      minFree: null,
+      ...preset.params,
+    });
+  };
+
+  const clearAll = () => {
+    startTransition(() => router.push('/app/coalition/beds'));
+  };
+
+  const onSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    const fd = new FormData(e.currentTarget);
+    const q = String(fd.get('q') ?? '').trim();
+    setParams({ q: q || null });
+  };
+
+  const hasAny = searchParams.toString().length > 0;
+
+  return (
+    <div className="space-y-3">
+      <form onSubmit={onSubmit} className="flex gap-2">
+        <Label htmlFor={queryId} className="sr-only">
+          Search shelters
+        </Label>
+        <Input
+          id={queryId}
+          name="q"
+          defaultValue={searchParams.get('q') ?? ''}
+          placeholder="Search shelter or partner name…"
+          maxLength={64}
+          disabled={pending}
+        />
+        <Button type="submit" variant="outline" disabled={pending}>
+          Search
+        </Button>
+      </form>
+
+      <div className="flex flex-wrap gap-2">
+        {PRESETS.map((p) => {
+          const active = Object.entries(p.params).every(([k, v]) => searchParams.get(k) === v);
+          return (
+            <Button
+              key={p.label}
+              type="button"
+              size="sm"
+              variant={active ? 'default' : 'outline'}
+              disabled={pending}
+              onClick={() => applyPreset(p)}
+            >
+              {p.label}
+            </Button>
+          );
+        })}
+        {hasAny ? (
+          <Button
+            type="button"
+            size="sm"
+            variant="ghost"
+            disabled={pending}
+            onClick={clearAll}
+            className="text-muted-foreground"
+          >
+            Clear filters
+          </Button>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/src/lib/coordination/bed-availability.test.ts
+++ b/src/lib/coordination/bed-availability.test.ts
@@ -1,5 +1,12 @@
 import { describe, expect, it } from 'vitest';
-import { freeBeds, matchesFilter, occupancyRate, validateBedCount } from './bed-availability';
+import {
+  freeBeds,
+  hasActiveFilter,
+  matchesFilter,
+  occupancyRate,
+  parseBedFilterParams,
+  validateBedCount,
+} from './bed-availability';
 
 const baseShelter = {
   capacity: 60,
@@ -62,6 +69,79 @@ describe('matchesFilter', () => {
   it('rejects when minFreeBeds is not met', () => {
     expect(matchesFilter({ ...baseShelter, currentOccupancy: 60 }, { minFreeBeds: 1 })).toBe(false);
     expect(matchesFilter({ ...baseShelter, currentOccupancy: 50 }, { minFreeBeds: 1 })).toBe(true);
+  });
+});
+
+describe('matchesFilter — query', () => {
+  it('matches case-insensitively against searchableText', () => {
+    expect(matchesFilter(baseShelter, { query: 'BENED' }, 'St. Benedict\u2019s — Owensboro')).toBe(
+      true,
+    );
+  });
+
+  it('rejects when query has no match', () => {
+    expect(matchesFilter(baseShelter, { query: 'zzz' }, 'St. Benedict\u2019s')).toBe(false);
+  });
+
+  it('rejects when searchableText is undefined and query is set', () => {
+    expect(matchesFilter(baseShelter, { query: 'foo' })).toBe(false);
+  });
+
+  it('ignores whitespace-only queries', () => {
+    // parseBedFilterParams strips these; matchesFilter only acts on
+    // non-empty queries (passes when query.trim() is empty).
+    expect(matchesFilter(baseShelter, { query: '   ' })).toBe(true);
+  });
+});
+
+describe('parseBedFilterParams', () => {
+  it('returns empty filter for empty params', () => {
+    expect(parseBedFilterParams({})).toEqual({});
+  });
+
+  it('parses a populated query string', () => {
+    expect(
+      parseBedFilterParams({
+        population: 'families',
+        pet: '1',
+        sud: 'true',
+        minFree: '3',
+        q: '  Boulware ',
+      }),
+    ).toEqual({
+      population: 'families',
+      petFriendly: true,
+      sudFriendly: true,
+      minFreeBeds: 3,
+      query: 'Boulware',
+    });
+  });
+
+  it('drops invalid population values', () => {
+    expect(parseBedFilterParams({ population: 'aliens' }).population).toBeUndefined();
+  });
+
+  it('drops zero / negative / non-numeric minFree', () => {
+    expect(parseBedFilterParams({ minFree: '0' }).minFreeBeds).toBeUndefined();
+    expect(parseBedFilterParams({ minFree: '-2' }).minFreeBeds).toBeUndefined();
+    expect(parseBedFilterParams({ minFree: 'abc' }).minFreeBeds).toBeUndefined();
+  });
+
+  it('caps long search queries to 64 chars', () => {
+    const long = 'a'.repeat(200);
+    expect(parseBedFilterParams({ q: long }).query?.length).toBe(64);
+  });
+});
+
+describe('hasActiveFilter', () => {
+  it('returns false for empty filter', () => {
+    expect(hasActiveFilter({})).toBe(false);
+  });
+
+  it('returns true when any dimension is set', () => {
+    expect(hasActiveFilter({ petFriendly: true })).toBe(true);
+    expect(hasActiveFilter({ query: 'foo' })).toBe(true);
+    expect(hasActiveFilter({ minFreeBeds: 1 })).toBe(true);
   });
 });
 

--- a/src/lib/coordination/bed-availability.ts
+++ b/src/lib/coordination/bed-availability.ts
@@ -7,7 +7,52 @@ export type BedFilter = {
   sudFriendly?: boolean;
   /** Minimum free beds the shelter must have right now. */
   minFreeBeds?: number;
+  /** Free-text query — matches shelter or partner-org name (case-insensitive). */
+  query?: string;
 };
+
+const VALID_POPULATIONS = ['men', 'women', 'families'] as const;
+type Population = (typeof VALID_POPULATIONS)[number];
+const isPopulation = (v: unknown): v is Population =>
+  typeof v === 'string' && (VALID_POPULATIONS as readonly string[]).includes(v);
+
+/**
+ * Parses a `URLSearchParams`-shaped record into a BedFilter, dropping
+ * unknown / malformed values. Used by the bed board page to read
+ * filters off the URL on the server side.
+ *
+ * Recognized keys: `population`, `pet=1`, `sud=1`, `minFree`, `q`.
+ */
+export function parseBedFilterParams(
+  params: Record<string, string | string[] | undefined>,
+): BedFilter {
+  const filter: BedFilter = {};
+  const pop = Array.isArray(params.population) ? params.population[0] : params.population;
+  if (isPopulation(pop)) filter.population = pop;
+  const pet = Array.isArray(params.pet) ? params.pet[0] : params.pet;
+  if (pet === '1' || pet === 'true') filter.petFriendly = true;
+  const sud = Array.isArray(params.sud) ? params.sud[0] : params.sud;
+  if (sud === '1' || sud === 'true') filter.sudFriendly = true;
+  const minFreeRaw = Array.isArray(params.minFree) ? params.minFree[0] : params.minFree;
+  if (minFreeRaw) {
+    const n = Number.parseInt(minFreeRaw, 10);
+    if (Number.isInteger(n) && n > 0) filter.minFreeBeds = n;
+  }
+  const q = Array.isArray(params.q) ? params.q[0] : params.q;
+  if (typeof q === 'string' && q.trim().length > 0) filter.query = q.trim().slice(0, 64);
+  return filter;
+}
+
+/** True when at least one filter dimension is populated. */
+export function hasActiveFilter(filter: BedFilter): boolean {
+  return Boolean(
+    filter.population ||
+      filter.petFriendly ||
+      filter.sudFriendly ||
+      filter.minFreeBeds ||
+      filter.query,
+  );
+}
 
 /** Free beds = capacity − current occupancy. Never negative. */
 export function freeBeds(shelter: Pick<Shelter, 'capacity' | 'currentOccupancy'>): number {
@@ -42,7 +87,9 @@ export function validateBedCount(newOccupancy: number, capacity: number): BedCou
 
 /**
  * True iff a shelter satisfies every populated criterion in `filter`.
- * Empty filter matches every active shelter.
+ * Empty filter matches every active shelter. The `query` text dimension
+ * is checked against `searchableText` (shelter name + partner-org name)
+ * when provided — pass `undefined` to skip text matching.
  */
 export function matchesFilter(
   shelter: Pick<
@@ -56,6 +103,7 @@ export function matchesFilter(
     | 'sudFriendly'
   >,
   filter: BedFilter,
+  searchableText?: string,
 ): boolean {
   if (filter.population === 'men' && !shelter.acceptsMen) return false;
   if (filter.population === 'women' && !shelter.acceptsWomen) return false;
@@ -64,6 +112,10 @@ export function matchesFilter(
   if (filter.sudFriendly && !shelter.sudFriendly) return false;
   if (typeof filter.minFreeBeds === 'number' && freeBeds(shelter) < filter.minFreeBeds) {
     return false;
+  }
+  if (filter.query && filter.query.trim().length > 0) {
+    if (!searchableText) return false;
+    if (!searchableText.toLowerCase().includes(filter.query.toLowerCase())) return false;
   }
   return true;
 }


### PR DESCRIPTION
Closes #57. Stacked on [#256](https://github.com/DobbsBoldry/homeless/pull/256) (COOR-003).

## Summary
- `BedBoardFilters` client component — URL-synced via search params, six one-tap presets:
  - **Open beds now**, **Men**, **Women**, **Families**, **Pet-friendly + family**, **SUD-OK**
- Free-text query input matches shelter or partner-org name (case-insensitive)
- `parseBedFilterParams` + `hasActiveFilter` pure helpers (parsed/dropped malformed values)
- `matchesFilter` extended with `query` dimension; tests cover the new shape
- Page totals reflect the filtered set; empty-filtered state shows guidance
- 11 new tests, 84 total passing

## Acceptance criteria
- [x] Filter UI on the bed board
- [x] At least one preset (\"Pet-friendly + family\")
- [x] Search across shelter / org names
- [x] Lint + typecheck + 84 tests + production build

## Test plan
- [ ] Click \"Pet-friendly + family\" — only Daniel Pitino remains in seed data
- [ ] Type \"Boulware\" in search — only Boulware shows
- [ ] Click \"Open beds now\" then \"Men\" — show men-accepting shelters with free beds
- [ ] Refresh the page mid-filter — state persists via URL
- [ ] Hit a deep link like `/app/coalition/beds?population=families&pet=1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)