### PR TITLE
feat(INDC-005/006): SMS shorthand + HOLD/RELEASE flow

### DIFF
--- a/drizzle/migrations/0020_quiet_metal_master.sql
+++ b/drizzle/migrations/0020_quiet_metal_master.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "sms_conversations" ADD COLUMN "last_results" jsonb;--> statement-breakpoint
+ALTER TABLE "sms_conversations" ADD COLUMN "last_hold_id" uuid;

--- a/drizzle/migrations/meta/0020_snapshot.json
+++ b/drizzle/migrations/meta/0020_snapshot.json
@@ -1,0 +1,2601 @@
+{
+  "id": "c6d45982-da16-4903-bd7f-46b41a8836d1",
+  "prevId": "f367cba4-3bfb-4d77-ac52-db36175fc490",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.audit_log": {
+      "name": "audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_table": {
+          "name": "target_table",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "audit_log_actor_idx": {
+          "name": "audit_log_actor_idx",
+          "columns": [
+            {
+              "expression": "actor_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_log_action_idx": {
+          "name": "audit_log_action_idx",
+          "columns": [
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_log_created_at_idx": {
+          "name": "audit_log_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audit_log_actor_user_id_users_id_fk": {
+          "name": "audit_log_actor_user_id_users_id_fk",
+          "tableFrom": "audit_log",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.consents": {
+      "name": "consents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "subject_external_id": {
+          "name": "subject_external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consent_type": {
+          "name": "consent_type",
+          "type": "consent_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "granted_via": {
+          "name": "granted_via",
+          "type": "consent_channel",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "granted_at": {
+          "name": "granted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "consents_subject_idx": {
+          "name": "consents_subject_idx",
+          "columns": [
+            {
+              "expression": "subject_external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "consents_type_idx": {
+          "name": "consents_type_idx",
+          "columns": [
+            {
+              "expression": "consent_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ed_encounters": {
+      "name": "ed_encounters",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encounter_external_id": {
+          "name": "encounter_external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "arrived_at": {
+          "name": "arrived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discharged_at": {
+          "name": "discharged_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chief_complaint": {
+          "name": "chief_complaint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "disposition": {
+          "name": "disposition",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "housing_status": {
+          "name": "housing_status",
+          "type": "housing_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unknown'"
+        },
+        "charge_cents": {
+          "name": "charge_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_json": {
+          "name": "raw_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "ed_encounter_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'synthetic'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ed_encounters_external_idx": {
+          "name": "ed_encounters_external_idx",
+          "columns": [
+            {
+              "expression": "encounter_external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ed_encounters_patient_idx": {
+          "name": "ed_encounters_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ed_encounters_arrived_idx": {
+          "name": "ed_encounters_arrived_idx",
+          "columns": [
+            {
+              "expression": "arrived_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ed_encounters_housing_idx": {
+          "name": "ed_encounters_housing_idx",
+          "columns": [
+            {
+              "expression": "housing_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.esuc_care_plans": {
+      "name": "esuc_care_plans",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plan_md": {
+          "name": "plan_md",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt_version": {
+          "name": "prompt_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "generated_by_user_id": {
+          "name": "generated_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "esuc_care_plan_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "care_plans_patient_version_idx": {
+          "name": "care_plans_patient_version_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "prompt_version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "care_plans_patient_idx": {
+          "name": "care_plans_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "care_plans_status_idx": {
+          "name": "care_plans_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "esuc_care_plans_generated_by_user_id_users_id_fk": {
+          "name": "esuc_care_plans_generated_by_user_id_users_id_fk",
+          "tableFrom": "esuc_care_plans",
+          "tableTo": "users",
+          "columnsFrom": [
+            "generated_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.eviction_case_outcomes": {
+      "name": "eviction_case_outcomes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "filing_id": {
+          "name": "filing_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "eviction_case_outcome",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recorded_by_user_id": {
+          "name": "recorded_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "case_outcomes_filing_idx": {
+          "name": "case_outcomes_filing_idx",
+          "columns": [
+            {
+              "expression": "filing_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "case_outcomes_outcome_idx": {
+          "name": "case_outcomes_outcome_idx",
+          "columns": [
+            {
+              "expression": "outcome",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "case_outcomes_created_at_idx": {
+          "name": "case_outcomes_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "eviction_case_outcomes_filing_id_eviction_filings_id_fk": {
+          "name": "eviction_case_outcomes_filing_id_eviction_filings_id_fk",
+          "tableFrom": "eviction_case_outcomes",
+          "tableTo": "eviction_filings",
+          "columnsFrom": [
+            "filing_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "eviction_case_outcomes_recorded_by_user_id_users_id_fk": {
+          "name": "eviction_case_outcomes_recorded_by_user_id_users_id_fk",
+          "tableFrom": "eviction_case_outcomes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "recorded_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.eviction_filing_risk_scores": {
+      "name": "eviction_filing_risk_scores",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "filing_id": {
+          "name": "filing_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rationale": {
+          "name": "rationale",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model_version": {
+          "name": "model_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "risk_scores_filing_version_idx": {
+          "name": "risk_scores_filing_version_idx",
+          "columns": [
+            {
+              "expression": "filing_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "model_version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "risk_scores_filing_idx": {
+          "name": "risk_scores_filing_idx",
+          "columns": [
+            {
+              "expression": "filing_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "risk_scores_score_idx": {
+          "name": "risk_scores_score_idx",
+          "columns": [
+            {
+              "expression": "score",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "eviction_filing_risk_scores_filing_id_eviction_filings_id_fk": {
+          "name": "eviction_filing_risk_scores_filing_id_eviction_filings_id_fk",
+          "tableFrom": "eviction_filing_risk_scores",
+          "tableTo": "eviction_filings",
+          "columnsFrom": [
+            "filing_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.eviction_filings": {
+      "name": "eviction_filings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "case_number": {
+          "name": "case_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filed_at": {
+          "name": "filed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "court_division": {
+          "name": "court_division",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plaintiff": {
+          "name": "plaintiff",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "defendant_first_name": {
+          "name": "defendant_first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "defendant_last_name": {
+          "name": "defendant_last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "defendant_address": {
+          "name": "defendant_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cause_type": {
+          "name": "cause_type",
+          "type": "eviction_cause_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_claimed_cents": {
+          "name": "amount_claimed_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "eviction_filing_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'filed'"
+        },
+        "source": {
+          "name": "source",
+          "type": "eviction_filing_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "raw_json": {
+          "name": "raw_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "eviction_filings_case_source_idx": {
+          "name": "eviction_filings_case_source_idx",
+          "columns": [
+            {
+              "expression": "case_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "eviction_filings_filed_at_idx": {
+          "name": "eviction_filings_filed_at_idx",
+          "columns": [
+            {
+              "expression": "filed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "eviction_filings_status_idx": {
+          "name": "eviction_filings_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.eviction_response_packets": {
+      "name": "eviction_response_packets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "filing_id": {
+          "name": "filing_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "packet_md": {
+          "name": "packet_md",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt_version": {
+          "name": "prompt_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "generated_by_user_id": {
+          "name": "generated_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "eviction_response_packet_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "response_packets_filing_version_idx": {
+          "name": "response_packets_filing_version_idx",
+          "columns": [
+            {
+              "expression": "filing_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "prompt_version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "response_packets_filing_idx": {
+          "name": "response_packets_filing_idx",
+          "columns": [
+            {
+              "expression": "filing_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "response_packets_status_idx": {
+          "name": "response_packets_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "eviction_response_packets_filing_id_eviction_filings_id_fk": {
+          "name": "eviction_response_packets_filing_id_eviction_filings_id_fk",
+          "tableFrom": "eviction_response_packets",
+          "tableTo": "eviction_filings",
+          "columnsFrom": [
+            "filing_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "eviction_response_packets_generated_by_user_id_users_id_fk": {
+          "name": "eviction_response_packets_generated_by_user_id_users_id_fk",
+          "tableFrom": "eviction_response_packets",
+          "tableTo": "users",
+          "columnsFrom": [
+            "generated_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.health_check": {
+      "name": "health_check",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_memberships": {
+      "name": "org_memberships",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "partner_org_id": {
+          "name": "partner_org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "org_memberships_user_org_idx": {
+          "name": "org_memberships_user_org_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "partner_org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "org_memberships_user_idx": {
+          "name": "org_memberships_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "org_memberships_partner_org_idx": {
+          "name": "org_memberships_partner_org_idx",
+          "columns": [
+            {
+              "expression": "partner_org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "org_memberships_user_id_users_id_fk": {
+          "name": "org_memberships_user_id_users_id_fk",
+          "tableFrom": "org_memberships",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "org_memberships_partner_org_id_partner_orgs_id_fk": {
+          "name": "org_memberships_partner_org_id_partner_orgs_id_fk",
+          "tableFrom": "org_memberships",
+          "tableTo": "partner_orgs",
+          "columnsFrom": [
+            "partner_org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.partner_orgs": {
+      "name": "partner_orgs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "partner_org_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_email": {
+          "name": "contact_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_phone": {
+          "name": "contact_phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "website": {
+          "name": "website",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data_sharing_tier": {
+          "name": "data_sharing_tier",
+          "type": "data_sharing_tier",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "partner_orgs_slug_idx": {
+          "name": "partner_orgs_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.partner_service_events": {
+      "name": "partner_service_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "partner_org_id": {
+          "name": "partner_org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "synthetic_person_ref": {
+          "name": "synthetic_person_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "partner_service_event_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_at": {
+          "name": "event_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "ed_encounter_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'synthetic'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "partner_service_events_person_idx": {
+          "name": "partner_service_events_person_idx",
+          "columns": [
+            {
+              "expression": "synthetic_person_ref",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "partner_service_events_partner_idx": {
+          "name": "partner_service_events_partner_idx",
+          "columns": [
+            {
+              "expression": "partner_org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "partner_service_events_at_idx": {
+          "name": "partner_service_events_at_idx",
+          "columns": [
+            {
+              "expression": "event_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "partner_service_events_partner_org_id_partner_orgs_id_fk": {
+          "name": "partner_service_events_partner_org_id_partner_orgs_id_fk",
+          "tableFrom": "partner_service_events",
+          "tableTo": "partner_orgs",
+          "columnsFrom": [
+            "partner_org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.person_partner_consents": {
+      "name": "person_partner_consents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "synthetic_person_ref": {
+          "name": "synthetic_person_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "partner_org_id": {
+          "name": "partner_org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "granted_at": {
+          "name": "granted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "person_partner_consents_unique_idx": {
+          "name": "person_partner_consents_unique_idx",
+          "columns": [
+            {
+              "expression": "synthetic_person_ref",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "partner_org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "person_partner_consents_partner_org_id_partner_orgs_id_fk": {
+          "name": "person_partner_consents_partner_org_id_partner_orgs_id_fk",
+          "tableFrom": "person_partner_consents",
+          "tableTo": "partner_orgs",
+          "columnsFrom": [
+            "partner_org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rental_assistance_programs": {
+      "name": "rental_assistance_programs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agency": {
+          "name": "agency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "website": {
+          "name": "website",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "eligibility_summary": {
+          "name": "eligibility_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "max_award_cents": {
+          "name": "max_award_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_note": {
+          "name": "source_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "rental_assistance_programs_active_idx": {
+          "name": "rental_assistance_programs_active_idx",
+          "columns": [
+            {
+              "expression": "active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bed_count_updates": {
+      "name": "bed_count_updates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "shelter_id": {
+          "name": "shelter_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_user_id": {
+          "name": "updated_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "previous_occupancy": {
+          "name": "previous_occupancy",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "new_occupancy": {
+          "name": "new_occupancy",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "bed_count_updates_shelter_idx": {
+          "name": "bed_count_updates_shelter_idx",
+          "columns": [
+            {
+              "expression": "shelter_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bed_count_updates_created_idx": {
+          "name": "bed_count_updates_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bed_count_updates_shelter_id_shelters_id_fk": {
+          "name": "bed_count_updates_shelter_id_shelters_id_fk",
+          "tableFrom": "bed_count_updates",
+          "tableTo": "shelters",
+          "columnsFrom": [
+            "shelter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bed_holds": {
+      "name": "bed_holds",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "shelter_id": {
+          "name": "shelter_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "held_by_user_id": {
+          "name": "held_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "person_label": {
+          "name": "person_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "bed_hold_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "released_at": {
+          "name": "released_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "bed_holds_shelter_idx": {
+          "name": "bed_holds_shelter_idx",
+          "columns": [
+            {
+              "expression": "shelter_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bed_holds_status_idx": {
+          "name": "bed_holds_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bed_holds_expires_idx": {
+          "name": "bed_holds_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bed_holds_shelter_id_shelters_id_fk": {
+          "name": "bed_holds_shelter_id_shelters_id_fk",
+          "tableFrom": "bed_holds",
+          "tableTo": "shelters",
+          "columnsFrom": [
+            "shelter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.shelters": {
+      "name": "shelters",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "partner_org_id": {
+          "name": "partner_org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address_line1": {
+          "name": "address_line1",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "city": {
+          "name": "city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "postal_code": {
+          "name": "postal_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_phone": {
+          "name": "contact_phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capacity": {
+          "name": "capacity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_occupancy": {
+          "name": "current_occupancy",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "accepts_men": {
+          "name": "accepts_men",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "accepts_women": {
+          "name": "accepts_women",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "accepts_families": {
+          "name": "accepts_families",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "pet_friendly": {
+          "name": "pet_friendly",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "sud_friendly": {
+          "name": "sud_friendly",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "shelters_slug_idx": {
+          "name": "shelters_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "shelters_partner_org_idx": {
+          "name": "shelters_partner_org_idx",
+          "columns": [
+            {
+              "expression": "partner_org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "shelters_partner_org_id_partner_orgs_id_fk": {
+          "name": "shelters_partner_org_id_partner_orgs_id_fk",
+          "tableFrom": "shelters",
+          "tableTo": "partner_orgs",
+          "columnsFrom": [
+            "partner_org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "shelters_capacity_nonneg": {
+          "name": "shelters_capacity_nonneg",
+          "value": "\"shelters\".\"capacity\" >= 0"
+        },
+        "shelters_occupancy_nonneg": {
+          "name": "shelters_occupancy_nonneg",
+          "value": "\"shelters\".\"current_occupancy\" >= 0"
+        },
+        "shelters_occupancy_le_capacity": {
+          "name": "shelters_occupancy_le_capacity",
+          "value": "\"shelters\".\"current_occupancy\" <= \"shelters\".\"capacity\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.sms_conversations": {
+      "name": "sms_conversations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "from_number": {
+          "name": "from_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "sms_conversation_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'idle'"
+        },
+        "pending_filter": {
+          "name": "pending_filter",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_location": {
+          "name": "last_location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_results": {
+          "name": "last_results",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_hold_id": {
+          "name": "last_hold_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_message_at": {
+          "name": "last_message_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sms_conversations_from_idx": {
+          "name": "sms_conversations_from_idx",
+          "columns": [
+            {
+              "expression": "from_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_conversations_state_idx": {
+          "name": "sms_conversations_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_conversations_expires_idx": {
+          "name": "sms_conversations_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sms_messages": {
+      "name": "sms_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "provider_message_id": {
+          "name": "provider_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "from_number": {
+          "name": "from_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_number": {
+          "name": "to_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "intent": {
+          "name": "intent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reply_body": {
+          "name": "reply_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sms_messages_received_idx": {
+          "name": "sms_messages_received_idx",
+          "columns": [
+            {
+              "expression": "received_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_messages_from_idx": {
+          "name": "sms_messages_from_idx",
+          "columns": [
+            {
+              "expression": "from_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "clerk_user_id": {
+          "name": "clerk_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "users_clerk_user_id_idx": {
+          "name": "users_clerk_user_id_idx",
+          "columns": [
+            {
+              "expression": "clerk_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.bed_hold_status": {
+      "name": "bed_hold_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "released",
+        "expired",
+        "converted"
+      ]
+    },
+    "public.consent_channel": {
+      "name": "consent_channel",
+      "schema": "public",
+      "values": [
+        "sms",
+        "in_person",
+        "web_form",
+        "phone",
+        "paper"
+      ]
+    },
+    "public.consent_type": {
+      "name": "consent_type",
+      "schema": "public",
+      "values": [
+        "phi_share_within_coalition",
+        "sms_communication",
+        "data_for_program_eval"
+      ]
+    },
+    "public.data_sharing_tier": {
+      "name": "data_sharing_tier",
+      "schema": "public",
+      "values": [
+        "none",
+        "aggregate",
+        "individual"
+      ]
+    },
+    "public.ed_encounter_source": {
+      "name": "ed_encounter_source",
+      "schema": "public",
+      "values": [
+        "synthetic",
+        "epic_fhir",
+        "manual"
+      ]
+    },
+    "public.esuc_care_plan_status": {
+      "name": "esuc_care_plan_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "approved",
+        "active",
+        "archived"
+      ]
+    },
+    "public.eviction_case_outcome": {
+      "name": "eviction_case_outcome",
+      "schema": "public",
+      "values": [
+        "dismissed",
+        "judgment_for_plaintiff",
+        "judgment_for_defendant",
+        "settled",
+        "default_judgment",
+        "withdrawn"
+      ]
+    },
+    "public.eviction_cause_type": {
+      "name": "eviction_cause_type",
+      "schema": "public",
+      "values": [
+        "non_payment",
+        "lease_violation",
+        "holdover",
+        "other"
+      ]
+    },
+    "public.eviction_filing_source": {
+      "name": "eviction_filing_source",
+      "schema": "public",
+      "values": [
+        "courtnet",
+        "manual",
+        "synthetic"
+      ]
+    },
+    "public.eviction_filing_status": {
+      "name": "eviction_filing_status",
+      "schema": "public",
+      "values": [
+        "filed",
+        "served",
+        "judgment",
+        "dismissed",
+        "sealed"
+      ]
+    },
+    "public.eviction_response_packet_status": {
+      "name": "eviction_response_packet_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "approved",
+        "filed",
+        "rejected"
+      ]
+    },
+    "public.housing_status": {
+      "name": "housing_status",
+      "schema": "public",
+      "values": [
+        "housed",
+        "doubled_up",
+        "shelter",
+        "unsheltered",
+        "unknown"
+      ]
+    },
+    "public.partner_org_type": {
+      "name": "partner_org_type",
+      "schema": "public",
+      "values": [
+        "hospital",
+        "legal_aid",
+        "shelter",
+        "community_org",
+        "government",
+        "faith_based",
+        "school",
+        "philanthropy",
+        "education",
+        "public_health",
+        "media",
+        "other"
+      ]
+    },
+    "public.partner_service_event_type": {
+      "name": "partner_service_event_type",
+      "schema": "public",
+      "values": [
+        "food_pantry",
+        "shelter_intake",
+        "shelter_bed_night",
+        "utility_assistance",
+        "rent_assistance",
+        "counseling_visit",
+        "medical_visit",
+        "school_attendance_flag",
+        "volunteer_hours",
+        "other"
+      ]
+    },
+    "public.sms_conversation_state": {
+      "name": "sms_conversation_state",
+      "schema": "public",
+      "values": [
+        "idle",
+        "awaiting_location"
+      ]
+    },
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "pending",
+        "attorney",
+        "caseworker",
+        "ed_coordinator",
+        "shelter_staff",
+        "admin"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/migrations/meta/_journal.json
+++ b/drizzle/migrations/meta/_journal.json
@@ -141,6 +141,13 @@
       "when": 1777235054698,
       "tag": "0019_safe_paladin",
       "breakpoints": true
+    },
+    {
+      "idx": 20,
+      "version": "7",
+      "when": 1777238311241,
+      "tag": "0020_quiet_metal_master",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/schema/sms-conversations.ts
+++ b/src/db/schema/sms-conversations.ts
@@ -22,6 +22,14 @@ export const smsConversations = pgTable(
     pendingFilter: jsonb('pending_filter').$type<BedFilter | null>(),
     /** Captured location text from the last 'awaiting_location' reply. Free-form. */
     lastLocation: text('last_location'),
+    /**
+     * The shelter ids and display order from the most recent bed-finder
+     * reply, in the same order they appeared. Lets `HOLD <#>` map a
+     * line number back to a shelter without re-running the search.
+     */
+    lastResults: jsonb('last_results').$type<Array<{ shelterId: string; name: string }>>(),
+    /** Most recent active hold the user created via SMS, for RELEASE shortcuts. */
+    lastHoldId: uuid('last_hold_id'),
     /** When the conversation auto-expires back to 'idle'. */
     expiresAt: timestamp('expires_at', { withTimezone: true }).notNull(),
     lastMessageAt: timestamp('last_message_at', { withTimezone: true }).notNull().defaultNow(),

--- a/src/lib/indc/sms-bed-holds.ts
+++ b/src/lib/indc/sms-bed-holds.ts
@@ -1,0 +1,142 @@
+import { and, count, eq, gt } from 'drizzle-orm';
+import { db } from '@/db/client';
+import { bedHolds, shelters } from '@/db/schema/shelters';
+import { logAuditEvent } from '@/lib/audit';
+
+/**
+ * Sentinel "user id" written into bed_holds.held_by_user_id when a hold
+ * is created from an SMS conversation rather than a signed-in coalition
+ * user. The bed_holds.held_by_user_id column is a uuid (not a FK), so
+ * this opaque marker is structurally fine; downstream UIs check for
+ * the prefix to render \"placed via SMS\" instead of looking up a name.
+ */
+export const SMS_HELD_BY_SENTINEL = '00000000-0000-0000-0000-00000000515d'; // last bytes spell "SMS" approximately
+export const HOLD_DURATION_MIN_SMS = 90;
+const PHONE_LABEL_MAX_LEN = 24;
+
+export type CreateSmsHoldResult =
+  | { ok: true; holdId: string; expiresAt: Date }
+  | { ok: false; error: string };
+
+/**
+ * Creates a 90-minute hold on behalf of an SMS caller. Same race-safe
+ * count check as the staff-side action; person_label is a redacted
+ * version of the caller's number (E.164 last-4) so staff can identify
+ * the caller without storing the full number on the hold row.
+ */
+export async function createBedHoldFromSms(
+  shelterId: string,
+  fromNumber: string,
+): Promise<CreateSmsHoldResult> {
+  const expiresAt = new Date(Date.now() + HOLD_DURATION_MIN_SMS * 60_000);
+  // E.164 numbers like "+15551234567" → "SMS caller …4567" — keeps
+  // staff context without the full number on the bed_holds row.
+  const last4 = fromNumber.replace(/[^0-9]/g, '').slice(-4) || 'unknown';
+  const personLabel = `SMS caller …${last4}`.slice(0, PHONE_LABEL_MAX_LEN);
+
+  const result = await db.transaction(async (tx) => {
+    const [shelter] = await tx
+      .select({
+        id: shelters.id,
+        capacity: shelters.capacity,
+        currentOccupancy: shelters.currentOccupancy,
+        active: shelters.active,
+        name: shelters.name,
+        contactPhone: shelters.contactPhone,
+      })
+      .from(shelters)
+      .where(eq(shelters.id, shelterId))
+      .limit(1);
+    if (!shelter) return { ok: false as const, error: 'shelter not found' };
+    if (!shelter.active) return { ok: false as const, error: 'shelter is inactive' };
+
+    const rawFree = shelter.capacity - shelter.currentOccupancy;
+    if (rawFree <= 0) return { ok: false as const, error: 'no free beds' };
+
+    const [{ value: activeHolds }] = await tx
+      .select({ value: count() })
+      .from(bedHolds)
+      .where(
+        and(
+          eq(bedHolds.shelterId, shelterId),
+          eq(bedHolds.status, 'active'),
+          gt(bedHolds.expiresAt, new Date()),
+        ),
+      );
+    if (Number(activeHolds) >= rawFree) {
+      return { ok: false as const, error: 'all free beds are already on hold' };
+    }
+
+    const [created] = await tx
+      .insert(bedHolds)
+      .values({
+        shelterId,
+        heldByUserId: SMS_HELD_BY_SENTINEL,
+        personLabel,
+        expiresAt,
+      })
+      .returning({ id: bedHolds.id, expiresAt: bedHolds.expiresAt });
+    return { ok: true as const, holdId: created.id, expiresAt: created.expiresAt };
+  });
+
+  if (!result.ok) return result;
+
+  await logAuditEvent({
+    actorUserId: null,
+    action: 'shelter.bed_hold_created_via_sms',
+    targetTable: 'bed_holds',
+    targetId: result.holdId,
+    metadata: { shelterId, last4 },
+  });
+
+  return result;
+}
+
+export type ReleaseSmsHoldResult = { ok: true; shelterName: string } | { ok: false; error: string };
+
+/**
+ * Releases a hold the SMS caller previously placed. Caller-scoped:
+ * we look up the hold by id AND verify it was created via SMS
+ * (`held_by_user_id = SMS_HELD_BY_SENTINEL`) so a leaked id can't be
+ * used to release a staff-created hold.
+ */
+export async function releaseBedHoldFromSms(holdId: string): Promise<ReleaseSmsHoldResult> {
+  const [hold] = await db
+    .select({
+      id: bedHolds.id,
+      shelterId: bedHolds.shelterId,
+      heldByUserId: bedHolds.heldByUserId,
+      status: bedHolds.status,
+    })
+    .from(bedHolds)
+    .where(eq(bedHolds.id, holdId))
+    .limit(1);
+  if (!hold) return { ok: false, error: 'hold not found' };
+  if (hold.heldByUserId !== SMS_HELD_BY_SENTINEL) {
+    return { ok: false, error: 'hold not owned by this SMS conversation' };
+  }
+  if (hold.status !== 'active') {
+    return { ok: false, error: 'hold already closed' };
+  }
+
+  const [shelter] = await db
+    .select({ name: shelters.name })
+    .from(shelters)
+    .where(eq(shelters.id, hold.shelterId))
+    .limit(1);
+
+  await db
+    .update(bedHolds)
+    .set({ status: 'released', releasedAt: new Date(), updatedAt: new Date() })
+    .where(eq(bedHolds.id, holdId));
+
+  await logAuditEvent({
+    actorUserId: null,
+    action: 'shelter.bed_hold_released_via_sms',
+    targetTable: 'bed_holds',
+    targetId: holdId,
+    metadata: { shelterId: hold.shelterId },
+  });
+
+  return { ok: true, shelterName: shelter?.name ?? 'shelter' };
+}

--- a/src/lib/indc/sms-conversation.ts
+++ b/src/lib/indc/sms-conversation.ts
@@ -68,15 +68,21 @@ export async function setAwaitingLocation(
 
 export async function markIdle(
   fromNumber: string,
-  capturedLocation?: string | null,
+  opts: {
+    capturedLocation?: string | null;
+    lastResults?: Array<{ shelterId: string; name: string }> | null;
+  } = {},
 ): Promise<void> {
   const now = new Date();
   const expiresAt = new Date(now.getTime() + CONVERSATION_TTL_MS);
+  const lastLocation = opts.capturedLocation ?? null;
+  const lastResults = opts.lastResults ?? null;
   const values: NewSmsConversation = {
     fromNumber,
     state: 'idle',
     pendingFilter: null,
-    lastLocation: capturedLocation ?? null,
+    lastLocation,
+    lastResults,
     lastMessageAt: now,
     expiresAt,
   };
@@ -88,12 +94,22 @@ export async function markIdle(
       set: {
         state: 'idle',
         pendingFilter: null,
-        lastLocation: capturedLocation ?? null,
+        lastLocation,
+        lastResults,
         lastMessageAt: now,
         expiresAt,
         updatedAt: now,
       },
     });
+}
+
+export async function setLastHoldId(fromNumber: string, holdId: string | null): Promise<void> {
+  const now = new Date();
+  const expiresAt = new Date(now.getTime() + CONVERSATION_TTL_MS);
+  await db
+    .update(smsConversations)
+    .set({ lastHoldId: holdId, lastMessageAt: now, expiresAt, updatedAt: now })
+    .where(eq(smsConversations.fromNumber, fromNumber));
 }
 
 export async function clearConversation(fromNumber: string): Promise<void> {

--- a/src/lib/indc/sms-formatter.test.ts
+++ b/src/lib/indc/sms-formatter.test.ts
@@ -4,9 +4,16 @@ import type { BedFinderResult } from './bed-finder';
 import {
   formatBedResults,
   SMS_MAX_LEN,
+  smsFood,
   smsHelp,
+  smsHoldConfirmed,
+  smsHoldFailed,
+  smsHoldReleased,
   smsLocationPrompt,
+  smsNoActiveHold,
+  smsNoHoldContext,
   smsStop,
+  smsStory,
   smsUnknown,
 } from './sms-formatter';
 
@@ -76,14 +83,52 @@ describe('formatBedResults', () => {
 
 describe('canned replies', () => {
   it('all stay within SMS_MAX_LEN', () => {
-    expect(smsHelp().length).toBeLessThanOrEqual(SMS_MAX_LEN);
-    expect(smsStop().length).toBeLessThanOrEqual(SMS_MAX_LEN);
-    expect(smsUnknown().length).toBeLessThanOrEqual(SMS_MAX_LEN);
-    expect(smsLocationPrompt().length).toBeLessThanOrEqual(SMS_MAX_LEN);
+    for (const reply of [
+      smsHelp(),
+      smsStop(),
+      smsUnknown(),
+      smsLocationPrompt(),
+      smsFood(),
+      smsStory(),
+      smsNoActiveHold(),
+      smsNoHoldContext(),
+    ]) {
+      expect(reply.length).toBeLessThanOrEqual(SMS_MAX_LEN);
+    }
   });
 
   it('location prompt mentions ANYWHERE escape hatch', () => {
     expect(smsLocationPrompt()).toMatch(/ANYWHERE/);
+  });
+
+  it('food reply names actual coalition partners', () => {
+    expect(smsFood()).toMatch(/Catholic Charities/);
+    expect(smsFood()).toMatch(/Boulware/);
+  });
+});
+
+describe('hold reply formatters', () => {
+  it('confirms a hold with shelter name + clock + phone', () => {
+    const expires = new Date('2026-04-26T15:30:00Z');
+    const reply = smsHoldConfirmed('Boulware Mission', '+1-270-683-1505', expires);
+    expect(reply).toContain('Boulware Mission');
+    expect(reply).toContain('270-683-1505');
+    expect(reply).toMatch(/RELEASE/);
+    expect(reply.length).toBeLessThanOrEqual(SMS_MAX_LEN);
+  });
+
+  it('drops phone fragment cleanly when shelter has no phone', () => {
+    const reply = smsHoldConfirmed('Anon Shelter', null, new Date());
+    expect(reply).not.toMatch(/Call/);
+  });
+
+  it('hold-released reply names the shelter', () => {
+    expect(smsHoldReleased('Daniel Pitino')).toContain('Daniel Pitino');
+  });
+
+  it('hold-failed reply ≤ SMS_MAX_LEN even with long reason', () => {
+    const reply = smsHoldFailed('a'.repeat(400));
+    expect(reply.length).toBeLessThanOrEqual(SMS_MAX_LEN);
   });
 });
 

--- a/src/lib/indc/sms-formatter.ts
+++ b/src/lib/indc/sms-formatter.ts
@@ -9,7 +9,7 @@ import type { BedFinderResult } from './bed-finder';
 export const SMS_MAX_LEN = 320;
 
 const HELP_REPLY =
-  'Coalition bed-finder. Reply BED for an open shelter bed. Add MEN, WOMEN, FAMILY, PET, or SUD to filter (e.g. BED FAMILY PET). HELP repeats this. STOP to opt out.';
+  'Coalition bed-finder. BED (+ MEN/WOMEN/FAMILY/PET/SUD) for an open bed. HOLD <#> to hold one. FOOD for pantries. STORY about this service. STOP to opt out.';
 
 const STOP_REPLY = "You're opted out. Reply START to opt back in.";
 
@@ -18,6 +18,17 @@ const UNKNOWN_REPLY =
 
 const NO_MATCH_REPLY =
   'No open beds match right now. Try BED for any open bed, or call 211 for live help.';
+
+const FOOD_REPLY =
+  'Food in Daviess Co: Catholic Charities Feeding Our Friends 270-683-1545. St Benedicts day meals 270-686-8410. Boulware Mission daily meals 270-683-1505. Call 211 for current hours.';
+
+const STORY_REPLY =
+  'This is the Daviess coalition bed-finder. Free, confidential, run with local partners. Texts go to staff during pilot; only HELP/STOP messages and bed counts are kept. Reply BED to start.';
+
+const NO_HOLD_CONTEXT_REPLY =
+  'No recent bed list to hold against. Reply BED first, then HOLD <#> against the list we send back.';
+
+const NO_ACTIVE_HOLD_REPLY = 'No active hold to release. Reply BED to look for a new bed.';
 
 function describeFilter(filter: BedFilter): string {
   const parts: string[] = [];
@@ -95,4 +106,53 @@ export function smsStop(): string {
 
 export function smsUnknown(): string {
   return UNKNOWN_REPLY;
+}
+
+export function smsFood(): string {
+  return FOOD_REPLY;
+}
+
+export function smsStory(): string {
+  return STORY_REPLY;
+}
+
+export function smsNoHoldContext(): string {
+  return NO_HOLD_CONTEXT_REPLY;
+}
+
+export function smsNoActiveHold(): string {
+  return NO_ACTIVE_HOLD_REPLY;
+}
+
+const fmtClock = (d: Date) =>
+  new Intl.DateTimeFormat('en-US', { timeStyle: 'short' }).format(new Date(d));
+
+/**
+ * Inline confirmation for a hold a caller just placed via SMS. Includes
+ * the shelter name, expiry clock, and a one-tap call link. The caller
+ * can text RELEASE to undo.
+ */
+export function smsHoldConfirmed(
+  shelterName: string,
+  phone: string | null,
+  expiresAt: Date,
+): string {
+  const callPart = phone ? ` Call ${phone} or` : '';
+  return `Bed held at ${shelterName} until ${fmtClock(expiresAt)}.${callPart} walk in to take it. Reply RELEASE to cancel.`.slice(
+    0,
+    SMS_MAX_LEN,
+  );
+}
+
+export function smsHoldReleased(shelterName: string): string {
+  return `Hold at ${shelterName} released. Reply BED to look for another open bed.`.slice(
+    0,
+    SMS_MAX_LEN,
+  );
+}
+
+export function smsHoldFailed(reason: string): string {
+  // Reason copy should already be user-safe — we cap to MAX_LEN as a
+  // defense against an unexpectedly long server message.
+  return `Couldn't hold a bed: ${reason} Reply BED to try again.`.slice(0, SMS_MAX_LEN);
 }

--- a/src/lib/indc/sms-parser.test.ts
+++ b/src/lib/indc/sms-parser.test.ts
@@ -37,15 +37,39 @@ describe('parseSmsCommand', () => {
     expect(result).toEqual({ kind: 'bed', filter: { minFreeBeds: 1 } });
   });
 
-  it('recognizes STOP variants', () => {
+  it('recognizes STOP variants (CANCEL routed to release instead)', () => {
     expect(parseSmsCommand('STOP').kind).toBe('stop');
     expect(parseSmsCommand('UNSUBSCRIBE').kind).toBe('stop');
-    expect(parseSmsCommand('cancel').kind).toBe('stop');
+    expect(parseSmsCommand('quit').kind).toBe('stop');
   });
 
   it('recognizes HELP variants', () => {
     expect(parseSmsCommand('HELP').kind).toBe('help');
     expect(parseSmsCommand('?').kind).toBe('help');
+  });
+
+  it('recognizes shorthand info commands', () => {
+    expect(parseSmsCommand('FOOD').kind).toBe('food');
+    expect(parseSmsCommand('hungry').kind).toBe('food');
+    expect(parseSmsCommand('STORY').kind).toBe('story');
+    expect(parseSmsCommand('about').kind).toBe('story');
+  });
+
+  it('parses HOLD with numeric arg into 0-indexed resultIndex', () => {
+    expect(parseSmsCommand('HOLD 1')).toEqual({ kind: 'hold', resultIndex: 0 });
+    expect(parseSmsCommand('HOLD 3')).toEqual({ kind: 'hold', resultIndex: 2 });
+    expect(parseSmsCommand('hold #2')).toEqual({ kind: 'hold', resultIndex: 1 });
+  });
+
+  it('defaults bare HOLD to slot 1', () => {
+    expect(parseSmsCommand('HOLD')).toEqual({ kind: 'hold', resultIndex: 0 });
+    expect(parseSmsCommand('RESERVE')).toEqual({ kind: 'hold', resultIndex: 0 });
+  });
+
+  it('routes RELEASE / CANCEL / NEVERMIND to release', () => {
+    expect(parseSmsCommand('RELEASE').kind).toBe('release');
+    expect(parseSmsCommand('cancel').kind).toBe('release');
+    expect(parseSmsCommand('Nevermind').kind).toBe('release');
   });
 
   it('returns unknown for empty / unrecognized input', () => {

--- a/src/lib/indc/sms-parser.ts
+++ b/src/lib/indc/sms-parser.ts
@@ -13,12 +13,20 @@ import type { BedFilter } from '@/lib/coordination/bed-availability';
  */
 export type ParsedSmsCommand =
   | { kind: 'bed'; filter: BedFilter }
+  | { kind: 'food' }
+  | { kind: 'story' }
+  | { kind: 'hold'; resultIndex: number }
+  | { kind: 'release' }
   | { kind: 'help' }
   | { kind: 'stop' }
   | { kind: 'unknown'; raw: string };
 
-const STOP_WORDS = new Set(['STOP', 'STOPALL', 'UNSUBSCRIBE', 'CANCEL', 'END', 'QUIT']);
+const STOP_WORDS = new Set(['STOP', 'STOPALL', 'UNSUBSCRIBE', 'END', 'QUIT']);
 const HELP_WORDS = new Set(['HELP', 'INFO', '?']);
+const FOOD_WORDS = new Set(['FOOD', 'EAT', 'PANTRY', 'MEAL', 'MEALS', 'HUNGRY']);
+const STORY_WORDS = new Set(['STORY', 'ABOUT', 'WHO', 'WHAT']);
+const HOLD_WORDS = new Set(['HOLD', 'RESERVE', 'CONFIRM']);
+const RELEASE_WORDS = new Set(['RELEASE', 'CANCEL', 'NEVERMIND']);
 
 const POPULATION_TOKENS: Record<string, NonNullable<BedFilter['population']>> = {
   MEN: 'men',
@@ -47,6 +55,22 @@ export function parseSmsCommand(raw: string): ParsedSmsCommand {
 
   if (STOP_WORDS.has(head)) return { kind: 'stop' };
   if (HELP_WORDS.has(head)) return { kind: 'help' };
+  if (FOOD_WORDS.has(head)) return { kind: 'food' };
+  if (STORY_WORDS.has(head)) return { kind: 'story' };
+
+  if (HOLD_WORDS.has(head)) {
+    // Accept `HOLD 1`, `HOLD #2`, `RESERVE 3`. Default to slot 1 when
+    // unspecified — the most-recent top result.
+    const arg = tokens[1];
+    let n = 1;
+    if (arg) {
+      const cleaned = arg.replace(/[^0-9]/g, '');
+      const parsed = Number.parseInt(cleaned, 10);
+      if (Number.isInteger(parsed) && parsed >= 1) n = parsed;
+    }
+    return { kind: 'hold', resultIndex: n - 1 };
+  }
+  if (RELEASE_WORDS.has(head)) return { kind: 'release' };
 
   if (head === 'BED' || head === 'BEDS' || head === 'SHELTER') {
     const filter: BedFilter = { minFreeBeds: 1 };

--- a/src/lib/indc/sms-pipeline.ts
+++ b/src/lib/indc/sms-pipeline.ts
@@ -1,6 +1,11 @@
 import { activeBedHoldCounts, listActiveShelters } from '@/db/queries/shelters';
-import type { BedFilter } from '@/lib/coordination/bed-availability';
-import { findOpenBeds } from './bed-finder';
+import {
+  type BedFilter,
+  effectiveFreeBeds,
+  matchesFilter,
+} from '@/lib/coordination/bed-availability';
+import { type BedFinderResult, findOpenBeds } from './bed-finder';
+import { createBedHoldFromSms, releaseBedHoldFromSms } from './sms-bed-holds';
 import {
   clearConversation,
   getConversation,
@@ -8,36 +13,60 @@ import {
   markIdle,
   normalizeLocation,
   setAwaitingLocation,
+  setLastHoldId,
 } from './sms-conversation';
-import { formatBedResults, smsHelp, smsLocationPrompt, smsStop, smsUnknown } from './sms-formatter';
+import {
+  formatBedResults,
+  smsFood,
+  smsHelp,
+  smsHoldConfirmed,
+  smsHoldFailed,
+  smsHoldReleased,
+  smsLocationPrompt,
+  smsNoActiveHold,
+  smsNoHoldContext,
+  smsStop,
+  smsStory,
+  smsUnknown,
+} from './sms-formatter';
 import { parseSmsCommand } from './sms-parser';
+
+export type SmsHandleIntent =
+  | 'bed_results'
+  | 'awaiting_location'
+  | 'location_received'
+  | 'help'
+  | 'stop'
+  | 'food'
+  | 'story'
+  | 'hold_confirmed'
+  | 'hold_failed'
+  | 'release_confirmed'
+  | 'release_failed'
+  | 'unknown'
+  | 'error';
 
 export type SmsHandleResult = {
   /** Reply body to return to the caller (≤ SMS_MAX_LEN). */
   reply: string;
   /** What kind of intent we recognized; useful for logs / tests. */
-  intent:
-    | 'bed_results'
-    | 'awaiting_location'
-    | 'help'
-    | 'stop'
-    | 'unknown'
-    | 'location_received'
-    | 'error';
+  intent: SmsHandleIntent;
 };
 
-async function bedResults(filter: BedFilter, nearLocation: string | null): Promise<string> {
+async function bedResults(
+  filter: BedFilter,
+  nearLocation: string | null,
+): Promise<{ reply: string; results: BedFinderResult[] }> {
   const [shelters, holdCounts] = await Promise.all([listActiveShelters(), activeBedHoldCounts()]);
   const matches = findOpenBeds({ shelters, activeHoldsByShelter: holdCounts, filter });
-  return formatBedResults(matches, filter, nearLocation);
+  return { reply: formatBedResults(matches, filter, nearLocation), results: matches };
 }
 
 /**
  * Stateful end-to-end SMS handler. The `fromNumber` keys the conversation
  * state so multi-turn flows ("BED FAMILY" → "where are you?" → "42301"
- * → results) work correctly. Pass an anonymous / empty fromNumber to
- * disable conversation state (the playground uses this — it operates
- * stateless against the same logic).
+ * → results, then HOLD <#> against the result list) work correctly.
+ * Pass an empty fromNumber to disable conversation state (playground).
  */
 export async function handleInboundSmsForNumber(
   fromNumber: string,
@@ -54,6 +83,8 @@ export async function handleInboundSmsForNumber(
     if (stateful) await clearConversation(fromNumber);
     return { reply: smsStop(), intent: 'stop' };
   }
+  if (cmd.kind === 'food') return { reply: smsFood(), intent: 'food' };
+  if (cmd.kind === 'story') return { reply: smsStory(), intent: 'story' };
 
   // Stateful BED command: park the filter and ask for location.
   if (cmd.kind === 'bed' && stateful) {
@@ -63,24 +94,84 @@ export async function handleInboundSmsForNumber(
 
   // Stateless BED (playground): immediate results, no location prompt.
   if (cmd.kind === 'bed') {
-    return { reply: await bedResults(cmd.filter, null), intent: 'bed_results' };
+    const { reply } = await bedResults(cmd.filter, null);
+    return { reply, intent: 'bed_results' };
   }
 
-  // From here cmd.kind === 'unknown'. Conversation context decides
-  // whether the body is a location reply or a true unknown.
+  if (cmd.kind === 'hold' && stateful) {
+    return await handleHold(fromNumber, cmd.resultIndex);
+  }
+
+  if (cmd.kind === 'release' && stateful) {
+    return await handleRelease(fromNumber);
+  }
+
+  // From here cmd.kind === 'unknown' (or hold/release in stateless mode).
   if (!stateful) {
     return { reply: smsUnknown(), intent: 'unknown' };
   }
 
   const convo = await getConversation(fromNumber);
-  if (convo?.state === 'awaiting_location' && convo.pendingFilter) {
+  if (cmd.kind === 'unknown' && convo?.state === 'awaiting_location' && convo.pendingFilter) {
     const nearLocation = isLocationSkip(body) ? null : normalizeLocation(body);
-    const reply = await bedResults(convo.pendingFilter, nearLocation);
-    await markIdle(fromNumber, nearLocation);
+    const { reply, results } = await bedResults(convo.pendingFilter, nearLocation);
+    await markIdle(fromNumber, {
+      capturedLocation: nearLocation,
+      lastResults: results.map((r) => ({ shelterId: r.shelter.id, name: r.shelter.name })),
+    });
     return { reply, intent: 'location_received' };
   }
 
   return { reply: smsUnknown(), intent: 'unknown' };
+}
+
+async function handleHold(fromNumber: string, resultIndex: number): Promise<SmsHandleResult> {
+  const convo = await getConversation(fromNumber);
+  const list = convo?.lastResults ?? [];
+  if (list.length === 0) {
+    return { reply: smsNoHoldContext(), intent: 'hold_failed' };
+  }
+  const target = list[Math.max(0, Math.min(resultIndex, list.length - 1))];
+  if (!target) {
+    return { reply: smsNoHoldContext(), intent: 'hold_failed' };
+  }
+  // Re-verify there's still an open bed against current data, since
+  // the list might be a few minutes stale by the time HOLD arrives.
+  const [shelters, holdCounts] = await Promise.all([listActiveShelters(), activeBedHoldCounts()]);
+  const shelter = shelters.find((s) => s.id === target.shelterId);
+  if (!shelter) {
+    return { reply: smsHoldFailed('that shelter is no longer listed.'), intent: 'hold_failed' };
+  }
+  const free = effectiveFreeBeds(shelter, holdCounts.get(shelter.id) ?? 0);
+  if (free <= 0 || !matchesFilter(shelter, { minFreeBeds: 1 })) {
+    return {
+      reply: smsHoldFailed(`${shelter.name} just filled up.`),
+      intent: 'hold_failed',
+    };
+  }
+
+  const created = await createBedHoldFromSms(target.shelterId, fromNumber);
+  if (!created.ok) {
+    return { reply: smsHoldFailed(`${created.error}.`), intent: 'hold_failed' };
+  }
+  await setLastHoldId(fromNumber, created.holdId);
+  return {
+    reply: smsHoldConfirmed(shelter.name, shelter.contactPhone, created.expiresAt),
+    intent: 'hold_confirmed',
+  };
+}
+
+async function handleRelease(fromNumber: string): Promise<SmsHandleResult> {
+  const convo = await getConversation(fromNumber);
+  const lastHoldId = convo?.lastHoldId;
+  if (!lastHoldId) return { reply: smsNoActiveHold(), intent: 'release_failed' };
+
+  const released = await releaseBedHoldFromSms(lastHoldId);
+  if (!released.ok) {
+    return { reply: smsNoActiveHold(), intent: 'release_failed' };
+  }
+  await setLastHoldId(fromNumber, null);
+  return { reply: smsHoldReleased(released.shelterName), intent: 'release_confirmed' };
 }
 
 /**


### PR DESCRIPTION
Closes #66, #67. Stacked on [#260](https://github.com/DobbsBoldry/homeless/pull/260) (INDC-004).

INDC-006's \"outbound confirmation\" is delivered inline as the TwiML reply to the user's HOLD message — no Twilio REST API call, no extra credentials, and the user gets the confirmation in the same SMS thread they asked in.

## Summary
- **Parser** — FOOD / EAT / HUNGRY → \`food\`; STORY / ABOUT → \`story\`; HOLD <#> / RESERVE / CONFIRM with 0-indexed result lookup; RELEASE / CANCEL / NEVERMIND → \`release\`. CANCEL no longer maps to STOP.
- **Conversation state** extended: \`last_results\` (jsonb of shelter ids + names from the most recent reply) + \`last_hold_id\`. HOLD <#> references the displayed list without re-running the search; RELEASE shortcut acts on the most recent hold.
- **`sms-bed-holds.ts`** — \`createBedHoldFromSms\` and \`releaseBedHoldFromSms\`. Same race-safe count check as the staff action, but no Clerk gate (webhook auth = signature). Sentinel \`held_by_user_id\` marks SMS-origin holds. \`person_label\` redacted to last-4 digits (\"SMS caller …4567\") so staff have context without storing the full number.
- **Formatter** — FOOD reply names actual coalition partners (Catholic Charities, St Benedict's, Boulware) with current phone numbers. STORY reply explains the service in plain language. Hold confirmations include shelter, expiry clock, optional phone link, and RELEASE instructions.
- **Pipeline** — all five new intents wired end-to-end. HOLD re-verifies free-bed availability against current data so a stale result list can't slip past a now-full shelter.
- 9 new tests; 136 total.

## Acceptance criteria
- INDC-005:
  - [x] FOOD shorthand routes to food info
  - [x] STORY shorthand routes to about-the-service
  - [x] HELP unchanged
- INDC-006:
  - [x] User receives confirmation when their hold lands (inline TwiML)
  - [x] User can RELEASE their own hold
  - [x] Hold rows from SMS are tagged so staff can tell them apart from staff-created holds
- [x] Lint + typecheck + 136 tests + production build

## Test plan
- [ ] Send \"FOOD\" via the playground or webhook → reply lists Catholic Charities + St Benedict's + Boulware numbers
- [ ] Send \"STORY\" → reply explains the service
- [ ] BED FAMILY → 42301 → results list. Then \"HOLD 1\" → confirmation: \"Bed held at Daniel Pitino until 4:30pm. Call 270-685-3747 or walk in. Reply RELEASE to cancel.\"
- [ ] On staff bed-hold panel, the row shows \"SMS caller …4567\" as the holder
- [ ] Reply \"RELEASE\" → \"Hold at Daniel Pitino released.\"
- [ ] HOLD when no recent results → \"No recent bed list…\"
- [ ] HOLD when shelter just filled → friendly \"Daniel Pitino just filled up.\" reply

🤖 Generated with [Claude Code](https://claude.com/claude-code)