### PR TITLE
feat(COOR-005): 90-min soft bed-hold flow

### DIFF
--- a/drizzle/migrations/0017_opposite_nitro.sql
+++ b/drizzle/migrations/0017_opposite_nitro.sql
@@ -1,0 +1,18 @@
+CREATE TYPE "public"."bed_hold_status" AS ENUM('active', 'released', 'expired', 'converted');--> statement-breakpoint
+CREATE TABLE "bed_holds" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"shelter_id" uuid NOT NULL,
+	"held_by_user_id" uuid NOT NULL,
+	"person_label" text NOT NULL,
+	"status" "bed_hold_status" DEFAULT 'active' NOT NULL,
+	"expires_at" timestamp with time zone NOT NULL,
+	"released_at" timestamp with time zone,
+	"notes" text,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "bed_holds" ADD CONSTRAINT "bed_holds_shelter_id_shelters_id_fk" FOREIGN KEY ("shelter_id") REFERENCES "public"."shelters"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "bed_holds_shelter_idx" ON "bed_holds" USING btree ("shelter_id");--> statement-breakpoint
+CREATE INDEX "bed_holds_status_idx" ON "bed_holds" USING btree ("status");--> statement-breakpoint
+CREATE INDEX "bed_holds_expires_idx" ON "bed_holds" USING btree ("expires_at");

--- a/drizzle/migrations/meta/0017_snapshot.json
+++ b/drizzle/migrations/meta/0017_snapshot.json
@@ -1,0 +1,2362 @@
+{
+  "id": "1d709487-8ba3-4b2f-8d91-8f5b7dd1b377",
+  "prevId": "52f7ed89-dedc-4ccb-bd67-78224c5a6bb7",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.audit_log": {
+      "name": "audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_table": {
+          "name": "target_table",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "audit_log_actor_idx": {
+          "name": "audit_log_actor_idx",
+          "columns": [
+            {
+              "expression": "actor_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_log_action_idx": {
+          "name": "audit_log_action_idx",
+          "columns": [
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_log_created_at_idx": {
+          "name": "audit_log_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audit_log_actor_user_id_users_id_fk": {
+          "name": "audit_log_actor_user_id_users_id_fk",
+          "tableFrom": "audit_log",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.consents": {
+      "name": "consents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "subject_external_id": {
+          "name": "subject_external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consent_type": {
+          "name": "consent_type",
+          "type": "consent_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "granted_via": {
+          "name": "granted_via",
+          "type": "consent_channel",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "granted_at": {
+          "name": "granted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "consents_subject_idx": {
+          "name": "consents_subject_idx",
+          "columns": [
+            {
+              "expression": "subject_external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "consents_type_idx": {
+          "name": "consents_type_idx",
+          "columns": [
+            {
+              "expression": "consent_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ed_encounters": {
+      "name": "ed_encounters",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encounter_external_id": {
+          "name": "encounter_external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "arrived_at": {
+          "name": "arrived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discharged_at": {
+          "name": "discharged_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chief_complaint": {
+          "name": "chief_complaint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "disposition": {
+          "name": "disposition",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "housing_status": {
+          "name": "housing_status",
+          "type": "housing_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unknown'"
+        },
+        "charge_cents": {
+          "name": "charge_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_json": {
+          "name": "raw_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "ed_encounter_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'synthetic'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ed_encounters_external_idx": {
+          "name": "ed_encounters_external_idx",
+          "columns": [
+            {
+              "expression": "encounter_external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ed_encounters_patient_idx": {
+          "name": "ed_encounters_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ed_encounters_arrived_idx": {
+          "name": "ed_encounters_arrived_idx",
+          "columns": [
+            {
+              "expression": "arrived_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ed_encounters_housing_idx": {
+          "name": "ed_encounters_housing_idx",
+          "columns": [
+            {
+              "expression": "housing_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.esuc_care_plans": {
+      "name": "esuc_care_plans",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plan_md": {
+          "name": "plan_md",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt_version": {
+          "name": "prompt_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "generated_by_user_id": {
+          "name": "generated_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "esuc_care_plan_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "care_plans_patient_version_idx": {
+          "name": "care_plans_patient_version_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "prompt_version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "care_plans_patient_idx": {
+          "name": "care_plans_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "care_plans_status_idx": {
+          "name": "care_plans_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "esuc_care_plans_generated_by_user_id_users_id_fk": {
+          "name": "esuc_care_plans_generated_by_user_id_users_id_fk",
+          "tableFrom": "esuc_care_plans",
+          "tableTo": "users",
+          "columnsFrom": [
+            "generated_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.eviction_case_outcomes": {
+      "name": "eviction_case_outcomes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "filing_id": {
+          "name": "filing_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "eviction_case_outcome",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recorded_by_user_id": {
+          "name": "recorded_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "case_outcomes_filing_idx": {
+          "name": "case_outcomes_filing_idx",
+          "columns": [
+            {
+              "expression": "filing_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "case_outcomes_outcome_idx": {
+          "name": "case_outcomes_outcome_idx",
+          "columns": [
+            {
+              "expression": "outcome",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "case_outcomes_created_at_idx": {
+          "name": "case_outcomes_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "eviction_case_outcomes_filing_id_eviction_filings_id_fk": {
+          "name": "eviction_case_outcomes_filing_id_eviction_filings_id_fk",
+          "tableFrom": "eviction_case_outcomes",
+          "tableTo": "eviction_filings",
+          "columnsFrom": [
+            "filing_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "eviction_case_outcomes_recorded_by_user_id_users_id_fk": {
+          "name": "eviction_case_outcomes_recorded_by_user_id_users_id_fk",
+          "tableFrom": "eviction_case_outcomes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "recorded_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.eviction_filing_risk_scores": {
+      "name": "eviction_filing_risk_scores",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "filing_id": {
+          "name": "filing_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rationale": {
+          "name": "rationale",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model_version": {
+          "name": "model_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "risk_scores_filing_version_idx": {
+          "name": "risk_scores_filing_version_idx",
+          "columns": [
+            {
+              "expression": "filing_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "model_version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "risk_scores_filing_idx": {
+          "name": "risk_scores_filing_idx",
+          "columns": [
+            {
+              "expression": "filing_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "risk_scores_score_idx": {
+          "name": "risk_scores_score_idx",
+          "columns": [
+            {
+              "expression": "score",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "eviction_filing_risk_scores_filing_id_eviction_filings_id_fk": {
+          "name": "eviction_filing_risk_scores_filing_id_eviction_filings_id_fk",
+          "tableFrom": "eviction_filing_risk_scores",
+          "tableTo": "eviction_filings",
+          "columnsFrom": [
+            "filing_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.eviction_filings": {
+      "name": "eviction_filings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "case_number": {
+          "name": "case_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filed_at": {
+          "name": "filed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "court_division": {
+          "name": "court_division",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plaintiff": {
+          "name": "plaintiff",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "defendant_first_name": {
+          "name": "defendant_first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "defendant_last_name": {
+          "name": "defendant_last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "defendant_address": {
+          "name": "defendant_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cause_type": {
+          "name": "cause_type",
+          "type": "eviction_cause_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_claimed_cents": {
+          "name": "amount_claimed_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "eviction_filing_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'filed'"
+        },
+        "source": {
+          "name": "source",
+          "type": "eviction_filing_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "raw_json": {
+          "name": "raw_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "eviction_filings_case_source_idx": {
+          "name": "eviction_filings_case_source_idx",
+          "columns": [
+            {
+              "expression": "case_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "eviction_filings_filed_at_idx": {
+          "name": "eviction_filings_filed_at_idx",
+          "columns": [
+            {
+              "expression": "filed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "eviction_filings_status_idx": {
+          "name": "eviction_filings_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.eviction_response_packets": {
+      "name": "eviction_response_packets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "filing_id": {
+          "name": "filing_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "packet_md": {
+          "name": "packet_md",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt_version": {
+          "name": "prompt_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "generated_by_user_id": {
+          "name": "generated_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "eviction_response_packet_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "response_packets_filing_version_idx": {
+          "name": "response_packets_filing_version_idx",
+          "columns": [
+            {
+              "expression": "filing_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "prompt_version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "response_packets_filing_idx": {
+          "name": "response_packets_filing_idx",
+          "columns": [
+            {
+              "expression": "filing_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "response_packets_status_idx": {
+          "name": "response_packets_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "eviction_response_packets_filing_id_eviction_filings_id_fk": {
+          "name": "eviction_response_packets_filing_id_eviction_filings_id_fk",
+          "tableFrom": "eviction_response_packets",
+          "tableTo": "eviction_filings",
+          "columnsFrom": [
+            "filing_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "eviction_response_packets_generated_by_user_id_users_id_fk": {
+          "name": "eviction_response_packets_generated_by_user_id_users_id_fk",
+          "tableFrom": "eviction_response_packets",
+          "tableTo": "users",
+          "columnsFrom": [
+            "generated_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.health_check": {
+      "name": "health_check",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_memberships": {
+      "name": "org_memberships",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "partner_org_id": {
+          "name": "partner_org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "org_memberships_user_org_idx": {
+          "name": "org_memberships_user_org_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "partner_org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "org_memberships_user_idx": {
+          "name": "org_memberships_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "org_memberships_partner_org_idx": {
+          "name": "org_memberships_partner_org_idx",
+          "columns": [
+            {
+              "expression": "partner_org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "org_memberships_user_id_users_id_fk": {
+          "name": "org_memberships_user_id_users_id_fk",
+          "tableFrom": "org_memberships",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "org_memberships_partner_org_id_partner_orgs_id_fk": {
+          "name": "org_memberships_partner_org_id_partner_orgs_id_fk",
+          "tableFrom": "org_memberships",
+          "tableTo": "partner_orgs",
+          "columnsFrom": [
+            "partner_org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.partner_orgs": {
+      "name": "partner_orgs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "partner_org_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_email": {
+          "name": "contact_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_phone": {
+          "name": "contact_phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "website": {
+          "name": "website",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data_sharing_tier": {
+          "name": "data_sharing_tier",
+          "type": "data_sharing_tier",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "partner_orgs_slug_idx": {
+          "name": "partner_orgs_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.partner_service_events": {
+      "name": "partner_service_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "partner_org_id": {
+          "name": "partner_org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "synthetic_person_ref": {
+          "name": "synthetic_person_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "partner_service_event_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_at": {
+          "name": "event_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "ed_encounter_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'synthetic'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "partner_service_events_person_idx": {
+          "name": "partner_service_events_person_idx",
+          "columns": [
+            {
+              "expression": "synthetic_person_ref",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "partner_service_events_partner_idx": {
+          "name": "partner_service_events_partner_idx",
+          "columns": [
+            {
+              "expression": "partner_org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "partner_service_events_at_idx": {
+          "name": "partner_service_events_at_idx",
+          "columns": [
+            {
+              "expression": "event_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "partner_service_events_partner_org_id_partner_orgs_id_fk": {
+          "name": "partner_service_events_partner_org_id_partner_orgs_id_fk",
+          "tableFrom": "partner_service_events",
+          "tableTo": "partner_orgs",
+          "columnsFrom": [
+            "partner_org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.person_partner_consents": {
+      "name": "person_partner_consents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "synthetic_person_ref": {
+          "name": "synthetic_person_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "partner_org_id": {
+          "name": "partner_org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "granted_at": {
+          "name": "granted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "person_partner_consents_unique_idx": {
+          "name": "person_partner_consents_unique_idx",
+          "columns": [
+            {
+              "expression": "synthetic_person_ref",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "partner_org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "person_partner_consents_partner_org_id_partner_orgs_id_fk": {
+          "name": "person_partner_consents_partner_org_id_partner_orgs_id_fk",
+          "tableFrom": "person_partner_consents",
+          "tableTo": "partner_orgs",
+          "columnsFrom": [
+            "partner_org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rental_assistance_programs": {
+      "name": "rental_assistance_programs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agency": {
+          "name": "agency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "website": {
+          "name": "website",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "eligibility_summary": {
+          "name": "eligibility_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "max_award_cents": {
+          "name": "max_award_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_note": {
+          "name": "source_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "rental_assistance_programs_active_idx": {
+          "name": "rental_assistance_programs_active_idx",
+          "columns": [
+            {
+              "expression": "active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bed_count_updates": {
+      "name": "bed_count_updates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "shelter_id": {
+          "name": "shelter_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_user_id": {
+          "name": "updated_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "previous_occupancy": {
+          "name": "previous_occupancy",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "new_occupancy": {
+          "name": "new_occupancy",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "bed_count_updates_shelter_idx": {
+          "name": "bed_count_updates_shelter_idx",
+          "columns": [
+            {
+              "expression": "shelter_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bed_count_updates_created_idx": {
+          "name": "bed_count_updates_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bed_count_updates_shelter_id_shelters_id_fk": {
+          "name": "bed_count_updates_shelter_id_shelters_id_fk",
+          "tableFrom": "bed_count_updates",
+          "tableTo": "shelters",
+          "columnsFrom": [
+            "shelter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bed_holds": {
+      "name": "bed_holds",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "shelter_id": {
+          "name": "shelter_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "held_by_user_id": {
+          "name": "held_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "person_label": {
+          "name": "person_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "bed_hold_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "released_at": {
+          "name": "released_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "bed_holds_shelter_idx": {
+          "name": "bed_holds_shelter_idx",
+          "columns": [
+            {
+              "expression": "shelter_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bed_holds_status_idx": {
+          "name": "bed_holds_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bed_holds_expires_idx": {
+          "name": "bed_holds_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bed_holds_shelter_id_shelters_id_fk": {
+          "name": "bed_holds_shelter_id_shelters_id_fk",
+          "tableFrom": "bed_holds",
+          "tableTo": "shelters",
+          "columnsFrom": [
+            "shelter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.shelters": {
+      "name": "shelters",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "partner_org_id": {
+          "name": "partner_org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address_line1": {
+          "name": "address_line1",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "city": {
+          "name": "city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "postal_code": {
+          "name": "postal_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_phone": {
+          "name": "contact_phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capacity": {
+          "name": "capacity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_occupancy": {
+          "name": "current_occupancy",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "accepts_men": {
+          "name": "accepts_men",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "accepts_women": {
+          "name": "accepts_women",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "accepts_families": {
+          "name": "accepts_families",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "pet_friendly": {
+          "name": "pet_friendly",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "sud_friendly": {
+          "name": "sud_friendly",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "shelters_slug_idx": {
+          "name": "shelters_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "shelters_partner_org_idx": {
+          "name": "shelters_partner_org_idx",
+          "columns": [
+            {
+              "expression": "partner_org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "shelters_partner_org_id_partner_orgs_id_fk": {
+          "name": "shelters_partner_org_id_partner_orgs_id_fk",
+          "tableFrom": "shelters",
+          "tableTo": "partner_orgs",
+          "columnsFrom": [
+            "partner_org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "shelters_capacity_nonneg": {
+          "name": "shelters_capacity_nonneg",
+          "value": "\"shelters\".\"capacity\" >= 0"
+        },
+        "shelters_occupancy_nonneg": {
+          "name": "shelters_occupancy_nonneg",
+          "value": "\"shelters\".\"current_occupancy\" >= 0"
+        },
+        "shelters_occupancy_le_capacity": {
+          "name": "shelters_occupancy_le_capacity",
+          "value": "\"shelters\".\"current_occupancy\" <= \"shelters\".\"capacity\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "clerk_user_id": {
+          "name": "clerk_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "users_clerk_user_id_idx": {
+          "name": "users_clerk_user_id_idx",
+          "columns": [
+            {
+              "expression": "clerk_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.bed_hold_status": {
+      "name": "bed_hold_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "released",
+        "expired",
+        "converted"
+      ]
+    },
+    "public.consent_channel": {
+      "name": "consent_channel",
+      "schema": "public",
+      "values": [
+        "sms",
+        "in_person",
+        "web_form",
+        "phone",
+        "paper"
+      ]
+    },
+    "public.consent_type": {
+      "name": "consent_type",
+      "schema": "public",
+      "values": [
+        "phi_share_within_coalition",
+        "sms_communication",
+        "data_for_program_eval"
+      ]
+    },
+    "public.data_sharing_tier": {
+      "name": "data_sharing_tier",
+      "schema": "public",
+      "values": [
+        "none",
+        "aggregate",
+        "individual"
+      ]
+    },
+    "public.ed_encounter_source": {
+      "name": "ed_encounter_source",
+      "schema": "public",
+      "values": [
+        "synthetic",
+        "epic_fhir",
+        "manual"
+      ]
+    },
+    "public.esuc_care_plan_status": {
+      "name": "esuc_care_plan_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "approved",
+        "active",
+        "archived"
+      ]
+    },
+    "public.eviction_case_outcome": {
+      "name": "eviction_case_outcome",
+      "schema": "public",
+      "values": [
+        "dismissed",
+        "judgment_for_plaintiff",
+        "judgment_for_defendant",
+        "settled",
+        "default_judgment",
+        "withdrawn"
+      ]
+    },
+    "public.eviction_cause_type": {
+      "name": "eviction_cause_type",
+      "schema": "public",
+      "values": [
+        "non_payment",
+        "lease_violation",
+        "holdover",
+        "other"
+      ]
+    },
+    "public.eviction_filing_source": {
+      "name": "eviction_filing_source",
+      "schema": "public",
+      "values": [
+        "courtnet",
+        "manual",
+        "synthetic"
+      ]
+    },
+    "public.eviction_filing_status": {
+      "name": "eviction_filing_status",
+      "schema": "public",
+      "values": [
+        "filed",
+        "served",
+        "judgment",
+        "dismissed",
+        "sealed"
+      ]
+    },
+    "public.eviction_response_packet_status": {
+      "name": "eviction_response_packet_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "approved",
+        "filed",
+        "rejected"
+      ]
+    },
+    "public.housing_status": {
+      "name": "housing_status",
+      "schema": "public",
+      "values": [
+        "housed",
+        "doubled_up",
+        "shelter",
+        "unsheltered",
+        "unknown"
+      ]
+    },
+    "public.partner_org_type": {
+      "name": "partner_org_type",
+      "schema": "public",
+      "values": [
+        "hospital",
+        "legal_aid",
+        "shelter",
+        "community_org",
+        "government",
+        "faith_based",
+        "school",
+        "philanthropy",
+        "education",
+        "public_health",
+        "media",
+        "other"
+      ]
+    },
+    "public.partner_service_event_type": {
+      "name": "partner_service_event_type",
+      "schema": "public",
+      "values": [
+        "food_pantry",
+        "shelter_intake",
+        "shelter_bed_night",
+        "utility_assistance",
+        "rent_assistance",
+        "counseling_visit",
+        "medical_visit",
+        "school_attendance_flag",
+        "volunteer_hours",
+        "other"
+      ]
+    },
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "pending",
+        "attorney",
+        "caseworker",
+        "ed_coordinator",
+        "shelter_staff",
+        "admin"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/migrations/meta/_journal.json
+++ b/drizzle/migrations/meta/_journal.json
@@ -120,6 +120,13 @@
       "when": 1777232613184,
       "tag": "0016_windy_ironclad",
       "breakpoints": true
+    },
+    {
+      "idx": 17,
+      "version": "7",
+      "when": 1777234082170,
+      "tag": "0017_opposite_nitro",
+      "breakpoints": true
     }
   ]
 }

--- a/src/app/actions/coordination.ts
+++ b/src/app/actions/coordination.ts
@@ -1,9 +1,9 @@
 'use server';
 
-import { eq } from 'drizzle-orm';
+import { and, count, eq, gt } from 'drizzle-orm';
 import { revalidatePath } from 'next/cache';
 import { db } from '@/db/client';
-import { bedCountUpdates, shelters } from '@/db/schema/shelters';
+import { bedCountUpdates, bedHolds, shelters } from '@/db/schema/shelters';
 import { logAuditEvent } from '@/lib/audit';
 import { requireRole } from '@/lib/auth';
 import { validateBedCount } from '@/lib/coordination/bed-availability';
@@ -11,8 +11,17 @@ import { validateBedCount } from '@/lib/coordination/bed-availability';
 export type UpdateBedCountResult = { ok: true } | { ok: false; error: string };
 
 const STAFF_ROLES = ['shelter_staff', 'admin'] as const;
+const HOLD_ROLES = ['caseworker', 'ed_coordinator', 'shelter_staff', 'admin'] as const;
 
 const MAX_NOTE_LEN = 280;
+const MAX_PERSON_LABEL_LEN = 80;
+/**
+ * Soft-hold lifetime. 90 minutes is the working number from the BACKLOG
+ * AC for COOR-005 — long enough that someone walking in from across town
+ * still has the bed waiting, short enough that no-shows free up beds
+ * within the same intake window.
+ */
+const HOLD_DURATION_MIN = 90;
 
 /**
  * Set a shelter's current_occupancy to `newOccupancy` and append the
@@ -87,6 +96,136 @@ export async function updateBedCountAction(
       },
     });
   }
+
+  revalidatePath('/app/coalition/beds');
+  revalidatePath('/app/coalition/beds/update');
+  return { ok: true };
+}
+
+export type CreateBedHoldResult =
+  | { ok: true; holdId: string; expiresAt: Date }
+  | { ok: false; error: string };
+
+/**
+ * Create a 90-minute soft hold against a shelter bed. The hold reserves
+ * one effective free bed without changing current_occupancy — the bed
+ * isn't physically taken until staff bumps occupancy on arrival.
+ *
+ * Race protection: we count active+unexpired holds inside the
+ * transaction and reject if it would push us above raw free beds. A
+ * concurrent second-clicker gets a friendly error instead of an
+ * overbooked shelter.
+ */
+export async function createBedHoldAction(
+  shelterId: string,
+  personLabel: string,
+  notes: string | null,
+): Promise<CreateBedHoldResult> {
+  const actor = await requireRole(HOLD_ROLES);
+
+  const trimmedLabel = personLabel.trim().slice(0, MAX_PERSON_LABEL_LEN);
+  if (trimmedLabel.length === 0) {
+    return { ok: false, error: 'Hold label is required (e.g., "211 caller #1234").' };
+  }
+  const trimmedNotes = notes?.trim() ? notes.trim().slice(0, MAX_NOTE_LEN) : null;
+
+  const expiresAt = new Date(Date.now() + HOLD_DURATION_MIN * 60_000);
+
+  const result = await db.transaction(async (tx) => {
+    const [shelter] = await tx
+      .select({
+        id: shelters.id,
+        capacity: shelters.capacity,
+        currentOccupancy: shelters.currentOccupancy,
+        active: shelters.active,
+      })
+      .from(shelters)
+      .where(eq(shelters.id, shelterId))
+      .limit(1);
+    if (!shelter) return { ok: false as const, error: 'Shelter not found.' };
+    if (!shelter.active) return { ok: false as const, error: 'Shelter is inactive.' };
+
+    const rawFree = shelter.capacity - shelter.currentOccupancy;
+    if (rawFree <= 0) return { ok: false as const, error: 'No free beds at this shelter.' };
+
+    const [{ value: activeHolds }] = await tx
+      .select({ value: count() })
+      .from(bedHolds)
+      .where(
+        and(
+          eq(bedHolds.shelterId, shelterId),
+          eq(bedHolds.status, 'active'),
+          gt(bedHolds.expiresAt, new Date()),
+        ),
+      );
+
+    if (Number(activeHolds) >= rawFree) {
+      return { ok: false as const, error: 'All free beds are already on hold.' };
+    }
+
+    const [created] = await tx
+      .insert(bedHolds)
+      .values({
+        shelterId,
+        heldByUserId: actor.id,
+        personLabel: trimmedLabel,
+        notes: trimmedNotes,
+        expiresAt,
+      })
+      .returning({ id: bedHolds.id, expiresAt: bedHolds.expiresAt });
+    return { ok: true as const, holdId: created.id, expiresAt: created.expiresAt };
+  });
+
+  if (!result.ok) return result;
+
+  await logAuditEvent({
+    actorUserId: actor.id,
+    action: 'shelter.bed_hold_created',
+    targetTable: 'bed_holds',
+    targetId: result.holdId,
+    metadata: { shelterId, durationMin: HOLD_DURATION_MIN },
+  });
+
+  revalidatePath('/app/coalition/beds');
+  revalidatePath('/app/coalition/beds/update');
+  return result;
+}
+
+export type ReleaseBedHoldResult = { ok: true } | { ok: false; error: string };
+
+const HOLD_TERMINAL_STATUSES = new Set(['released', 'expired', 'converted']);
+
+/**
+ * Manually release a hold (typically: caller said "never mind" or
+ * staff freed the bed). Only flips status from 'active' → 'released';
+ * already-terminal holds return ok without re-flipping.
+ */
+export async function releaseBedHoldAction(holdId: string): Promise<ReleaseBedHoldResult> {
+  const actor = await requireRole(HOLD_ROLES);
+
+  const [hold] = await db
+    .select({ id: bedHolds.id, shelterId: bedHolds.shelterId, status: bedHolds.status })
+    .from(bedHolds)
+    .where(eq(bedHolds.id, holdId))
+    .limit(1);
+  if (!hold) return { ok: false, error: 'Hold not found.' };
+
+  if (HOLD_TERMINAL_STATUSES.has(hold.status)) {
+    return { ok: true };
+  }
+
+  await db
+    .update(bedHolds)
+    .set({ status: 'released', releasedAt: new Date(), updatedAt: new Date() })
+    .where(eq(bedHolds.id, holdId));
+
+  await logAuditEvent({
+    actorUserId: actor.id,
+    action: 'shelter.bed_hold_released',
+    targetTable: 'bed_holds',
+    targetId: holdId,
+    metadata: { shelterId: hold.shelterId, previousStatus: hold.status },
+  });
 
   revalidatePath('/app/coalition/beds');
   revalidatePath('/app/coalition/beds/update');

--- a/src/app/app/coalition/beds/page.tsx
+++ b/src/app/app/coalition/beds/page.tsx
@@ -2,10 +2,15 @@ import { AutoRefresh } from '@/components/coordination/auto-refresh';
 import { BedBoardCard } from '@/components/coordination/bed-board-card';
 import { BedBoardFilters } from '@/components/coordination/bed-board-filters';
 import { Card, CardContent } from '@/components/ui/card';
-import { lastBedCountUpdateByShelter, listActiveShelters } from '@/db/queries/shelters';
+import {
+  type BedHoldWithHolder,
+  lastBedCountUpdateByShelter,
+  listActiveHolds,
+  listActiveShelters,
+} from '@/db/queries/shelters';
 import { requireRole } from '@/lib/auth';
 import {
-  freeBeds,
+  effectiveFreeBeds,
   hasActiveFilter,
   matchesFilter,
   parseBedFilterParams,
@@ -13,12 +18,20 @@ import {
 
 export const dynamic = 'force-dynamic';
 
+const HOLD_ROLES = ['caseworker', 'ed_coordinator', 'shelter_staff', 'admin'];
+
 export default async function BedAvailabilityBoardPage({
   searchParams,
 }: {
   searchParams: Promise<Record<string, string | string[] | undefined>>;
 }) {
-  await requireRole(['attorney', 'caseworker', 'ed_coordinator', 'shelter_staff', 'admin']);
+  const me = await requireRole([
+    'attorney',
+    'caseworker',
+    'ed_coordinator',
+    'shelter_staff',
+    'admin',
+  ]);
   const params = await searchParams;
   const filter = parseBedFilterParams(params);
 
@@ -27,14 +40,24 @@ export default async function BedAvailabilityBoardPage({
     lastBedCountUpdateByShelter(),
   ]);
 
+  const holdLists = await Promise.all(allShelters.map((s) => listActiveHolds(s.id)));
+  const holdsByShelter = new Map<string, BedHoldWithHolder[]>(
+    allShelters.map((s, i) => [s.id, holdLists[i]]),
+  );
+
   const filtered = allShelters.filter((s) =>
     matchesFilter(s, filter, `${s.name} ${s.partnerOrg.name}`),
   );
 
   const totalCapacity = filtered.reduce((sum, s) => sum + s.capacity, 0);
   const totalOccupied = filtered.reduce((sum, s) => sum + s.currentOccupancy, 0);
-  const totalFree = filtered.reduce((sum, s) => sum + freeBeds(s), 0);
+  const totalFree = filtered.reduce(
+    (sum, s) => sum + effectiveFreeBeds(s, holdsByShelter.get(s.id)?.length ?? 0),
+    0,
+  );
+  const totalHolds = filtered.reduce((sum, s) => sum + (holdsByShelter.get(s.id)?.length ?? 0), 0);
   const filterActive = hasActiveFilter(filter);
+  const canHold = HOLD_ROLES.includes(me.role);
 
   return (
     <div className="mx-auto max-w-6xl space-y-4 p-4 md:p-6">
@@ -42,8 +65,8 @@ export default async function BedAvailabilityBoardPage({
         <div>
           <h1 className="font-serif text-3xl font-bold text-primary">Bed availability</h1>
           <p className="text-sm text-muted-foreground">
-            Live across {allShelters.length} Daviess shelters. Numbers reflect what staff entered
-            most recently in the bed-count update view.
+            Live across {allShelters.length} Daviess shelters. Free counts subtract active 90-min
+            holds.
           </p>
         </div>
         <AutoRefresh />
@@ -52,7 +75,7 @@ export default async function BedAvailabilityBoardPage({
       <BedBoardFilters />
 
       <Card>
-        <CardContent className="grid grid-cols-3 gap-3 text-center">
+        <CardContent className="grid grid-cols-4 gap-3 text-center">
           <div>
             <p className="text-xs uppercase tracking-wide text-muted-foreground">
               Free {filterActive ? '(filtered)' : ''}
@@ -60,6 +83,10 @@ export default async function BedAvailabilityBoardPage({
             <p className="text-2xl font-semibold text-emerald-600 dark:text-emerald-400">
               {totalFree}
             </p>
+          </div>
+          <div>
+            <p className="text-xs uppercase tracking-wide text-muted-foreground">On hold</p>
+            <p className="text-2xl font-semibold">{totalHolds}</p>
           </div>
           <div>
             <p className="text-xs uppercase tracking-wide text-muted-foreground">Occupied</p>
@@ -92,6 +119,8 @@ export default async function BedAvailabilityBoardPage({
               key={shelter.id}
               shelter={shelter}
               lastUpdatedAt={lastUpdates.get(shelter.id) ?? null}
+              activeHolds={holdsByShelter.get(shelter.id) ?? []}
+              canHold={canHold}
             />
           ))}
         </div>

--- a/src/components/coordination/bed-board-card.tsx
+++ b/src/components/coordination/bed-board-card.tsx
@@ -1,6 +1,7 @@
+import { BedHoldControls } from '@/components/coordination/bed-hold-controls';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import type { ShelterWithOrg } from '@/db/queries/shelters';
-import { freeBeds, occupancyRate } from '@/lib/coordination/bed-availability';
+import type { BedHoldWithHolder, ShelterWithOrg } from '@/db/queries/shelters';
+import { effectiveFreeBeds, freeBeds, occupancyRate } from '@/lib/coordination/bed-availability';
 
 const fmtTime = (d: Date) =>
   new Intl.DateTimeFormat('en-US', { dateStyle: 'medium', timeStyle: 'short' }).format(new Date(d));
@@ -18,11 +19,16 @@ function popChips(shelter: ShelterWithOrg): string[] {
 export function BedBoardCard({
   shelter,
   lastUpdatedAt,
+  activeHolds,
+  canHold,
 }: {
   shelter: ShelterWithOrg;
   lastUpdatedAt: Date | null;
+  activeHolds: BedHoldWithHolder[];
+  canHold: boolean;
 }) {
-  const free = freeBeds(shelter);
+  const rawFree = freeBeds(shelter);
+  const free = effectiveFreeBeds(shelter, activeHolds.length);
   const rate = occupancyRate(shelter);
   const isFull = free === 0;
   const isTight = !isFull && rate >= 0.85;
@@ -47,6 +53,11 @@ export function BedBoardCard({
           <div>
             <p className="text-xs uppercase tracking-wide text-muted-foreground">Free</p>
             <p className={`text-3xl font-semibold ${freeColor}`}>{free}</p>
+            {activeHolds.length > 0 ? (
+              <p className="text-xs text-muted-foreground">
+                {rawFree} unoccupied · {activeHolds.length} on hold
+              </p>
+            ) : null}
           </div>
           <p className="text-sm text-muted-foreground">
             {shelter.currentOccupancy} / {shelter.capacity} occupied
@@ -94,6 +105,14 @@ export function BedBoardCard({
         <p className="text-xs text-muted-foreground">
           {lastUpdatedAt ? `Last update ${fmtTime(lastUpdatedAt)}` : 'No updates yet'}
         </p>
+
+        <BedHoldControls
+          shelterId={shelter.id}
+          shelterName={shelter.name}
+          freeBeds={free}
+          activeHolds={activeHolds}
+          canHold={canHold}
+        />
       </CardContent>
     </Card>
   );

--- a/src/components/coordination/bed-hold-controls.tsx
+++ b/src/components/coordination/bed-hold-controls.tsx
@@ -1,0 +1,163 @@
+'use client';
+
+import { useId, useState, useTransition } from 'react';
+import { createBedHoldAction, releaseBedHoldAction } from '@/app/actions/coordination';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import type { BedHoldWithHolder } from '@/db/queries/shelters';
+
+const fmtTime = (d: Date) =>
+  new Intl.DateTimeFormat('en-US', { timeStyle: 'short' }).format(new Date(d));
+
+const minutesFromNow = (d: Date): number =>
+  Math.max(0, Math.round((new Date(d).getTime() - Date.now()) / 60_000));
+
+export function BedHoldControls({
+  shelterId,
+  shelterName,
+  freeBeds,
+  activeHolds,
+  canHold,
+}: {
+  shelterId: string;
+  shelterName: string;
+  freeBeds: number;
+  activeHolds: BedHoldWithHolder[];
+  canHold: boolean;
+}) {
+  const labelId = useId();
+  const noteId = useId();
+  const [open, setOpen] = useState(false);
+  const [label, setLabel] = useState('');
+  const [note, setNote] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [pending, startTransition] = useTransition();
+
+  const onCreate = () => {
+    setError(null);
+    startTransition(async () => {
+      const r = await createBedHoldAction(shelterId, label, note || null);
+      if (!r.ok) {
+        setError(r.error);
+        return;
+      }
+      setLabel('');
+      setNote('');
+      setOpen(false);
+    });
+  };
+
+  const onRelease = (id: string) => {
+    setError(null);
+    startTransition(async () => {
+      const r = await releaseBedHoldAction(id);
+      if (!r.ok) setError(r.error);
+    });
+  };
+
+  const cannotCreate = !canHold || freeBeds <= 0;
+
+  return (
+    <div className="space-y-2 border-t border-border pt-3 text-sm">
+      <div className="flex items-center justify-between gap-2">
+        <p className="text-xs uppercase tracking-wide text-muted-foreground">
+          Holds{' '}
+          <span className="text-foreground">
+            {activeHolds.length}
+            {activeHolds.length > 0 ? ' active' : ''}
+          </span>
+        </p>
+        {canHold ? (
+          <Button
+            type="button"
+            size="sm"
+            variant={open ? 'ghost' : 'outline'}
+            disabled={pending || (cannotCreate && !open)}
+            onClick={() => setOpen((v) => !v)}
+            title={cannotCreate ? 'No free beds to hold' : `Hold a bed at ${shelterName}`}
+          >
+            {open ? 'Cancel' : 'Hold a bed'}
+          </Button>
+        ) : null}
+      </div>
+
+      {activeHolds.length > 0 ? (
+        <ul className="space-y-1 text-xs">
+          {activeHolds.map((h) => {
+            const mins = minutesFromNow(h.expiresAt);
+            return (
+              <li
+                key={h.id}
+                className="flex items-center justify-between gap-2 rounded bg-muted/40 px-2 py-1"
+              >
+                <span className="truncate">
+                  <span className="font-medium">{h.personLabel}</span>
+                  <span className="text-muted-foreground">
+                    {' '}
+                    · expires {fmtTime(h.expiresAt)} ({mins}m)
+                  </span>
+                </span>
+                {canHold ? (
+                  <Button
+                    type="button"
+                    size="sm"
+                    variant="ghost"
+                    disabled={pending}
+                    onClick={() => onRelease(h.id)}
+                  >
+                    Release
+                  </Button>
+                ) : null}
+              </li>
+            );
+          })}
+        </ul>
+      ) : null}
+
+      {open ? (
+        <div className="space-y-2 rounded border border-border bg-card p-3">
+          <div className="space-y-1">
+            <Label htmlFor={labelId} className="text-xs uppercase tracking-wide">
+              Hold for
+            </Label>
+            <Input
+              id={labelId}
+              value={label}
+              maxLength={80}
+              disabled={pending}
+              placeholder='e.g. "211 caller #1234"'
+              onChange={(e) => setLabel(e.target.value)}
+            />
+          </div>
+          <div className="space-y-1">
+            <Label htmlFor={noteId} className="text-xs uppercase tracking-wide">
+              Note (optional)
+            </Label>
+            <Input
+              id={noteId}
+              value={note}
+              maxLength={280}
+              disabled={pending}
+              placeholder="walking from downtown, ETA 30 min"
+              onChange={(e) => setNote(e.target.value)}
+            />
+          </div>
+          {error ? <p className="text-xs text-destructive">{error}</p> : null}
+          <div className="flex justify-end">
+            <Button
+              type="button"
+              size="sm"
+              disabled={pending || cannotCreate || label.trim().length === 0}
+              onClick={onCreate}
+            >
+              {pending ? 'Saving…' : 'Hold for 90 min'}
+            </Button>
+          </div>
+        </div>
+      ) : error && activeHolds.length > 0 ? (
+        <p className="text-xs text-destructive">{error}</p>
+      ) : null}
+    </div>
+  );
+}

--- a/src/db/queries/shelters.ts
+++ b/src/db/queries/shelters.ts
@@ -1,7 +1,15 @@
-import { and, asc, desc, eq, max } from 'drizzle-orm';
+import { and, asc, count, desc, eq, gt, max } from 'drizzle-orm';
 import { db } from '@/db/client';
 import { type PartnerOrg, partnerOrgs } from '@/db/schema/partner-orgs';
-import { type BedCountUpdate, bedCountUpdates, type Shelter, shelters } from '@/db/schema/shelters';
+import {
+  type BedCountUpdate,
+  type BedHold,
+  bedCountUpdates,
+  bedHolds,
+  type Shelter,
+  shelters,
+} from '@/db/schema/shelters';
+import { users } from '@/db/schema/users';
 
 export type ShelterWithOrg = Shelter & { partnerOrg: Pick<PartnerOrg, 'id' | 'name' | 'slug'> };
 
@@ -69,4 +77,43 @@ export async function lastBedCountUpdateByShelter(): Promise<Map<string, Date | 
     .from(bedCountUpdates)
     .groupBy(bedCountUpdates.shelterId);
   return new Map(rows.map((r) => [r.shelterId, r.lastAt ? new Date(r.lastAt) : null]));
+}
+
+/**
+ * Count of active, not-yet-expired holds per shelter. The board uses
+ * this to show effective free beds (capacity − occupancy − holds).
+ */
+export async function activeBedHoldCounts(): Promise<Map<string, number>> {
+  const now = new Date();
+  const rows = await db
+    .select({ shelterId: bedHolds.shelterId, value: count() })
+    .from(bedHolds)
+    .where(and(eq(bedHolds.status, 'active'), gt(bedHolds.expiresAt, now)))
+    .groupBy(bedHolds.shelterId);
+  return new Map(rows.map((r) => [r.shelterId, Number(r.value)]));
+}
+
+export type BedHoldWithHolder = BedHold & {
+  heldBy: { firstName: string | null; lastName: string | null; email: string };
+};
+
+/** Active (status=active AND expires_at > now) holds for one shelter, newest first. */
+export async function listActiveHolds(shelterId: string): Promise<BedHoldWithHolder[]> {
+  const now = new Date();
+  const rows = await db
+    .select({
+      hold: bedHolds,
+      heldBy: { firstName: users.firstName, lastName: users.lastName, email: users.email },
+    })
+    .from(bedHolds)
+    .innerJoin(users, eq(bedHolds.heldByUserId, users.id))
+    .where(
+      and(
+        eq(bedHolds.shelterId, shelterId),
+        eq(bedHolds.status, 'active'),
+        gt(bedHolds.expiresAt, now),
+      ),
+    )
+    .orderBy(desc(bedHolds.createdAt));
+  return rows.map((r) => ({ ...r.hold, heldBy: r.heldBy }));
 }

--- a/src/db/schema/enums.ts
+++ b/src/db/schema/enums.ts
@@ -125,6 +125,15 @@ export const dataSharingTierEnum = pgEnum('data_sharing_tier', ['none', 'aggrega
 
 export type DataSharingTier = (typeof dataSharingTierEnum.enumValues)[number];
 
+export const bedHoldStatusEnum = pgEnum('bed_hold_status', [
+  'active',
+  'released',
+  'expired',
+  'converted',
+]);
+
+export type BedHoldStatus = (typeof bedHoldStatusEnum.enumValues)[number];
+
 export const partnerServiceEventTypeEnum = pgEnum('partner_service_event_type', [
   'food_pantry',
   'shelter_intake',

--- a/src/db/schema/shelters.ts
+++ b/src/db/schema/shelters.ts
@@ -10,6 +10,7 @@ import {
   uniqueIndex,
   uuid,
 } from 'drizzle-orm/pg-core';
+import { bedHoldStatusEnum } from './enums';
 import { partnerOrgs } from './partner-orgs';
 
 /**
@@ -96,3 +97,46 @@ export const bedCountUpdates = pgTable(
 
 export type BedCountUpdate = typeof bedCountUpdates.$inferSelect;
 export type NewBedCountUpdate = typeof bedCountUpdates.$inferInsert;
+
+/**
+ * Soft 90-minute reservation against a shelter bed (COOR-005). A hold
+ * decrements effective free beds (free = capacity − occupancy − active
+ * holds) without touching `current_occupancy` itself — the bed is still
+ * unoccupied until the person arrives and the staff bumps occupancy.
+ *
+ * Identity is opaque on purpose: `personLabel` is whatever the dispatcher
+ * wrote ("211 caller #1234", "Phone: 270-555-0100"). No real PHI lands
+ * here pre-BAA.
+ *
+ * Lifecycle:
+ *  - active   → released   (manual release, person didn't show)
+ *  - active   → expired    (auto-released by Inngest after expires_at)
+ *  - active   → converted  (intake completed; occupancy bumped manually)
+ */
+export const bedHolds = pgTable(
+  'bed_holds',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    shelterId: uuid('shelter_id')
+      .notNull()
+      .references(() => shelters.id, { onDelete: 'cascade' }),
+    /** Internal user who created the hold. */
+    heldByUserId: uuid('held_by_user_id').notNull(),
+    /** Free-text label for the requesting party. NEVER PHI. */
+    personLabel: text('person_label').notNull(),
+    status: bedHoldStatusEnum('status').notNull().default('active'),
+    expiresAt: timestamp('expires_at', { withTimezone: true }).notNull(),
+    releasedAt: timestamp('released_at', { withTimezone: true }),
+    notes: text('notes'),
+    createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),
+  },
+  (t) => [
+    index('bed_holds_shelter_idx').on(t.shelterId),
+    index('bed_holds_status_idx').on(t.status),
+    index('bed_holds_expires_idx').on(t.expiresAt),
+  ],
+);
+
+export type BedHold = typeof bedHolds.$inferSelect;
+export type NewBedHold = typeof bedHolds.$inferInsert;

--- a/src/inngest/functions/expire-bed-holds.ts
+++ b/src/inngest/functions/expire-bed-holds.ts
@@ -1,0 +1,35 @@
+import { and, eq, lt } from 'drizzle-orm';
+import { db } from '@/db/client';
+import { bedHolds } from '@/db/schema/shelters';
+import { inngest } from '../client';
+
+/**
+ * Auto-expires soft bed holds whose `expires_at` has passed (COOR-005
+ * AC: "Expires, releases automatically"). Runs every minute so a hold
+ * never lingers visibly past its 90-minute window.
+ *
+ * The board already filters by `expires_at > now()` when computing
+ * effective free beds, so the cron is a tidiness step — it normalizes
+ * the row to status='expired' so the audit trail reflects what
+ * actually happened, and so an admin browsing the table doesn't see
+ * lingering 'active' rows that are functionally dead.
+ */
+export const expireBedHolds = inngest.createFunction(
+  {
+    id: 'expire-bed-holds',
+    retries: 1,
+    triggers: [{ cron: '* * * * *' }], // every minute
+  },
+  async ({ step }) => {
+    const result = await step.run('flip-expired', async () => {
+      const now = new Date();
+      const expired = await db
+        .update(bedHolds)
+        .set({ status: 'expired', updatedAt: now })
+        .where(and(eq(bedHolds.status, 'active'), lt(bedHolds.expiresAt, now)))
+        .returning({ id: bedHolds.id });
+      return { count: expired.length };
+    });
+    return { ok: true, expired: result.count };
+  },
+);

--- a/src/inngest/functions/index.ts
+++ b/src/inngest/functions/index.ts
@@ -1,6 +1,13 @@
 import { dailyAttorneyDigest } from './daily-attorney-digest';
 import { dailyCourtnetScrape } from './daily-courtnet-scrape';
 import { dailyHealthPing } from './daily-health-ping';
+import { expireBedHolds } from './expire-bed-holds';
 import { userSignedUp } from './user-signed-up';
 
-export const functions = [dailyHealthPing, userSignedUp, dailyCourtnetScrape, dailyAttorneyDigest];
+export const functions = [
+  dailyHealthPing,
+  userSignedUp,
+  dailyCourtnetScrape,
+  dailyAttorneyDigest,
+  expireBedHolds,
+];

--- a/src/lib/coordination/bed-availability.test.ts
+++ b/src/lib/coordination/bed-availability.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import {
+  effectiveFreeBeds,
   freeBeds,
   hasActiveFilter,
   matchesFilter,
@@ -29,6 +30,20 @@ describe('freeBeds', () => {
 
   it('returns 0 when at capacity', () => {
     expect(freeBeds({ capacity: 10, currentOccupancy: 10 })).toBe(0);
+  });
+});
+
+describe('effectiveFreeBeds', () => {
+  it('subtracts active holds from raw free', () => {
+    expect(effectiveFreeBeds({ capacity: 10, currentOccupancy: 4 }, 2)).toBe(4);
+  });
+
+  it('clamps to 0 when holds exceed raw free', () => {
+    expect(effectiveFreeBeds({ capacity: 10, currentOccupancy: 8 }, 5)).toBe(0);
+  });
+
+  it('treats negative hold counts as 0', () => {
+    expect(effectiveFreeBeds({ capacity: 10, currentOccupancy: 4 }, -1)).toBe(6);
   });
 });
 

--- a/src/lib/coordination/bed-availability.ts
+++ b/src/lib/coordination/bed-availability.ts
@@ -59,6 +59,19 @@ export function freeBeds(shelter: Pick<Shelter, 'capacity' | 'currentOccupancy'>
   return Math.max(0, shelter.capacity - shelter.currentOccupancy);
 }
 
+/**
+ * Effective free beds, accounting for active soft holds. A hold reserves
+ * a bed for the holder for `expires_at` minutes; until released or
+ * expired it should not be advertised as available. Capped at the raw
+ * free count so a stale hold count never makes free go negative.
+ */
+export function effectiveFreeBeds(
+  shelter: Pick<Shelter, 'capacity' | 'currentOccupancy'>,
+  activeHolds: number,
+): number {
+  return Math.max(0, freeBeds(shelter) - Math.max(0, activeHolds));
+}
+
 /** Occupancy rate as a fraction in [0, 1]. Capacity 0 → 1 (treat as full). */
 export function occupancyRate(shelter: Pick<Shelter, 'capacity' | 'currentOccupancy'>): number {
   if (shelter.capacity <= 0) return 1;


### PR DESCRIPTION
Closes #58. Stacked on [#257](https://github.com/DobbsBoldry/homeless/pull/257) (COOR-004).

## Summary
- `bed_holds` table — active / released / expired / converted, opaque `person_label` (never PHI), `expires_at`, holder
- `createBedHoldAction` — 90-min hold, transactional race-safe count check (no overbooking on simultaneous clicks); gated to caseworker / ed_coordinator / shelter_staff / admin
- `releaseBedHoldAction` — manual release; idempotent on terminal states
- `effectiveFreeBeds(shelter, holds)` — subtracts active holds from raw free; the board's headline number uses this
- `BedHoldControls` on each board card — list active holds with expiry countdown, inline "Hold a bed" form, per-hold Release
- New summary stat on the board: \"On hold\" alongside Free / Occupied / Capacity
- `expire-bed-holds` Inngest cron — every minute, flips active rows past expires_at to `expired` so the audit trail reflects what happened
- 87 tests passing; added effectiveFreeBeds cases

## Acceptance criteria
- [x] 90-minute soft hold (not occupancy)
- [x] Auto-release on expiry (Inngest cron + read-side filter)
- [x] Lint + typecheck + tests + production build

## Test plan
- [ ] As caseworker, hit /app/coalition/beds, click \"Hold a bed\" on Boulware → free count drops by 1, hold appears with countdown
- [ ] Click Release → free count restores, hold disappears
- [ ] Try to hold beds beyond raw-free count from two tabs simultaneously — second tab should reject
- [ ] Manually backdate a hold's `expires_at` and let the cron run (or trigger expire-bed-holds in Inngest dev) → status flips to `expired`, board removes it
- [ ] Sign in as attorney role — \"Hold a bed\" button is hidden

🤖 Generated with [Claude Code](https://claude.com/claude-code)