### PR TITLE
feat(CWT-007/008): benefits eligibility screener + dollar estimator

### DIFF
--- a/src/app/app/clients/screener/page.tsx
+++ b/src/app/app/clients/screener/page.tsx
@@ -1,0 +1,30 @@
+import { BenefitsScreener } from '@/components/cwt/benefits-screener';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { requireRole } from '@/lib/auth';
+
+export const dynamic = 'force-dynamic';
+
+export default async function BenefitsScreenerPage() {
+  await requireRole(['caseworker', 'shelter_staff', 'admin']);
+
+  return (
+    <div className="mx-auto max-w-5xl space-y-4 p-4 md:p-6">
+      <header>
+        <h1 className="font-serif text-3xl font-bold text-primary">Benefits screener</h1>
+        <p className="text-sm text-muted-foreground">
+          Quick eligibility screen across SNAP, KCHIP, Medicaid, KTAP, SSI, VA, and LIHEAP. Type the
+          household details on the left; results update live on the right. Nothing is saved.
+        </p>
+      </header>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">Household details</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <BenefitsScreener />
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/components/app-shell/nav-config.ts
+++ b/src/components/app-shell/nav-config.ts
@@ -41,6 +41,11 @@ export const NAV_ITEMS: NavItem[] = [
     roles: ['caseworker', 'ed_coordinator', 'shelter_staff', 'admin'],
   },
   {
+    label: 'Benefits screener',
+    href: '/app/clients/screener',
+    roles: ['caseworker', 'shelter_staff', 'admin'],
+  },
+  {
     label: 'Outcomes',
     href: '/app/metrics',
     roles: ['attorney', 'admin'],

--- a/src/components/cwt/benefits-screener.tsx
+++ b/src/components/cwt/benefits-screener.tsx
@@ -1,0 +1,204 @@
+'use client';
+
+import { useId, useMemo, useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import {
+  type EligibilityMatch,
+  fplPercent,
+  type Household,
+  screenHousehold,
+  totalLikelyMonthlyCents,
+} from '@/lib/cwt/benefits';
+
+const fmtMoney = (cents: number) =>
+  new Intl.NumberFormat('en-US', {
+    style: 'currency',
+    currency: 'USD',
+    maximumFractionDigits: 0,
+  }).format(cents / 100);
+
+const STATUS_BADGE: Record<EligibilityMatch['status'], string> = {
+  likely: 'bg-emerald-600/15 text-emerald-700 dark:text-emerald-400',
+  maybe: 'bg-amber-500/15 text-amber-700 dark:text-amber-400',
+  ineligible: 'bg-muted text-muted-foreground',
+};
+
+export function BenefitsScreener() {
+  const incomeId = useId();
+  const sizeId = useId();
+  const [household, setHousehold] = useState<Household>({
+    monthlyIncomeCents: 100_000,
+    householdSize: 1,
+    hasChildrenUnder18: false,
+    hasPregnantMember: false,
+    isVeteran: false,
+    isDisabled: false,
+    ageOldest: 35,
+    kyResident: true,
+    citizenOrQualified: true,
+  });
+
+  const results = useMemo(() => screenHousehold(household), [household]);
+  const totalLikely = useMemo(() => totalLikelyMonthlyCents(results), [results]);
+  const fplPct = useMemo(
+    () => fplPercent(household.monthlyIncomeCents, household.householdSize),
+    [household.monthlyIncomeCents, household.householdSize],
+  );
+
+  const set =
+    <K extends keyof Household>(key: K) =>
+    (value: Household[K]) => {
+      setHousehold((prev) => ({ ...prev, [key]: value }));
+    };
+
+  return (
+    <div className="grid gap-6 md:grid-cols-2">
+      <section className="space-y-4">
+        <h2 className="font-serif text-lg font-semibold">Household</h2>
+
+        <div className="space-y-1">
+          <Label htmlFor={incomeId}>Monthly income (gross, before deductions)</Label>
+          <Input
+            id={incomeId}
+            type="number"
+            inputMode="numeric"
+            min={0}
+            step={50}
+            value={Math.round(household.monthlyIncomeCents / 100)}
+            onChange={(e) => {
+              const dollars = Number.parseInt(e.target.value, 10);
+              set('monthlyIncomeCents')(Number.isFinite(dollars) ? Math.max(0, dollars) * 100 : 0);
+            }}
+          />
+          <p className="text-xs text-muted-foreground">{fplPct}% of the federal poverty line</p>
+        </div>
+
+        <div className="space-y-1">
+          <Label htmlFor={sizeId}>Household size</Label>
+          <Input
+            id={sizeId}
+            type="number"
+            inputMode="numeric"
+            min={1}
+            max={20}
+            value={household.householdSize}
+            onChange={(e) => {
+              const n = Number.parseInt(e.target.value, 10);
+              if (Number.isInteger(n) && n >= 1 && n <= 20) set('householdSize')(n);
+            }}
+          />
+        </div>
+
+        <div className="space-y-1">
+          <Label>Age of the oldest member</Label>
+          <Input
+            type="number"
+            inputMode="numeric"
+            min={0}
+            max={120}
+            value={household.ageOldest ?? ''}
+            onChange={(e) => {
+              const n = Number.parseInt(e.target.value, 10);
+              set('ageOldest')(Number.isInteger(n) ? n : null);
+            }}
+          />
+        </div>
+
+        <fieldset className="space-y-1">
+          <legend className="text-sm font-medium">Situation</legend>
+          {[
+            { k: 'hasChildrenUnder18', label: 'Children under 18 in household' },
+            { k: 'hasPregnantMember', label: 'Pregnant member' },
+            { k: 'isVeteran', label: 'Veteran' },
+            { k: 'isDisabled', label: 'Disabled or qualifying medical condition' },
+            { k: 'kyResident', label: 'Kentucky resident' },
+            {
+              k: 'citizenOrQualified',
+              label: 'US citizen OR qualified non-citizen (LPR 5+ yrs, refugee, etc.)',
+            },
+          ].map(({ k, label }) => (
+            <label
+              key={k}
+              className="flex items-center gap-2 rounded p-1.5 text-sm hover:bg-muted/40"
+            >
+              <input
+                type="checkbox"
+                checked={Boolean(household[k as keyof Household])}
+                onChange={(e) => {
+                  setHousehold((prev) => ({ ...prev, [k]: e.target.checked }));
+                }}
+                className="h-4 w-4"
+              />
+              {label}
+            </label>
+          ))}
+        </fieldset>
+
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          onClick={() =>
+            setHousehold({
+              monthlyIncomeCents: 100_000,
+              householdSize: 1,
+              hasChildrenUnder18: false,
+              hasPregnantMember: false,
+              isVeteran: false,
+              isDisabled: false,
+              ageOldest: 35,
+              kyResident: true,
+              citizenOrQualified: true,
+            })
+          }
+        >
+          Reset
+        </Button>
+      </section>
+
+      <section className="space-y-3">
+        <div className="flex items-baseline justify-between">
+          <h2 className="font-serif text-lg font-semibold">Likely benefits</h2>
+          {totalLikely > 0 ? (
+            <p className="text-sm">
+              Estimated <strong>{fmtMoney(totalLikely)}/mo</strong>
+            </p>
+          ) : null}
+        </div>
+        <ul className="space-y-2">
+          {results.map((r) => (
+            <li key={r.programId} className="rounded-md border border-border bg-card p-3 text-sm">
+              <div className="flex items-baseline justify-between gap-2">
+                <p className="font-medium">{r.programName}</p>
+                <span className={`rounded px-2 py-0.5 text-xs ${STATUS_BADGE[r.status]}`}>
+                  {r.status}
+                </span>
+              </div>
+              {r.estimatedMonthlyCents !== null ? (
+                <p className="mt-1 text-base font-semibold">
+                  ~{fmtMoney(r.estimatedMonthlyCents)}/mo
+                </p>
+              ) : null}
+              <p className="mt-1 text-muted-foreground">{r.reason}</p>
+              {r.status !== 'ineligible' ? (
+                <p className="mt-2 text-xs">{r.applicationPath}</p>
+              ) : null}
+            </li>
+          ))}
+        </ul>
+
+        <div className="rounded-md border border-amber-500/40 bg-amber-500/5 p-3 text-xs">
+          <p className="font-medium">[SAMPLE] estimates only.</p>
+          <p className="mt-1 text-muted-foreground">
+            Income thresholds and benefit amounts are based on 2024 federal poverty figures and
+            published KY program rules. Actual benefits depend on disregards, deductions, household
+            composition, and current funding. Use these as a starting point — verify with the
+            program before quoting an amount to a client.
+          </p>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/src/lib/cwt/benefits.test.ts
+++ b/src/lib/cwt/benefits.test.ts
@@ -1,0 +1,212 @@
+import { describe, expect, it } from 'vitest';
+import {
+  fplMonthlyCents,
+  fplPercent,
+  type Household,
+  screenHousehold,
+  totalLikelyMonthlyCents,
+} from './benefits';
+
+const baseHousehold = (overrides: Partial<Household> = {}): Household => ({
+  monthlyIncomeCents: 100_000, // $1,000 / mo
+  householdSize: 1,
+  hasChildrenUnder18: false,
+  hasPregnantMember: false,
+  isVeteran: false,
+  isDisabled: false,
+  ageOldest: 35,
+  kyResident: true,
+  citizenOrQualified: true,
+  ...overrides,
+});
+
+const findById = (results: ReturnType<typeof screenHousehold>, id: string) =>
+  results.find((r) => r.programId === id);
+
+describe('fplMonthlyCents', () => {
+  it('matches the 2024 HHS table for sizes 1-8', () => {
+    expect(fplMonthlyCents(1)).toBe(125_400);
+    expect(fplMonthlyCents(4)).toBe(257_400);
+    expect(fplMonthlyCents(8)).toBe(433_400);
+  });
+
+  it('extrapolates linearly above 8', () => {
+    expect(fplMonthlyCents(10)).toBe(433_400 + 2 * 44_000);
+  });
+
+  it('clamps non-positive household size to 1', () => {
+    expect(fplMonthlyCents(0)).toBe(125_400);
+  });
+});
+
+describe('fplPercent', () => {
+  it('returns income as percent of FPL with one decimal', () => {
+    // Single household, $1254/mo = 100% FPL.
+    expect(fplPercent(125_400, 1)).toBe(100);
+    // $627/mo single = 50%.
+    expect(fplPercent(62_700, 1)).toBe(50);
+  });
+});
+
+describe('screenHousehold — SNAP', () => {
+  it('marks SNAP likely for low-income KY resident citizen', () => {
+    const r = findById(screenHousehold(baseHousehold()), 'snap');
+    expect(r?.status).toBe('likely');
+    expect(r?.estimatedMonthlyCents).toBeGreaterThan(0);
+  });
+
+  it('marks SNAP ineligible above 130% FPL', () => {
+    const r = findById(screenHousehold(baseHousehold({ monthlyIncomeCents: 200_000 })), 'snap');
+    expect(r?.status).toBe('ineligible');
+  });
+
+  it('marks SNAP ineligible for non-KY resident', () => {
+    const r = findById(screenHousehold(baseHousehold({ kyResident: false })), 'snap');
+    expect(r?.status).toBe('ineligible');
+  });
+
+  it('marks SNAP maybe when citizenship is unclear', () => {
+    const r = findById(screenHousehold(baseHousehold({ citizenOrQualified: false })), 'snap');
+    expect(r?.status).toBe('maybe');
+  });
+});
+
+describe('screenHousehold — KCHIP', () => {
+  it('likely for kid-having low-income KY family', () => {
+    const r = findById(
+      screenHousehold(
+        baseHousehold({
+          householdSize: 4,
+          hasChildrenUnder18: true,
+          monthlyIncomeCents: 250_000,
+        }),
+      ),
+      'kchip',
+    );
+    expect(r?.status).toBe('likely');
+  });
+
+  it('ineligible without a child or pregnancy', () => {
+    const r = findById(screenHousehold(baseHousehold()), 'kchip');
+    expect(r?.status).toBe('ineligible');
+    expect(r?.reason).toMatch(/under 18/);
+  });
+});
+
+describe('screenHousehold — KTAP', () => {
+  it('likely for very-low-income family with kids', () => {
+    const r = findById(
+      screenHousehold(
+        baseHousehold({
+          householdSize: 3,
+          hasChildrenUnder18: true,
+          monthlyIncomeCents: 30_000, // $300 / mo
+        }),
+      ),
+      'ktap',
+    );
+    expect(r?.status).toBe('likely');
+    expect(r?.estimatedMonthlyCents).toBeGreaterThan(0);
+  });
+
+  it('maybe when income is borderline', () => {
+    const r = findById(
+      screenHousehold(
+        baseHousehold({
+          householdSize: 3,
+          hasChildrenUnder18: true,
+          monthlyIncomeCents: 80_000,
+        }),
+      ),
+      'ktap',
+    );
+    expect(r?.status).toBe('maybe');
+  });
+
+  it('ineligible without a child', () => {
+    const r = findById(screenHousehold(baseHousehold()), 'ktap');
+    expect(r?.status).toBe('ineligible');
+  });
+});
+
+describe('screenHousehold — SSI', () => {
+  it('likely for an aged or disabled household member with low income', () => {
+    const r = findById(
+      screenHousehold(baseHousehold({ ageOldest: 70, monthlyIncomeCents: 30_000 })),
+      'ssi',
+    );
+    expect(r?.status).toBe('likely');
+  });
+
+  it('ineligible for under-65 non-disabled', () => {
+    const r = findById(screenHousehold(baseHousehold({ ageOldest: 35 })), 'ssi');
+    expect(r?.status).toBe('ineligible');
+  });
+
+  it('maybe when income near or above SSI FBR', () => {
+    const r = findById(
+      screenHousehold(baseHousehold({ isDisabled: true, monthlyIncomeCents: 100_000 })),
+      'ssi',
+    );
+    expect(r?.status).toBe('maybe');
+  });
+});
+
+describe('screenHousehold — VA', () => {
+  it('marks VA maybe for any veteran', () => {
+    const r = findById(screenHousehold(baseHousehold({ isVeteran: true })), 'va_pension');
+    expect(r?.status).toBe('maybe');
+  });
+
+  it('ineligible for non-veteran', () => {
+    const r = findById(screenHousehold(baseHousehold()), 'va_pension');
+    expect(r?.status).toBe('ineligible');
+  });
+});
+
+describe('screenHousehold — LIHEAP', () => {
+  it('likely for KY resident under 130% FPL', () => {
+    const r = findById(screenHousehold(baseHousehold()), 'liheap');
+    expect(r?.status).toBe('likely');
+  });
+
+  it('ineligible above 130% FPL', () => {
+    const r = findById(screenHousehold(baseHousehold({ monthlyIncomeCents: 200_000 })), 'liheap');
+    expect(r?.status).toBe('ineligible');
+  });
+});
+
+describe('screenHousehold — sort order', () => {
+  it('puts likely first, maybe next, ineligible last', () => {
+    const results = screenHousehold(
+      baseHousehold({
+        householdSize: 4,
+        hasChildrenUnder18: true,
+        monthlyIncomeCents: 100_000,
+      }),
+    );
+    let phase = 0;
+    for (const r of results) {
+      const next = r.status === 'likely' ? 0 : r.status === 'maybe' ? 1 : 2;
+      expect(next).toBeGreaterThanOrEqual(phase);
+      phase = next;
+    }
+  });
+});
+
+describe('totalLikelyMonthlyCents', () => {
+  it('sums only likely matches with estimates', () => {
+    const results = screenHousehold(
+      baseHousehold({
+        householdSize: 3,
+        hasChildrenUnder18: true,
+        monthlyIncomeCents: 30_000,
+      }),
+    );
+    expect(totalLikelyMonthlyCents(results)).toBeGreaterThan(0);
+  });
+
+  it('returns 0 when no estimates', () => {
+    expect(totalLikelyMonthlyCents([])).toBe(0);
+  });
+});

--- a/src/lib/cwt/benefits.ts
+++ b/src/lib/cwt/benefits.ts
@@ -1,0 +1,423 @@
+/**
+ * Benefits eligibility rule engine (CWT-007) + dollar-value estimator
+ * (CWT-008). KY-specific income thresholds. Static rules first; the
+ * vocabulary is intentionally narrow because every program has dozens
+ * of edge cases the legal team will refine over Phase 2.
+ *
+ * Every rule output is marked `[SAMPLE]` in copy until a verification
+ * pass against current KY DCBS / KHC / SSA documentation lands. The
+ * caseworker UI surfaces this prominently so no one acts on a number
+ * before it's been reviewed.
+ *
+ * Federal Poverty Level numbers are 2024 (HHS) — the working set we
+ * have access to today. Bump these when 2025/2026 numbers publish.
+ */
+
+/** Monthly income, in CENTS, that equals 100% of FPL by household size. */
+export const FPL_2024_MONTHLY_CENTS: Record<number, number> = {
+  1: 125_400, // $1,254 / mo
+  2: 169_400,
+  3: 213_400,
+  4: 257_400,
+  5: 301_400,
+  6: 345_400,
+  7: 389_400,
+  8: 433_400,
+};
+
+/** Each additional household member above 8. */
+const FPL_2024_PER_ADDL_CENTS = 44_000;
+
+export function fplMonthlyCents(householdSize: number): number {
+  if (householdSize <= 0) return FPL_2024_MONTHLY_CENTS[1];
+  if (householdSize <= 8) return FPL_2024_MONTHLY_CENTS[householdSize];
+  const over = householdSize - 8;
+  return FPL_2024_MONTHLY_CENTS[8] + over * FPL_2024_PER_ADDL_CENTS;
+}
+
+export function fplPercent(monthlyIncomeCents: number, householdSize: number): number {
+  const baseline = fplMonthlyCents(householdSize);
+  if (baseline <= 0) return 0;
+  return Math.round((monthlyIncomeCents / baseline) * 1000) / 10; // one decimal place
+}
+
+export type Household = {
+  monthlyIncomeCents: number;
+  householdSize: number;
+  hasChildrenUnder18: boolean;
+  hasPregnantMember: boolean;
+  isVeteran: boolean;
+  isDisabled: boolean;
+  /** Age of the oldest household member; affects SSI / Medicare paths. */
+  ageOldest?: number | null;
+  kyResident: boolean;
+  /** US citizen or qualified non-citizen. SNAP / KCHIP gate this. */
+  citizenOrQualified: boolean;
+};
+
+export type ProgramId =
+  | 'snap'
+  | 'kchip'
+  | 'medicaid_adult'
+  | 'ktap'
+  | 'ssi'
+  | 'va_pension'
+  | 'liheap';
+
+export type EligibilityMatch = {
+  programId: ProgramId;
+  programName: string;
+  /** "likely" / "maybe" / "ineligible". Maybe = caseworker should verify. */
+  status: 'likely' | 'maybe' | 'ineligible';
+  /** 1-2 sentences of plain-language reasoning. */
+  reason: string;
+  /** Estimated monthly dollar value (cents). null when not estimable. */
+  estimatedMonthlyCents: number | null;
+  /** How to apply — phone number / website / in-person path. */
+  applicationPath: string;
+  /** Display order priority; lower = surfaced first. */
+  priority: number;
+};
+
+/** SNAP gross-income test: 130% FPL for most households. */
+function evaluateSnap(h: Household): EligibilityMatch {
+  const fplPct = fplPercent(h.monthlyIncomeCents, h.householdSize);
+  if (!h.kyResident) {
+    return mk('snap', 'SNAP food benefits', 'ineligible', 'Must be a Kentucky resident.', null, 5);
+  }
+  if (!h.citizenOrQualified) {
+    return mk(
+      'snap',
+      'SNAP food benefits',
+      'maybe',
+      'Citizenship rules limit SNAP. Some non-citizens still qualify (refugees, lawful permanent residents past 5 years, others). Caseworker should verify.',
+      null,
+      5,
+    );
+  }
+  if (fplPct <= 130) {
+    // SNAP formula (rough): benefit = max − 0.3 × (gross − standard deduction).
+    // 2024 standard deduction for HH ≤ 3 is $198/mo, scaling up. We use a
+    // flat $200 to keep the estimator readable; actuals are off by a few
+    // dollars and the screener marks every output [SAMPLE] anyway.
+    const STD_DEDUCTION_CENTS = 20_000;
+    const max = snapMaxMonthlyCents(h.householdSize);
+    const net = Math.max(0, h.monthlyIncomeCents - STD_DEDUCTION_CENTS);
+    const estimate = Math.max(0, Math.round(max - net * 0.3));
+    return mk(
+      'snap',
+      'SNAP food benefits',
+      'likely',
+      `Income is ${fplPct}% of poverty line — under the 130% gross-income limit for SNAP.`,
+      Math.min(max, estimate),
+      1,
+    );
+  }
+  return mk(
+    'snap',
+    'SNAP food benefits',
+    'ineligible',
+    `Gross income (${fplPct}% FPL) exceeds the 130% SNAP gross-income limit.`,
+    null,
+    5,
+  );
+}
+
+/** Max SNAP allotment by household size (FY2024 CONUS). */
+function snapMaxMonthlyCents(householdSize: number): number {
+  const TABLE: Record<number, number> = {
+    1: 29_100,
+    2: 53_500,
+    3: 76_600,
+    4: 97_300,
+    5: 115_500,
+    6: 138_600,
+    7: 153_200,
+    8: 175_100,
+  };
+  if (householdSize <= 0) return TABLE[1];
+  if (householdSize <= 8) return TABLE[householdSize];
+  return TABLE[8] + (householdSize - 8) * 21_900;
+}
+
+/** KCHIP: KY children's Medicaid, up to 218% FPL. */
+function evaluateKchip(h: Household): EligibilityMatch {
+  if (!h.kyResident) {
+    return mk('kchip', 'KCHIP children\u2019s Medicaid', 'ineligible', 'KY-only program.', null, 7);
+  }
+  if (!h.hasChildrenUnder18 && !h.hasPregnantMember) {
+    return mk(
+      'kchip',
+      'KCHIP children\u2019s Medicaid',
+      'ineligible',
+      'KCHIP covers children under 18 (and pregnant household members). No qualifying member listed.',
+      null,
+      7,
+    );
+  }
+  const fplPct = fplPercent(h.monthlyIncomeCents, h.householdSize);
+  if (fplPct <= 218) {
+    return mk(
+      'kchip',
+      'KCHIP children\u2019s Medicaid',
+      'likely',
+      `Income (${fplPct}% FPL) is within the 218% threshold for KCHIP.`,
+      null,
+      2,
+    );
+  }
+  return mk(
+    'kchip',
+    'KCHIP children\u2019s Medicaid',
+    'ineligible',
+    `Income (${fplPct}% FPL) exceeds the 218% KCHIP threshold.`,
+    null,
+    7,
+  );
+}
+
+/** Adult Medicaid expansion (KY): up to 138% FPL. */
+function evaluateMedicaidAdult(h: Household): EligibilityMatch {
+  if (!h.kyResident) {
+    return mk('medicaid_adult', 'KY Medicaid (adult)', 'ineligible', 'KY-only program.', null, 8);
+  }
+  const fplPct = fplPercent(h.monthlyIncomeCents, h.householdSize);
+  if (fplPct <= 138) {
+    return mk(
+      'medicaid_adult',
+      'KY Medicaid (adult expansion)',
+      'likely',
+      `Income (${fplPct}% FPL) is within the 138% threshold for adult Medicaid.`,
+      null,
+      3,
+    );
+  }
+  return mk(
+    'medicaid_adult',
+    'KY Medicaid (adult expansion)',
+    'ineligible',
+    `Income (${fplPct}% FPL) exceeds the 138% adult Medicaid threshold.`,
+    null,
+    8,
+  );
+}
+
+/** KTAP — KY's TANF: families with children, ~30% FPL after disregards. */
+function evaluateKtap(h: Household): EligibilityMatch {
+  if (!h.kyResident) return mk('ktap', 'KTAP cash assistance', 'ineligible', 'KY-only.', null, 9);
+  if (!h.hasChildrenUnder18) {
+    return mk(
+      'ktap',
+      'KTAP cash assistance',
+      'ineligible',
+      'KTAP requires a dependent child in the household.',
+      null,
+      9,
+    );
+  }
+  const fplPct = fplPercent(h.monthlyIncomeCents, h.householdSize);
+  if (fplPct <= 30) {
+    // Rough KTAP base: $186/mo for 1, $234 for 2, $292 for 3 — rounded.
+    const base = ktapMonthlyCents(h.householdSize);
+    return mk(
+      'ktap',
+      'KTAP cash assistance',
+      'likely',
+      `Income (${fplPct}% FPL) is well below KTAP's working threshold.`,
+      base,
+      4,
+    );
+  }
+  if (fplPct <= 50) {
+    return mk(
+      'ktap',
+      'KTAP cash assistance',
+      'maybe',
+      `Income (${fplPct}% FPL) is borderline. Disregards (childcare, work expenses) may bring it under the limit.`,
+      null,
+      4,
+    );
+  }
+  return mk(
+    'ktap',
+    'KTAP cash assistance',
+    'ineligible',
+    `Income (${fplPct}% FPL) exceeds KTAP's threshold even with typical disregards.`,
+    null,
+    9,
+  );
+}
+
+function ktapMonthlyCents(householdSize: number): number {
+  const TABLE: Record<number, number> = {
+    1: 18_600,
+    2: 23_400,
+    3: 29_200,
+    4: 35_900,
+    5: 41_500,
+    6: 47_000,
+    7: 52_600,
+    8: 58_100,
+  };
+  if (householdSize <= 0) return TABLE[1];
+  if (householdSize <= 8) return TABLE[householdSize];
+  return TABLE[8] + (householdSize - 8) * 5_500;
+}
+
+function evaluateSsi(h: Household): EligibilityMatch {
+  const ageBased = (h.ageOldest ?? 0) >= 65;
+  if (!h.isDisabled && !ageBased) {
+    return mk(
+      'ssi',
+      'SSI (Supplemental Security Income)',
+      'ineligible',
+      'SSI requires either a qualifying disability OR age 65+.',
+      null,
+      10,
+    );
+  }
+  // 2024 SSI federal benefit rate: $943/mo individual.
+  const SSI_FBR_INDIVIDUAL_CENTS = 94_300;
+  if (h.monthlyIncomeCents >= SSI_FBR_INDIVIDUAL_CENTS) {
+    return mk(
+      'ssi',
+      'SSI (Supplemental Security Income)',
+      'maybe',
+      'Income is near or above the SSI federal benefit rate. SSA still applies disregards (first $20 + first $65 of earned income); a caseworker should verify.',
+      null,
+      6,
+    );
+  }
+  // Estimate: FBR minus countable income (rough — SSA disregards $20 unearned + $65 earned + ½ remainder).
+  const countable = Math.max(0, h.monthlyIncomeCents - 2_000);
+  const estimate = Math.max(0, SSI_FBR_INDIVIDUAL_CENTS - countable);
+  return mk(
+    'ssi',
+    'SSI (Supplemental Security Income)',
+    'likely',
+    ageBased ? 'Age 65+ and income below SSI cap.' : 'Disability + income below SSI cap.',
+    estimate,
+    5,
+  );
+}
+
+function evaluateVa(h: Household): EligibilityMatch {
+  if (!h.isVeteran) {
+    return mk(
+      'va_pension',
+      'VA pension / benefits',
+      'ineligible',
+      'VA benefits require veteran status.',
+      null,
+      11,
+    );
+  }
+  return mk(
+    'va_pension',
+    'VA pension / benefits',
+    'maybe',
+    'Several veterans benefits apply (HUD-VASH housing voucher, VA pension, healthcare). Eligibility depends on service period and income; a Veterans Service Officer review is the right next step.',
+    null,
+    6,
+  );
+}
+
+function evaluateLiheap(h: Household): EligibilityMatch {
+  if (!h.kyResident) {
+    return mk('liheap', 'LIHEAP utility assistance', 'ineligible', 'KY-only.', null, 12);
+  }
+  // KY LIHEAP threshold: 130% FPL (winter / summer programs vary slightly).
+  const fplPct = fplPercent(h.monthlyIncomeCents, h.householdSize);
+  if (fplPct <= 130) {
+    return mk(
+      'liheap',
+      'LIHEAP utility assistance',
+      'likely',
+      `Income (${fplPct}% FPL) is within KY LIHEAP's 130% threshold.`,
+      null,
+      3,
+    );
+  }
+  return mk(
+    'liheap',
+    'LIHEAP utility assistance',
+    'ineligible',
+    `Income (${fplPct}% FPL) exceeds the 130% LIHEAP threshold.`,
+    null,
+    11,
+  );
+}
+
+const APPLICATION_PATHS: Record<ProgramId, string> = {
+  snap: 'Apply at benefind.ky.gov or call DCBS at +1-855-306-8959.',
+  kchip: 'Apply at kynect.ky.gov or call +1-855-459-6328.',
+  medicaid_adult: 'Apply at kynect.ky.gov or call +1-855-459-6328.',
+  ktap: 'Apply at benefind.ky.gov or your local DCBS office.',
+  ssi: 'Apply at ssa.gov/benefits/ssi or call +1-800-772-1213.',
+  va_pension: 'Contact a KY Department of Veterans Affairs benefits counselor at +1-502-595-4447.',
+  liheap: 'Apply through Audubon Area Community Services at +1-270-686-1600 (Daviess County).',
+};
+
+const PROGRAM_NAMES: Record<ProgramId, string> = {
+  snap: 'SNAP food benefits',
+  kchip: 'KCHIP children\u2019s Medicaid',
+  medicaid_adult: 'KY Medicaid (adult expansion)',
+  ktap: 'KTAP cash assistance',
+  ssi: 'SSI (Supplemental Security Income)',
+  va_pension: 'VA pension / benefits',
+  liheap: 'LIHEAP utility assistance',
+};
+
+function mk(
+  id: ProgramId,
+  _displayName: string,
+  status: EligibilityMatch['status'],
+  reason: string,
+  estimatedMonthlyCents: number | null,
+  priority: number,
+): EligibilityMatch {
+  return {
+    programId: id,
+    programName: PROGRAM_NAMES[id],
+    status,
+    reason,
+    estimatedMonthlyCents,
+    applicationPath: APPLICATION_PATHS[id],
+    priority,
+  };
+}
+
+/**
+ * Run every program rule against the household. Results are sorted with
+ * 'likely' first, 'maybe' next, ineligible last; ties broken by `priority`.
+ */
+export function screenHousehold(h: Household): EligibilityMatch[] {
+  const results = [
+    evaluateSnap(h),
+    evaluateKchip(h),
+    evaluateMedicaidAdult(h),
+    evaluateKtap(h),
+    evaluateSsi(h),
+    evaluateVa(h),
+    evaluateLiheap(h),
+  ];
+  const statusRank: Record<EligibilityMatch['status'], number> = {
+    likely: 0,
+    maybe: 1,
+    ineligible: 2,
+  };
+  results.sort((a, b) => {
+    if (statusRank[a.status] !== statusRank[b.status]) {
+      return statusRank[a.status] - statusRank[b.status];
+    }
+    return a.priority - b.priority;
+  });
+  return results;
+}
+
+/** Total estimated monthly $ across all 'likely' matches. */
+export function totalLikelyMonthlyCents(matches: EligibilityMatch[]): number {
+  return matches
+    .filter((m) => m.status === 'likely' && m.estimatedMonthlyCents !== null)
+    .reduce((sum, m) => sum + (m.estimatedMonthlyCents ?? 0), 0);
+}


### PR DESCRIPTION
Closes #45, #46. Stacked on #264 (DTRS-003/004).

## Summary
- Pure **rule engine** in `src/lib/cwt/benefits.ts` covering SNAP, KCHIP, KY adult Medicaid, KTAP, SSI, VA pension, LIHEAP. KY-specific income thresholds against 2024 FPL; gross-income tests where public, conservative "maybe" on edge cases (citizenship, SSI disregards, KTAP borderline).
- **Dollar estimates** where computable: SNAP, SSI, KTAP. KCHIP / Medicaid / VA / LIHEAP are status-only (amounts depend on factors the screener doesn't capture).
- Sort order: likely → maybe → ineligible, ties broken by per-program priority so highest-yield programs surface first.
- `BenefitsScreener` client component — left panel collects gross income / size / population flags; right panel updates live with status badges, application paths, "~$X/mo total" headline.
- New route `/app/clients/screener` (caseworker / shelter_staff / admin). **Stateless** — nothing persists.
- 23 new unit tests; 179 total passing.
- Every output marked **[SAMPLE]** until DCBS / KHC / SSA verification pass.

## Acceptance criteria
- CWT-007: SNAP, KCHIP, KTAP, SSI, VA, LIHEAP rules ✓ (plus adult Medicaid as a 7th, since KY's expansion materially affects this caseload)
- CWT-008: "You'd qualify for ~$X/mo, here's how to apply" ✓ for SNAP / KTAP / SSI; status-only for the rest with explicit reasoning
- KY-specific thresholds ✓
- 179 tests passing total + production build clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)