### PR TITLE
feat(INDC-007/008/009): SMS observability + client handout

### DIFF
--- a/src/app/app/coalition/sms/handout/page.tsx
+++ b/src/app/app/coalition/sms/handout/page.tsx
@@ -1,0 +1,121 @@
+import { PrintButton } from '@/components/coordination/print-button';
+import { requireRole } from '@/lib/auth';
+
+export const dynamic = 'force-dynamic';
+
+/**
+ * INDC-008 — printable one-pager staff hand to clients. Designed
+ * for letter-paper / 4×6 reprinting. Avoids the app shell so the
+ * page prints clean.
+ */
+export default async function SmsHandoutPage() {
+  await requireRole(['admin', 'shelter_staff', 'caseworker', 'ed_coordinator']);
+  // The actual SMS shortcode / number is configured per environment;
+  // staff printing this should override [SHORTCODE] before laminating.
+  // Phase 1: Twilio long-code; Phase 2 (post-BAA): coalition shortcode.
+  const shortcode = process.env.NEXT_PUBLIC_INDC_SMS_NUMBER ?? '[number TBD]';
+
+  return (
+    <div className="mx-auto max-w-2xl p-8 print:p-0">
+      <div className="space-y-6 rounded-lg border border-border bg-white p-8 text-black shadow-sm print:border-0 print:shadow-none">
+        <header className="space-y-1">
+          <p className="text-xs uppercase tracking-wide text-stone-500">
+            Daviess County Homeless Coalition
+          </p>
+          <h1 className="font-serif text-3xl font-bold">Find a bed by text.</h1>
+          <p className="text-stone-700">Free. Confidential. Local partners. No app to install.</p>
+        </header>
+
+        <section>
+          <p className="text-sm">Text the word below to:</p>
+          <p className="mt-1 font-mono text-2xl font-semibold">{shortcode}</p>
+        </section>
+
+        <section className="space-y-3 rounded-md bg-stone-50 p-4">
+          <h2 className="font-serif text-lg font-semibold">Quick commands</h2>
+          <table className="w-full text-sm">
+            <tbody className="[&_td]:py-1 [&_td:first-child]:font-mono [&_td:first-child]:font-semibold [&_td:first-child]:pr-3">
+              <tr>
+                <td>BED</td>
+                <td>find an open shelter bed</td>
+              </tr>
+              <tr>
+                <td>BED FAMILY</td>
+                <td>only family-accepting shelters</td>
+              </tr>
+              <tr>
+                <td>BED PET</td>
+                <td>only pet-friendly shelters</td>
+              </tr>
+              <tr>
+                <td>BED MEN / WOMEN</td>
+                <td>filter by population</td>
+              </tr>
+              <tr>
+                <td>BED SUD</td>
+                <td>recovery / SUD-friendly</td>
+              </tr>
+              <tr>
+                <td>HOLD 1</td>
+                <td>hold the first bed for 90 minutes</td>
+              </tr>
+              <tr>
+                <td>RELEASE</td>
+                <td>cancel a hold you placed</td>
+              </tr>
+              <tr>
+                <td>FOOD</td>
+                <td>nearby food pantry numbers</td>
+              </tr>
+              <tr>
+                <td>STORY</td>
+                <td>about this service</td>
+              </tr>
+              <tr>
+                <td>HELP</td>
+                <td>show this list again</td>
+              </tr>
+              <tr>
+                <td>STOP</td>
+                <td>opt out of texts</td>
+              </tr>
+            </tbody>
+          </table>
+        </section>
+
+        <section className="space-y-2 text-sm">
+          <h2 className="font-serif text-lg font-semibold">How it works</h2>
+          <ol className="list-decimal space-y-1 pl-5">
+            <li>
+              Text <span className="font-mono font-semibold">BED</span> (or BED FAMILY / BED PET).
+            </li>
+            <li>Reply with a neighborhood, intersection, or ZIP — or ANYWHERE.</li>
+            <li>You'll get up to 3 shelters with current open beds and phone numbers.</li>
+            <li>Reply HOLD &lt;#&gt; to hold the bed for 90 minutes while you walk over.</li>
+          </ol>
+        </section>
+
+        <section className="space-y-1 text-xs text-stone-700">
+          <p>
+            <strong>Privacy.</strong> The coalition stores the messages and your phone number during
+            the pilot to make the service work. We don't share your number with shelters unless you
+            ask us to.
+          </p>
+          <p>
+            <strong>Need a person?</strong> Call <span className="font-mono">211</span> for live
+            referrals 24/7.
+          </p>
+        </section>
+      </div>
+
+      <div className="mt-4 space-y-2 print:hidden">
+        <PrintButton />
+        <p className="text-xs text-muted-foreground">
+          Print this on letter paper, or trim down to a quarter-sheet. Replace
+          <code className="font-mono"> [number TBD]</code> with the real Twilio number once it's
+          provisioned (set <code className="font-mono">NEXT_PUBLIC_INDC_SMS_NUMBER</code>).
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/app/app/coalition/sms/metrics/page.tsx
+++ b/src/app/app/coalition/sms/metrics/page.tsx
@@ -1,0 +1,212 @@
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import {
+  dailyIntentCounts,
+  intentTotals,
+  recentRedactedMessages,
+  uniqueCallerCount,
+} from '@/db/queries/sms-metrics';
+import { requireRole } from '@/lib/auth';
+
+export const dynamic = 'force-dynamic';
+
+const WINDOW_DAYS = 7;
+
+const fmtTime = (d: Date) =>
+  new Intl.DateTimeFormat('en-US', { dateStyle: 'short', timeStyle: 'short' }).format(new Date(d));
+
+/**
+ * INTENT_LABELS keeps the dashboard copy stable even as the pipeline
+ * evolves; unknown intents fall through to their raw key so we can
+ * still see them in the breakdown.
+ */
+const INTENT_LABELS: Record<string, string> = {
+  bed_results: 'Bed list shown',
+  awaiting_location: 'Asked for location',
+  location_received: 'Location received → results',
+  help: 'HELP',
+  food: 'FOOD',
+  story: 'STORY',
+  stop: 'STOP / opt-out',
+  hold_confirmed: 'Hold confirmed',
+  hold_failed: 'Hold failed',
+  release_confirmed: 'Hold released',
+  release_failed: 'Release failed',
+  unknown: 'Unknown / didn\u2019t match',
+  error: 'Pipeline error',
+};
+
+export default async function SmsMetricsPage() {
+  await requireRole(['admin']);
+
+  const [byDay, totals, callers, recent] = await Promise.all([
+    dailyIntentCounts(WINDOW_DAYS),
+    intentTotals(WINDOW_DAYS),
+    uniqueCallerCount(WINDOW_DAYS),
+    recentRedactedMessages(20),
+  ]);
+
+  const totalMessages = totals.reduce((sum, t) => sum + t.count, 0);
+  const beds = totals.find((t) => t.intent === 'bed_results')?.count ?? 0;
+  const askedLocation = totals.find((t) => t.intent === 'awaiting_location')?.count ?? 0;
+  const locationReplies = totals.find((t) => t.intent === 'location_received')?.count ?? 0;
+  const completionRate =
+    askedLocation > 0 ? Math.round((locationReplies / askedLocation) * 100) : null;
+  const unknown = totals.find((t) => t.intent === 'unknown')?.count ?? 0;
+
+  // Build a per-day stack: array of { day, total, byIntent: { intent: count } }
+  const dayMap = new Map<string, Map<string, number>>();
+  for (const r of byDay) {
+    if (!dayMap.has(r.day)) dayMap.set(r.day, new Map());
+    dayMap.get(r.day)!.set(r.intent, r.count);
+  }
+  const days = Array.from(dayMap.entries())
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([day, intents]) => ({
+      day,
+      total: Array.from(intents.values()).reduce((s, n) => s + n, 0),
+      intents: Array.from(intents.entries()).map(([k, v]) => ({ intent: k, count: v })),
+    }));
+  const peakDayCount = days.reduce((m, d) => Math.max(m, d.total), 0) || 1;
+
+  return (
+    <div className="mx-auto max-w-6xl space-y-4 p-4 md:p-6">
+      <header>
+        <h1 className="font-serif text-3xl font-bold text-primary">SMS bed-finder metrics</h1>
+        <p className="text-sm text-muted-foreground">
+          Last {WINDOW_DAYS} days. Phone numbers never leave the database — only counts do.
+          Simulated playground traffic is excluded.
+        </p>
+      </header>
+
+      <div className="grid gap-4 md:grid-cols-4">
+        <Card>
+          <CardContent>
+            <p className="text-xs uppercase tracking-wide text-muted-foreground">Messages</p>
+            <p className="text-3xl font-semibold">{totalMessages}</p>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardContent>
+            <p className="text-xs uppercase tracking-wide text-muted-foreground">Unique callers</p>
+            <p className="text-3xl font-semibold">{callers}</p>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardContent>
+            <p className="text-xs uppercase tracking-wide text-muted-foreground">Bed lists shown</p>
+            <p className="text-3xl font-semibold">{beds + locationReplies}</p>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardContent>
+            <p className="text-xs uppercase tracking-wide text-muted-foreground">
+              Location-prompt completion
+            </p>
+            <p className="text-3xl font-semibold">
+              {completionRate === null ? '—' : `${completionRate}%`}
+            </p>
+            <p className="text-xs text-muted-foreground">
+              {locationReplies} of {askedLocation} prompts answered
+            </p>
+          </CardContent>
+        </Card>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">Daily volume</CardTitle>
+        </CardHeader>
+        <CardContent>
+          {days.length === 0 ? (
+            <p className="text-sm text-muted-foreground">No traffic in the window.</p>
+          ) : (
+            <div className="grid grid-cols-7 gap-2">
+              {days.map((d) => (
+                <div key={d.day} className="text-center">
+                  <div
+                    role="img"
+                    aria-label={`${d.total} messages on ${d.day}`}
+                    className="relative mx-auto h-32 w-8 overflow-hidden rounded bg-muted"
+                  >
+                    <div
+                      className="absolute bottom-0 w-full bg-primary"
+                      style={{ height: `${(d.total / peakDayCount) * 100}%` }}
+                    />
+                  </div>
+                  <p className="mt-1 text-xs text-muted-foreground">{d.day.slice(5)}</p>
+                  <p className="text-xs font-medium">{d.total}</p>
+                </div>
+              ))}
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">Intent breakdown</CardTitle>
+        </CardHeader>
+        <CardContent>
+          {totals.length === 0 ? (
+            <p className="text-sm text-muted-foreground">No traffic in the window.</p>
+          ) : (
+            <ul className="space-y-2">
+              {totals.map((t) => {
+                const pct = totalMessages > 0 ? (t.count / totalMessages) * 100 : 0;
+                return (
+                  <li key={t.intent} className="text-sm">
+                    <div className="flex justify-between">
+                      <span>{INTENT_LABELS[t.intent] ?? t.intent}</span>
+                      <span className="text-muted-foreground">
+                        {t.count} <span className="text-xs">({Math.round(pct)}%)</span>
+                      </span>
+                    </div>
+                    <div className="mt-1 h-1.5 w-full overflow-hidden rounded-full bg-muted">
+                      <div className="h-full bg-primary" style={{ width: `${Math.round(pct)}%` }} />
+                    </div>
+                  </li>
+                );
+              })}
+            </ul>
+          )}
+          {unknown > 0 ? (
+            <p className="mt-3 rounded-md border border-amber-500/40 bg-amber-500/5 p-2 text-xs">
+              <strong>Friction signal:</strong> {unknown} unknown messages in the window —
+              candidates for parser additions or improved help copy.
+            </p>
+          ) : null}
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">Recent traffic (redacted)</CardTitle>
+        </CardHeader>
+        <CardContent>
+          {recent.length === 0 ? (
+            <p className="text-sm text-muted-foreground">No messages yet.</p>
+          ) : (
+            <ul className="space-y-1 text-xs">
+              {recent.map((m) => (
+                <li
+                  key={m.id}
+                  className="flex flex-wrap items-baseline justify-between gap-2 rounded bg-muted/40 px-2 py-1"
+                >
+                  <span className="font-mono text-muted-foreground">
+                    {fmtTime(m.receivedAt)} · …{m.fromLast4} · {m.intent}
+                  </span>
+                  <span className="truncate font-mono">{m.bodyExcerpt}</span>
+                </li>
+              ))}
+            </ul>
+          )}
+          <p className="mt-3 text-xs text-muted-foreground">
+            Phone numbers shown only as last-4 digits. Full numbers stay in the
+            <code className="font-mono"> sms_messages</code> table for audit; this view is for fast
+            triage.
+          </p>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/components/app-shell/nav-config.ts
+++ b/src/components/app-shell/nav-config.ts
@@ -66,6 +66,16 @@ export const NAV_ITEMS: NavItem[] = [
     href: '/app/coalition/sms',
     roles: ['admin', 'shelter_staff', 'caseworker', 'ed_coordinator'],
   },
+  {
+    label: 'SMS metrics',
+    href: '/app/coalition/sms/metrics',
+    roles: ['admin'],
+  },
+  {
+    label: 'SMS handout',
+    href: '/app/coalition/sms/handout',
+    roles: ['admin', 'shelter_staff', 'caseworker', 'ed_coordinator'],
+  },
   { label: 'Settings', href: '/app/settings', roles: 'all' },
   { label: 'Admin · Users', href: '/app/admin/users', roles: ['admin'] },
 ];

--- a/src/components/coordination/print-button.tsx
+++ b/src/components/coordination/print-button.tsx
@@ -1,0 +1,11 @@
+'use client';
+
+import { Button } from '@/components/ui/button';
+
+export function PrintButton() {
+  return (
+    <Button type="button" variant="outline" size="sm" onClick={() => window.print()}>
+      Print
+    </Button>
+  );
+}

--- a/src/db/queries/sms-metrics.ts
+++ b/src/db/queries/sms-metrics.ts
@@ -1,0 +1,112 @@
+import { sql } from 'drizzle-orm';
+import { db } from '@/db/client';
+import { smsMessages } from '@/db/schema/sms-messages';
+
+export type DailyIntentCount = {
+  /** UTC date string `YYYY-MM-DD`. */
+  day: string;
+  intent: string;
+  count: number;
+};
+
+export type IntentTotal = { intent: string; count: number };
+
+/**
+ * Aggregate inbound message counts by UTC day × intent for the last
+ * `windowDays` days. Phone numbers are NEVER returned by this query —
+ * the dashboard built on top of it is volume-tracking, not surveillance.
+ *
+ * The simulated playground messages (from_number prefixed
+ * "SIMULATED-") are excluded so dashboard counts reflect real traffic.
+ */
+export async function dailyIntentCounts(windowDays = 7): Promise<DailyIntentCount[]> {
+  const rows = await db.execute(sql`
+    SELECT
+      to_char(date_trunc('day', received_at AT TIME ZONE 'UTC'), 'YYYY-MM-DD') AS day,
+      intent,
+      COUNT(*)::int AS count
+    FROM ${smsMessages}
+    WHERE received_at >= now() - (${windowDays} || ' days')::interval
+      AND from_number NOT LIKE 'SIMULATED-%'
+    GROUP BY 1, 2
+    ORDER BY 1 ASC, 2 ASC
+  `);
+  return (rows as unknown as Array<{ day: string; intent: string; count: number }>).map((r) => ({
+    day: r.day,
+    intent: r.intent,
+    count: Number(r.count),
+  }));
+}
+
+/**
+ * Intent totals across the window. Useful for the headline pie/list:
+ * "of 142 messages this week, 87 were BED, 12 HELP, 4 STOP, 39 unknown".
+ */
+export async function intentTotals(windowDays = 7): Promise<IntentTotal[]> {
+  const rows = await db.execute(sql`
+    SELECT intent, COUNT(*)::int AS count
+    FROM ${smsMessages}
+    WHERE received_at >= now() - (${windowDays} || ' days')::interval
+      AND from_number NOT LIKE 'SIMULATED-%'
+    GROUP BY 1
+    ORDER BY count DESC, intent ASC
+  `);
+  return (rows as unknown as Array<{ intent: string; count: number }>).map((r) => ({
+    intent: r.intent,
+    count: Number(r.count),
+  }));
+}
+
+/**
+ * Count of distinct phone numbers seen in the window. Phone numbers
+ * never leave this query — only the count does.
+ */
+export async function uniqueCallerCount(windowDays = 7): Promise<number> {
+  const rows = await db.execute(sql`
+    SELECT COUNT(DISTINCT from_number)::int AS count
+    FROM ${smsMessages}
+    WHERE received_at >= now() - (${windowDays} || ' days')::interval
+      AND from_number NOT LIKE 'SIMULATED-%'
+  `);
+  const first = (rows as unknown as Array<{ count: number }>)[0];
+  return first ? Number(first.count) : 0;
+}
+
+/**
+ * Lightweight last-N "what just happened" feed for admin debugging.
+ * Phone numbers are returned redacted to last-4 ("…4567") so the page
+ * doesn't accidentally surface PII.
+ */
+export type RecentRedactedMessage = {
+  id: string;
+  receivedAt: Date;
+  fromLast4: string;
+  intent: string;
+  bodyExcerpt: string;
+};
+
+export async function recentRedactedMessages(limit = 20): Promise<RecentRedactedMessage[]> {
+  const rows = await db
+    .select({
+      id: smsMessages.id,
+      receivedAt: smsMessages.receivedAt,
+      fromNumber: smsMessages.fromNumber,
+      intent: smsMessages.intent,
+      body: smsMessages.body,
+    })
+    .from(smsMessages)
+    .orderBy(sql`${smsMessages.receivedAt} DESC`)
+    .limit(limit);
+  return rows.map((r) => {
+    const digits = r.fromNumber.replace(/[^0-9]/g, '');
+    const last4 = digits.slice(-4) || '----';
+    const bodyExcerpt = r.body.length > 80 ? `${r.body.slice(0, 77)}…` : r.body;
+    return {
+      id: r.id,
+      receivedAt: new Date(r.receivedAt),
+      fromLast4: last4,
+      intent: r.intent,
+      bodyExcerpt,
+    };
+  });
+}


### PR DESCRIPTION
Closes #68, #69, #70. Stacked on [#261](https://github.com/DobbsBoldry/homeless/pull/261) (INDC-005/006).

## Summary
- **`/app/coalition/sms/metrics`** (admin-only) — 7-day daily-volume bars; headline counters: messages, unique callers, bed lists shown, location-prompt completion %; full intent breakdown with per-row bars; friction-signal callout when *unknown* count grows (parser-coverage hint).
- **Privacy-respecting log (INDC-007)** — recent-traffic list shows phone numbers as last-4 (\"…4567\") only. Full numbers stay in `sms_messages` for audit. Aggregate queries exclude playground traffic (`from_number LIKE 'SIMULATED-%'`).
- **`/app/coalition/sms/handout`** (INDC-008) — printable one-pager for clients. Plain-language command guide, privacy paragraph, 211 fallback. Twilio number injected via `NEXT_PUBLIC_INDC_SMS_NUMBER`. Print-only CSS hides chrome.
- **Nav**: \"SMS metrics\" (admin) + \"SMS handout\" (admin/staff/CW/EDC).
- 136 tests passing (no new tests — surfaces are purely query + rendering; SQL aggregates are best validated end-to-end against seeded data).

## Acceptance criteria
- INDC-007 (privacy-respecting log):
  - [x] Phone numbers redacted in any UI surface
  - [x] Full numbers preserved only in audit table (no UI access)
- INDC-008 (handout):
  - [x] Single-page printable
  - [x] Plain-language command list
  - [x] Privacy explainer + 211 fallback
- INDC-009 (first-week metrics review):
  - [x] Volume by day
  - [x] Intent breakdown
  - [x] Completion-rate (location-prompt → results) signal
  - [x] Friction signal (unknown count)
- [x] Lint + typecheck + 136 tests + build

## Test plan
- [ ] Sign in as admin → /app/coalition/sms/metrics → confirm seeded/synthetic traffic shows up; numbers add up
- [ ] Send a few real-shape messages via the playground → metrics page should NOT count them (they're prefixed SIMULATED-)
- [ ] Send a real flow via webhook (signature-bypass mode in dev) → counts increment, last-4 redacted in recent-traffic list
- [ ] /app/coalition/sms/handout → looks clean printed (Cmd-P), [number TBD] shows when env var unset
- [ ] Set NEXT_PUBLIC_INDC_SMS_NUMBER and reload → real number appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)