### PR TITLE
feat(CWT-009): rule-based triage tier recommendation

### DIFF
--- a/src/app/app/clients/triage/page.tsx
+++ b/src/app/app/clients/triage/page.tsx
@@ -1,0 +1,31 @@
+import { TriageTierTool } from '@/components/cwt/triage-tier';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { requireRole } from '@/lib/auth';
+
+export const dynamic = 'force-dynamic';
+
+export default async function TriageTierPage() {
+  await requireRole(['caseworker', 'shelter_staff', 'admin']);
+
+  return (
+    <div className="mx-auto max-w-5xl space-y-4 p-4 md:p-6">
+      <header>
+        <h1 className="font-serif text-3xl font-bold text-primary">Triage tier</h1>
+        <p className="text-sm text-muted-foreground">
+          Quick rule-based recommendation for a household's housing-stability potential. Each
+          factor's weight is shown so you can argue with the result rather than just accept it.
+          Nothing is saved.
+        </p>
+      </header>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">Household details</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <TriageTierTool />
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/components/app-shell/nav-config.ts
+++ b/src/components/app-shell/nav-config.ts
@@ -46,6 +46,11 @@ export const NAV_ITEMS: NavItem[] = [
     roles: ['caseworker', 'shelter_staff', 'admin'],
   },
   {
+    label: 'Triage tier',
+    href: '/app/clients/triage',
+    roles: ['caseworker', 'shelter_staff', 'admin'],
+  },
+  {
     label: 'Outcomes',
     href: '/app/metrics',
     roles: ['attorney', 'admin'],

--- a/src/components/cwt/triage-tier.tsx
+++ b/src/components/cwt/triage-tier.tsx
@@ -1,0 +1,153 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { recommendTriageTier, type TriageInputs, type TriageTier } from '@/lib/cwt/triage';
+
+const TIER_BADGE: Record<TriageTier, string> = {
+  high: 'bg-emerald-600/15 text-emerald-700 dark:text-emerald-400',
+  medium: 'bg-amber-500/15 text-amber-700 dark:text-amber-400',
+  low: 'bg-destructive/15 text-destructive',
+};
+
+const TIER_LABEL: Record<TriageTier, string> = {
+  high: 'High potential',
+  medium: 'Medium potential',
+  low: 'High intensity needed',
+};
+
+const FIELDS: Array<{ k: keyof TriageInputs; label: string; type: 'bool' | 'count' }> = [
+  {
+    k: 'hasStableIncome',
+    label: 'Stable income source (job, SSI, retirement, etc.)',
+    type: 'bool',
+  },
+  { k: 'hasVoucher', label: 'Active rental-assistance voucher', type: 'bool' },
+  { k: 'isEmployed', label: 'Currently employed (any hours)', type: 'bool' },
+  { k: 'hasCaseworkerRelationship', label: 'Existing caseworker relationship', type: 'bool' },
+  { k: 'inSudTreatment', label: 'Engaged in SUD treatment (when relevant)', type: 'bool' },
+  { k: 'inMentalHealthTreatment', label: 'Engaged in mental-health treatment', type: 'bool' },
+  { k: 'recentEvictionCount', label: 'Evictions in last 24 months', type: 'count' },
+  { k: 'daysUnsheltered', label: 'Days unsheltered in last 12 months', type: 'count' },
+  { k: 'hasChildrenUnder18', label: 'Children under 18 in household', type: 'bool' },
+  { k: 'isDvSurvivor', label: 'DV survivor (routing only — no scoring impact)', type: 'bool' },
+  { k: 'hasId', label: 'Has photo ID', type: 'bool' },
+  { k: 'hasSsn', label: 'Has Social Security card', type: 'bool' },
+  { k: 'hasBirthCert', label: 'Has birth certificate', type: 'bool' },
+];
+
+const blankInputs = (): TriageInputs => ({
+  hasStableIncome: false,
+  hasVoucher: false,
+  isEmployed: false,
+  hasCaseworkerRelationship: false,
+  inSudTreatment: false,
+  inMentalHealthTreatment: false,
+  recentEvictionCount: 0,
+  daysUnsheltered: 0,
+  hasChildrenUnder18: false,
+  isDvSurvivor: false,
+  hasId: false,
+  hasSsn: false,
+  hasBirthCert: false,
+});
+
+export function TriageTierTool() {
+  const [inputs, setInputs] = useState<TriageInputs>(() => blankInputs());
+  const result = useMemo(() => recommendTriageTier(inputs), [inputs]);
+
+  return (
+    <div className="grid gap-6 md:grid-cols-2">
+      <section className="space-y-2">
+        <h2 className="font-serif text-lg font-semibold">Stability factors</h2>
+        <ul className="space-y-1">
+          {FIELDS.map(({ k, label, type }) => (
+            <li key={k} className="rounded p-1.5 hover:bg-muted/40">
+              {type === 'bool' ? (
+                <label className="flex items-center gap-2 text-sm">
+                  <input
+                    type="checkbox"
+                    checked={Boolean(inputs[k])}
+                    onChange={(e) =>
+                      setInputs((prev) => ({ ...prev, [k]: e.target.checked }) as TriageInputs)
+                    }
+                    className="h-4 w-4"
+                  />
+                  {label}
+                </label>
+              ) : (
+                <label className="flex items-center justify-between gap-2 text-sm">
+                  <span>{label}</span>
+                  <input
+                    type="number"
+                    min={0}
+                    max={365}
+                    value={inputs[k] as number}
+                    onChange={(e) => {
+                      const n = Number.parseInt(e.target.value, 10);
+                      setInputs(
+                        (prev) =>
+                          ({ ...prev, [k]: Number.isInteger(n) && n >= 0 ? n : 0 }) as TriageInputs,
+                      );
+                    }}
+                    className="h-9 w-20 rounded-md border border-input bg-background px-2 text-sm"
+                  />
+                </label>
+              )}
+            </li>
+          ))}
+        </ul>
+        <Button type="button" variant="outline" size="sm" onClick={() => setInputs(blankInputs())}>
+          Reset
+        </Button>
+      </section>
+
+      <section className="space-y-3">
+        <div className="flex items-baseline justify-between">
+          <h2 className="font-serif text-lg font-semibold">Recommendation</h2>
+          <span className={`rounded px-2 py-0.5 text-xs font-medium ${TIER_BADGE[result.tier]}`}>
+            {TIER_LABEL[result.tier]}
+          </span>
+        </div>
+        <div className="rounded-md border border-border bg-card p-4">
+          <p className="text-xs uppercase tracking-wide text-muted-foreground">Score</p>
+          <p className="text-3xl font-semibold">{result.score} / 100</p>
+          <p className="mt-3 text-sm">{result.recommendation}</p>
+        </div>
+        <div>
+          <p className="text-xs uppercase tracking-wide text-muted-foreground">Factors</p>
+          <ul className="mt-1 space-y-1 text-sm">
+            {result.factors.length === 0 ? (
+              <li className="text-muted-foreground">No factors triggered yet.</li>
+            ) : (
+              result.factors.map((f) => (
+                <li key={f.label} className="flex items-baseline justify-between gap-2">
+                  <span>{f.label}</span>
+                  <span
+                    className={`font-mono text-xs ${
+                      f.delta > 0
+                        ? 'text-emerald-600 dark:text-emerald-400'
+                        : f.delta < 0
+                          ? 'text-destructive'
+                          : 'text-muted-foreground'
+                    }`}
+                  >
+                    {f.delta > 0 ? `+${f.delta}` : f.delta}
+                  </span>
+                </li>
+              ))
+            )}
+          </ul>
+        </div>
+        <div className="rounded-md border border-amber-500/40 bg-amber-500/5 p-3 text-xs">
+          <p className="font-medium">Rule-based v1.</p>
+          <p className="mt-1 text-muted-foreground">
+            Tier comes from a transparent additive score. Phase 2 replaces this with an ML model
+            trained on labeled outcomes from the pilot. Override the recommendation any time —
+            overrides themselves become training data.
+          </p>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/src/lib/cwt/triage.test.ts
+++ b/src/lib/cwt/triage.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from 'vitest';
+import { recommendTriageTier, type TriageInputs } from './triage';
+
+const baseInputs = (overrides: Partial<TriageInputs> = {}): TriageInputs => ({
+  hasStableIncome: false,
+  hasVoucher: false,
+  isEmployed: false,
+  hasCaseworkerRelationship: false,
+  inSudTreatment: false,
+  inMentalHealthTreatment: false,
+  recentEvictionCount: 0,
+  daysUnsheltered: 0,
+  hasChildrenUnder18: false,
+  isDvSurvivor: false,
+  hasId: false,
+  hasSsn: false,
+  hasBirthCert: false,
+  ...overrides,
+});
+
+describe('recommendTriageTier', () => {
+  it('returns medium tier for the empty/baseline case (score 50)', () => {
+    const r = recommendTriageTier(baseInputs());
+    expect(r.tier).toBe('medium');
+    expect(r.score).toBe(50);
+    expect(r.factors).toEqual([]);
+  });
+
+  it('high tier for stable income + voucher + employed', () => {
+    const r = recommendTriageTier(
+      baseInputs({ hasStableIncome: true, hasVoucher: true, isEmployed: true }),
+    );
+    expect(r.tier).toBe('high');
+    expect(r.score).toBeGreaterThanOrEqual(67);
+  });
+
+  it('low tier for severe instability', () => {
+    const r = recommendTriageTier(baseInputs({ recentEvictionCount: 3, daysUnsheltered: 120 }));
+    expect(r.tier).toBe('low');
+    expect(r.score).toBeLessThanOrEqual(32);
+  });
+
+  it('clamps score to [0, 100]', () => {
+    const veryHigh = recommendTriageTier(
+      baseInputs({
+        hasStableIncome: true,
+        hasVoucher: true,
+        isEmployed: true,
+        hasCaseworkerRelationship: true,
+        inSudTreatment: true,
+        inMentalHealthTreatment: true,
+        hasId: true,
+        hasSsn: true,
+        hasBirthCert: true,
+      }),
+    );
+    expect(veryHigh.score).toBeLessThanOrEqual(100);
+    expect(veryHigh.tier).toBe('high');
+
+    const veryLow = recommendTriageTier(
+      baseInputs({ recentEvictionCount: 5, daysUnsheltered: 365 }),
+    );
+    expect(veryLow.score).toBeGreaterThanOrEqual(0);
+    expect(veryLow.tier).toBe('low');
+  });
+
+  it('records each factor that fires, with non-zero delta', () => {
+    const r = recommendTriageTier(baseInputs({ hasStableIncome: true, recentEvictionCount: 2 }));
+    const labels = r.factors.map((f) => f.label);
+    expect(labels).toContain('Stable income source');
+    expect(labels.some((l) => l.startsWith('2 evictions'))).toBe(true);
+  });
+
+  it('children + DV are surfaced as factors but DV is delta=0 (handling-routing only)', () => {
+    const r = recommendTriageTier(baseInputs({ hasChildrenUnder18: true, isDvSurvivor: true }));
+    const dv = r.factors.find((f) => f.label.includes('DV survivor'));
+    expect(dv?.delta).toBe(0);
+    const kids = r.factors.find((f) => f.label.includes('Children under 18'));
+    expect(kids?.delta).toBeGreaterThan(0);
+  });
+
+  it('returns a tier-appropriate recommendation', () => {
+    const high = recommendTriageTier(baseInputs({ hasVoucher: true, hasStableIncome: true }));
+    expect(high.recommendation).toMatch(/light-touch/);
+    const low = recommendTriageTier(baseInputs({ recentEvictionCount: 3, daysUnsheltered: 120 }));
+    expect(low.recommendation).toMatch(/Recuperative Care|PSH/);
+  });
+});

--- a/src/lib/cwt/triage.ts
+++ b/src/lib/cwt/triage.ts
@@ -1,0 +1,137 @@
+/**
+ * Triage tier recommendation (CWT-009). Rule-based v1; the BACKLOG
+ * explicitly calls this out as a placeholder to be replaced by ML in
+ * Phase 2 once enough labeled outcomes exist. The whole point right
+ * now is consistency — give caseworkers a tier they can argue with,
+ * not predict outcomes precisely.
+ *
+ * Output: tier ∈ {high, medium, low} reflecting "housing-stability
+ * potential" (high = most likely to stabilize quickly with the right
+ * supports; low = needs the most intensive intervention). Score is
+ * 0-100; the tier bands are deliberately wide so a small input change
+ * doesn't flip a tier.
+ *
+ * Every contribution is captured in `factors` so the caseworker UI
+ * can show "this is high tier because: stable income source, prior
+ * housing history, no recent evictions" — explainable by design.
+ */
+
+export type TriageInputs = {
+  /** Stable income source (job, SSI, disability, retirement, etc.). */
+  hasStableIncome: boolean;
+  /** Active rental-assistance voucher in hand. */
+  hasVoucher: boolean;
+  /** Currently employed (any hours). */
+  isEmployed: boolean;
+  /** Existing relationship with a caseworker (current or recent). */
+  hasCaseworkerRelationship: boolean;
+  /** Currently engaged in substance-use treatment, if relevant. */
+  inSudTreatment: boolean;
+  /** Currently engaged in mental-health treatment, if relevant. */
+  inMentalHealthTreatment: boolean;
+  /** Number of evictions in the last 24 months (0 = none). */
+  recentEvictionCount: number;
+  /** Days unsheltered in the last 12 months (0 if always housed/sheltered). */
+  daysUnsheltered: number;
+  /** Children in household — adds urgency, not stability per se. */
+  hasChildrenUnder18: boolean;
+  /** Domestic-violence survivor — DTRS-004 abuser-blind handling already applies. */
+  isDvSurvivor: boolean;
+  /** Documents in hand: ID, SSN, birth certificate. Each ~5 stability points. */
+  hasId: boolean;
+  hasSsn: boolean;
+  hasBirthCert: boolean;
+};
+
+export type TriageFactor = {
+  /** Plain-language label shown in the UI. */
+  label: string;
+  /** +N raises stability tier; -N lowers. */
+  delta: number;
+};
+
+export type TriageTier = 'high' | 'medium' | 'low';
+
+export type TriageResult = {
+  tier: TriageTier;
+  /** 0-100 score; band thresholds are 33 / 67. */
+  score: number;
+  factors: TriageFactor[];
+  /** When tier == 'low', a one-line "what to do next" suggestion. */
+  recommendation: string;
+};
+
+const BASE_SCORE = 50;
+const TIER_LOW_MAX = 32;
+const TIER_HIGH_MIN = 67;
+
+/**
+ * Pure scorer. Each factor pushes the score up or down; the final
+ * tier is just a banding of the clamped score. Deliberately small set
+ * — broader feature space is what Phase 2's ML replacement is for.
+ */
+export function recommendTriageTier(inputs: TriageInputs): TriageResult {
+  const factors: TriageFactor[] = [];
+
+  if (inputs.hasStableIncome) factors.push({ label: 'Stable income source', delta: +12 });
+  if (inputs.hasVoucher) factors.push({ label: 'Active rental-assistance voucher', delta: +18 });
+  if (inputs.isEmployed) factors.push({ label: 'Currently employed', delta: +10 });
+  if (inputs.hasCaseworkerRelationship)
+    factors.push({ label: 'Existing caseworker relationship', delta: +6 });
+  if (inputs.inSudTreatment) factors.push({ label: 'Engaged in SUD treatment', delta: +5 });
+  if (inputs.inMentalHealthTreatment)
+    factors.push({ label: 'Engaged in mental-health treatment', delta: +5 });
+
+  if (inputs.recentEvictionCount === 1)
+    factors.push({ label: '1 eviction in last 24 months', delta: -8 });
+  else if (inputs.recentEvictionCount >= 2)
+    factors.push({
+      label: `${inputs.recentEvictionCount} evictions in last 24 months`,
+      delta: -16,
+    });
+
+  if (inputs.daysUnsheltered >= 30 && inputs.daysUnsheltered < 90)
+    factors.push({ label: '30-89 days unsheltered in last year', delta: -8 });
+  else if (inputs.daysUnsheltered >= 90)
+    factors.push({ label: '90+ days unsheltered in last year', delta: -16 });
+
+  if (inputs.hasChildrenUnder18)
+    factors.push({ label: 'Children under 18 in household — prioritize', delta: +4 });
+
+  if (inputs.isDvSurvivor)
+    factors.push({
+      label: 'DV survivor — route through OASIS + abuser-blind handling',
+      delta: +0,
+    });
+
+  // Documents in hand are small individual signals but additive.
+  let docPoints = 0;
+  if (inputs.hasId) docPoints += 4;
+  if (inputs.hasSsn) docPoints += 4;
+  if (inputs.hasBirthCert) docPoints += 3;
+  if (docPoints > 0) {
+    factors.push({ label: `Vital documents in hand (+${docPoints})`, delta: docPoints });
+  }
+
+  const raw = BASE_SCORE + factors.reduce((sum, f) => sum + f.delta, 0);
+  const score = Math.max(0, Math.min(100, raw));
+
+  let tier: TriageTier;
+  if (score <= TIER_LOW_MAX) tier = 'low';
+  else if (score >= TIER_HIGH_MIN) tier = 'high';
+  else tier = 'medium';
+
+  let recommendation: string;
+  if (tier === 'high') {
+    recommendation =
+      'Likely stabilizes with light-touch support. Connect to KCHIP/SNAP/voucher renewal as needed; check in monthly.';
+  } else if (tier === 'medium') {
+    recommendation =
+      'Moderate intensity. Pair with active caseworker; address top 1-2 documents/income gaps before placement.';
+  } else {
+    recommendation =
+      'High intensity. Recommend Recuperative Care or PSH route (TEAMKY HRSN if eligible); wraparound case management.';
+  }
+
+  return { tier, score, factors, recommendation };
+}


### PR DESCRIPTION
Closes #47. Stacked on #265 (CWT-007/008).

## Summary
- `recommendTriageTier(inputs)` — pure additive scorer over 13 stability signals (income source, voucher, employment, caseworker relationship, SUD/MH treatment engagement, eviction count, unsheltered days, kids in household, DV status, vital documents). Score 0-100, banded **low ≤32 / medium / high ≥67**. Each contributing factor captured with its delta so the UI can show its work.
- **DV survivor flag** is recorded with delta=0 — it routes to abuser-blind handling (DTRS-004) but doesn't move the score.
- Tier-specific recommendation copy: *light-touch* for high, *moderate intensity* for medium, *Recuperative Care / PSH* for low.
- `TriageTierTool` client component — paired field list + live recommendation panel; "Rule-based v1" callout reminds caseworkers this is the placeholder Phase 2 ML replaces.
- New route `/app/clients/triage` (caseworker / shelter_staff / admin). **Stateless** — nothing persists; overrides become training data later.
- 7 new unit tests; 186 total passing.

## Acceptance criteria
- [x] Rule-based v1
- [x] high / medium / low banding
- [x] Explainable factors (each delta surfaced)
- [x] Lint + typecheck + 186 tests + build

🤖 Generated with [Claude Code](https://claude.com/claude-code)