### PR TITLE
feat(DTRS-001/002/005): consent state machine + plain-language form

### DIFF
--- a/docs/dtrs-005-advisor-review.md
+++ b/docs/dtrs-005-advisor-review.md
@@ -1,0 +1,64 @@
+# DTRS-005 — Lived-experience advisor consent UX review
+
+**Status:** Pending. Blocks first real-PHI flow (gating story per BACKLOG).
+**Engineering side:** ready (DTRS-001 schema + DTRS-002 form merged).
+**Coalition side:** schedule paid 90-min session per advisor, $100/session honorarium per FAG comp policy.
+
+## Why this exists
+
+Before any client data flows through the consent surface, the wording, the
+default checkbox states, and the data-class vocabulary need to be reviewed by
+people who have actually been on the receiving end of consent forms in
+shelter / ED / legal-aid contexts. Reading-level, framing, and the plain-
+language commitments all have to be vetted; a grade-6 Flesch-Kincaid score is
+the floor, not the ceiling. The wording is in
+[`src/lib/dtrs/consent-text.ts`](../src/lib/dtrs/consent-text.ts) — bump
+`CURRENT_CONSENT_VERSION` whenever the wording changes.
+
+## What to bring to the session
+
+- Printed copy of [`/p/[ref]/consent/grant`](../src/app/p/[ref]/consent/grant/page.tsx)
+  for each of the three consent types (PHI share, SMS, program eval).
+- Printed handout from [`/app/coalition/sms/handout`](../src/app/app/coalition/sms/handout/page.tsx) for tone calibration.
+- The `DATA_CLASSES` list (identity / health / housing_history / service_events).
+- A blank legal pad — what *isn't* on the form should be heard, not just
+  what's on it.
+
+## Questions to ask
+
+1. Does the framing assume things you wouldn't trust the coalition with at first
+   contact? Where?
+2. Are any of the bullet promises ones you'd doubt? Why?
+3. Are the data-class checkboxes named in language someone in your shoes would
+   actually use?
+4. Is there a category of info that should be checkable but isn't? Is there one
+   that shouldn't be checkable at all?
+5. Where would you have walked away from this form if you'd encountered it
+   during your worst week?
+
+## What to capture
+
+- Verbatim wording suggestions, by section.
+- Defaults to flip (e.g. \"start with health *unchecked*\").
+- Data-class additions or merges.
+- Friction points in the flow that aren't about wording (e.g. \"the link
+  came at the wrong moment\").
+- A go / no-go on whether the engineering work is ready for first real
+  client.
+
+## After the session
+
+- Bump `CURRENT_CONSENT_VERSION` in `src/db/schema/consents.ts` and
+  `src/lib/dtrs/consent-text.ts` (they import from each other — keep in
+  sync) and edit the copy to match the advisor's wording.
+- File a follow-up issue per advisor session for any structural change
+  (new data class, default flip, defaults that need to be configurable
+  per partner).
+- File the session notes here as `docs/dtrs-005-session-YYYY-MM-DD.md`.
+- Pay the honorarium per OPRT-004's compensation tracker.
+
+## Compensation policy
+
+$100 per advisor per session, plus food and transit if the session is in
+person. The coalition's frontline-advisory-group compensation tracker (OPRT-004)
+records both. Pay at the time of the session, not after.

--- a/drizzle/migrations/0021_nice_senator_kelly.sql
+++ b/drizzle/migrations/0021_nice_senator_kelly.sql
@@ -1,0 +1,6 @@
+ALTER TABLE "consents" ADD COLUMN "consent_version" text DEFAULT '2026-04-1' NOT NULL;--> statement-breakpoint
+ALTER TABLE "consents" ADD COLUMN "scope_partner_ids" jsonb;--> statement-breakpoint
+ALTER TABLE "consents" ADD COLUMN "scope_data_classes" jsonb;--> statement-breakpoint
+ALTER TABLE "consents" ADD COLUMN "signature_text" text;--> statement-breakpoint
+ALTER TABLE "consents" ADD COLUMN "expires_at" timestamp with time zone;--> statement-breakpoint
+CREATE INDEX "consents_expires_at_idx" ON "consents" USING btree ("expires_at");

--- a/drizzle/migrations/meta/0021_snapshot.json
+++ b/drizzle/migrations/meta/0021_snapshot.json
@@ -1,0 +1,2647 @@
+{
+  "id": "4d3e1f8a-8924-44c9-a3d2-88e8e8ac6ba2",
+  "prevId": "c6d45982-da16-4903-bd7f-46b41a8836d1",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.audit_log": {
+      "name": "audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_table": {
+          "name": "target_table",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "audit_log_actor_idx": {
+          "name": "audit_log_actor_idx",
+          "columns": [
+            {
+              "expression": "actor_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_log_action_idx": {
+          "name": "audit_log_action_idx",
+          "columns": [
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_log_created_at_idx": {
+          "name": "audit_log_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audit_log_actor_user_id_users_id_fk": {
+          "name": "audit_log_actor_user_id_users_id_fk",
+          "tableFrom": "audit_log",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.consents": {
+      "name": "consents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "subject_external_id": {
+          "name": "subject_external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consent_type": {
+          "name": "consent_type",
+          "type": "consent_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "granted_via": {
+          "name": "granted_via",
+          "type": "consent_channel",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consent_version": {
+          "name": "consent_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'2026-04-1'"
+        },
+        "scope_partner_ids": {
+          "name": "scope_partner_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope_data_classes": {
+          "name": "scope_data_classes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "signature_text": {
+          "name": "signature_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "granted_at": {
+          "name": "granted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "consents_subject_idx": {
+          "name": "consents_subject_idx",
+          "columns": [
+            {
+              "expression": "subject_external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "consents_type_idx": {
+          "name": "consents_type_idx",
+          "columns": [
+            {
+              "expression": "consent_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "consents_expires_at_idx": {
+          "name": "consents_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ed_encounters": {
+      "name": "ed_encounters",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encounter_external_id": {
+          "name": "encounter_external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "arrived_at": {
+          "name": "arrived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discharged_at": {
+          "name": "discharged_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chief_complaint": {
+          "name": "chief_complaint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "disposition": {
+          "name": "disposition",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "housing_status": {
+          "name": "housing_status",
+          "type": "housing_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unknown'"
+        },
+        "charge_cents": {
+          "name": "charge_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_json": {
+          "name": "raw_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "ed_encounter_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'synthetic'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ed_encounters_external_idx": {
+          "name": "ed_encounters_external_idx",
+          "columns": [
+            {
+              "expression": "encounter_external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ed_encounters_patient_idx": {
+          "name": "ed_encounters_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ed_encounters_arrived_idx": {
+          "name": "ed_encounters_arrived_idx",
+          "columns": [
+            {
+              "expression": "arrived_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ed_encounters_housing_idx": {
+          "name": "ed_encounters_housing_idx",
+          "columns": [
+            {
+              "expression": "housing_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.esuc_care_plans": {
+      "name": "esuc_care_plans",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plan_md": {
+          "name": "plan_md",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt_version": {
+          "name": "prompt_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "generated_by_user_id": {
+          "name": "generated_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "esuc_care_plan_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "care_plans_patient_version_idx": {
+          "name": "care_plans_patient_version_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "prompt_version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "care_plans_patient_idx": {
+          "name": "care_plans_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "care_plans_status_idx": {
+          "name": "care_plans_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "esuc_care_plans_generated_by_user_id_users_id_fk": {
+          "name": "esuc_care_plans_generated_by_user_id_users_id_fk",
+          "tableFrom": "esuc_care_plans",
+          "tableTo": "users",
+          "columnsFrom": [
+            "generated_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.eviction_case_outcomes": {
+      "name": "eviction_case_outcomes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "filing_id": {
+          "name": "filing_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "eviction_case_outcome",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recorded_by_user_id": {
+          "name": "recorded_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "case_outcomes_filing_idx": {
+          "name": "case_outcomes_filing_idx",
+          "columns": [
+            {
+              "expression": "filing_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "case_outcomes_outcome_idx": {
+          "name": "case_outcomes_outcome_idx",
+          "columns": [
+            {
+              "expression": "outcome",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "case_outcomes_created_at_idx": {
+          "name": "case_outcomes_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "eviction_case_outcomes_filing_id_eviction_filings_id_fk": {
+          "name": "eviction_case_outcomes_filing_id_eviction_filings_id_fk",
+          "tableFrom": "eviction_case_outcomes",
+          "tableTo": "eviction_filings",
+          "columnsFrom": [
+            "filing_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "eviction_case_outcomes_recorded_by_user_id_users_id_fk": {
+          "name": "eviction_case_outcomes_recorded_by_user_id_users_id_fk",
+          "tableFrom": "eviction_case_outcomes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "recorded_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.eviction_filing_risk_scores": {
+      "name": "eviction_filing_risk_scores",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "filing_id": {
+          "name": "filing_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rationale": {
+          "name": "rationale",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model_version": {
+          "name": "model_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "risk_scores_filing_version_idx": {
+          "name": "risk_scores_filing_version_idx",
+          "columns": [
+            {
+              "expression": "filing_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "model_version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "risk_scores_filing_idx": {
+          "name": "risk_scores_filing_idx",
+          "columns": [
+            {
+              "expression": "filing_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "risk_scores_score_idx": {
+          "name": "risk_scores_score_idx",
+          "columns": [
+            {
+              "expression": "score",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "eviction_filing_risk_scores_filing_id_eviction_filings_id_fk": {
+          "name": "eviction_filing_risk_scores_filing_id_eviction_filings_id_fk",
+          "tableFrom": "eviction_filing_risk_scores",
+          "tableTo": "eviction_filings",
+          "columnsFrom": [
+            "filing_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.eviction_filings": {
+      "name": "eviction_filings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "case_number": {
+          "name": "case_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filed_at": {
+          "name": "filed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "court_division": {
+          "name": "court_division",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plaintiff": {
+          "name": "plaintiff",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "defendant_first_name": {
+          "name": "defendant_first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "defendant_last_name": {
+          "name": "defendant_last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "defendant_address": {
+          "name": "defendant_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cause_type": {
+          "name": "cause_type",
+          "type": "eviction_cause_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_claimed_cents": {
+          "name": "amount_claimed_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "eviction_filing_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'filed'"
+        },
+        "source": {
+          "name": "source",
+          "type": "eviction_filing_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "raw_json": {
+          "name": "raw_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "eviction_filings_case_source_idx": {
+          "name": "eviction_filings_case_source_idx",
+          "columns": [
+            {
+              "expression": "case_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "eviction_filings_filed_at_idx": {
+          "name": "eviction_filings_filed_at_idx",
+          "columns": [
+            {
+              "expression": "filed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "eviction_filings_status_idx": {
+          "name": "eviction_filings_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.eviction_response_packets": {
+      "name": "eviction_response_packets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "filing_id": {
+          "name": "filing_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "packet_md": {
+          "name": "packet_md",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt_version": {
+          "name": "prompt_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "generated_by_user_id": {
+          "name": "generated_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "eviction_response_packet_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "response_packets_filing_version_idx": {
+          "name": "response_packets_filing_version_idx",
+          "columns": [
+            {
+              "expression": "filing_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "prompt_version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "response_packets_filing_idx": {
+          "name": "response_packets_filing_idx",
+          "columns": [
+            {
+              "expression": "filing_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "response_packets_status_idx": {
+          "name": "response_packets_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "eviction_response_packets_filing_id_eviction_filings_id_fk": {
+          "name": "eviction_response_packets_filing_id_eviction_filings_id_fk",
+          "tableFrom": "eviction_response_packets",
+          "tableTo": "eviction_filings",
+          "columnsFrom": [
+            "filing_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "eviction_response_packets_generated_by_user_id_users_id_fk": {
+          "name": "eviction_response_packets_generated_by_user_id_users_id_fk",
+          "tableFrom": "eviction_response_packets",
+          "tableTo": "users",
+          "columnsFrom": [
+            "generated_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.health_check": {
+      "name": "health_check",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_memberships": {
+      "name": "org_memberships",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "partner_org_id": {
+          "name": "partner_org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "org_memberships_user_org_idx": {
+          "name": "org_memberships_user_org_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "partner_org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "org_memberships_user_idx": {
+          "name": "org_memberships_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "org_memberships_partner_org_idx": {
+          "name": "org_memberships_partner_org_idx",
+          "columns": [
+            {
+              "expression": "partner_org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "org_memberships_user_id_users_id_fk": {
+          "name": "org_memberships_user_id_users_id_fk",
+          "tableFrom": "org_memberships",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "org_memberships_partner_org_id_partner_orgs_id_fk": {
+          "name": "org_memberships_partner_org_id_partner_orgs_id_fk",
+          "tableFrom": "org_memberships",
+          "tableTo": "partner_orgs",
+          "columnsFrom": [
+            "partner_org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.partner_orgs": {
+      "name": "partner_orgs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "partner_org_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_email": {
+          "name": "contact_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_phone": {
+          "name": "contact_phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "website": {
+          "name": "website",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data_sharing_tier": {
+          "name": "data_sharing_tier",
+          "type": "data_sharing_tier",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "partner_orgs_slug_idx": {
+          "name": "partner_orgs_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.partner_service_events": {
+      "name": "partner_service_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "partner_org_id": {
+          "name": "partner_org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "synthetic_person_ref": {
+          "name": "synthetic_person_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "partner_service_event_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_at": {
+          "name": "event_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "ed_encounter_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'synthetic'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "partner_service_events_person_idx": {
+          "name": "partner_service_events_person_idx",
+          "columns": [
+            {
+              "expression": "synthetic_person_ref",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "partner_service_events_partner_idx": {
+          "name": "partner_service_events_partner_idx",
+          "columns": [
+            {
+              "expression": "partner_org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "partner_service_events_at_idx": {
+          "name": "partner_service_events_at_idx",
+          "columns": [
+            {
+              "expression": "event_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "partner_service_events_partner_org_id_partner_orgs_id_fk": {
+          "name": "partner_service_events_partner_org_id_partner_orgs_id_fk",
+          "tableFrom": "partner_service_events",
+          "tableTo": "partner_orgs",
+          "columnsFrom": [
+            "partner_org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.person_partner_consents": {
+      "name": "person_partner_consents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "synthetic_person_ref": {
+          "name": "synthetic_person_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "partner_org_id": {
+          "name": "partner_org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "granted_at": {
+          "name": "granted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "person_partner_consents_unique_idx": {
+          "name": "person_partner_consents_unique_idx",
+          "columns": [
+            {
+              "expression": "synthetic_person_ref",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "partner_org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "person_partner_consents_partner_org_id_partner_orgs_id_fk": {
+          "name": "person_partner_consents_partner_org_id_partner_orgs_id_fk",
+          "tableFrom": "person_partner_consents",
+          "tableTo": "partner_orgs",
+          "columnsFrom": [
+            "partner_org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rental_assistance_programs": {
+      "name": "rental_assistance_programs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agency": {
+          "name": "agency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "website": {
+          "name": "website",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "eligibility_summary": {
+          "name": "eligibility_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "max_award_cents": {
+          "name": "max_award_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_note": {
+          "name": "source_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "rental_assistance_programs_active_idx": {
+          "name": "rental_assistance_programs_active_idx",
+          "columns": [
+            {
+              "expression": "active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bed_count_updates": {
+      "name": "bed_count_updates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "shelter_id": {
+          "name": "shelter_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_user_id": {
+          "name": "updated_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "previous_occupancy": {
+          "name": "previous_occupancy",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "new_occupancy": {
+          "name": "new_occupancy",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "bed_count_updates_shelter_idx": {
+          "name": "bed_count_updates_shelter_idx",
+          "columns": [
+            {
+              "expression": "shelter_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bed_count_updates_created_idx": {
+          "name": "bed_count_updates_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bed_count_updates_shelter_id_shelters_id_fk": {
+          "name": "bed_count_updates_shelter_id_shelters_id_fk",
+          "tableFrom": "bed_count_updates",
+          "tableTo": "shelters",
+          "columnsFrom": [
+            "shelter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bed_holds": {
+      "name": "bed_holds",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "shelter_id": {
+          "name": "shelter_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "held_by_user_id": {
+          "name": "held_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "person_label": {
+          "name": "person_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "bed_hold_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "released_at": {
+          "name": "released_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "bed_holds_shelter_idx": {
+          "name": "bed_holds_shelter_idx",
+          "columns": [
+            {
+              "expression": "shelter_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bed_holds_status_idx": {
+          "name": "bed_holds_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bed_holds_expires_idx": {
+          "name": "bed_holds_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bed_holds_shelter_id_shelters_id_fk": {
+          "name": "bed_holds_shelter_id_shelters_id_fk",
+          "tableFrom": "bed_holds",
+          "tableTo": "shelters",
+          "columnsFrom": [
+            "shelter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.shelters": {
+      "name": "shelters",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "partner_org_id": {
+          "name": "partner_org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address_line1": {
+          "name": "address_line1",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "city": {
+          "name": "city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "postal_code": {
+          "name": "postal_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_phone": {
+          "name": "contact_phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capacity": {
+          "name": "capacity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_occupancy": {
+          "name": "current_occupancy",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "accepts_men": {
+          "name": "accepts_men",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "accepts_women": {
+          "name": "accepts_women",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "accepts_families": {
+          "name": "accepts_families",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "pet_friendly": {
+          "name": "pet_friendly",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "sud_friendly": {
+          "name": "sud_friendly",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "shelters_slug_idx": {
+          "name": "shelters_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "shelters_partner_org_idx": {
+          "name": "shelters_partner_org_idx",
+          "columns": [
+            {
+              "expression": "partner_org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "shelters_partner_org_id_partner_orgs_id_fk": {
+          "name": "shelters_partner_org_id_partner_orgs_id_fk",
+          "tableFrom": "shelters",
+          "tableTo": "partner_orgs",
+          "columnsFrom": [
+            "partner_org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "shelters_capacity_nonneg": {
+          "name": "shelters_capacity_nonneg",
+          "value": "\"shelters\".\"capacity\" >= 0"
+        },
+        "shelters_occupancy_nonneg": {
+          "name": "shelters_occupancy_nonneg",
+          "value": "\"shelters\".\"current_occupancy\" >= 0"
+        },
+        "shelters_occupancy_le_capacity": {
+          "name": "shelters_occupancy_le_capacity",
+          "value": "\"shelters\".\"current_occupancy\" <= \"shelters\".\"capacity\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.sms_conversations": {
+      "name": "sms_conversations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "from_number": {
+          "name": "from_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "sms_conversation_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'idle'"
+        },
+        "pending_filter": {
+          "name": "pending_filter",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_location": {
+          "name": "last_location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_results": {
+          "name": "last_results",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_hold_id": {
+          "name": "last_hold_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_message_at": {
+          "name": "last_message_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sms_conversations_from_idx": {
+          "name": "sms_conversations_from_idx",
+          "columns": [
+            {
+              "expression": "from_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_conversations_state_idx": {
+          "name": "sms_conversations_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_conversations_expires_idx": {
+          "name": "sms_conversations_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sms_messages": {
+      "name": "sms_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "provider_message_id": {
+          "name": "provider_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "from_number": {
+          "name": "from_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_number": {
+          "name": "to_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "intent": {
+          "name": "intent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reply_body": {
+          "name": "reply_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sms_messages_received_idx": {
+          "name": "sms_messages_received_idx",
+          "columns": [
+            {
+              "expression": "received_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_messages_from_idx": {
+          "name": "sms_messages_from_idx",
+          "columns": [
+            {
+              "expression": "from_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "clerk_user_id": {
+          "name": "clerk_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "users_clerk_user_id_idx": {
+          "name": "users_clerk_user_id_idx",
+          "columns": [
+            {
+              "expression": "clerk_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.bed_hold_status": {
+      "name": "bed_hold_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "released",
+        "expired",
+        "converted"
+      ]
+    },
+    "public.consent_channel": {
+      "name": "consent_channel",
+      "schema": "public",
+      "values": [
+        "sms",
+        "in_person",
+        "web_form",
+        "phone",
+        "paper"
+      ]
+    },
+    "public.consent_type": {
+      "name": "consent_type",
+      "schema": "public",
+      "values": [
+        "phi_share_within_coalition",
+        "sms_communication",
+        "data_for_program_eval"
+      ]
+    },
+    "public.data_sharing_tier": {
+      "name": "data_sharing_tier",
+      "schema": "public",
+      "values": [
+        "none",
+        "aggregate",
+        "individual"
+      ]
+    },
+    "public.ed_encounter_source": {
+      "name": "ed_encounter_source",
+      "schema": "public",
+      "values": [
+        "synthetic",
+        "epic_fhir",
+        "manual"
+      ]
+    },
+    "public.esuc_care_plan_status": {
+      "name": "esuc_care_plan_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "approved",
+        "active",
+        "archived"
+      ]
+    },
+    "public.eviction_case_outcome": {
+      "name": "eviction_case_outcome",
+      "schema": "public",
+      "values": [
+        "dismissed",
+        "judgment_for_plaintiff",
+        "judgment_for_defendant",
+        "settled",
+        "default_judgment",
+        "withdrawn"
+      ]
+    },
+    "public.eviction_cause_type": {
+      "name": "eviction_cause_type",
+      "schema": "public",
+      "values": [
+        "non_payment",
+        "lease_violation",
+        "holdover",
+        "other"
+      ]
+    },
+    "public.eviction_filing_source": {
+      "name": "eviction_filing_source",
+      "schema": "public",
+      "values": [
+        "courtnet",
+        "manual",
+        "synthetic"
+      ]
+    },
+    "public.eviction_filing_status": {
+      "name": "eviction_filing_status",
+      "schema": "public",
+      "values": [
+        "filed",
+        "served",
+        "judgment",
+        "dismissed",
+        "sealed"
+      ]
+    },
+    "public.eviction_response_packet_status": {
+      "name": "eviction_response_packet_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "approved",
+        "filed",
+        "rejected"
+      ]
+    },
+    "public.housing_status": {
+      "name": "housing_status",
+      "schema": "public",
+      "values": [
+        "housed",
+        "doubled_up",
+        "shelter",
+        "unsheltered",
+        "unknown"
+      ]
+    },
+    "public.partner_org_type": {
+      "name": "partner_org_type",
+      "schema": "public",
+      "values": [
+        "hospital",
+        "legal_aid",
+        "shelter",
+        "community_org",
+        "government",
+        "faith_based",
+        "school",
+        "philanthropy",
+        "education",
+        "public_health",
+        "media",
+        "other"
+      ]
+    },
+    "public.partner_service_event_type": {
+      "name": "partner_service_event_type",
+      "schema": "public",
+      "values": [
+        "food_pantry",
+        "shelter_intake",
+        "shelter_bed_night",
+        "utility_assistance",
+        "rent_assistance",
+        "counseling_visit",
+        "medical_visit",
+        "school_attendance_flag",
+        "volunteer_hours",
+        "other"
+      ]
+    },
+    "public.sms_conversation_state": {
+      "name": "sms_conversation_state",
+      "schema": "public",
+      "values": [
+        "idle",
+        "awaiting_location"
+      ]
+    },
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "pending",
+        "attorney",
+        "caseworker",
+        "ed_coordinator",
+        "shelter_staff",
+        "admin"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/migrations/meta/_journal.json
+++ b/drizzle/migrations/meta/_journal.json
@@ -148,6 +148,13 @@
       "when": 1777238311241,
       "tag": "0020_quiet_metal_master",
       "breakpoints": true
+    },
+    {
+      "idx": 21,
+      "version": "7",
+      "when": 1777239126177,
+      "tag": "0021_nice_senator_kelly",
+      "breakpoints": true
     }
   ]
 }

--- a/src/app/actions/consent.ts
+++ b/src/app/actions/consent.ts
@@ -3,8 +3,11 @@
 import { eq } from 'drizzle-orm';
 import { revalidatePath } from 'next/cache';
 import { db } from '@/db/client';
+import { consents } from '@/db/schema/consents';
+import { type ConsentChannel, type ConsentType, consentChannelEnum } from '@/db/schema/enums';
 import { personPartnerConsents } from '@/db/schema/person-partner-consents';
 import { logAuditEvent } from '@/lib/audit';
+import { CURRENT_CONSENT_VERSION, DATA_CLASSES } from '@/lib/dtrs/consent-text';
 import { isValidSyntheticPersonRef } from '@/lib/synthetic-person';
 
 export type ConsentResult = { ok: true } | { ok: false; error: string };
@@ -41,6 +44,114 @@ export async function revokeConsentAction(
   });
 
   revalidatePath(`/p/${syntheticPersonRef}/consent`);
+  return { ok: true };
+}
+
+const VALID_DATA_CLASSES: Set<string> = new Set(DATA_CLASSES.map((d) => d.id as string));
+const VALID_CHANNELS = new Set<ConsentChannel>(consentChannelEnum.enumValues);
+const SIGNATURE_MIN = 1;
+const SIGNATURE_MAX = 80;
+
+export type GrantConsentInput = {
+  subjectExternalId: string;
+  consentType: ConsentType;
+  grantedVia: ConsentChannel;
+  signatureText: string;
+  scopeDataClasses?: string[] | null;
+  scopePartnerIds?: string[] | null;
+  expiresAt?: Date | null;
+};
+
+export type GrantConsentResult = { ok: true; id: string } | { ok: false; error: string };
+
+/**
+ * Public-surface server action: record a fresh, versioned consent grant
+ * (DTRS-001 schema, DTRS-002 form). The subject themselves writes here
+ * — no role gate, but inputs are validated and capped, and every grant
+ * lands in audit_log so spurious grants are traceable. The opaque
+ * subject_external_id is the auth boundary: only the caseworker who
+ * shared the link knows the value.
+ *
+ * Once a one-time-link auth gate ships (#251), this action gets the
+ * token check too.
+ */
+export async function grantConsentAction(input: GrantConsentInput): Promise<GrantConsentResult> {
+  const subject = input.subjectExternalId.trim();
+  if (subject.length === 0) return { ok: false, error: 'Missing subject identifier.' };
+
+  if (!VALID_CHANNELS.has(input.grantedVia)) {
+    return { ok: false, error: 'Invalid consent channel.' };
+  }
+
+  const sig = input.signatureText.trim();
+  if (sig.length < SIGNATURE_MIN || sig.length > SIGNATURE_MAX) {
+    return { ok: false, error: 'Please type your name to sign.' };
+  }
+
+  const dataClasses =
+    input.scopeDataClasses === null
+      ? null
+      : (input.scopeDataClasses ?? []).filter((c) => VALID_DATA_CLASSES.has(c));
+  if (dataClasses && dataClasses.length === 0) {
+    return { ok: false, error: 'Pick at least one kind of info to share.' };
+  }
+
+  const [created] = await db
+    .insert(consents)
+    .values({
+      subjectExternalId: subject,
+      consentType: input.consentType,
+      grantedVia: input.grantedVia,
+      consentVersion: CURRENT_CONSENT_VERSION,
+      signatureText: sig,
+      scopeDataClasses: dataClasses,
+      scopePartnerIds: input.scopePartnerIds ?? null,
+      expiresAt: input.expiresAt ?? null,
+    })
+    .returning({ id: consents.id });
+
+  await logAuditEvent({
+    actorUserId: null,
+    action: 'consent.granted',
+    targetTable: 'consents',
+    targetId: created.id,
+    metadata: {
+      consentType: input.consentType,
+      grantedVia: input.grantedVia,
+      consentVersion: CURRENT_CONSENT_VERSION,
+      hasDataClassScope: dataClasses !== null,
+      hasPartnerScope: input.scopePartnerIds != null,
+      hasExpiry: Boolean(input.expiresAt),
+    },
+  });
+
+  return { ok: true, id: created.id };
+}
+
+export type RevokeVersionedConsentResult = { ok: true } | { ok: false; error: string };
+
+/** Revoke a versioned `consents` row. Idempotent on already-revoked rows. */
+export async function revokeVersionedConsentAction(
+  consentId: string,
+): Promise<RevokeVersionedConsentResult> {
+  const [existing] = await db
+    .select({ id: consents.id, subject: consents.subjectExternalId, revokedAt: consents.revokedAt })
+    .from(consents)
+    .where(eq(consents.id, consentId))
+    .limit(1);
+  if (!existing) return { ok: false, error: 'Consent not found.' };
+  if (existing.revokedAt) return { ok: true };
+
+  await db.update(consents).set({ revokedAt: new Date() }).where(eq(consents.id, consentId));
+
+  await logAuditEvent({
+    actorUserId: null,
+    action: 'consent.revoked',
+    targetTable: 'consents',
+    targetId: consentId,
+    metadata: { subject: existing.subject },
+  });
+
   return { ok: true };
 }
 

--- a/src/app/p/[ref]/consent/grant/page.tsx
+++ b/src/app/p/[ref]/consent/grant/page.tsx
@@ -1,0 +1,58 @@
+import { notFound } from 'next/navigation';
+import { ConsentForm } from '@/components/consent/consent-form';
+import { Card, CardContent } from '@/components/ui/card';
+import { type ConsentType, consentTypeEnum } from '@/db/schema/enums';
+import { consentTextFor } from '@/lib/dtrs/consent-text';
+import { isValidSyntheticPersonRef } from '@/lib/synthetic-person';
+
+export const metadata = {
+  title: 'Sharing agreement',
+};
+
+const VALID_TYPES = new Set<ConsentType>(consentTypeEnum.enumValues);
+
+export default async function GrantConsentPage({
+  params,
+  searchParams,
+}: {
+  params: Promise<{ ref: string }>;
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+}) {
+  const { ref } = await params;
+  const sp = await searchParams;
+  if (!isValidSyntheticPersonRef(ref)) notFound();
+
+  const rawType = Array.isArray(sp.type) ? sp.type[0] : sp.type;
+  const consentType: ConsentType =
+    rawType && VALID_TYPES.has(rawType as ConsentType)
+      ? (rawType as ConsentType)
+      : 'phi_share_within_coalition';
+  const copy = consentTextFor(consentType);
+
+  return (
+    <div className="mx-auto max-w-xl space-y-4 p-6">
+      <header>
+        <p className="text-xs text-muted-foreground">
+          Identifier <span className="font-mono">{ref}</span>
+        </p>
+      </header>
+
+      <Card>
+        <CardContent className="pt-6">
+          <ConsentForm subjectExternalId={ref} consentType={consentType} copy={copy} />
+        </CardContent>
+      </Card>
+
+      <Card className="border-amber-500/40 bg-amber-500/5">
+        <CardContent className="text-xs">
+          <p className="font-medium">Phase-1 stub.</p>
+          <p className="mt-1 text-muted-foreground">
+            This page is open to anyone with the URL today. A one-time-link auth gate (#251) is the
+            follow-up that scopes write access to the right person. The wording itself is reviewed
+            in DTRS-005 advisor sessions before any client traffic flows.
+          </p>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/components/consent/consent-form.tsx
+++ b/src/components/consent/consent-form.tsx
@@ -1,0 +1,147 @@
+'use client';
+
+import { useId, useState, useTransition } from 'react';
+import { grantConsentAction } from '@/app/actions/consent';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import type { ConsentType } from '@/db/schema/enums';
+import { type ConsentCopy, DATA_CLASSES } from '@/lib/dtrs/consent-text';
+
+/**
+ * Plain-language consent form (DTRS-002). Reading-level target: grade 6.
+ * Every label is in `consent-text.ts` so the wording can be reviewed in
+ * lived-experience advisor sessions (DTRS-005) without code changes.
+ */
+export function ConsentForm({
+  subjectExternalId,
+  consentType,
+  copy,
+}: {
+  subjectExternalId: string;
+  consentType: ConsentType;
+  copy: ConsentCopy;
+}) {
+  const sigId = useId();
+  const [signature, setSignature] = useState('');
+  const [checked, setChecked] = useState<Set<string>>(() => new Set(DATA_CLASSES.map((d) => d.id)));
+  const [pending, startTransition] = useTransition();
+  const [error, setError] = useState<string | null>(null);
+  const [submitted, setSubmitted] = useState<boolean>(false);
+
+  const toggle = (id: string) => {
+    setChecked((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  };
+
+  const onSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    setError(null);
+    if (signature.trim().length === 0) {
+      setError('Please type your name on the line below.');
+      return;
+    }
+    if (checked.size === 0) {
+      setError('Pick at least one kind of info to share.');
+      return;
+    }
+    startTransition(async () => {
+      const r = await grantConsentAction({
+        subjectExternalId,
+        consentType,
+        grantedVia: 'web_form',
+        signatureText: signature,
+        scopeDataClasses: Array.from(checked),
+      });
+      if (!r.ok) {
+        setError(r.error);
+        return;
+      }
+      setSubmitted(true);
+    });
+  };
+
+  if (submitted) {
+    return (
+      <div className="rounded-md border border-emerald-500/40 bg-emerald-500/5 p-4 text-sm">
+        <p className="font-semibold text-emerald-700 dark:text-emerald-400">Saved.</p>
+        <p className="mt-1">
+          Thank you, {signature.trim()}. You can change these settings any time at this same link,
+          or by replying STOP to any text we send you.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <form onSubmit={onSubmit} className="space-y-5">
+      <header>
+        <h2 className="font-serif text-2xl font-semibold">{copy.title}</h2>
+        <p className="mt-2 text-base">{copy.intro}</p>
+      </header>
+
+      <div className="rounded-md border border-border bg-muted/20 p-4 text-sm">
+        <ul className="list-disc space-y-1 pl-5">
+          {copy.bullets.map((b) => (
+            <li key={b}>{b}</li>
+          ))}
+        </ul>
+      </div>
+
+      <fieldset className="space-y-2">
+        <legend className="text-sm font-medium">What can we share?</legend>
+        <p className="text-xs text-muted-foreground">
+          Uncheck anything you do not want shared. You can change this later.
+        </p>
+        <div className="space-y-1">
+          {DATA_CLASSES.map((d) => {
+            const id = `data-class-${d.id}`;
+            return (
+              <label
+                key={d.id}
+                htmlFor={id}
+                className="flex cursor-pointer items-center gap-2 rounded p-2 hover:bg-muted/40"
+              >
+                <input
+                  id={id}
+                  type="checkbox"
+                  checked={checked.has(d.id)}
+                  onChange={() => toggle(d.id)}
+                  disabled={pending}
+                  className="h-4 w-4"
+                />
+                <span>{d.label}</span>
+              </label>
+            );
+          })}
+        </div>
+      </fieldset>
+
+      <div className="space-y-1">
+        <Label htmlFor={sigId}>Your name (this counts as your signature)</Label>
+        <Input
+          id={sigId}
+          value={signature}
+          onChange={(e) => setSignature(e.target.value)}
+          placeholder="e.g. Sarah J"
+          maxLength={80}
+          disabled={pending}
+        />
+      </div>
+
+      <p className="text-xs text-muted-foreground">{copy.footer}</p>
+
+      {error ? <p className="text-sm text-destructive">{error}</p> : null}
+
+      <div className="flex flex-wrap gap-2">
+        <Button type="submit" disabled={pending}>
+          {pending ? 'Saving…' : 'I agree'}
+        </Button>
+      </div>
+    </form>
+  );
+}

--- a/src/db/schema/consents.ts
+++ b/src/db/schema/consents.ts
@@ -1,14 +1,20 @@
-import { index, pgTable, text, timestamp, uuid } from 'drizzle-orm/pg-core';
+import { index, jsonb, pgTable, text, timestamp, uuid } from 'drizzle-orm/pg-core';
 import { consentChannelEnum, consentTypeEnum } from './enums';
 
 /**
  * Consent records for individuals to share PHI within the coalition, receive
- * SMS communication, etc. Phase 0 captures the structure; client linkage
- * (subject_external_id -> a real clients.id) lands in a Phase 1 story when
- * the clients table exists and PHI flows are unlocked post-BAA.
+ * SMS communication, etc. Phase 0 captured the bare shape; DTRS-001 adds
+ * the state machine on top: granted → revoked OR granted → expired,
+ * scoped to specific partner orgs and data classes, versioned by the
+ * consent text the subject saw.
  *
  * Append-only in spirit: revocations are recorded by setting revoked_at,
- * NOT by deleting the row.
+ * NOT by deleting the row. Re-granting after a revocation creates a NEW
+ * row so the historical state is queryable forever.
+ *
+ * State is computed (not stored): see `consentState` in
+ * `src/lib/dtrs/consent.ts`. Storing computed state risks drift between
+ * the column and the wall-clock check against expires_at.
  */
 export const consents = pgTable(
   'consents',
@@ -19,6 +25,27 @@ export const consents = pgTable(
     subjectExternalId: text('subject_external_id').notNull(),
     consentType: consentTypeEnum('consent_type').notNull(),
     grantedVia: consentChannelEnum('granted_via').notNull(),
+    /**
+     * Version of the consent text the subject was shown. Bump
+     * `CURRENT_CONSENT_VERSION` and `consentTextFor(...)` together.
+     * A row whose `consent_version` is older than the current version
+     * is treated as still-valid (we don't auto-revoke) but flagged in
+     * the dashboard as needing a re-prompt.
+     */
+    consentVersion: text('consent_version').notNull().default('2026-04-1'),
+    /** Specific partner orgs this consent covers; null = coalition-wide. */
+    scopePartnerIds: jsonb('scope_partner_ids').$type<string[] | null>(),
+    /**
+     * Data classes the subject opted into; null = all. Phase-1 vocabulary
+     * is intentionally short: 'identity', 'health', 'housing_history',
+     * 'service_events'. Wider taxonomy is a follow-up once the FAG
+     * weighs in (see DTRS-005 advisor session).
+     */
+    scopeDataClasses: jsonb('scope_data_classes').$type<string[] | null>(),
+    /** Plain-language signature text typed by the subject ("Sarah J", "X"). */
+    signatureText: text('signature_text'),
+    /** Optional expiry. null = no expiration; coalition can re-prompt at will. */
+    expiresAt: timestamp('expires_at', { withTimezone: true }),
     grantedAt: timestamp('granted_at', { withTimezone: true }).notNull().defaultNow(),
     revokedAt: timestamp('revoked_at', { withTimezone: true }),
     notes: text('notes'),
@@ -27,6 +54,7 @@ export const consents = pgTable(
   (t) => [
     index('consents_subject_idx').on(t.subjectExternalId),
     index('consents_type_idx').on(t.consentType),
+    index('consents_expires_at_idx').on(t.expiresAt),
   ],
 );
 

--- a/src/lib/dtrs/consent-text.ts
+++ b/src/lib/dtrs/consent-text.ts
@@ -1,0 +1,79 @@
+/**
+ * Plain-language consent text shown to subjects. Reading-level target:
+ * Flesch-Kincaid grade 6 or below. Reviewed in DTRS-005 advisor sessions
+ * before any client traffic flows.
+ *
+ * Bump `CURRENT_CONSENT_VERSION` (in src/db/schema/consents.ts) every
+ * time the wording materially changes. Old consent rows keep their
+ * version stamp; the dashboard can flag them as "out of date" and the
+ * subject can be re-prompted.
+ */
+
+import type { ConsentType } from '@/db/schema/enums';
+
+export const CURRENT_CONSENT_VERSION = '2026-04-1';
+
+/** Short data-class vocabulary the consent form lets subjects scope. */
+export const DATA_CLASSES = [
+  { id: 'identity', label: 'My name and contact info' },
+  { id: 'health', label: 'My health visits' },
+  { id: 'housing_history', label: 'Where I have stayed' },
+  { id: 'service_events', label: 'Help I have received (food, utility, shelter)' },
+] as const;
+
+export type DataClassId = (typeof DATA_CLASSES)[number]['id'];
+
+export type ConsentCopy = {
+  /** One-line title shown at the top of the form. */
+  title: string;
+  /** 1-3 short sentences explaining what the subject is agreeing to. */
+  intro: string;
+  /** Bullet list of plain-language commitments / rights. */
+  bullets: string[];
+  /** Footer text — opt-out instructions. */
+  footer: string;
+};
+
+const PHI_COPY: ConsentCopy = {
+  title: 'Can we share your info with your case team?',
+  intro:
+    "Saying yes lets the people helping you talk to each other about your situation, so you don't have to repeat your story.",
+  bullets: [
+    'We will only share what you check off below.',
+    'Only people on your case team will see it.',
+    "We won't sell or give it to anyone else.",
+    'You can change your mind any time. Reply STOP or call 270-555-COAL.',
+    "If you don't say yes, you still get help. We just won't share between agencies.",
+  ],
+  footer:
+    'Your name on the line at the bottom counts as your signature, like signing a paper form.',
+};
+
+const SMS_COPY: ConsentCopy = {
+  title: 'Can we text you?',
+  intro: "Saying yes lets us text you about beds, food, and your case. We won't share your number.",
+  bullets: [
+    'We text only about your situation.',
+    "Reply STOP at any time and we won't text again.",
+    'Standard text rates from your phone company may apply.',
+  ],
+  footer: 'Your name on the line below counts as your signature.',
+};
+
+const PROGRAM_EVAL_COPY: ConsentCopy = {
+  title: 'Can we use your info to make this program better?',
+  intro:
+    "We learn what works by looking at the patterns in everyone's stories. Saying yes lets us count what helped without sharing your name.",
+  bullets: [
+    'Your name and contact info are removed before we count.',
+    'We share only the patterns, not the people.',
+    'You can say no and still get every service.',
+  ],
+  footer: 'Your name on the line below counts as your signature.',
+};
+
+export function consentTextFor(consentType: ConsentType): ConsentCopy {
+  if (consentType === 'phi_share_within_coalition') return PHI_COPY;
+  if (consentType === 'sms_communication') return SMS_COPY;
+  return PROGRAM_EVAL_COPY;
+}

--- a/src/lib/dtrs/consent.test.ts
+++ b/src/lib/dtrs/consent.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from 'vitest';
+import type { Consent } from '@/db/schema/consents';
+import { consentCovers, consentNeedsRefresh, consentState } from './consent';
+import { CURRENT_CONSENT_VERSION } from './consent-text';
+
+const baseConsent = (overrides: Partial<Consent> = {}): Consent => ({
+  id: '11111111-1111-1111-1111-111111111111',
+  subjectExternalId: 'SYN-PERSON-001',
+  consentType: 'phi_share_within_coalition',
+  grantedVia: 'web_form',
+  consentVersion: CURRENT_CONSENT_VERSION,
+  scopePartnerIds: null,
+  scopeDataClasses: null,
+  signatureText: 'Sarah J',
+  expiresAt: null,
+  grantedAt: new Date('2026-01-01T00:00:00Z'),
+  revokedAt: null,
+  notes: null,
+  createdAt: new Date('2026-01-01T00:00:00Z'),
+  ...overrides,
+});
+
+const NOW = new Date('2026-04-26T12:00:00Z');
+
+describe('consentState', () => {
+  it('returns granted for an open-ended consent', () => {
+    expect(consentState(baseConsent(), NOW)).toBe('granted');
+  });
+
+  it('returns revoked when revoked_at is set, even before any expiry', () => {
+    expect(
+      consentState(
+        baseConsent({
+          revokedAt: new Date('2026-02-01T00:00:00Z'),
+          expiresAt: new Date('2027-01-01T00:00:00Z'),
+        }),
+        NOW,
+      ),
+    ).toBe('revoked');
+  });
+
+  it('returns expired when expires_at has passed', () => {
+    const c = baseConsent({ expiresAt: new Date('2026-04-01T00:00:00Z') });
+    expect(consentState(c, NOW)).toBe('expired');
+  });
+
+  it('still granted when expires_at is in the future', () => {
+    const c = baseConsent({ expiresAt: new Date('2027-01-01T00:00:00Z') });
+    expect(consentState(c, NOW)).toBe('granted');
+  });
+
+  it('revoked beats expired even if both timestamps are past', () => {
+    expect(
+      consentState(
+        baseConsent({
+          revokedAt: new Date('2026-03-01T00:00:00Z'),
+          expiresAt: new Date('2026-02-01T00:00:00Z'),
+        }),
+        NOW,
+      ),
+    ).toBe('revoked');
+  });
+});
+
+describe('consentCovers', () => {
+  it('null scopes mean coalition-wide', () => {
+    expect(consentCovers({ partnerOrgIds: null, dataClasses: null }, 'org1', 'health')).toBe(true);
+  });
+
+  it('rejects non-listed partners', () => {
+    const scope = { partnerOrgIds: ['org1'], dataClasses: null };
+    expect(consentCovers(scope, 'org2', 'identity')).toBe(false);
+  });
+
+  it('rejects non-listed data classes', () => {
+    const scope = { partnerOrgIds: null, dataClasses: ['identity'] };
+    expect(consentCovers(scope, 'org1', 'health')).toBe(false);
+  });
+
+  it('matches when both lists include the request', () => {
+    const scope = { partnerOrgIds: ['org1', 'org2'], dataClasses: ['identity', 'health'] };
+    expect(consentCovers(scope, 'org2', 'health')).toBe(true);
+  });
+});
+
+describe('consentNeedsRefresh', () => {
+  it('returns false for the current version', () => {
+    expect(consentNeedsRefresh(baseConsent())).toBe(false);
+  });
+
+  it('returns true for an older version', () => {
+    expect(consentNeedsRefresh(baseConsent({ consentVersion: '2025-01-1' }))).toBe(true);
+  });
+});

--- a/src/lib/dtrs/consent.ts
+++ b/src/lib/dtrs/consent.ts
@@ -1,0 +1,54 @@
+import type { Consent } from '@/db/schema/consents';
+import { CURRENT_CONSENT_VERSION } from './consent-text';
+
+export type ConsentState = 'granted' | 'revoked' | 'expired';
+
+/**
+ * Compute the live state of a consent record. Stored fields are the
+ * source of truth (granted_at, revoked_at, expires_at); the state is
+ * derived at read time so wall-clock changes (TTL passing) flip the
+ * label without a write.
+ *
+ * Order matters: revoked beats expired beats granted. A subject who
+ * revokes mid-window stays revoked even after the original window
+ * passes.
+ */
+export function consentState(c: Consent, now: Date = new Date()): ConsentState {
+  if (c.revokedAt) return 'revoked';
+  if (c.expiresAt && new Date(c.expiresAt).getTime() <= now.getTime()) return 'expired';
+  return 'granted';
+}
+
+export type ConsentScope = {
+  partnerOrgIds: string[] | null;
+  dataClasses: string[] | null;
+};
+
+/**
+ * True iff a consent in `granted` state covers the (partner_org, data_class)
+ * being requested. `null` scopes mean "any" — that's the default for
+ * coalition-wide consents that don't single out specific partners or data.
+ *
+ * Callers asking "can partner X see data class Y about subject Z?" should:
+ *   1. fetch consents WHERE subject_external_id = Z and consent_type = …
+ *   2. filter to consentState === 'granted'
+ *   3. check at least one row covers (X, Y) via this helper.
+ */
+export function consentCovers(
+  scope: ConsentScope,
+  partnerOrgId: string,
+  dataClass: string,
+): boolean {
+  const partnerOk = scope.partnerOrgIds === null || scope.partnerOrgIds.includes(partnerOrgId);
+  const classOk = scope.dataClasses === null || scope.dataClasses.includes(dataClass);
+  return partnerOk && classOk;
+}
+
+/**
+ * True if the consent text the subject saw is older than the current
+ * version. Doesn't invalidate the consent — surfaced in the dashboard
+ * as a re-prompt candidate.
+ */
+export function consentNeedsRefresh(c: Consent): boolean {
+  return c.consentVersion !== CURRENT_CONSENT_VERSION;
+}


### PR DESCRIPTION
Closes #49, #50, #53. Stacked on [#262](https://github.com/DobbsBoldry/homeless/pull/262).

## Summary
- **DTRS-001 — state machine**: `consents` schema extended with \`consent_version\`, \`scope_partner_ids\`, \`scope_data_classes\`, \`signature_text\`, \`expires_at\`. State (granted/revoked/expired) is *computed* at read time so a TTL passing flips the label without a write. \`consentState / consentCovers / consentNeedsRefresh\` helpers in \`src/lib/dtrs/consent.ts\` with 11 unit tests.
- **DTRS-002 — plain-language form**: \`ConsentForm\` client component, grade-6 copy in \`consent-text.ts\`, per-class toggle, typed-name signature. New unauthenticated route \`/p/[ref]/consent/grant?type=...\`. \`grantConsentAction\` writes a versioned row and audit-logs the grant; \`revokeVersionedConsentAction\` is idempotent.
- **DTRS-005 — advisor review**: \`docs/dtrs-005-advisor-review.md\` is the pre-session checklist + capture template + post-session steps. Engineering side ready; coalition side still has to schedule + pay the advisor before any real PHI flows (the gating step per BACKLOG).

147 tests passing (11 new). State precedence covered: revoked beats expired beats granted.

## Acceptance criteria
- DTRS-001:
  - [x] States: granted, scoped (partner + data class), revoked, expired
  - [x] Versioned (consent_version stamped at grant time)
  - [x] Partner-scoped + data-class-scoped
- DTRS-002:
  - [x] Plain-language form (grade-6 target, reviewed in DTRS-005)
  - [x] Signed (typed name as e-signature)
  - [x] Revocable (revoked_at flip, audit-logged)
- DTRS-005:
  - [x] Doc captures session prep + script + post-session next steps

## Test plan
- [ ] Visit \`/p/SYN-PERSON-001/consent/grant\` → form loads, grade-6 copy
- [ ] Submit blank signature → friendly error
- [ ] Submit with all classes unchecked → \"pick at least one\" error
- [ ] Submit valid → \"Saved\" confirmation; row appears in \`consents\`; audit_log row \`consent.granted\`
- [ ] Visit \`?type=sms_communication\` and \`?type=data_for_program_eval\` → different copy
- [ ] Bump \`CURRENT_CONSENT_VERSION\` locally → existing rows show as needing refresh in tests
- [ ] Schedule advisor session and follow \`docs/dtrs-005-advisor-review.md\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)