### PR TITLE
feat: ship Phase-1 sprint stack (COOR + INDC + DTRS + CWT-007/008/009 + #251)

### DIFF
--- a/docs/dtrs-005-advisor-review.md
+++ b/docs/dtrs-005-advisor-review.md
@@ -1,0 +1,64 @@
+# DTRS-005 — Lived-experience advisor consent UX review
+
+**Status:** Pending. Blocks first real-PHI flow (gating story per BACKLOG).
+**Engineering side:** ready (DTRS-001 schema + DTRS-002 form merged).
+**Coalition side:** schedule paid 90-min session per advisor, $100/session honorarium per FAG comp policy.
+
+## Why this exists
+
+Before any client data flows through the consent surface, the wording, the
+default checkbox states, and the data-class vocabulary need to be reviewed by
+people who have actually been on the receiving end of consent forms in
+shelter / ED / legal-aid contexts. Reading-level, framing, and the plain-
+language commitments all have to be vetted; a grade-6 Flesch-Kincaid score is
+the floor, not the ceiling. The wording is in
+[`src/lib/dtrs/consent-text.ts`](../src/lib/dtrs/consent-text.ts) — bump
+`CURRENT_CONSENT_VERSION` whenever the wording changes.
+
+## What to bring to the session
+
+- Printed copy of [`/p/[ref]/consent/grant`](../src/app/p/[ref]/consent/grant/page.tsx)
+  for each of the three consent types (PHI share, SMS, program eval).
+- Printed handout from [`/app/coalition/sms/handout`](../src/app/app/coalition/sms/handout/page.tsx) for tone calibration.
+- The `DATA_CLASSES` list (identity / health / housing_history / service_events).
+- A blank legal pad — what *isn't* on the form should be heard, not just
+  what's on it.
+
+## Questions to ask
+
+1. Does the framing assume things you wouldn't trust the coalition with at first
+   contact? Where?
+2. Are any of the bullet promises ones you'd doubt? Why?
+3. Are the data-class checkboxes named in language someone in your shoes would
+   actually use?
+4. Is there a category of info that should be checkable but isn't? Is there one
+   that shouldn't be checkable at all?
+5. Where would you have walked away from this form if you'd encountered it
+   during your worst week?
+
+## What to capture
+
+- Verbatim wording suggestions, by section.
+- Defaults to flip (e.g. \"start with health *unchecked*\").
+- Data-class additions or merges.
+- Friction points in the flow that aren't about wording (e.g. \"the link
+  came at the wrong moment\").
+- A go / no-go on whether the engineering work is ready for first real
+  client.
+
+## After the session
+
+- Bump `CURRENT_CONSENT_VERSION` in `src/db/schema/consents.ts` and
+  `src/lib/dtrs/consent-text.ts` (they import from each other — keep in
+  sync) and edit the copy to match the advisor's wording.
+- File a follow-up issue per advisor session for any structural change
+  (new data class, default flip, defaults that need to be configurable
+  per partner).
+- File the session notes here as `docs/dtrs-005-session-YYYY-MM-DD.md`.
+- Pay the honorarium per OPRT-004's compensation tracker.
+
+## Compensation policy
+
+$100 per advisor per session, plus food and transit if the session is in
+person. The coalition's frontline-advisory-group compensation tracker (OPRT-004)
+records both. Pay at the time of the session, not after.

--- a/drizzle/migrations/0017_opposite_nitro.sql
+++ b/drizzle/migrations/0017_opposite_nitro.sql
@@ -1,0 +1,18 @@
+CREATE TYPE "public"."bed_hold_status" AS ENUM('active', 'released', 'expired', 'converted');--> statement-breakpoint
+CREATE TABLE "bed_holds" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"shelter_id" uuid NOT NULL,
+	"held_by_user_id" uuid NOT NULL,
+	"person_label" text NOT NULL,
+	"status" "bed_hold_status" DEFAULT 'active' NOT NULL,
+	"expires_at" timestamp with time zone NOT NULL,
+	"released_at" timestamp with time zone,
+	"notes" text,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "bed_holds" ADD CONSTRAINT "bed_holds_shelter_id_shelters_id_fk" FOREIGN KEY ("shelter_id") REFERENCES "public"."shelters"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "bed_holds_shelter_idx" ON "bed_holds" USING btree ("shelter_id");--> statement-breakpoint
+CREATE INDEX "bed_holds_status_idx" ON "bed_holds" USING btree ("status");--> statement-breakpoint
+CREATE INDEX "bed_holds_expires_idx" ON "bed_holds" USING btree ("expires_at");

--- a/drizzle/migrations/0018_true_karma.sql
+++ b/drizzle/migrations/0018_true_karma.sql
@@ -1,0 +1,14 @@
+CREATE TABLE "sms_messages" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"provider_message_id" text,
+	"from_number" text NOT NULL,
+	"to_number" text NOT NULL,
+	"body" text NOT NULL,
+	"intent" text NOT NULL,
+	"reply_body" text NOT NULL,
+	"metadata" jsonb,
+	"received_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE INDEX "sms_messages_received_idx" ON "sms_messages" USING btree ("received_at");--> statement-breakpoint
+CREATE INDEX "sms_messages_from_idx" ON "sms_messages" USING btree ("from_number");

--- a/drizzle/migrations/0019_safe_paladin.sql
+++ b/drizzle/migrations/0019_safe_paladin.sql
@@ -1,0 +1,16 @@
+CREATE TYPE "public"."sms_conversation_state" AS ENUM('idle', 'awaiting_location');--> statement-breakpoint
+CREATE TABLE "sms_conversations" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"from_number" text NOT NULL,
+	"state" "sms_conversation_state" DEFAULT 'idle' NOT NULL,
+	"pending_filter" jsonb,
+	"last_location" text,
+	"expires_at" timestamp with time zone NOT NULL,
+	"last_message_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX "sms_conversations_from_idx" ON "sms_conversations" USING btree ("from_number");--> statement-breakpoint
+CREATE INDEX "sms_conversations_state_idx" ON "sms_conversations" USING btree ("state");--> statement-breakpoint
+CREATE INDEX "sms_conversations_expires_idx" ON "sms_conversations" USING btree ("expires_at");

--- a/drizzle/migrations/0020_quiet_metal_master.sql
+++ b/drizzle/migrations/0020_quiet_metal_master.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "sms_conversations" ADD COLUMN "last_results" jsonb;--> statement-breakpoint
+ALTER TABLE "sms_conversations" ADD COLUMN "last_hold_id" uuid;

--- a/drizzle/migrations/0021_nice_senator_kelly.sql
+++ b/drizzle/migrations/0021_nice_senator_kelly.sql
@@ -1,0 +1,6 @@
+ALTER TABLE "consents" ADD COLUMN "consent_version" text DEFAULT '2026-04-1' NOT NULL;--> statement-breakpoint
+ALTER TABLE "consents" ADD COLUMN "scope_partner_ids" jsonb;--> statement-breakpoint
+ALTER TABLE "consents" ADD COLUMN "scope_data_classes" jsonb;--> statement-breakpoint
+ALTER TABLE "consents" ADD COLUMN "signature_text" text;--> statement-breakpoint
+ALTER TABLE "consents" ADD COLUMN "expires_at" timestamp with time zone;--> statement-breakpoint
+CREATE INDEX "consents_expires_at_idx" ON "consents" USING btree ("expires_at");

--- a/drizzle/migrations/0022_woozy_black_panther.sql
+++ b/drizzle/migrations/0022_woozy_black_panther.sql
@@ -1,0 +1,13 @@
+CREATE TABLE "dv_flagged_persons" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"subject_identifier" text NOT NULL,
+	"notes" text,
+	"flag_set_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"flag_cleared_at" timestamp with time zone,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "eviction_filings" ADD COLUMN "dv_flag" boolean DEFAULT false NOT NULL;--> statement-breakpoint
+CREATE UNIQUE INDEX "dv_flagged_persons_subject_idx" ON "dv_flagged_persons" USING btree ("subject_identifier");--> statement-breakpoint
+CREATE INDEX "dv_flagged_persons_set_at_idx" ON "dv_flagged_persons" USING btree ("flag_set_at");

--- a/drizzle/migrations/0023_curious_tarot.sql
+++ b/drizzle/migrations/0023_curious_tarot.sql
@@ -1,0 +1,16 @@
+CREATE TABLE "consent_access_tokens" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"token" text NOT NULL,
+	"synthetic_person_ref" text NOT NULL,
+	"issued_by_user_id" uuid NOT NULL,
+	"expires_at" timestamp with time zone NOT NULL,
+	"used_at" timestamp with time zone,
+	"revoked_at" timestamp with time zone,
+	"notes" text,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "consent_access_tokens" ADD CONSTRAINT "consent_access_tokens_issued_by_user_id_users_id_fk" FOREIGN KEY ("issued_by_user_id") REFERENCES "public"."users"("id") ON DELETE restrict ON UPDATE no action;--> statement-breakpoint
+CREATE UNIQUE INDEX "consent_access_tokens_token_idx" ON "consent_access_tokens" USING btree ("token");--> statement-breakpoint
+CREATE INDEX "consent_access_tokens_ref_idx" ON "consent_access_tokens" USING btree ("synthetic_person_ref");--> statement-breakpoint
+CREATE INDEX "consent_access_tokens_expires_idx" ON "consent_access_tokens" USING btree ("expires_at");

--- a/drizzle/migrations/meta/0017_snapshot.json
+++ b/drizzle/migrations/meta/0017_snapshot.json
@@ -1,0 +1,2362 @@
+{
+  "id": "1d709487-8ba3-4b2f-8d91-8f5b7dd1b377",
+  "prevId": "52f7ed89-dedc-4ccb-bd67-78224c5a6bb7",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.audit_log": {
+      "name": "audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_table": {
+          "name": "target_table",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "audit_log_actor_idx": {
+          "name": "audit_log_actor_idx",
+          "columns": [
+            {
+              "expression": "actor_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_log_action_idx": {
+          "name": "audit_log_action_idx",
+          "columns": [
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_log_created_at_idx": {
+          "name": "audit_log_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audit_log_actor_user_id_users_id_fk": {
+          "name": "audit_log_actor_user_id_users_id_fk",
+          "tableFrom": "audit_log",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.consents": {
+      "name": "consents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "subject_external_id": {
+          "name": "subject_external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consent_type": {
+          "name": "consent_type",
+          "type": "consent_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "granted_via": {
+          "name": "granted_via",
+          "type": "consent_channel",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "granted_at": {
+          "name": "granted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "consents_subject_idx": {
+          "name": "consents_subject_idx",
+          "columns": [
+            {
+              "expression": "subject_external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "consents_type_idx": {
+          "name": "consents_type_idx",
+          "columns": [
+            {
+              "expression": "consent_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ed_encounters": {
+      "name": "ed_encounters",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encounter_external_id": {
+          "name": "encounter_external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "arrived_at": {
+          "name": "arrived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discharged_at": {
+          "name": "discharged_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chief_complaint": {
+          "name": "chief_complaint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "disposition": {
+          "name": "disposition",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "housing_status": {
+          "name": "housing_status",
+          "type": "housing_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unknown'"
+        },
+        "charge_cents": {
+          "name": "charge_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_json": {
+          "name": "raw_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "ed_encounter_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'synthetic'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ed_encounters_external_idx": {
+          "name": "ed_encounters_external_idx",
+          "columns": [
+            {
+              "expression": "encounter_external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ed_encounters_patient_idx": {
+          "name": "ed_encounters_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ed_encounters_arrived_idx": {
+          "name": "ed_encounters_arrived_idx",
+          "columns": [
+            {
+              "expression": "arrived_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ed_encounters_housing_idx": {
+          "name": "ed_encounters_housing_idx",
+          "columns": [
+            {
+              "expression": "housing_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.esuc_care_plans": {
+      "name": "esuc_care_plans",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plan_md": {
+          "name": "plan_md",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt_version": {
+          "name": "prompt_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "generated_by_user_id": {
+          "name": "generated_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "esuc_care_plan_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "care_plans_patient_version_idx": {
+          "name": "care_plans_patient_version_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "prompt_version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "care_plans_patient_idx": {
+          "name": "care_plans_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "care_plans_status_idx": {
+          "name": "care_plans_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "esuc_care_plans_generated_by_user_id_users_id_fk": {
+          "name": "esuc_care_plans_generated_by_user_id_users_id_fk",
+          "tableFrom": "esuc_care_plans",
+          "tableTo": "users",
+          "columnsFrom": [
+            "generated_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.eviction_case_outcomes": {
+      "name": "eviction_case_outcomes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "filing_id": {
+          "name": "filing_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "eviction_case_outcome",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recorded_by_user_id": {
+          "name": "recorded_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "case_outcomes_filing_idx": {
+          "name": "case_outcomes_filing_idx",
+          "columns": [
+            {
+              "expression": "filing_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "case_outcomes_outcome_idx": {
+          "name": "case_outcomes_outcome_idx",
+          "columns": [
+            {
+              "expression": "outcome",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "case_outcomes_created_at_idx": {
+          "name": "case_outcomes_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "eviction_case_outcomes_filing_id_eviction_filings_id_fk": {
+          "name": "eviction_case_outcomes_filing_id_eviction_filings_id_fk",
+          "tableFrom": "eviction_case_outcomes",
+          "tableTo": "eviction_filings",
+          "columnsFrom": [
+            "filing_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "eviction_case_outcomes_recorded_by_user_id_users_id_fk": {
+          "name": "eviction_case_outcomes_recorded_by_user_id_users_id_fk",
+          "tableFrom": "eviction_case_outcomes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "recorded_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.eviction_filing_risk_scores": {
+      "name": "eviction_filing_risk_scores",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "filing_id": {
+          "name": "filing_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rationale": {
+          "name": "rationale",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model_version": {
+          "name": "model_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "risk_scores_filing_version_idx": {
+          "name": "risk_scores_filing_version_idx",
+          "columns": [
+            {
+              "expression": "filing_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "model_version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "risk_scores_filing_idx": {
+          "name": "risk_scores_filing_idx",
+          "columns": [
+            {
+              "expression": "filing_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "risk_scores_score_idx": {
+          "name": "risk_scores_score_idx",
+          "columns": [
+            {
+              "expression": "score",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "eviction_filing_risk_scores_filing_id_eviction_filings_id_fk": {
+          "name": "eviction_filing_risk_scores_filing_id_eviction_filings_id_fk",
+          "tableFrom": "eviction_filing_risk_scores",
+          "tableTo": "eviction_filings",
+          "columnsFrom": [
+            "filing_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.eviction_filings": {
+      "name": "eviction_filings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "case_number": {
+          "name": "case_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filed_at": {
+          "name": "filed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "court_division": {
+          "name": "court_division",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plaintiff": {
+          "name": "plaintiff",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "defendant_first_name": {
+          "name": "defendant_first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "defendant_last_name": {
+          "name": "defendant_last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "defendant_address": {
+          "name": "defendant_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cause_type": {
+          "name": "cause_type",
+          "type": "eviction_cause_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_claimed_cents": {
+          "name": "amount_claimed_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "eviction_filing_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'filed'"
+        },
+        "source": {
+          "name": "source",
+          "type": "eviction_filing_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "raw_json": {
+          "name": "raw_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "eviction_filings_case_source_idx": {
+          "name": "eviction_filings_case_source_idx",
+          "columns": [
+            {
+              "expression": "case_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "eviction_filings_filed_at_idx": {
+          "name": "eviction_filings_filed_at_idx",
+          "columns": [
+            {
+              "expression": "filed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "eviction_filings_status_idx": {
+          "name": "eviction_filings_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.eviction_response_packets": {
+      "name": "eviction_response_packets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "filing_id": {
+          "name": "filing_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "packet_md": {
+          "name": "packet_md",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt_version": {
+          "name": "prompt_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "generated_by_user_id": {
+          "name": "generated_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "eviction_response_packet_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "response_packets_filing_version_idx": {
+          "name": "response_packets_filing_version_idx",
+          "columns": [
+            {
+              "expression": "filing_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "prompt_version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "response_packets_filing_idx": {
+          "name": "response_packets_filing_idx",
+          "columns": [
+            {
+              "expression": "filing_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "response_packets_status_idx": {
+          "name": "response_packets_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "eviction_response_packets_filing_id_eviction_filings_id_fk": {
+          "name": "eviction_response_packets_filing_id_eviction_filings_id_fk",
+          "tableFrom": "eviction_response_packets",
+          "tableTo": "eviction_filings",
+          "columnsFrom": [
+            "filing_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "eviction_response_packets_generated_by_user_id_users_id_fk": {
+          "name": "eviction_response_packets_generated_by_user_id_users_id_fk",
+          "tableFrom": "eviction_response_packets",
+          "tableTo": "users",
+          "columnsFrom": [
+            "generated_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.health_check": {
+      "name": "health_check",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_memberships": {
+      "name": "org_memberships",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "partner_org_id": {
+          "name": "partner_org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "org_memberships_user_org_idx": {
+          "name": "org_memberships_user_org_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "partner_org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "org_memberships_user_idx": {
+          "name": "org_memberships_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "org_memberships_partner_org_idx": {
+          "name": "org_memberships_partner_org_idx",
+          "columns": [
+            {
+              "expression": "partner_org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "org_memberships_user_id_users_id_fk": {
+          "name": "org_memberships_user_id_users_id_fk",
+          "tableFrom": "org_memberships",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "org_memberships_partner_org_id_partner_orgs_id_fk": {
+          "name": "org_memberships_partner_org_id_partner_orgs_id_fk",
+          "tableFrom": "org_memberships",
+          "tableTo": "partner_orgs",
+          "columnsFrom": [
+            "partner_org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.partner_orgs": {
+      "name": "partner_orgs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "partner_org_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_email": {
+          "name": "contact_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_phone": {
+          "name": "contact_phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "website": {
+          "name": "website",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data_sharing_tier": {
+          "name": "data_sharing_tier",
+          "type": "data_sharing_tier",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "partner_orgs_slug_idx": {
+          "name": "partner_orgs_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.partner_service_events": {
+      "name": "partner_service_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "partner_org_id": {
+          "name": "partner_org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "synthetic_person_ref": {
+          "name": "synthetic_person_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "partner_service_event_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_at": {
+          "name": "event_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "ed_encounter_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'synthetic'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "partner_service_events_person_idx": {
+          "name": "partner_service_events_person_idx",
+          "columns": [
+            {
+              "expression": "synthetic_person_ref",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "partner_service_events_partner_idx": {
+          "name": "partner_service_events_partner_idx",
+          "columns": [
+            {
+              "expression": "partner_org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "partner_service_events_at_idx": {
+          "name": "partner_service_events_at_idx",
+          "columns": [
+            {
+              "expression": "event_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "partner_service_events_partner_org_id_partner_orgs_id_fk": {
+          "name": "partner_service_events_partner_org_id_partner_orgs_id_fk",
+          "tableFrom": "partner_service_events",
+          "tableTo": "partner_orgs",
+          "columnsFrom": [
+            "partner_org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.person_partner_consents": {
+      "name": "person_partner_consents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "synthetic_person_ref": {
+          "name": "synthetic_person_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "partner_org_id": {
+          "name": "partner_org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "granted_at": {
+          "name": "granted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "person_partner_consents_unique_idx": {
+          "name": "person_partner_consents_unique_idx",
+          "columns": [
+            {
+              "expression": "synthetic_person_ref",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "partner_org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "person_partner_consents_partner_org_id_partner_orgs_id_fk": {
+          "name": "person_partner_consents_partner_org_id_partner_orgs_id_fk",
+          "tableFrom": "person_partner_consents",
+          "tableTo": "partner_orgs",
+          "columnsFrom": [
+            "partner_org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rental_assistance_programs": {
+      "name": "rental_assistance_programs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agency": {
+          "name": "agency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "website": {
+          "name": "website",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "eligibility_summary": {
+          "name": "eligibility_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "max_award_cents": {
+          "name": "max_award_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_note": {
+          "name": "source_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "rental_assistance_programs_active_idx": {
+          "name": "rental_assistance_programs_active_idx",
+          "columns": [
+            {
+              "expression": "active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bed_count_updates": {
+      "name": "bed_count_updates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "shelter_id": {
+          "name": "shelter_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_user_id": {
+          "name": "updated_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "previous_occupancy": {
+          "name": "previous_occupancy",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "new_occupancy": {
+          "name": "new_occupancy",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "bed_count_updates_shelter_idx": {
+          "name": "bed_count_updates_shelter_idx",
+          "columns": [
+            {
+              "expression": "shelter_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bed_count_updates_created_idx": {
+          "name": "bed_count_updates_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bed_count_updates_shelter_id_shelters_id_fk": {
+          "name": "bed_count_updates_shelter_id_shelters_id_fk",
+          "tableFrom": "bed_count_updates",
+          "tableTo": "shelters",
+          "columnsFrom": [
+            "shelter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bed_holds": {
+      "name": "bed_holds",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "shelter_id": {
+          "name": "shelter_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "held_by_user_id": {
+          "name": "held_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "person_label": {
+          "name": "person_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "bed_hold_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "released_at": {
+          "name": "released_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "bed_holds_shelter_idx": {
+          "name": "bed_holds_shelter_idx",
+          "columns": [
+            {
+              "expression": "shelter_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bed_holds_status_idx": {
+          "name": "bed_holds_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bed_holds_expires_idx": {
+          "name": "bed_holds_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bed_holds_shelter_id_shelters_id_fk": {
+          "name": "bed_holds_shelter_id_shelters_id_fk",
+          "tableFrom": "bed_holds",
+          "tableTo": "shelters",
+          "columnsFrom": [
+            "shelter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.shelters": {
+      "name": "shelters",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "partner_org_id": {
+          "name": "partner_org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address_line1": {
+          "name": "address_line1",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "city": {
+          "name": "city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "postal_code": {
+          "name": "postal_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_phone": {
+          "name": "contact_phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capacity": {
+          "name": "capacity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_occupancy": {
+          "name": "current_occupancy",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "accepts_men": {
+          "name": "accepts_men",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "accepts_women": {
+          "name": "accepts_women",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "accepts_families": {
+          "name": "accepts_families",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "pet_friendly": {
+          "name": "pet_friendly",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "sud_friendly": {
+          "name": "sud_friendly",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "shelters_slug_idx": {
+          "name": "shelters_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "shelters_partner_org_idx": {
+          "name": "shelters_partner_org_idx",
+          "columns": [
+            {
+              "expression": "partner_org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "shelters_partner_org_id_partner_orgs_id_fk": {
+          "name": "shelters_partner_org_id_partner_orgs_id_fk",
+          "tableFrom": "shelters",
+          "tableTo": "partner_orgs",
+          "columnsFrom": [
+            "partner_org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "shelters_capacity_nonneg": {
+          "name": "shelters_capacity_nonneg",
+          "value": "\"shelters\".\"capacity\" >= 0"
+        },
+        "shelters_occupancy_nonneg": {
+          "name": "shelters_occupancy_nonneg",
+          "value": "\"shelters\".\"current_occupancy\" >= 0"
+        },
+        "shelters_occupancy_le_capacity": {
+          "name": "shelters_occupancy_le_capacity",
+          "value": "\"shelters\".\"current_occupancy\" <= \"shelters\".\"capacity\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "clerk_user_id": {
+          "name": "clerk_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "users_clerk_user_id_idx": {
+          "name": "users_clerk_user_id_idx",
+          "columns": [
+            {
+              "expression": "clerk_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.bed_hold_status": {
+      "name": "bed_hold_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "released",
+        "expired",
+        "converted"
+      ]
+    },
+    "public.consent_channel": {
+      "name": "consent_channel",
+      "schema": "public",
+      "values": [
+        "sms",
+        "in_person",
+        "web_form",
+        "phone",
+        "paper"
+      ]
+    },
+    "public.consent_type": {
+      "name": "consent_type",
+      "schema": "public",
+      "values": [
+        "phi_share_within_coalition",
+        "sms_communication",
+        "data_for_program_eval"
+      ]
+    },
+    "public.data_sharing_tier": {
+      "name": "data_sharing_tier",
+      "schema": "public",
+      "values": [
+        "none",
+        "aggregate",
+        "individual"
+      ]
+    },
+    "public.ed_encounter_source": {
+      "name": "ed_encounter_source",
+      "schema": "public",
+      "values": [
+        "synthetic",
+        "epic_fhir",
+        "manual"
+      ]
+    },
+    "public.esuc_care_plan_status": {
+      "name": "esuc_care_plan_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "approved",
+        "active",
+        "archived"
+      ]
+    },
+    "public.eviction_case_outcome": {
+      "name": "eviction_case_outcome",
+      "schema": "public",
+      "values": [
+        "dismissed",
+        "judgment_for_plaintiff",
+        "judgment_for_defendant",
+        "settled",
+        "default_judgment",
+        "withdrawn"
+      ]
+    },
+    "public.eviction_cause_type": {
+      "name": "eviction_cause_type",
+      "schema": "public",
+      "values": [
+        "non_payment",
+        "lease_violation",
+        "holdover",
+        "other"
+      ]
+    },
+    "public.eviction_filing_source": {
+      "name": "eviction_filing_source",
+      "schema": "public",
+      "values": [
+        "courtnet",
+        "manual",
+        "synthetic"
+      ]
+    },
+    "public.eviction_filing_status": {
+      "name": "eviction_filing_status",
+      "schema": "public",
+      "values": [
+        "filed",
+        "served",
+        "judgment",
+        "dismissed",
+        "sealed"
+      ]
+    },
+    "public.eviction_response_packet_status": {
+      "name": "eviction_response_packet_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "approved",
+        "filed",
+        "rejected"
+      ]
+    },
+    "public.housing_status": {
+      "name": "housing_status",
+      "schema": "public",
+      "values": [
+        "housed",
+        "doubled_up",
+        "shelter",
+        "unsheltered",
+        "unknown"
+      ]
+    },
+    "public.partner_org_type": {
+      "name": "partner_org_type",
+      "schema": "public",
+      "values": [
+        "hospital",
+        "legal_aid",
+        "shelter",
+        "community_org",
+        "government",
+        "faith_based",
+        "school",
+        "philanthropy",
+        "education",
+        "public_health",
+        "media",
+        "other"
+      ]
+    },
+    "public.partner_service_event_type": {
+      "name": "partner_service_event_type",
+      "schema": "public",
+      "values": [
+        "food_pantry",
+        "shelter_intake",
+        "shelter_bed_night",
+        "utility_assistance",
+        "rent_assistance",
+        "counseling_visit",
+        "medical_visit",
+        "school_attendance_flag",
+        "volunteer_hours",
+        "other"
+      ]
+    },
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "pending",
+        "attorney",
+        "caseworker",
+        "ed_coordinator",
+        "shelter_staff",
+        "admin"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/migrations/meta/0018_snapshot.json
+++ b/drizzle/migrations/meta/0018_snapshot.json
@@ -1,0 +1,2462 @@
+{
+  "id": "218ae72b-1b08-4f7d-b353-7e9c0eb6b8fc",
+  "prevId": "1d709487-8ba3-4b2f-8d91-8f5b7dd1b377",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.audit_log": {
+      "name": "audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_table": {
+          "name": "target_table",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "audit_log_actor_idx": {
+          "name": "audit_log_actor_idx",
+          "columns": [
+            {
+              "expression": "actor_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_log_action_idx": {
+          "name": "audit_log_action_idx",
+          "columns": [
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_log_created_at_idx": {
+          "name": "audit_log_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audit_log_actor_user_id_users_id_fk": {
+          "name": "audit_log_actor_user_id_users_id_fk",
+          "tableFrom": "audit_log",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.consents": {
+      "name": "consents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "subject_external_id": {
+          "name": "subject_external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consent_type": {
+          "name": "consent_type",
+          "type": "consent_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "granted_via": {
+          "name": "granted_via",
+          "type": "consent_channel",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "granted_at": {
+          "name": "granted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "consents_subject_idx": {
+          "name": "consents_subject_idx",
+          "columns": [
+            {
+              "expression": "subject_external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "consents_type_idx": {
+          "name": "consents_type_idx",
+          "columns": [
+            {
+              "expression": "consent_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ed_encounters": {
+      "name": "ed_encounters",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encounter_external_id": {
+          "name": "encounter_external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "arrived_at": {
+          "name": "arrived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discharged_at": {
+          "name": "discharged_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chief_complaint": {
+          "name": "chief_complaint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "disposition": {
+          "name": "disposition",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "housing_status": {
+          "name": "housing_status",
+          "type": "housing_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unknown'"
+        },
+        "charge_cents": {
+          "name": "charge_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_json": {
+          "name": "raw_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "ed_encounter_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'synthetic'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ed_encounters_external_idx": {
+          "name": "ed_encounters_external_idx",
+          "columns": [
+            {
+              "expression": "encounter_external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ed_encounters_patient_idx": {
+          "name": "ed_encounters_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ed_encounters_arrived_idx": {
+          "name": "ed_encounters_arrived_idx",
+          "columns": [
+            {
+              "expression": "arrived_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ed_encounters_housing_idx": {
+          "name": "ed_encounters_housing_idx",
+          "columns": [
+            {
+              "expression": "housing_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.esuc_care_plans": {
+      "name": "esuc_care_plans",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plan_md": {
+          "name": "plan_md",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt_version": {
+          "name": "prompt_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "generated_by_user_id": {
+          "name": "generated_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "esuc_care_plan_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "care_plans_patient_version_idx": {
+          "name": "care_plans_patient_version_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "prompt_version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "care_plans_patient_idx": {
+          "name": "care_plans_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "care_plans_status_idx": {
+          "name": "care_plans_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "esuc_care_plans_generated_by_user_id_users_id_fk": {
+          "name": "esuc_care_plans_generated_by_user_id_users_id_fk",
+          "tableFrom": "esuc_care_plans",
+          "tableTo": "users",
+          "columnsFrom": [
+            "generated_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.eviction_case_outcomes": {
+      "name": "eviction_case_outcomes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "filing_id": {
+          "name": "filing_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "eviction_case_outcome",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recorded_by_user_id": {
+          "name": "recorded_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "case_outcomes_filing_idx": {
+          "name": "case_outcomes_filing_idx",
+          "columns": [
+            {
+              "expression": "filing_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "case_outcomes_outcome_idx": {
+          "name": "case_outcomes_outcome_idx",
+          "columns": [
+            {
+              "expression": "outcome",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "case_outcomes_created_at_idx": {
+          "name": "case_outcomes_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "eviction_case_outcomes_filing_id_eviction_filings_id_fk": {
+          "name": "eviction_case_outcomes_filing_id_eviction_filings_id_fk",
+          "tableFrom": "eviction_case_outcomes",
+          "tableTo": "eviction_filings",
+          "columnsFrom": [
+            "filing_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "eviction_case_outcomes_recorded_by_user_id_users_id_fk": {
+          "name": "eviction_case_outcomes_recorded_by_user_id_users_id_fk",
+          "tableFrom": "eviction_case_outcomes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "recorded_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.eviction_filing_risk_scores": {
+      "name": "eviction_filing_risk_scores",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "filing_id": {
+          "name": "filing_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rationale": {
+          "name": "rationale",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model_version": {
+          "name": "model_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "risk_scores_filing_version_idx": {
+          "name": "risk_scores_filing_version_idx",
+          "columns": [
+            {
+              "expression": "filing_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "model_version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "risk_scores_filing_idx": {
+          "name": "risk_scores_filing_idx",
+          "columns": [
+            {
+              "expression": "filing_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "risk_scores_score_idx": {
+          "name": "risk_scores_score_idx",
+          "columns": [
+            {
+              "expression": "score",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "eviction_filing_risk_scores_filing_id_eviction_filings_id_fk": {
+          "name": "eviction_filing_risk_scores_filing_id_eviction_filings_id_fk",
+          "tableFrom": "eviction_filing_risk_scores",
+          "tableTo": "eviction_filings",
+          "columnsFrom": [
+            "filing_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.eviction_filings": {
+      "name": "eviction_filings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "case_number": {
+          "name": "case_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filed_at": {
+          "name": "filed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "court_division": {
+          "name": "court_division",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plaintiff": {
+          "name": "plaintiff",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "defendant_first_name": {
+          "name": "defendant_first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "defendant_last_name": {
+          "name": "defendant_last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "defendant_address": {
+          "name": "defendant_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cause_type": {
+          "name": "cause_type",
+          "type": "eviction_cause_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_claimed_cents": {
+          "name": "amount_claimed_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "eviction_filing_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'filed'"
+        },
+        "source": {
+          "name": "source",
+          "type": "eviction_filing_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "raw_json": {
+          "name": "raw_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "eviction_filings_case_source_idx": {
+          "name": "eviction_filings_case_source_idx",
+          "columns": [
+            {
+              "expression": "case_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "eviction_filings_filed_at_idx": {
+          "name": "eviction_filings_filed_at_idx",
+          "columns": [
+            {
+              "expression": "filed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "eviction_filings_status_idx": {
+          "name": "eviction_filings_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.eviction_response_packets": {
+      "name": "eviction_response_packets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "filing_id": {
+          "name": "filing_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "packet_md": {
+          "name": "packet_md",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt_version": {
+          "name": "prompt_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "generated_by_user_id": {
+          "name": "generated_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "eviction_response_packet_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "response_packets_filing_version_idx": {
+          "name": "response_packets_filing_version_idx",
+          "columns": [
+            {
+              "expression": "filing_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "prompt_version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "response_packets_filing_idx": {
+          "name": "response_packets_filing_idx",
+          "columns": [
+            {
+              "expression": "filing_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "response_packets_status_idx": {
+          "name": "response_packets_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "eviction_response_packets_filing_id_eviction_filings_id_fk": {
+          "name": "eviction_response_packets_filing_id_eviction_filings_id_fk",
+          "tableFrom": "eviction_response_packets",
+          "tableTo": "eviction_filings",
+          "columnsFrom": [
+            "filing_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "eviction_response_packets_generated_by_user_id_users_id_fk": {
+          "name": "eviction_response_packets_generated_by_user_id_users_id_fk",
+          "tableFrom": "eviction_response_packets",
+          "tableTo": "users",
+          "columnsFrom": [
+            "generated_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.health_check": {
+      "name": "health_check",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_memberships": {
+      "name": "org_memberships",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "partner_org_id": {
+          "name": "partner_org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "org_memberships_user_org_idx": {
+          "name": "org_memberships_user_org_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "partner_org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "org_memberships_user_idx": {
+          "name": "org_memberships_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "org_memberships_partner_org_idx": {
+          "name": "org_memberships_partner_org_idx",
+          "columns": [
+            {
+              "expression": "partner_org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "org_memberships_user_id_users_id_fk": {
+          "name": "org_memberships_user_id_users_id_fk",
+          "tableFrom": "org_memberships",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "org_memberships_partner_org_id_partner_orgs_id_fk": {
+          "name": "org_memberships_partner_org_id_partner_orgs_id_fk",
+          "tableFrom": "org_memberships",
+          "tableTo": "partner_orgs",
+          "columnsFrom": [
+            "partner_org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.partner_orgs": {
+      "name": "partner_orgs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "partner_org_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_email": {
+          "name": "contact_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_phone": {
+          "name": "contact_phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "website": {
+          "name": "website",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data_sharing_tier": {
+          "name": "data_sharing_tier",
+          "type": "data_sharing_tier",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "partner_orgs_slug_idx": {
+          "name": "partner_orgs_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.partner_service_events": {
+      "name": "partner_service_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "partner_org_id": {
+          "name": "partner_org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "synthetic_person_ref": {
+          "name": "synthetic_person_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "partner_service_event_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_at": {
+          "name": "event_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "ed_encounter_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'synthetic'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "partner_service_events_person_idx": {
+          "name": "partner_service_events_person_idx",
+          "columns": [
+            {
+              "expression": "synthetic_person_ref",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "partner_service_events_partner_idx": {
+          "name": "partner_service_events_partner_idx",
+          "columns": [
+            {
+              "expression": "partner_org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "partner_service_events_at_idx": {
+          "name": "partner_service_events_at_idx",
+          "columns": [
+            {
+              "expression": "event_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "partner_service_events_partner_org_id_partner_orgs_id_fk": {
+          "name": "partner_service_events_partner_org_id_partner_orgs_id_fk",
+          "tableFrom": "partner_service_events",
+          "tableTo": "partner_orgs",
+          "columnsFrom": [
+            "partner_org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.person_partner_consents": {
+      "name": "person_partner_consents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "synthetic_person_ref": {
+          "name": "synthetic_person_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "partner_org_id": {
+          "name": "partner_org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "granted_at": {
+          "name": "granted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "person_partner_consents_unique_idx": {
+          "name": "person_partner_consents_unique_idx",
+          "columns": [
+            {
+              "expression": "synthetic_person_ref",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "partner_org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "person_partner_consents_partner_org_id_partner_orgs_id_fk": {
+          "name": "person_partner_consents_partner_org_id_partner_orgs_id_fk",
+          "tableFrom": "person_partner_consents",
+          "tableTo": "partner_orgs",
+          "columnsFrom": [
+            "partner_org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rental_assistance_programs": {
+      "name": "rental_assistance_programs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agency": {
+          "name": "agency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "website": {
+          "name": "website",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "eligibility_summary": {
+          "name": "eligibility_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "max_award_cents": {
+          "name": "max_award_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_note": {
+          "name": "source_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "rental_assistance_programs_active_idx": {
+          "name": "rental_assistance_programs_active_idx",
+          "columns": [
+            {
+              "expression": "active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bed_count_updates": {
+      "name": "bed_count_updates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "shelter_id": {
+          "name": "shelter_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_user_id": {
+          "name": "updated_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "previous_occupancy": {
+          "name": "previous_occupancy",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "new_occupancy": {
+          "name": "new_occupancy",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "bed_count_updates_shelter_idx": {
+          "name": "bed_count_updates_shelter_idx",
+          "columns": [
+            {
+              "expression": "shelter_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bed_count_updates_created_idx": {
+          "name": "bed_count_updates_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bed_count_updates_shelter_id_shelters_id_fk": {
+          "name": "bed_count_updates_shelter_id_shelters_id_fk",
+          "tableFrom": "bed_count_updates",
+          "tableTo": "shelters",
+          "columnsFrom": [
+            "shelter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bed_holds": {
+      "name": "bed_holds",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "shelter_id": {
+          "name": "shelter_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "held_by_user_id": {
+          "name": "held_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "person_label": {
+          "name": "person_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "bed_hold_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "released_at": {
+          "name": "released_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "bed_holds_shelter_idx": {
+          "name": "bed_holds_shelter_idx",
+          "columns": [
+            {
+              "expression": "shelter_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bed_holds_status_idx": {
+          "name": "bed_holds_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bed_holds_expires_idx": {
+          "name": "bed_holds_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bed_holds_shelter_id_shelters_id_fk": {
+          "name": "bed_holds_shelter_id_shelters_id_fk",
+          "tableFrom": "bed_holds",
+          "tableTo": "shelters",
+          "columnsFrom": [
+            "shelter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.shelters": {
+      "name": "shelters",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "partner_org_id": {
+          "name": "partner_org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address_line1": {
+          "name": "address_line1",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "city": {
+          "name": "city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "postal_code": {
+          "name": "postal_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_phone": {
+          "name": "contact_phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capacity": {
+          "name": "capacity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_occupancy": {
+          "name": "current_occupancy",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "accepts_men": {
+          "name": "accepts_men",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "accepts_women": {
+          "name": "accepts_women",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "accepts_families": {
+          "name": "accepts_families",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "pet_friendly": {
+          "name": "pet_friendly",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "sud_friendly": {
+          "name": "sud_friendly",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "shelters_slug_idx": {
+          "name": "shelters_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "shelters_partner_org_idx": {
+          "name": "shelters_partner_org_idx",
+          "columns": [
+            {
+              "expression": "partner_org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "shelters_partner_org_id_partner_orgs_id_fk": {
+          "name": "shelters_partner_org_id_partner_orgs_id_fk",
+          "tableFrom": "shelters",
+          "tableTo": "partner_orgs",
+          "columnsFrom": [
+            "partner_org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "shelters_capacity_nonneg": {
+          "name": "shelters_capacity_nonneg",
+          "value": "\"shelters\".\"capacity\" >= 0"
+        },
+        "shelters_occupancy_nonneg": {
+          "name": "shelters_occupancy_nonneg",
+          "value": "\"shelters\".\"current_occupancy\" >= 0"
+        },
+        "shelters_occupancy_le_capacity": {
+          "name": "shelters_occupancy_le_capacity",
+          "value": "\"shelters\".\"current_occupancy\" <= \"shelters\".\"capacity\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.sms_messages": {
+      "name": "sms_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "provider_message_id": {
+          "name": "provider_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "from_number": {
+          "name": "from_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_number": {
+          "name": "to_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "intent": {
+          "name": "intent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reply_body": {
+          "name": "reply_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sms_messages_received_idx": {
+          "name": "sms_messages_received_idx",
+          "columns": [
+            {
+              "expression": "received_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_messages_from_idx": {
+          "name": "sms_messages_from_idx",
+          "columns": [
+            {
+              "expression": "from_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "clerk_user_id": {
+          "name": "clerk_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "users_clerk_user_id_idx": {
+          "name": "users_clerk_user_id_idx",
+          "columns": [
+            {
+              "expression": "clerk_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.bed_hold_status": {
+      "name": "bed_hold_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "released",
+        "expired",
+        "converted"
+      ]
+    },
+    "public.consent_channel": {
+      "name": "consent_channel",
+      "schema": "public",
+      "values": [
+        "sms",
+        "in_person",
+        "web_form",
+        "phone",
+        "paper"
+      ]
+    },
+    "public.consent_type": {
+      "name": "consent_type",
+      "schema": "public",
+      "values": [
+        "phi_share_within_coalition",
+        "sms_communication",
+        "data_for_program_eval"
+      ]
+    },
+    "public.data_sharing_tier": {
+      "name": "data_sharing_tier",
+      "schema": "public",
+      "values": [
+        "none",
+        "aggregate",
+        "individual"
+      ]
+    },
+    "public.ed_encounter_source": {
+      "name": "ed_encounter_source",
+      "schema": "public",
+      "values": [
+        "synthetic",
+        "epic_fhir",
+        "manual"
+      ]
+    },
+    "public.esuc_care_plan_status": {
+      "name": "esuc_care_plan_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "approved",
+        "active",
+        "archived"
+      ]
+    },
+    "public.eviction_case_outcome": {
+      "name": "eviction_case_outcome",
+      "schema": "public",
+      "values": [
+        "dismissed",
+        "judgment_for_plaintiff",
+        "judgment_for_defendant",
+        "settled",
+        "default_judgment",
+        "withdrawn"
+      ]
+    },
+    "public.eviction_cause_type": {
+      "name": "eviction_cause_type",
+      "schema": "public",
+      "values": [
+        "non_payment",
+        "lease_violation",
+        "holdover",
+        "other"
+      ]
+    },
+    "public.eviction_filing_source": {
+      "name": "eviction_filing_source",
+      "schema": "public",
+      "values": [
+        "courtnet",
+        "manual",
+        "synthetic"
+      ]
+    },
+    "public.eviction_filing_status": {
+      "name": "eviction_filing_status",
+      "schema": "public",
+      "values": [
+        "filed",
+        "served",
+        "judgment",
+        "dismissed",
+        "sealed"
+      ]
+    },
+    "public.eviction_response_packet_status": {
+      "name": "eviction_response_packet_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "approved",
+        "filed",
+        "rejected"
+      ]
+    },
+    "public.housing_status": {
+      "name": "housing_status",
+      "schema": "public",
+      "values": [
+        "housed",
+        "doubled_up",
+        "shelter",
+        "unsheltered",
+        "unknown"
+      ]
+    },
+    "public.partner_org_type": {
+      "name": "partner_org_type",
+      "schema": "public",
+      "values": [
+        "hospital",
+        "legal_aid",
+        "shelter",
+        "community_org",
+        "government",
+        "faith_based",
+        "school",
+        "philanthropy",
+        "education",
+        "public_health",
+        "media",
+        "other"
+      ]
+    },
+    "public.partner_service_event_type": {
+      "name": "partner_service_event_type",
+      "schema": "public",
+      "values": [
+        "food_pantry",
+        "shelter_intake",
+        "shelter_bed_night",
+        "utility_assistance",
+        "rent_assistance",
+        "counseling_visit",
+        "medical_visit",
+        "school_attendance_flag",
+        "volunteer_hours",
+        "other"
+      ]
+    },
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "pending",
+        "attorney",
+        "caseworker",
+        "ed_coordinator",
+        "shelter_staff",
+        "admin"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/migrations/meta/0019_snapshot.json
+++ b/drizzle/migrations/meta/0019_snapshot.json
@@ -1,0 +1,2589 @@
+{
+  "id": "f367cba4-3bfb-4d77-ac52-db36175fc490",
+  "prevId": "218ae72b-1b08-4f7d-b353-7e9c0eb6b8fc",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.audit_log": {
+      "name": "audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_table": {
+          "name": "target_table",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "audit_log_actor_idx": {
+          "name": "audit_log_actor_idx",
+          "columns": [
+            {
+              "expression": "actor_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_log_action_idx": {
+          "name": "audit_log_action_idx",
+          "columns": [
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_log_created_at_idx": {
+          "name": "audit_log_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audit_log_actor_user_id_users_id_fk": {
+          "name": "audit_log_actor_user_id_users_id_fk",
+          "tableFrom": "audit_log",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.consents": {
+      "name": "consents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "subject_external_id": {
+          "name": "subject_external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consent_type": {
+          "name": "consent_type",
+          "type": "consent_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "granted_via": {
+          "name": "granted_via",
+          "type": "consent_channel",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "granted_at": {
+          "name": "granted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "consents_subject_idx": {
+          "name": "consents_subject_idx",
+          "columns": [
+            {
+              "expression": "subject_external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "consents_type_idx": {
+          "name": "consents_type_idx",
+          "columns": [
+            {
+              "expression": "consent_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ed_encounters": {
+      "name": "ed_encounters",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encounter_external_id": {
+          "name": "encounter_external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "arrived_at": {
+          "name": "arrived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discharged_at": {
+          "name": "discharged_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chief_complaint": {
+          "name": "chief_complaint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "disposition": {
+          "name": "disposition",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "housing_status": {
+          "name": "housing_status",
+          "type": "housing_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unknown'"
+        },
+        "charge_cents": {
+          "name": "charge_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_json": {
+          "name": "raw_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "ed_encounter_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'synthetic'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ed_encounters_external_idx": {
+          "name": "ed_encounters_external_idx",
+          "columns": [
+            {
+              "expression": "encounter_external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ed_encounters_patient_idx": {
+          "name": "ed_encounters_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ed_encounters_arrived_idx": {
+          "name": "ed_encounters_arrived_idx",
+          "columns": [
+            {
+              "expression": "arrived_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ed_encounters_housing_idx": {
+          "name": "ed_encounters_housing_idx",
+          "columns": [
+            {
+              "expression": "housing_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.esuc_care_plans": {
+      "name": "esuc_care_plans",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plan_md": {
+          "name": "plan_md",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt_version": {
+          "name": "prompt_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "generated_by_user_id": {
+          "name": "generated_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "esuc_care_plan_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "care_plans_patient_version_idx": {
+          "name": "care_plans_patient_version_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "prompt_version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "care_plans_patient_idx": {
+          "name": "care_plans_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "care_plans_status_idx": {
+          "name": "care_plans_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "esuc_care_plans_generated_by_user_id_users_id_fk": {
+          "name": "esuc_care_plans_generated_by_user_id_users_id_fk",
+          "tableFrom": "esuc_care_plans",
+          "tableTo": "users",
+          "columnsFrom": [
+            "generated_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.eviction_case_outcomes": {
+      "name": "eviction_case_outcomes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "filing_id": {
+          "name": "filing_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "eviction_case_outcome",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recorded_by_user_id": {
+          "name": "recorded_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "case_outcomes_filing_idx": {
+          "name": "case_outcomes_filing_idx",
+          "columns": [
+            {
+              "expression": "filing_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "case_outcomes_outcome_idx": {
+          "name": "case_outcomes_outcome_idx",
+          "columns": [
+            {
+              "expression": "outcome",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "case_outcomes_created_at_idx": {
+          "name": "case_outcomes_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "eviction_case_outcomes_filing_id_eviction_filings_id_fk": {
+          "name": "eviction_case_outcomes_filing_id_eviction_filings_id_fk",
+          "tableFrom": "eviction_case_outcomes",
+          "tableTo": "eviction_filings",
+          "columnsFrom": [
+            "filing_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "eviction_case_outcomes_recorded_by_user_id_users_id_fk": {
+          "name": "eviction_case_outcomes_recorded_by_user_id_users_id_fk",
+          "tableFrom": "eviction_case_outcomes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "recorded_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.eviction_filing_risk_scores": {
+      "name": "eviction_filing_risk_scores",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "filing_id": {
+          "name": "filing_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rationale": {
+          "name": "rationale",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model_version": {
+          "name": "model_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "risk_scores_filing_version_idx": {
+          "name": "risk_scores_filing_version_idx",
+          "columns": [
+            {
+              "expression": "filing_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "model_version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "risk_scores_filing_idx": {
+          "name": "risk_scores_filing_idx",
+          "columns": [
+            {
+              "expression": "filing_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "risk_scores_score_idx": {
+          "name": "risk_scores_score_idx",
+          "columns": [
+            {
+              "expression": "score",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "eviction_filing_risk_scores_filing_id_eviction_filings_id_fk": {
+          "name": "eviction_filing_risk_scores_filing_id_eviction_filings_id_fk",
+          "tableFrom": "eviction_filing_risk_scores",
+          "tableTo": "eviction_filings",
+          "columnsFrom": [
+            "filing_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.eviction_filings": {
+      "name": "eviction_filings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "case_number": {
+          "name": "case_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filed_at": {
+          "name": "filed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "court_division": {
+          "name": "court_division",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plaintiff": {
+          "name": "plaintiff",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "defendant_first_name": {
+          "name": "defendant_first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "defendant_last_name": {
+          "name": "defendant_last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "defendant_address": {
+          "name": "defendant_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cause_type": {
+          "name": "cause_type",
+          "type": "eviction_cause_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_claimed_cents": {
+          "name": "amount_claimed_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "eviction_filing_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'filed'"
+        },
+        "source": {
+          "name": "source",
+          "type": "eviction_filing_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "raw_json": {
+          "name": "raw_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "eviction_filings_case_source_idx": {
+          "name": "eviction_filings_case_source_idx",
+          "columns": [
+            {
+              "expression": "case_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "eviction_filings_filed_at_idx": {
+          "name": "eviction_filings_filed_at_idx",
+          "columns": [
+            {
+              "expression": "filed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "eviction_filings_status_idx": {
+          "name": "eviction_filings_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.eviction_response_packets": {
+      "name": "eviction_response_packets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "filing_id": {
+          "name": "filing_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "packet_md": {
+          "name": "packet_md",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt_version": {
+          "name": "prompt_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "generated_by_user_id": {
+          "name": "generated_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "eviction_response_packet_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "response_packets_filing_version_idx": {
+          "name": "response_packets_filing_version_idx",
+          "columns": [
+            {
+              "expression": "filing_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "prompt_version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "response_packets_filing_idx": {
+          "name": "response_packets_filing_idx",
+          "columns": [
+            {
+              "expression": "filing_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "response_packets_status_idx": {
+          "name": "response_packets_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "eviction_response_packets_filing_id_eviction_filings_id_fk": {
+          "name": "eviction_response_packets_filing_id_eviction_filings_id_fk",
+          "tableFrom": "eviction_response_packets",
+          "tableTo": "eviction_filings",
+          "columnsFrom": [
+            "filing_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "eviction_response_packets_generated_by_user_id_users_id_fk": {
+          "name": "eviction_response_packets_generated_by_user_id_users_id_fk",
+          "tableFrom": "eviction_response_packets",
+          "tableTo": "users",
+          "columnsFrom": [
+            "generated_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.health_check": {
+      "name": "health_check",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_memberships": {
+      "name": "org_memberships",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "partner_org_id": {
+          "name": "partner_org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "org_memberships_user_org_idx": {
+          "name": "org_memberships_user_org_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "partner_org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "org_memberships_user_idx": {
+          "name": "org_memberships_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "org_memberships_partner_org_idx": {
+          "name": "org_memberships_partner_org_idx",
+          "columns": [
+            {
+              "expression": "partner_org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "org_memberships_user_id_users_id_fk": {
+          "name": "org_memberships_user_id_users_id_fk",
+          "tableFrom": "org_memberships",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "org_memberships_partner_org_id_partner_orgs_id_fk": {
+          "name": "org_memberships_partner_org_id_partner_orgs_id_fk",
+          "tableFrom": "org_memberships",
+          "tableTo": "partner_orgs",
+          "columnsFrom": [
+            "partner_org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.partner_orgs": {
+      "name": "partner_orgs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "partner_org_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_email": {
+          "name": "contact_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_phone": {
+          "name": "contact_phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "website": {
+          "name": "website",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data_sharing_tier": {
+          "name": "data_sharing_tier",
+          "type": "data_sharing_tier",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "partner_orgs_slug_idx": {
+          "name": "partner_orgs_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.partner_service_events": {
+      "name": "partner_service_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "partner_org_id": {
+          "name": "partner_org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "synthetic_person_ref": {
+          "name": "synthetic_person_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "partner_service_event_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_at": {
+          "name": "event_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "ed_encounter_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'synthetic'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "partner_service_events_person_idx": {
+          "name": "partner_service_events_person_idx",
+          "columns": [
+            {
+              "expression": "synthetic_person_ref",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "partner_service_events_partner_idx": {
+          "name": "partner_service_events_partner_idx",
+          "columns": [
+            {
+              "expression": "partner_org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "partner_service_events_at_idx": {
+          "name": "partner_service_events_at_idx",
+          "columns": [
+            {
+              "expression": "event_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "partner_service_events_partner_org_id_partner_orgs_id_fk": {
+          "name": "partner_service_events_partner_org_id_partner_orgs_id_fk",
+          "tableFrom": "partner_service_events",
+          "tableTo": "partner_orgs",
+          "columnsFrom": [
+            "partner_org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.person_partner_consents": {
+      "name": "person_partner_consents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "synthetic_person_ref": {
+          "name": "synthetic_person_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "partner_org_id": {
+          "name": "partner_org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "granted_at": {
+          "name": "granted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "person_partner_consents_unique_idx": {
+          "name": "person_partner_consents_unique_idx",
+          "columns": [
+            {
+              "expression": "synthetic_person_ref",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "partner_org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "person_partner_consents_partner_org_id_partner_orgs_id_fk": {
+          "name": "person_partner_consents_partner_org_id_partner_orgs_id_fk",
+          "tableFrom": "person_partner_consents",
+          "tableTo": "partner_orgs",
+          "columnsFrom": [
+            "partner_org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rental_assistance_programs": {
+      "name": "rental_assistance_programs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agency": {
+          "name": "agency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "website": {
+          "name": "website",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "eligibility_summary": {
+          "name": "eligibility_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "max_award_cents": {
+          "name": "max_award_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_note": {
+          "name": "source_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "rental_assistance_programs_active_idx": {
+          "name": "rental_assistance_programs_active_idx",
+          "columns": [
+            {
+              "expression": "active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bed_count_updates": {
+      "name": "bed_count_updates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "shelter_id": {
+          "name": "shelter_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_user_id": {
+          "name": "updated_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "previous_occupancy": {
+          "name": "previous_occupancy",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "new_occupancy": {
+          "name": "new_occupancy",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "bed_count_updates_shelter_idx": {
+          "name": "bed_count_updates_shelter_idx",
+          "columns": [
+            {
+              "expression": "shelter_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bed_count_updates_created_idx": {
+          "name": "bed_count_updates_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bed_count_updates_shelter_id_shelters_id_fk": {
+          "name": "bed_count_updates_shelter_id_shelters_id_fk",
+          "tableFrom": "bed_count_updates",
+          "tableTo": "shelters",
+          "columnsFrom": [
+            "shelter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bed_holds": {
+      "name": "bed_holds",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "shelter_id": {
+          "name": "shelter_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "held_by_user_id": {
+          "name": "held_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "person_label": {
+          "name": "person_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "bed_hold_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "released_at": {
+          "name": "released_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "bed_holds_shelter_idx": {
+          "name": "bed_holds_shelter_idx",
+          "columns": [
+            {
+              "expression": "shelter_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bed_holds_status_idx": {
+          "name": "bed_holds_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bed_holds_expires_idx": {
+          "name": "bed_holds_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bed_holds_shelter_id_shelters_id_fk": {
+          "name": "bed_holds_shelter_id_shelters_id_fk",
+          "tableFrom": "bed_holds",
+          "tableTo": "shelters",
+          "columnsFrom": [
+            "shelter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.shelters": {
+      "name": "shelters",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "partner_org_id": {
+          "name": "partner_org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address_line1": {
+          "name": "address_line1",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "city": {
+          "name": "city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "postal_code": {
+          "name": "postal_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_phone": {
+          "name": "contact_phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capacity": {
+          "name": "capacity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_occupancy": {
+          "name": "current_occupancy",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "accepts_men": {
+          "name": "accepts_men",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "accepts_women": {
+          "name": "accepts_women",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "accepts_families": {
+          "name": "accepts_families",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "pet_friendly": {
+          "name": "pet_friendly",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "sud_friendly": {
+          "name": "sud_friendly",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "shelters_slug_idx": {
+          "name": "shelters_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "shelters_partner_org_idx": {
+          "name": "shelters_partner_org_idx",
+          "columns": [
+            {
+              "expression": "partner_org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "shelters_partner_org_id_partner_orgs_id_fk": {
+          "name": "shelters_partner_org_id_partner_orgs_id_fk",
+          "tableFrom": "shelters",
+          "tableTo": "partner_orgs",
+          "columnsFrom": [
+            "partner_org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "shelters_capacity_nonneg": {
+          "name": "shelters_capacity_nonneg",
+          "value": "\"shelters\".\"capacity\" >= 0"
+        },
+        "shelters_occupancy_nonneg": {
+          "name": "shelters_occupancy_nonneg",
+          "value": "\"shelters\".\"current_occupancy\" >= 0"
+        },
+        "shelters_occupancy_le_capacity": {
+          "name": "shelters_occupancy_le_capacity",
+          "value": "\"shelters\".\"current_occupancy\" <= \"shelters\".\"capacity\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.sms_conversations": {
+      "name": "sms_conversations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "from_number": {
+          "name": "from_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "sms_conversation_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'idle'"
+        },
+        "pending_filter": {
+          "name": "pending_filter",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_location": {
+          "name": "last_location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_message_at": {
+          "name": "last_message_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sms_conversations_from_idx": {
+          "name": "sms_conversations_from_idx",
+          "columns": [
+            {
+              "expression": "from_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_conversations_state_idx": {
+          "name": "sms_conversations_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_conversations_expires_idx": {
+          "name": "sms_conversations_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sms_messages": {
+      "name": "sms_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "provider_message_id": {
+          "name": "provider_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "from_number": {
+          "name": "from_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_number": {
+          "name": "to_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "intent": {
+          "name": "intent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reply_body": {
+          "name": "reply_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sms_messages_received_idx": {
+          "name": "sms_messages_received_idx",
+          "columns": [
+            {
+              "expression": "received_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_messages_from_idx": {
+          "name": "sms_messages_from_idx",
+          "columns": [
+            {
+              "expression": "from_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "clerk_user_id": {
+          "name": "clerk_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "users_clerk_user_id_idx": {
+          "name": "users_clerk_user_id_idx",
+          "columns": [
+            {
+              "expression": "clerk_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.bed_hold_status": {
+      "name": "bed_hold_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "released",
+        "expired",
+        "converted"
+      ]
+    },
+    "public.consent_channel": {
+      "name": "consent_channel",
+      "schema": "public",
+      "values": [
+        "sms",
+        "in_person",
+        "web_form",
+        "phone",
+        "paper"
+      ]
+    },
+    "public.consent_type": {
+      "name": "consent_type",
+      "schema": "public",
+      "values": [
+        "phi_share_within_coalition",
+        "sms_communication",
+        "data_for_program_eval"
+      ]
+    },
+    "public.data_sharing_tier": {
+      "name": "data_sharing_tier",
+      "schema": "public",
+      "values": [
+        "none",
+        "aggregate",
+        "individual"
+      ]
+    },
+    "public.ed_encounter_source": {
+      "name": "ed_encounter_source",
+      "schema": "public",
+      "values": [
+        "synthetic",
+        "epic_fhir",
+        "manual"
+      ]
+    },
+    "public.esuc_care_plan_status": {
+      "name": "esuc_care_plan_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "approved",
+        "active",
+        "archived"
+      ]
+    },
+    "public.eviction_case_outcome": {
+      "name": "eviction_case_outcome",
+      "schema": "public",
+      "values": [
+        "dismissed",
+        "judgment_for_plaintiff",
+        "judgment_for_defendant",
+        "settled",
+        "default_judgment",
+        "withdrawn"
+      ]
+    },
+    "public.eviction_cause_type": {
+      "name": "eviction_cause_type",
+      "schema": "public",
+      "values": [
+        "non_payment",
+        "lease_violation",
+        "holdover",
+        "other"
+      ]
+    },
+    "public.eviction_filing_source": {
+      "name": "eviction_filing_source",
+      "schema": "public",
+      "values": [
+        "courtnet",
+        "manual",
+        "synthetic"
+      ]
+    },
+    "public.eviction_filing_status": {
+      "name": "eviction_filing_status",
+      "schema": "public",
+      "values": [
+        "filed",
+        "served",
+        "judgment",
+        "dismissed",
+        "sealed"
+      ]
+    },
+    "public.eviction_response_packet_status": {
+      "name": "eviction_response_packet_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "approved",
+        "filed",
+        "rejected"
+      ]
+    },
+    "public.housing_status": {
+      "name": "housing_status",
+      "schema": "public",
+      "values": [
+        "housed",
+        "doubled_up",
+        "shelter",
+        "unsheltered",
+        "unknown"
+      ]
+    },
+    "public.partner_org_type": {
+      "name": "partner_org_type",
+      "schema": "public",
+      "values": [
+        "hospital",
+        "legal_aid",
+        "shelter",
+        "community_org",
+        "government",
+        "faith_based",
+        "school",
+        "philanthropy",
+        "education",
+        "public_health",
+        "media",
+        "other"
+      ]
+    },
+    "public.partner_service_event_type": {
+      "name": "partner_service_event_type",
+      "schema": "public",
+      "values": [
+        "food_pantry",
+        "shelter_intake",
+        "shelter_bed_night",
+        "utility_assistance",
+        "rent_assistance",
+        "counseling_visit",
+        "medical_visit",
+        "school_attendance_flag",
+        "volunteer_hours",
+        "other"
+      ]
+    },
+    "public.sms_conversation_state": {
+      "name": "sms_conversation_state",
+      "schema": "public",
+      "values": [
+        "idle",
+        "awaiting_location"
+      ]
+    },
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "pending",
+        "attorney",
+        "caseworker",
+        "ed_coordinator",
+        "shelter_staff",
+        "admin"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/migrations/meta/0020_snapshot.json
+++ b/drizzle/migrations/meta/0020_snapshot.json
@@ -1,0 +1,2601 @@
+{
+  "id": "c6d45982-da16-4903-bd7f-46b41a8836d1",
+  "prevId": "f367cba4-3bfb-4d77-ac52-db36175fc490",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.audit_log": {
+      "name": "audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_table": {
+          "name": "target_table",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "audit_log_actor_idx": {
+          "name": "audit_log_actor_idx",
+          "columns": [
+            {
+              "expression": "actor_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_log_action_idx": {
+          "name": "audit_log_action_idx",
+          "columns": [
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_log_created_at_idx": {
+          "name": "audit_log_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audit_log_actor_user_id_users_id_fk": {
+          "name": "audit_log_actor_user_id_users_id_fk",
+          "tableFrom": "audit_log",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.consents": {
+      "name": "consents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "subject_external_id": {
+          "name": "subject_external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consent_type": {
+          "name": "consent_type",
+          "type": "consent_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "granted_via": {
+          "name": "granted_via",
+          "type": "consent_channel",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "granted_at": {
+          "name": "granted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "consents_subject_idx": {
+          "name": "consents_subject_idx",
+          "columns": [
+            {
+              "expression": "subject_external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "consents_type_idx": {
+          "name": "consents_type_idx",
+          "columns": [
+            {
+              "expression": "consent_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ed_encounters": {
+      "name": "ed_encounters",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encounter_external_id": {
+          "name": "encounter_external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "arrived_at": {
+          "name": "arrived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discharged_at": {
+          "name": "discharged_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chief_complaint": {
+          "name": "chief_complaint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "disposition": {
+          "name": "disposition",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "housing_status": {
+          "name": "housing_status",
+          "type": "housing_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unknown'"
+        },
+        "charge_cents": {
+          "name": "charge_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_json": {
+          "name": "raw_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "ed_encounter_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'synthetic'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ed_encounters_external_idx": {
+          "name": "ed_encounters_external_idx",
+          "columns": [
+            {
+              "expression": "encounter_external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ed_encounters_patient_idx": {
+          "name": "ed_encounters_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ed_encounters_arrived_idx": {
+          "name": "ed_encounters_arrived_idx",
+          "columns": [
+            {
+              "expression": "arrived_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ed_encounters_housing_idx": {
+          "name": "ed_encounters_housing_idx",
+          "columns": [
+            {
+              "expression": "housing_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.esuc_care_plans": {
+      "name": "esuc_care_plans",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plan_md": {
+          "name": "plan_md",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt_version": {
+          "name": "prompt_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "generated_by_user_id": {
+          "name": "generated_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "esuc_care_plan_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "care_plans_patient_version_idx": {
+          "name": "care_plans_patient_version_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "prompt_version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "care_plans_patient_idx": {
+          "name": "care_plans_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "care_plans_status_idx": {
+          "name": "care_plans_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "esuc_care_plans_generated_by_user_id_users_id_fk": {
+          "name": "esuc_care_plans_generated_by_user_id_users_id_fk",
+          "tableFrom": "esuc_care_plans",
+          "tableTo": "users",
+          "columnsFrom": [
+            "generated_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.eviction_case_outcomes": {
+      "name": "eviction_case_outcomes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "filing_id": {
+          "name": "filing_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "eviction_case_outcome",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recorded_by_user_id": {
+          "name": "recorded_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "case_outcomes_filing_idx": {
+          "name": "case_outcomes_filing_idx",
+          "columns": [
+            {
+              "expression": "filing_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "case_outcomes_outcome_idx": {
+          "name": "case_outcomes_outcome_idx",
+          "columns": [
+            {
+              "expression": "outcome",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "case_outcomes_created_at_idx": {
+          "name": "case_outcomes_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "eviction_case_outcomes_filing_id_eviction_filings_id_fk": {
+          "name": "eviction_case_outcomes_filing_id_eviction_filings_id_fk",
+          "tableFrom": "eviction_case_outcomes",
+          "tableTo": "eviction_filings",
+          "columnsFrom": [
+            "filing_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "eviction_case_outcomes_recorded_by_user_id_users_id_fk": {
+          "name": "eviction_case_outcomes_recorded_by_user_id_users_id_fk",
+          "tableFrom": "eviction_case_outcomes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "recorded_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.eviction_filing_risk_scores": {
+      "name": "eviction_filing_risk_scores",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "filing_id": {
+          "name": "filing_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rationale": {
+          "name": "rationale",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model_version": {
+          "name": "model_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "risk_scores_filing_version_idx": {
+          "name": "risk_scores_filing_version_idx",
+          "columns": [
+            {
+              "expression": "filing_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "model_version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "risk_scores_filing_idx": {
+          "name": "risk_scores_filing_idx",
+          "columns": [
+            {
+              "expression": "filing_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "risk_scores_score_idx": {
+          "name": "risk_scores_score_idx",
+          "columns": [
+            {
+              "expression": "score",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "eviction_filing_risk_scores_filing_id_eviction_filings_id_fk": {
+          "name": "eviction_filing_risk_scores_filing_id_eviction_filings_id_fk",
+          "tableFrom": "eviction_filing_risk_scores",
+          "tableTo": "eviction_filings",
+          "columnsFrom": [
+            "filing_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.eviction_filings": {
+      "name": "eviction_filings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "case_number": {
+          "name": "case_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filed_at": {
+          "name": "filed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "court_division": {
+          "name": "court_division",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plaintiff": {
+          "name": "plaintiff",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "defendant_first_name": {
+          "name": "defendant_first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "defendant_last_name": {
+          "name": "defendant_last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "defendant_address": {
+          "name": "defendant_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cause_type": {
+          "name": "cause_type",
+          "type": "eviction_cause_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_claimed_cents": {
+          "name": "amount_claimed_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "eviction_filing_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'filed'"
+        },
+        "source": {
+          "name": "source",
+          "type": "eviction_filing_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "raw_json": {
+          "name": "raw_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "eviction_filings_case_source_idx": {
+          "name": "eviction_filings_case_source_idx",
+          "columns": [
+            {
+              "expression": "case_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "eviction_filings_filed_at_idx": {
+          "name": "eviction_filings_filed_at_idx",
+          "columns": [
+            {
+              "expression": "filed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "eviction_filings_status_idx": {
+          "name": "eviction_filings_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.eviction_response_packets": {
+      "name": "eviction_response_packets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "filing_id": {
+          "name": "filing_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "packet_md": {
+          "name": "packet_md",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt_version": {
+          "name": "prompt_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "generated_by_user_id": {
+          "name": "generated_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "eviction_response_packet_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "response_packets_filing_version_idx": {
+          "name": "response_packets_filing_version_idx",
+          "columns": [
+            {
+              "expression": "filing_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "prompt_version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "response_packets_filing_idx": {
+          "name": "response_packets_filing_idx",
+          "columns": [
+            {
+              "expression": "filing_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "response_packets_status_idx": {
+          "name": "response_packets_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "eviction_response_packets_filing_id_eviction_filings_id_fk": {
+          "name": "eviction_response_packets_filing_id_eviction_filings_id_fk",
+          "tableFrom": "eviction_response_packets",
+          "tableTo": "eviction_filings",
+          "columnsFrom": [
+            "filing_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "eviction_response_packets_generated_by_user_id_users_id_fk": {
+          "name": "eviction_response_packets_generated_by_user_id_users_id_fk",
+          "tableFrom": "eviction_response_packets",
+          "tableTo": "users",
+          "columnsFrom": [
+            "generated_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.health_check": {
+      "name": "health_check",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_memberships": {
+      "name": "org_memberships",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "partner_org_id": {
+          "name": "partner_org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "org_memberships_user_org_idx": {
+          "name": "org_memberships_user_org_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "partner_org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "org_memberships_user_idx": {
+          "name": "org_memberships_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "org_memberships_partner_org_idx": {
+          "name": "org_memberships_partner_org_idx",
+          "columns": [
+            {
+              "expression": "partner_org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "org_memberships_user_id_users_id_fk": {
+          "name": "org_memberships_user_id_users_id_fk",
+          "tableFrom": "org_memberships",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "org_memberships_partner_org_id_partner_orgs_id_fk": {
+          "name": "org_memberships_partner_org_id_partner_orgs_id_fk",
+          "tableFrom": "org_memberships",
+          "tableTo": "partner_orgs",
+          "columnsFrom": [
+            "partner_org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.partner_orgs": {
+      "name": "partner_orgs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "partner_org_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_email": {
+          "name": "contact_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_phone": {
+          "name": "contact_phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "website": {
+          "name": "website",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data_sharing_tier": {
+          "name": "data_sharing_tier",
+          "type": "data_sharing_tier",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "partner_orgs_slug_idx": {
+          "name": "partner_orgs_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.partner_service_events": {
+      "name": "partner_service_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "partner_org_id": {
+          "name": "partner_org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "synthetic_person_ref": {
+          "name": "synthetic_person_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "partner_service_event_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_at": {
+          "name": "event_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "ed_encounter_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'synthetic'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "partner_service_events_person_idx": {
+          "name": "partner_service_events_person_idx",
+          "columns": [
+            {
+              "expression": "synthetic_person_ref",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "partner_service_events_partner_idx": {
+          "name": "partner_service_events_partner_idx",
+          "columns": [
+            {
+              "expression": "partner_org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "partner_service_events_at_idx": {
+          "name": "partner_service_events_at_idx",
+          "columns": [
+            {
+              "expression": "event_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "partner_service_events_partner_org_id_partner_orgs_id_fk": {
+          "name": "partner_service_events_partner_org_id_partner_orgs_id_fk",
+          "tableFrom": "partner_service_events",
+          "tableTo": "partner_orgs",
+          "columnsFrom": [
+            "partner_org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.person_partner_consents": {
+      "name": "person_partner_consents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "synthetic_person_ref": {
+          "name": "synthetic_person_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "partner_org_id": {
+          "name": "partner_org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "granted_at": {
+          "name": "granted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "person_partner_consents_unique_idx": {
+          "name": "person_partner_consents_unique_idx",
+          "columns": [
+            {
+              "expression": "synthetic_person_ref",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "partner_org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "person_partner_consents_partner_org_id_partner_orgs_id_fk": {
+          "name": "person_partner_consents_partner_org_id_partner_orgs_id_fk",
+          "tableFrom": "person_partner_consents",
+          "tableTo": "partner_orgs",
+          "columnsFrom": [
+            "partner_org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rental_assistance_programs": {
+      "name": "rental_assistance_programs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agency": {
+          "name": "agency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "website": {
+          "name": "website",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "eligibility_summary": {
+          "name": "eligibility_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "max_award_cents": {
+          "name": "max_award_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_note": {
+          "name": "source_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "rental_assistance_programs_active_idx": {
+          "name": "rental_assistance_programs_active_idx",
+          "columns": [
+            {
+              "expression": "active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bed_count_updates": {
+      "name": "bed_count_updates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "shelter_id": {
+          "name": "shelter_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_user_id": {
+          "name": "updated_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "previous_occupancy": {
+          "name": "previous_occupancy",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "new_occupancy": {
+          "name": "new_occupancy",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "bed_count_updates_shelter_idx": {
+          "name": "bed_count_updates_shelter_idx",
+          "columns": [
+            {
+              "expression": "shelter_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bed_count_updates_created_idx": {
+          "name": "bed_count_updates_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bed_count_updates_shelter_id_shelters_id_fk": {
+          "name": "bed_count_updates_shelter_id_shelters_id_fk",
+          "tableFrom": "bed_count_updates",
+          "tableTo": "shelters",
+          "columnsFrom": [
+            "shelter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bed_holds": {
+      "name": "bed_holds",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "shelter_id": {
+          "name": "shelter_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "held_by_user_id": {
+          "name": "held_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "person_label": {
+          "name": "person_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "bed_hold_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "released_at": {
+          "name": "released_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "bed_holds_shelter_idx": {
+          "name": "bed_holds_shelter_idx",
+          "columns": [
+            {
+              "expression": "shelter_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bed_holds_status_idx": {
+          "name": "bed_holds_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bed_holds_expires_idx": {
+          "name": "bed_holds_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bed_holds_shelter_id_shelters_id_fk": {
+          "name": "bed_holds_shelter_id_shelters_id_fk",
+          "tableFrom": "bed_holds",
+          "tableTo": "shelters",
+          "columnsFrom": [
+            "shelter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.shelters": {
+      "name": "shelters",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "partner_org_id": {
+          "name": "partner_org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address_line1": {
+          "name": "address_line1",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "city": {
+          "name": "city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "postal_code": {
+          "name": "postal_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_phone": {
+          "name": "contact_phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capacity": {
+          "name": "capacity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_occupancy": {
+          "name": "current_occupancy",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "accepts_men": {
+          "name": "accepts_men",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "accepts_women": {
+          "name": "accepts_women",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "accepts_families": {
+          "name": "accepts_families",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "pet_friendly": {
+          "name": "pet_friendly",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "sud_friendly": {
+          "name": "sud_friendly",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "shelters_slug_idx": {
+          "name": "shelters_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "shelters_partner_org_idx": {
+          "name": "shelters_partner_org_idx",
+          "columns": [
+            {
+              "expression": "partner_org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "shelters_partner_org_id_partner_orgs_id_fk": {
+          "name": "shelters_partner_org_id_partner_orgs_id_fk",
+          "tableFrom": "shelters",
+          "tableTo": "partner_orgs",
+          "columnsFrom": [
+            "partner_org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "shelters_capacity_nonneg": {
+          "name": "shelters_capacity_nonneg",
+          "value": "\"shelters\".\"capacity\" >= 0"
+        },
+        "shelters_occupancy_nonneg": {
+          "name": "shelters_occupancy_nonneg",
+          "value": "\"shelters\".\"current_occupancy\" >= 0"
+        },
+        "shelters_occupancy_le_capacity": {
+          "name": "shelters_occupancy_le_capacity",
+          "value": "\"shelters\".\"current_occupancy\" <= \"shelters\".\"capacity\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.sms_conversations": {
+      "name": "sms_conversations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "from_number": {
+          "name": "from_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "sms_conversation_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'idle'"
+        },
+        "pending_filter": {
+          "name": "pending_filter",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_location": {
+          "name": "last_location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_results": {
+          "name": "last_results",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_hold_id": {
+          "name": "last_hold_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_message_at": {
+          "name": "last_message_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sms_conversations_from_idx": {
+          "name": "sms_conversations_from_idx",
+          "columns": [
+            {
+              "expression": "from_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_conversations_state_idx": {
+          "name": "sms_conversations_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_conversations_expires_idx": {
+          "name": "sms_conversations_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sms_messages": {
+      "name": "sms_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "provider_message_id": {
+          "name": "provider_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "from_number": {
+          "name": "from_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_number": {
+          "name": "to_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "intent": {
+          "name": "intent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reply_body": {
+          "name": "reply_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sms_messages_received_idx": {
+          "name": "sms_messages_received_idx",
+          "columns": [
+            {
+              "expression": "received_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_messages_from_idx": {
+          "name": "sms_messages_from_idx",
+          "columns": [
+            {
+              "expression": "from_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "clerk_user_id": {
+          "name": "clerk_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "users_clerk_user_id_idx": {
+          "name": "users_clerk_user_id_idx",
+          "columns": [
+            {
+              "expression": "clerk_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.bed_hold_status": {
+      "name": "bed_hold_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "released",
+        "expired",
+        "converted"
+      ]
+    },
+    "public.consent_channel": {
+      "name": "consent_channel",
+      "schema": "public",
+      "values": [
+        "sms",
+        "in_person",
+        "web_form",
+        "phone",
+        "paper"
+      ]
+    },
+    "public.consent_type": {
+      "name": "consent_type",
+      "schema": "public",
+      "values": [
+        "phi_share_within_coalition",
+        "sms_communication",
+        "data_for_program_eval"
+      ]
+    },
+    "public.data_sharing_tier": {
+      "name": "data_sharing_tier",
+      "schema": "public",
+      "values": [
+        "none",
+        "aggregate",
+        "individual"
+      ]
+    },
+    "public.ed_encounter_source": {
+      "name": "ed_encounter_source",
+      "schema": "public",
+      "values": [
+        "synthetic",
+        "epic_fhir",
+        "manual"
+      ]
+    },
+    "public.esuc_care_plan_status": {
+      "name": "esuc_care_plan_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "approved",
+        "active",
+        "archived"
+      ]
+    },
+    "public.eviction_case_outcome": {
+      "name": "eviction_case_outcome",
+      "schema": "public",
+      "values": [
+        "dismissed",
+        "judgment_for_plaintiff",
+        "judgment_for_defendant",
+        "settled",
+        "default_judgment",
+        "withdrawn"
+      ]
+    },
+    "public.eviction_cause_type": {
+      "name": "eviction_cause_type",
+      "schema": "public",
+      "values": [
+        "non_payment",
+        "lease_violation",
+        "holdover",
+        "other"
+      ]
+    },
+    "public.eviction_filing_source": {
+      "name": "eviction_filing_source",
+      "schema": "public",
+      "values": [
+        "courtnet",
+        "manual",
+        "synthetic"
+      ]
+    },
+    "public.eviction_filing_status": {
+      "name": "eviction_filing_status",
+      "schema": "public",
+      "values": [
+        "filed",
+        "served",
+        "judgment",
+        "dismissed",
+        "sealed"
+      ]
+    },
+    "public.eviction_response_packet_status": {
+      "name": "eviction_response_packet_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "approved",
+        "filed",
+        "rejected"
+      ]
+    },
+    "public.housing_status": {
+      "name": "housing_status",
+      "schema": "public",
+      "values": [
+        "housed",
+        "doubled_up",
+        "shelter",
+        "unsheltered",
+        "unknown"
+      ]
+    },
+    "public.partner_org_type": {
+      "name": "partner_org_type",
+      "schema": "public",
+      "values": [
+        "hospital",
+        "legal_aid",
+        "shelter",
+        "community_org",
+        "government",
+        "faith_based",
+        "school",
+        "philanthropy",
+        "education",
+        "public_health",
+        "media",
+        "other"
+      ]
+    },
+    "public.partner_service_event_type": {
+      "name": "partner_service_event_type",
+      "schema": "public",
+      "values": [
+        "food_pantry",
+        "shelter_intake",
+        "shelter_bed_night",
+        "utility_assistance",
+        "rent_assistance",
+        "counseling_visit",
+        "medical_visit",
+        "school_attendance_flag",
+        "volunteer_hours",
+        "other"
+      ]
+    },
+    "public.sms_conversation_state": {
+      "name": "sms_conversation_state",
+      "schema": "public",
+      "values": [
+        "idle",
+        "awaiting_location"
+      ]
+    },
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "pending",
+        "attorney",
+        "caseworker",
+        "ed_coordinator",
+        "shelter_staff",
+        "admin"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/migrations/meta/0021_snapshot.json
+++ b/drizzle/migrations/meta/0021_snapshot.json
@@ -1,0 +1,2647 @@
+{
+  "id": "4d3e1f8a-8924-44c9-a3d2-88e8e8ac6ba2",
+  "prevId": "c6d45982-da16-4903-bd7f-46b41a8836d1",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.audit_log": {
+      "name": "audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_table": {
+          "name": "target_table",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "audit_log_actor_idx": {
+          "name": "audit_log_actor_idx",
+          "columns": [
+            {
+              "expression": "actor_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_log_action_idx": {
+          "name": "audit_log_action_idx",
+          "columns": [
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_log_created_at_idx": {
+          "name": "audit_log_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audit_log_actor_user_id_users_id_fk": {
+          "name": "audit_log_actor_user_id_users_id_fk",
+          "tableFrom": "audit_log",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.consents": {
+      "name": "consents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "subject_external_id": {
+          "name": "subject_external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consent_type": {
+          "name": "consent_type",
+          "type": "consent_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "granted_via": {
+          "name": "granted_via",
+          "type": "consent_channel",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consent_version": {
+          "name": "consent_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'2026-04-1'"
+        },
+        "scope_partner_ids": {
+          "name": "scope_partner_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope_data_classes": {
+          "name": "scope_data_classes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "signature_text": {
+          "name": "signature_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "granted_at": {
+          "name": "granted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "consents_subject_idx": {
+          "name": "consents_subject_idx",
+          "columns": [
+            {
+              "expression": "subject_external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "consents_type_idx": {
+          "name": "consents_type_idx",
+          "columns": [
+            {
+              "expression": "consent_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "consents_expires_at_idx": {
+          "name": "consents_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ed_encounters": {
+      "name": "ed_encounters",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encounter_external_id": {
+          "name": "encounter_external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "arrived_at": {
+          "name": "arrived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discharged_at": {
+          "name": "discharged_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chief_complaint": {
+          "name": "chief_complaint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "disposition": {
+          "name": "disposition",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "housing_status": {
+          "name": "housing_status",
+          "type": "housing_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unknown'"
+        },
+        "charge_cents": {
+          "name": "charge_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_json": {
+          "name": "raw_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "ed_encounter_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'synthetic'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ed_encounters_external_idx": {
+          "name": "ed_encounters_external_idx",
+          "columns": [
+            {
+              "expression": "encounter_external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ed_encounters_patient_idx": {
+          "name": "ed_encounters_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ed_encounters_arrived_idx": {
+          "name": "ed_encounters_arrived_idx",
+          "columns": [
+            {
+              "expression": "arrived_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ed_encounters_housing_idx": {
+          "name": "ed_encounters_housing_idx",
+          "columns": [
+            {
+              "expression": "housing_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.esuc_care_plans": {
+      "name": "esuc_care_plans",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plan_md": {
+          "name": "plan_md",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt_version": {
+          "name": "prompt_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "generated_by_user_id": {
+          "name": "generated_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "esuc_care_plan_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "care_plans_patient_version_idx": {
+          "name": "care_plans_patient_version_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "prompt_version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "care_plans_patient_idx": {
+          "name": "care_plans_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "care_plans_status_idx": {
+          "name": "care_plans_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "esuc_care_plans_generated_by_user_id_users_id_fk": {
+          "name": "esuc_care_plans_generated_by_user_id_users_id_fk",
+          "tableFrom": "esuc_care_plans",
+          "tableTo": "users",
+          "columnsFrom": [
+            "generated_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.eviction_case_outcomes": {
+      "name": "eviction_case_outcomes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "filing_id": {
+          "name": "filing_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "eviction_case_outcome",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recorded_by_user_id": {
+          "name": "recorded_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "case_outcomes_filing_idx": {
+          "name": "case_outcomes_filing_idx",
+          "columns": [
+            {
+              "expression": "filing_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "case_outcomes_outcome_idx": {
+          "name": "case_outcomes_outcome_idx",
+          "columns": [
+            {
+              "expression": "outcome",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "case_outcomes_created_at_idx": {
+          "name": "case_outcomes_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "eviction_case_outcomes_filing_id_eviction_filings_id_fk": {
+          "name": "eviction_case_outcomes_filing_id_eviction_filings_id_fk",
+          "tableFrom": "eviction_case_outcomes",
+          "tableTo": "eviction_filings",
+          "columnsFrom": [
+            "filing_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "eviction_case_outcomes_recorded_by_user_id_users_id_fk": {
+          "name": "eviction_case_outcomes_recorded_by_user_id_users_id_fk",
+          "tableFrom": "eviction_case_outcomes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "recorded_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.eviction_filing_risk_scores": {
+      "name": "eviction_filing_risk_scores",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "filing_id": {
+          "name": "filing_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rationale": {
+          "name": "rationale",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model_version": {
+          "name": "model_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "risk_scores_filing_version_idx": {
+          "name": "risk_scores_filing_version_idx",
+          "columns": [
+            {
+              "expression": "filing_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "model_version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "risk_scores_filing_idx": {
+          "name": "risk_scores_filing_idx",
+          "columns": [
+            {
+              "expression": "filing_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "risk_scores_score_idx": {
+          "name": "risk_scores_score_idx",
+          "columns": [
+            {
+              "expression": "score",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "eviction_filing_risk_scores_filing_id_eviction_filings_id_fk": {
+          "name": "eviction_filing_risk_scores_filing_id_eviction_filings_id_fk",
+          "tableFrom": "eviction_filing_risk_scores",
+          "tableTo": "eviction_filings",
+          "columnsFrom": [
+            "filing_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.eviction_filings": {
+      "name": "eviction_filings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "case_number": {
+          "name": "case_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filed_at": {
+          "name": "filed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "court_division": {
+          "name": "court_division",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plaintiff": {
+          "name": "plaintiff",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "defendant_first_name": {
+          "name": "defendant_first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "defendant_last_name": {
+          "name": "defendant_last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "defendant_address": {
+          "name": "defendant_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cause_type": {
+          "name": "cause_type",
+          "type": "eviction_cause_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_claimed_cents": {
+          "name": "amount_claimed_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "eviction_filing_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'filed'"
+        },
+        "source": {
+          "name": "source",
+          "type": "eviction_filing_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "raw_json": {
+          "name": "raw_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "eviction_filings_case_source_idx": {
+          "name": "eviction_filings_case_source_idx",
+          "columns": [
+            {
+              "expression": "case_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "eviction_filings_filed_at_idx": {
+          "name": "eviction_filings_filed_at_idx",
+          "columns": [
+            {
+              "expression": "filed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "eviction_filings_status_idx": {
+          "name": "eviction_filings_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.eviction_response_packets": {
+      "name": "eviction_response_packets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "filing_id": {
+          "name": "filing_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "packet_md": {
+          "name": "packet_md",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt_version": {
+          "name": "prompt_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "generated_by_user_id": {
+          "name": "generated_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "eviction_response_packet_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "response_packets_filing_version_idx": {
+          "name": "response_packets_filing_version_idx",
+          "columns": [
+            {
+              "expression": "filing_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "prompt_version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "response_packets_filing_idx": {
+          "name": "response_packets_filing_idx",
+          "columns": [
+            {
+              "expression": "filing_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "response_packets_status_idx": {
+          "name": "response_packets_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "eviction_response_packets_filing_id_eviction_filings_id_fk": {
+          "name": "eviction_response_packets_filing_id_eviction_filings_id_fk",
+          "tableFrom": "eviction_response_packets",
+          "tableTo": "eviction_filings",
+          "columnsFrom": [
+            "filing_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "eviction_response_packets_generated_by_user_id_users_id_fk": {
+          "name": "eviction_response_packets_generated_by_user_id_users_id_fk",
+          "tableFrom": "eviction_response_packets",
+          "tableTo": "users",
+          "columnsFrom": [
+            "generated_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.health_check": {
+      "name": "health_check",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_memberships": {
+      "name": "org_memberships",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "partner_org_id": {
+          "name": "partner_org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "org_memberships_user_org_idx": {
+          "name": "org_memberships_user_org_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "partner_org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "org_memberships_user_idx": {
+          "name": "org_memberships_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "org_memberships_partner_org_idx": {
+          "name": "org_memberships_partner_org_idx",
+          "columns": [
+            {
+              "expression": "partner_org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "org_memberships_user_id_users_id_fk": {
+          "name": "org_memberships_user_id_users_id_fk",
+          "tableFrom": "org_memberships",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "org_memberships_partner_org_id_partner_orgs_id_fk": {
+          "name": "org_memberships_partner_org_id_partner_orgs_id_fk",
+          "tableFrom": "org_memberships",
+          "tableTo": "partner_orgs",
+          "columnsFrom": [
+            "partner_org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.partner_orgs": {
+      "name": "partner_orgs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "partner_org_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_email": {
+          "name": "contact_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_phone": {
+          "name": "contact_phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "website": {
+          "name": "website",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data_sharing_tier": {
+          "name": "data_sharing_tier",
+          "type": "data_sharing_tier",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "partner_orgs_slug_idx": {
+          "name": "partner_orgs_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.partner_service_events": {
+      "name": "partner_service_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "partner_org_id": {
+          "name": "partner_org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "synthetic_person_ref": {
+          "name": "synthetic_person_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "partner_service_event_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_at": {
+          "name": "event_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "ed_encounter_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'synthetic'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "partner_service_events_person_idx": {
+          "name": "partner_service_events_person_idx",
+          "columns": [
+            {
+              "expression": "synthetic_person_ref",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "partner_service_events_partner_idx": {
+          "name": "partner_service_events_partner_idx",
+          "columns": [
+            {
+              "expression": "partner_org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "partner_service_events_at_idx": {
+          "name": "partner_service_events_at_idx",
+          "columns": [
+            {
+              "expression": "event_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "partner_service_events_partner_org_id_partner_orgs_id_fk": {
+          "name": "partner_service_events_partner_org_id_partner_orgs_id_fk",
+          "tableFrom": "partner_service_events",
+          "tableTo": "partner_orgs",
+          "columnsFrom": [
+            "partner_org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.person_partner_consents": {
+      "name": "person_partner_consents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "synthetic_person_ref": {
+          "name": "synthetic_person_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "partner_org_id": {
+          "name": "partner_org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "granted_at": {
+          "name": "granted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "person_partner_consents_unique_idx": {
+          "name": "person_partner_consents_unique_idx",
+          "columns": [
+            {
+              "expression": "synthetic_person_ref",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "partner_org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "person_partner_consents_partner_org_id_partner_orgs_id_fk": {
+          "name": "person_partner_consents_partner_org_id_partner_orgs_id_fk",
+          "tableFrom": "person_partner_consents",
+          "tableTo": "partner_orgs",
+          "columnsFrom": [
+            "partner_org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rental_assistance_programs": {
+      "name": "rental_assistance_programs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agency": {
+          "name": "agency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "website": {
+          "name": "website",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "eligibility_summary": {
+          "name": "eligibility_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "max_award_cents": {
+          "name": "max_award_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_note": {
+          "name": "source_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "rental_assistance_programs_active_idx": {
+          "name": "rental_assistance_programs_active_idx",
+          "columns": [
+            {
+              "expression": "active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bed_count_updates": {
+      "name": "bed_count_updates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "shelter_id": {
+          "name": "shelter_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_user_id": {
+          "name": "updated_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "previous_occupancy": {
+          "name": "previous_occupancy",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "new_occupancy": {
+          "name": "new_occupancy",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "bed_count_updates_shelter_idx": {
+          "name": "bed_count_updates_shelter_idx",
+          "columns": [
+            {
+              "expression": "shelter_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bed_count_updates_created_idx": {
+          "name": "bed_count_updates_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bed_count_updates_shelter_id_shelters_id_fk": {
+          "name": "bed_count_updates_shelter_id_shelters_id_fk",
+          "tableFrom": "bed_count_updates",
+          "tableTo": "shelters",
+          "columnsFrom": [
+            "shelter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bed_holds": {
+      "name": "bed_holds",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "shelter_id": {
+          "name": "shelter_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "held_by_user_id": {
+          "name": "held_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "person_label": {
+          "name": "person_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "bed_hold_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "released_at": {
+          "name": "released_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "bed_holds_shelter_idx": {
+          "name": "bed_holds_shelter_idx",
+          "columns": [
+            {
+              "expression": "shelter_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bed_holds_status_idx": {
+          "name": "bed_holds_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bed_holds_expires_idx": {
+          "name": "bed_holds_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bed_holds_shelter_id_shelters_id_fk": {
+          "name": "bed_holds_shelter_id_shelters_id_fk",
+          "tableFrom": "bed_holds",
+          "tableTo": "shelters",
+          "columnsFrom": [
+            "shelter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.shelters": {
+      "name": "shelters",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "partner_org_id": {
+          "name": "partner_org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address_line1": {
+          "name": "address_line1",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "city": {
+          "name": "city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "postal_code": {
+          "name": "postal_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_phone": {
+          "name": "contact_phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capacity": {
+          "name": "capacity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_occupancy": {
+          "name": "current_occupancy",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "accepts_men": {
+          "name": "accepts_men",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "accepts_women": {
+          "name": "accepts_women",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "accepts_families": {
+          "name": "accepts_families",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "pet_friendly": {
+          "name": "pet_friendly",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "sud_friendly": {
+          "name": "sud_friendly",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "shelters_slug_idx": {
+          "name": "shelters_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "shelters_partner_org_idx": {
+          "name": "shelters_partner_org_idx",
+          "columns": [
+            {
+              "expression": "partner_org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "shelters_partner_org_id_partner_orgs_id_fk": {
+          "name": "shelters_partner_org_id_partner_orgs_id_fk",
+          "tableFrom": "shelters",
+          "tableTo": "partner_orgs",
+          "columnsFrom": [
+            "partner_org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "shelters_capacity_nonneg": {
+          "name": "shelters_capacity_nonneg",
+          "value": "\"shelters\".\"capacity\" >= 0"
+        },
+        "shelters_occupancy_nonneg": {
+          "name": "shelters_occupancy_nonneg",
+          "value": "\"shelters\".\"current_occupancy\" >= 0"
+        },
+        "shelters_occupancy_le_capacity": {
+          "name": "shelters_occupancy_le_capacity",
+          "value": "\"shelters\".\"current_occupancy\" <= \"shelters\".\"capacity\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.sms_conversations": {
+      "name": "sms_conversations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "from_number": {
+          "name": "from_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "sms_conversation_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'idle'"
+        },
+        "pending_filter": {
+          "name": "pending_filter",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_location": {
+          "name": "last_location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_results": {
+          "name": "last_results",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_hold_id": {
+          "name": "last_hold_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_message_at": {
+          "name": "last_message_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sms_conversations_from_idx": {
+          "name": "sms_conversations_from_idx",
+          "columns": [
+            {
+              "expression": "from_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_conversations_state_idx": {
+          "name": "sms_conversations_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_conversations_expires_idx": {
+          "name": "sms_conversations_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sms_messages": {
+      "name": "sms_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "provider_message_id": {
+          "name": "provider_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "from_number": {
+          "name": "from_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_number": {
+          "name": "to_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "intent": {
+          "name": "intent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reply_body": {
+          "name": "reply_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sms_messages_received_idx": {
+          "name": "sms_messages_received_idx",
+          "columns": [
+            {
+              "expression": "received_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_messages_from_idx": {
+          "name": "sms_messages_from_idx",
+          "columns": [
+            {
+              "expression": "from_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "clerk_user_id": {
+          "name": "clerk_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "users_clerk_user_id_idx": {
+          "name": "users_clerk_user_id_idx",
+          "columns": [
+            {
+              "expression": "clerk_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.bed_hold_status": {
+      "name": "bed_hold_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "released",
+        "expired",
+        "converted"
+      ]
+    },
+    "public.consent_channel": {
+      "name": "consent_channel",
+      "schema": "public",
+      "values": [
+        "sms",
+        "in_person",
+        "web_form",
+        "phone",
+        "paper"
+      ]
+    },
+    "public.consent_type": {
+      "name": "consent_type",
+      "schema": "public",
+      "values": [
+        "phi_share_within_coalition",
+        "sms_communication",
+        "data_for_program_eval"
+      ]
+    },
+    "public.data_sharing_tier": {
+      "name": "data_sharing_tier",
+      "schema": "public",
+      "values": [
+        "none",
+        "aggregate",
+        "individual"
+      ]
+    },
+    "public.ed_encounter_source": {
+      "name": "ed_encounter_source",
+      "schema": "public",
+      "values": [
+        "synthetic",
+        "epic_fhir",
+        "manual"
+      ]
+    },
+    "public.esuc_care_plan_status": {
+      "name": "esuc_care_plan_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "approved",
+        "active",
+        "archived"
+      ]
+    },
+    "public.eviction_case_outcome": {
+      "name": "eviction_case_outcome",
+      "schema": "public",
+      "values": [
+        "dismissed",
+        "judgment_for_plaintiff",
+        "judgment_for_defendant",
+        "settled",
+        "default_judgment",
+        "withdrawn"
+      ]
+    },
+    "public.eviction_cause_type": {
+      "name": "eviction_cause_type",
+      "schema": "public",
+      "values": [
+        "non_payment",
+        "lease_violation",
+        "holdover",
+        "other"
+      ]
+    },
+    "public.eviction_filing_source": {
+      "name": "eviction_filing_source",
+      "schema": "public",
+      "values": [
+        "courtnet",
+        "manual",
+        "synthetic"
+      ]
+    },
+    "public.eviction_filing_status": {
+      "name": "eviction_filing_status",
+      "schema": "public",
+      "values": [
+        "filed",
+        "served",
+        "judgment",
+        "dismissed",
+        "sealed"
+      ]
+    },
+    "public.eviction_response_packet_status": {
+      "name": "eviction_response_packet_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "approved",
+        "filed",
+        "rejected"
+      ]
+    },
+    "public.housing_status": {
+      "name": "housing_status",
+      "schema": "public",
+      "values": [
+        "housed",
+        "doubled_up",
+        "shelter",
+        "unsheltered",
+        "unknown"
+      ]
+    },
+    "public.partner_org_type": {
+      "name": "partner_org_type",
+      "schema": "public",
+      "values": [
+        "hospital",
+        "legal_aid",
+        "shelter",
+        "community_org",
+        "government",
+        "faith_based",
+        "school",
+        "philanthropy",
+        "education",
+        "public_health",
+        "media",
+        "other"
+      ]
+    },
+    "public.partner_service_event_type": {
+      "name": "partner_service_event_type",
+      "schema": "public",
+      "values": [
+        "food_pantry",
+        "shelter_intake",
+        "shelter_bed_night",
+        "utility_assistance",
+        "rent_assistance",
+        "counseling_visit",
+        "medical_visit",
+        "school_attendance_flag",
+        "volunteer_hours",
+        "other"
+      ]
+    },
+    "public.sms_conversation_state": {
+      "name": "sms_conversation_state",
+      "schema": "public",
+      "values": [
+        "idle",
+        "awaiting_location"
+      ]
+    },
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "pending",
+        "attorney",
+        "caseworker",
+        "ed_coordinator",
+        "shelter_staff",
+        "admin"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/migrations/meta/0022_snapshot.json
+++ b/drizzle/migrations/meta/0022_snapshot.json
@@ -1,0 +1,2744 @@
+{
+  "id": "d54dc92c-36c9-4b39-8bc6-675cbceba5ed",
+  "prevId": "4d3e1f8a-8924-44c9-a3d2-88e8e8ac6ba2",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.audit_log": {
+      "name": "audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_table": {
+          "name": "target_table",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "audit_log_actor_idx": {
+          "name": "audit_log_actor_idx",
+          "columns": [
+            {
+              "expression": "actor_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_log_action_idx": {
+          "name": "audit_log_action_idx",
+          "columns": [
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_log_created_at_idx": {
+          "name": "audit_log_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audit_log_actor_user_id_users_id_fk": {
+          "name": "audit_log_actor_user_id_users_id_fk",
+          "tableFrom": "audit_log",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.consents": {
+      "name": "consents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "subject_external_id": {
+          "name": "subject_external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consent_type": {
+          "name": "consent_type",
+          "type": "consent_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "granted_via": {
+          "name": "granted_via",
+          "type": "consent_channel",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consent_version": {
+          "name": "consent_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'2026-04-1'"
+        },
+        "scope_partner_ids": {
+          "name": "scope_partner_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope_data_classes": {
+          "name": "scope_data_classes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "signature_text": {
+          "name": "signature_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "granted_at": {
+          "name": "granted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "consents_subject_idx": {
+          "name": "consents_subject_idx",
+          "columns": [
+            {
+              "expression": "subject_external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "consents_type_idx": {
+          "name": "consents_type_idx",
+          "columns": [
+            {
+              "expression": "consent_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "consents_expires_at_idx": {
+          "name": "consents_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.dv_flagged_persons": {
+      "name": "dv_flagged_persons",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "subject_identifier": {
+          "name": "subject_identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "flag_set_at": {
+          "name": "flag_set_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "flag_cleared_at": {
+          "name": "flag_cleared_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "dv_flagged_persons_subject_idx": {
+          "name": "dv_flagged_persons_subject_idx",
+          "columns": [
+            {
+              "expression": "subject_identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dv_flagged_persons_set_at_idx": {
+          "name": "dv_flagged_persons_set_at_idx",
+          "columns": [
+            {
+              "expression": "flag_set_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ed_encounters": {
+      "name": "ed_encounters",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encounter_external_id": {
+          "name": "encounter_external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "arrived_at": {
+          "name": "arrived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discharged_at": {
+          "name": "discharged_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chief_complaint": {
+          "name": "chief_complaint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "disposition": {
+          "name": "disposition",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "housing_status": {
+          "name": "housing_status",
+          "type": "housing_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unknown'"
+        },
+        "charge_cents": {
+          "name": "charge_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_json": {
+          "name": "raw_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "ed_encounter_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'synthetic'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ed_encounters_external_idx": {
+          "name": "ed_encounters_external_idx",
+          "columns": [
+            {
+              "expression": "encounter_external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ed_encounters_patient_idx": {
+          "name": "ed_encounters_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ed_encounters_arrived_idx": {
+          "name": "ed_encounters_arrived_idx",
+          "columns": [
+            {
+              "expression": "arrived_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ed_encounters_housing_idx": {
+          "name": "ed_encounters_housing_idx",
+          "columns": [
+            {
+              "expression": "housing_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.esuc_care_plans": {
+      "name": "esuc_care_plans",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plan_md": {
+          "name": "plan_md",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt_version": {
+          "name": "prompt_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "generated_by_user_id": {
+          "name": "generated_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "esuc_care_plan_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "care_plans_patient_version_idx": {
+          "name": "care_plans_patient_version_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "prompt_version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "care_plans_patient_idx": {
+          "name": "care_plans_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "care_plans_status_idx": {
+          "name": "care_plans_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "esuc_care_plans_generated_by_user_id_users_id_fk": {
+          "name": "esuc_care_plans_generated_by_user_id_users_id_fk",
+          "tableFrom": "esuc_care_plans",
+          "tableTo": "users",
+          "columnsFrom": [
+            "generated_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.eviction_case_outcomes": {
+      "name": "eviction_case_outcomes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "filing_id": {
+          "name": "filing_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "eviction_case_outcome",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recorded_by_user_id": {
+          "name": "recorded_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "case_outcomes_filing_idx": {
+          "name": "case_outcomes_filing_idx",
+          "columns": [
+            {
+              "expression": "filing_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "case_outcomes_outcome_idx": {
+          "name": "case_outcomes_outcome_idx",
+          "columns": [
+            {
+              "expression": "outcome",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "case_outcomes_created_at_idx": {
+          "name": "case_outcomes_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "eviction_case_outcomes_filing_id_eviction_filings_id_fk": {
+          "name": "eviction_case_outcomes_filing_id_eviction_filings_id_fk",
+          "tableFrom": "eviction_case_outcomes",
+          "tableTo": "eviction_filings",
+          "columnsFrom": [
+            "filing_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "eviction_case_outcomes_recorded_by_user_id_users_id_fk": {
+          "name": "eviction_case_outcomes_recorded_by_user_id_users_id_fk",
+          "tableFrom": "eviction_case_outcomes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "recorded_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.eviction_filing_risk_scores": {
+      "name": "eviction_filing_risk_scores",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "filing_id": {
+          "name": "filing_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rationale": {
+          "name": "rationale",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model_version": {
+          "name": "model_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "risk_scores_filing_version_idx": {
+          "name": "risk_scores_filing_version_idx",
+          "columns": [
+            {
+              "expression": "filing_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "model_version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "risk_scores_filing_idx": {
+          "name": "risk_scores_filing_idx",
+          "columns": [
+            {
+              "expression": "filing_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "risk_scores_score_idx": {
+          "name": "risk_scores_score_idx",
+          "columns": [
+            {
+              "expression": "score",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "eviction_filing_risk_scores_filing_id_eviction_filings_id_fk": {
+          "name": "eviction_filing_risk_scores_filing_id_eviction_filings_id_fk",
+          "tableFrom": "eviction_filing_risk_scores",
+          "tableTo": "eviction_filings",
+          "columnsFrom": [
+            "filing_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.eviction_filings": {
+      "name": "eviction_filings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "case_number": {
+          "name": "case_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filed_at": {
+          "name": "filed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "court_division": {
+          "name": "court_division",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plaintiff": {
+          "name": "plaintiff",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "defendant_first_name": {
+          "name": "defendant_first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "defendant_last_name": {
+          "name": "defendant_last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "defendant_address": {
+          "name": "defendant_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cause_type": {
+          "name": "cause_type",
+          "type": "eviction_cause_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_claimed_cents": {
+          "name": "amount_claimed_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "eviction_filing_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'filed'"
+        },
+        "source": {
+          "name": "source",
+          "type": "eviction_filing_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "raw_json": {
+          "name": "raw_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dv_flag": {
+          "name": "dv_flag",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "eviction_filings_case_source_idx": {
+          "name": "eviction_filings_case_source_idx",
+          "columns": [
+            {
+              "expression": "case_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "eviction_filings_filed_at_idx": {
+          "name": "eviction_filings_filed_at_idx",
+          "columns": [
+            {
+              "expression": "filed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "eviction_filings_status_idx": {
+          "name": "eviction_filings_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.eviction_response_packets": {
+      "name": "eviction_response_packets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "filing_id": {
+          "name": "filing_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "packet_md": {
+          "name": "packet_md",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt_version": {
+          "name": "prompt_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "generated_by_user_id": {
+          "name": "generated_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "eviction_response_packet_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "response_packets_filing_version_idx": {
+          "name": "response_packets_filing_version_idx",
+          "columns": [
+            {
+              "expression": "filing_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "prompt_version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "response_packets_filing_idx": {
+          "name": "response_packets_filing_idx",
+          "columns": [
+            {
+              "expression": "filing_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "response_packets_status_idx": {
+          "name": "response_packets_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "eviction_response_packets_filing_id_eviction_filings_id_fk": {
+          "name": "eviction_response_packets_filing_id_eviction_filings_id_fk",
+          "tableFrom": "eviction_response_packets",
+          "tableTo": "eviction_filings",
+          "columnsFrom": [
+            "filing_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "eviction_response_packets_generated_by_user_id_users_id_fk": {
+          "name": "eviction_response_packets_generated_by_user_id_users_id_fk",
+          "tableFrom": "eviction_response_packets",
+          "tableTo": "users",
+          "columnsFrom": [
+            "generated_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.health_check": {
+      "name": "health_check",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_memberships": {
+      "name": "org_memberships",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "partner_org_id": {
+          "name": "partner_org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "org_memberships_user_org_idx": {
+          "name": "org_memberships_user_org_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "partner_org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "org_memberships_user_idx": {
+          "name": "org_memberships_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "org_memberships_partner_org_idx": {
+          "name": "org_memberships_partner_org_idx",
+          "columns": [
+            {
+              "expression": "partner_org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "org_memberships_user_id_users_id_fk": {
+          "name": "org_memberships_user_id_users_id_fk",
+          "tableFrom": "org_memberships",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "org_memberships_partner_org_id_partner_orgs_id_fk": {
+          "name": "org_memberships_partner_org_id_partner_orgs_id_fk",
+          "tableFrom": "org_memberships",
+          "tableTo": "partner_orgs",
+          "columnsFrom": [
+            "partner_org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.partner_orgs": {
+      "name": "partner_orgs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "partner_org_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_email": {
+          "name": "contact_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_phone": {
+          "name": "contact_phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "website": {
+          "name": "website",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data_sharing_tier": {
+          "name": "data_sharing_tier",
+          "type": "data_sharing_tier",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "partner_orgs_slug_idx": {
+          "name": "partner_orgs_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.partner_service_events": {
+      "name": "partner_service_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "partner_org_id": {
+          "name": "partner_org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "synthetic_person_ref": {
+          "name": "synthetic_person_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "partner_service_event_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_at": {
+          "name": "event_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "ed_encounter_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'synthetic'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "partner_service_events_person_idx": {
+          "name": "partner_service_events_person_idx",
+          "columns": [
+            {
+              "expression": "synthetic_person_ref",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "partner_service_events_partner_idx": {
+          "name": "partner_service_events_partner_idx",
+          "columns": [
+            {
+              "expression": "partner_org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "partner_service_events_at_idx": {
+          "name": "partner_service_events_at_idx",
+          "columns": [
+            {
+              "expression": "event_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "partner_service_events_partner_org_id_partner_orgs_id_fk": {
+          "name": "partner_service_events_partner_org_id_partner_orgs_id_fk",
+          "tableFrom": "partner_service_events",
+          "tableTo": "partner_orgs",
+          "columnsFrom": [
+            "partner_org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.person_partner_consents": {
+      "name": "person_partner_consents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "synthetic_person_ref": {
+          "name": "synthetic_person_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "partner_org_id": {
+          "name": "partner_org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "granted_at": {
+          "name": "granted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "person_partner_consents_unique_idx": {
+          "name": "person_partner_consents_unique_idx",
+          "columns": [
+            {
+              "expression": "synthetic_person_ref",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "partner_org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "person_partner_consents_partner_org_id_partner_orgs_id_fk": {
+          "name": "person_partner_consents_partner_org_id_partner_orgs_id_fk",
+          "tableFrom": "person_partner_consents",
+          "tableTo": "partner_orgs",
+          "columnsFrom": [
+            "partner_org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rental_assistance_programs": {
+      "name": "rental_assistance_programs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agency": {
+          "name": "agency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "website": {
+          "name": "website",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "eligibility_summary": {
+          "name": "eligibility_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "max_award_cents": {
+          "name": "max_award_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_note": {
+          "name": "source_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "rental_assistance_programs_active_idx": {
+          "name": "rental_assistance_programs_active_idx",
+          "columns": [
+            {
+              "expression": "active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bed_count_updates": {
+      "name": "bed_count_updates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "shelter_id": {
+          "name": "shelter_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_user_id": {
+          "name": "updated_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "previous_occupancy": {
+          "name": "previous_occupancy",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "new_occupancy": {
+          "name": "new_occupancy",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "bed_count_updates_shelter_idx": {
+          "name": "bed_count_updates_shelter_idx",
+          "columns": [
+            {
+              "expression": "shelter_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bed_count_updates_created_idx": {
+          "name": "bed_count_updates_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bed_count_updates_shelter_id_shelters_id_fk": {
+          "name": "bed_count_updates_shelter_id_shelters_id_fk",
+          "tableFrom": "bed_count_updates",
+          "tableTo": "shelters",
+          "columnsFrom": [
+            "shelter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bed_holds": {
+      "name": "bed_holds",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "shelter_id": {
+          "name": "shelter_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "held_by_user_id": {
+          "name": "held_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "person_label": {
+          "name": "person_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "bed_hold_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "released_at": {
+          "name": "released_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "bed_holds_shelter_idx": {
+          "name": "bed_holds_shelter_idx",
+          "columns": [
+            {
+              "expression": "shelter_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bed_holds_status_idx": {
+          "name": "bed_holds_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bed_holds_expires_idx": {
+          "name": "bed_holds_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bed_holds_shelter_id_shelters_id_fk": {
+          "name": "bed_holds_shelter_id_shelters_id_fk",
+          "tableFrom": "bed_holds",
+          "tableTo": "shelters",
+          "columnsFrom": [
+            "shelter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.shelters": {
+      "name": "shelters",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "partner_org_id": {
+          "name": "partner_org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address_line1": {
+          "name": "address_line1",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "city": {
+          "name": "city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "postal_code": {
+          "name": "postal_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_phone": {
+          "name": "contact_phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capacity": {
+          "name": "capacity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_occupancy": {
+          "name": "current_occupancy",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "accepts_men": {
+          "name": "accepts_men",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "accepts_women": {
+          "name": "accepts_women",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "accepts_families": {
+          "name": "accepts_families",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "pet_friendly": {
+          "name": "pet_friendly",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "sud_friendly": {
+          "name": "sud_friendly",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "shelters_slug_idx": {
+          "name": "shelters_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "shelters_partner_org_idx": {
+          "name": "shelters_partner_org_idx",
+          "columns": [
+            {
+              "expression": "partner_org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "shelters_partner_org_id_partner_orgs_id_fk": {
+          "name": "shelters_partner_org_id_partner_orgs_id_fk",
+          "tableFrom": "shelters",
+          "tableTo": "partner_orgs",
+          "columnsFrom": [
+            "partner_org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "shelters_capacity_nonneg": {
+          "name": "shelters_capacity_nonneg",
+          "value": "\"shelters\".\"capacity\" >= 0"
+        },
+        "shelters_occupancy_nonneg": {
+          "name": "shelters_occupancy_nonneg",
+          "value": "\"shelters\".\"current_occupancy\" >= 0"
+        },
+        "shelters_occupancy_le_capacity": {
+          "name": "shelters_occupancy_le_capacity",
+          "value": "\"shelters\".\"current_occupancy\" <= \"shelters\".\"capacity\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.sms_conversations": {
+      "name": "sms_conversations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "from_number": {
+          "name": "from_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "sms_conversation_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'idle'"
+        },
+        "pending_filter": {
+          "name": "pending_filter",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_location": {
+          "name": "last_location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_results": {
+          "name": "last_results",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_hold_id": {
+          "name": "last_hold_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_message_at": {
+          "name": "last_message_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sms_conversations_from_idx": {
+          "name": "sms_conversations_from_idx",
+          "columns": [
+            {
+              "expression": "from_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_conversations_state_idx": {
+          "name": "sms_conversations_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_conversations_expires_idx": {
+          "name": "sms_conversations_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sms_messages": {
+      "name": "sms_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "provider_message_id": {
+          "name": "provider_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "from_number": {
+          "name": "from_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_number": {
+          "name": "to_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "intent": {
+          "name": "intent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reply_body": {
+          "name": "reply_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sms_messages_received_idx": {
+          "name": "sms_messages_received_idx",
+          "columns": [
+            {
+              "expression": "received_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_messages_from_idx": {
+          "name": "sms_messages_from_idx",
+          "columns": [
+            {
+              "expression": "from_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "clerk_user_id": {
+          "name": "clerk_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "users_clerk_user_id_idx": {
+          "name": "users_clerk_user_id_idx",
+          "columns": [
+            {
+              "expression": "clerk_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.bed_hold_status": {
+      "name": "bed_hold_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "released",
+        "expired",
+        "converted"
+      ]
+    },
+    "public.consent_channel": {
+      "name": "consent_channel",
+      "schema": "public",
+      "values": [
+        "sms",
+        "in_person",
+        "web_form",
+        "phone",
+        "paper"
+      ]
+    },
+    "public.consent_type": {
+      "name": "consent_type",
+      "schema": "public",
+      "values": [
+        "phi_share_within_coalition",
+        "sms_communication",
+        "data_for_program_eval"
+      ]
+    },
+    "public.data_sharing_tier": {
+      "name": "data_sharing_tier",
+      "schema": "public",
+      "values": [
+        "none",
+        "aggregate",
+        "individual"
+      ]
+    },
+    "public.ed_encounter_source": {
+      "name": "ed_encounter_source",
+      "schema": "public",
+      "values": [
+        "synthetic",
+        "epic_fhir",
+        "manual"
+      ]
+    },
+    "public.esuc_care_plan_status": {
+      "name": "esuc_care_plan_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "approved",
+        "active",
+        "archived"
+      ]
+    },
+    "public.eviction_case_outcome": {
+      "name": "eviction_case_outcome",
+      "schema": "public",
+      "values": [
+        "dismissed",
+        "judgment_for_plaintiff",
+        "judgment_for_defendant",
+        "settled",
+        "default_judgment",
+        "withdrawn"
+      ]
+    },
+    "public.eviction_cause_type": {
+      "name": "eviction_cause_type",
+      "schema": "public",
+      "values": [
+        "non_payment",
+        "lease_violation",
+        "holdover",
+        "other"
+      ]
+    },
+    "public.eviction_filing_source": {
+      "name": "eviction_filing_source",
+      "schema": "public",
+      "values": [
+        "courtnet",
+        "manual",
+        "synthetic"
+      ]
+    },
+    "public.eviction_filing_status": {
+      "name": "eviction_filing_status",
+      "schema": "public",
+      "values": [
+        "filed",
+        "served",
+        "judgment",
+        "dismissed",
+        "sealed"
+      ]
+    },
+    "public.eviction_response_packet_status": {
+      "name": "eviction_response_packet_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "approved",
+        "filed",
+        "rejected"
+      ]
+    },
+    "public.housing_status": {
+      "name": "housing_status",
+      "schema": "public",
+      "values": [
+        "housed",
+        "doubled_up",
+        "shelter",
+        "unsheltered",
+        "unknown"
+      ]
+    },
+    "public.partner_org_type": {
+      "name": "partner_org_type",
+      "schema": "public",
+      "values": [
+        "hospital",
+        "legal_aid",
+        "shelter",
+        "community_org",
+        "government",
+        "faith_based",
+        "school",
+        "philanthropy",
+        "education",
+        "public_health",
+        "media",
+        "other"
+      ]
+    },
+    "public.partner_service_event_type": {
+      "name": "partner_service_event_type",
+      "schema": "public",
+      "values": [
+        "food_pantry",
+        "shelter_intake",
+        "shelter_bed_night",
+        "utility_assistance",
+        "rent_assistance",
+        "counseling_visit",
+        "medical_visit",
+        "school_attendance_flag",
+        "volunteer_hours",
+        "other"
+      ]
+    },
+    "public.sms_conversation_state": {
+      "name": "sms_conversation_state",
+      "schema": "public",
+      "values": [
+        "idle",
+        "awaiting_location"
+      ]
+    },
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "pending",
+        "attorney",
+        "caseworker",
+        "ed_coordinator",
+        "shelter_staff",
+        "admin"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/migrations/meta/0023_snapshot.json
+++ b/drizzle/migrations/meta/0023_snapshot.json
@@ -1,0 +1,2873 @@
+{
+  "id": "418b7757-36d7-4726-b9a4-5ef97a04d9bf",
+  "prevId": "d54dc92c-36c9-4b39-8bc6-675cbceba5ed",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.audit_log": {
+      "name": "audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_table": {
+          "name": "target_table",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "audit_log_actor_idx": {
+          "name": "audit_log_actor_idx",
+          "columns": [
+            {
+              "expression": "actor_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_log_action_idx": {
+          "name": "audit_log_action_idx",
+          "columns": [
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_log_created_at_idx": {
+          "name": "audit_log_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audit_log_actor_user_id_users_id_fk": {
+          "name": "audit_log_actor_user_id_users_id_fk",
+          "tableFrom": "audit_log",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.consent_access_tokens": {
+      "name": "consent_access_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "synthetic_person_ref": {
+          "name": "synthetic_person_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issued_by_user_id": {
+          "name": "issued_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "consent_access_tokens_token_idx": {
+          "name": "consent_access_tokens_token_idx",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "consent_access_tokens_ref_idx": {
+          "name": "consent_access_tokens_ref_idx",
+          "columns": [
+            {
+              "expression": "synthetic_person_ref",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "consent_access_tokens_expires_idx": {
+          "name": "consent_access_tokens_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "consent_access_tokens_issued_by_user_id_users_id_fk": {
+          "name": "consent_access_tokens_issued_by_user_id_users_id_fk",
+          "tableFrom": "consent_access_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "issued_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.consents": {
+      "name": "consents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "subject_external_id": {
+          "name": "subject_external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consent_type": {
+          "name": "consent_type",
+          "type": "consent_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "granted_via": {
+          "name": "granted_via",
+          "type": "consent_channel",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consent_version": {
+          "name": "consent_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'2026-04-1'"
+        },
+        "scope_partner_ids": {
+          "name": "scope_partner_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope_data_classes": {
+          "name": "scope_data_classes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "signature_text": {
+          "name": "signature_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "granted_at": {
+          "name": "granted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "consents_subject_idx": {
+          "name": "consents_subject_idx",
+          "columns": [
+            {
+              "expression": "subject_external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "consents_type_idx": {
+          "name": "consents_type_idx",
+          "columns": [
+            {
+              "expression": "consent_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "consents_expires_at_idx": {
+          "name": "consents_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.dv_flagged_persons": {
+      "name": "dv_flagged_persons",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "subject_identifier": {
+          "name": "subject_identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "flag_set_at": {
+          "name": "flag_set_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "flag_cleared_at": {
+          "name": "flag_cleared_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "dv_flagged_persons_subject_idx": {
+          "name": "dv_flagged_persons_subject_idx",
+          "columns": [
+            {
+              "expression": "subject_identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dv_flagged_persons_set_at_idx": {
+          "name": "dv_flagged_persons_set_at_idx",
+          "columns": [
+            {
+              "expression": "flag_set_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ed_encounters": {
+      "name": "ed_encounters",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encounter_external_id": {
+          "name": "encounter_external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "arrived_at": {
+          "name": "arrived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discharged_at": {
+          "name": "discharged_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chief_complaint": {
+          "name": "chief_complaint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "disposition": {
+          "name": "disposition",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "housing_status": {
+          "name": "housing_status",
+          "type": "housing_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unknown'"
+        },
+        "charge_cents": {
+          "name": "charge_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_json": {
+          "name": "raw_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "ed_encounter_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'synthetic'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ed_encounters_external_idx": {
+          "name": "ed_encounters_external_idx",
+          "columns": [
+            {
+              "expression": "encounter_external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ed_encounters_patient_idx": {
+          "name": "ed_encounters_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ed_encounters_arrived_idx": {
+          "name": "ed_encounters_arrived_idx",
+          "columns": [
+            {
+              "expression": "arrived_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ed_encounters_housing_idx": {
+          "name": "ed_encounters_housing_idx",
+          "columns": [
+            {
+              "expression": "housing_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.esuc_care_plans": {
+      "name": "esuc_care_plans",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plan_md": {
+          "name": "plan_md",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt_version": {
+          "name": "prompt_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "generated_by_user_id": {
+          "name": "generated_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "esuc_care_plan_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "care_plans_patient_version_idx": {
+          "name": "care_plans_patient_version_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "prompt_version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "care_plans_patient_idx": {
+          "name": "care_plans_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "care_plans_status_idx": {
+          "name": "care_plans_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "esuc_care_plans_generated_by_user_id_users_id_fk": {
+          "name": "esuc_care_plans_generated_by_user_id_users_id_fk",
+          "tableFrom": "esuc_care_plans",
+          "tableTo": "users",
+          "columnsFrom": [
+            "generated_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.eviction_case_outcomes": {
+      "name": "eviction_case_outcomes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "filing_id": {
+          "name": "filing_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "eviction_case_outcome",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recorded_by_user_id": {
+          "name": "recorded_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "case_outcomes_filing_idx": {
+          "name": "case_outcomes_filing_idx",
+          "columns": [
+            {
+              "expression": "filing_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "case_outcomes_outcome_idx": {
+          "name": "case_outcomes_outcome_idx",
+          "columns": [
+            {
+              "expression": "outcome",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "case_outcomes_created_at_idx": {
+          "name": "case_outcomes_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "eviction_case_outcomes_filing_id_eviction_filings_id_fk": {
+          "name": "eviction_case_outcomes_filing_id_eviction_filings_id_fk",
+          "tableFrom": "eviction_case_outcomes",
+          "tableTo": "eviction_filings",
+          "columnsFrom": [
+            "filing_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "eviction_case_outcomes_recorded_by_user_id_users_id_fk": {
+          "name": "eviction_case_outcomes_recorded_by_user_id_users_id_fk",
+          "tableFrom": "eviction_case_outcomes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "recorded_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.eviction_filing_risk_scores": {
+      "name": "eviction_filing_risk_scores",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "filing_id": {
+          "name": "filing_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rationale": {
+          "name": "rationale",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model_version": {
+          "name": "model_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "risk_scores_filing_version_idx": {
+          "name": "risk_scores_filing_version_idx",
+          "columns": [
+            {
+              "expression": "filing_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "model_version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "risk_scores_filing_idx": {
+          "name": "risk_scores_filing_idx",
+          "columns": [
+            {
+              "expression": "filing_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "risk_scores_score_idx": {
+          "name": "risk_scores_score_idx",
+          "columns": [
+            {
+              "expression": "score",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "eviction_filing_risk_scores_filing_id_eviction_filings_id_fk": {
+          "name": "eviction_filing_risk_scores_filing_id_eviction_filings_id_fk",
+          "tableFrom": "eviction_filing_risk_scores",
+          "tableTo": "eviction_filings",
+          "columnsFrom": [
+            "filing_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.eviction_filings": {
+      "name": "eviction_filings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "case_number": {
+          "name": "case_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filed_at": {
+          "name": "filed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "court_division": {
+          "name": "court_division",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plaintiff": {
+          "name": "plaintiff",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "defendant_first_name": {
+          "name": "defendant_first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "defendant_last_name": {
+          "name": "defendant_last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "defendant_address": {
+          "name": "defendant_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cause_type": {
+          "name": "cause_type",
+          "type": "eviction_cause_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_claimed_cents": {
+          "name": "amount_claimed_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "eviction_filing_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'filed'"
+        },
+        "source": {
+          "name": "source",
+          "type": "eviction_filing_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "raw_json": {
+          "name": "raw_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dv_flag": {
+          "name": "dv_flag",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "eviction_filings_case_source_idx": {
+          "name": "eviction_filings_case_source_idx",
+          "columns": [
+            {
+              "expression": "case_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "eviction_filings_filed_at_idx": {
+          "name": "eviction_filings_filed_at_idx",
+          "columns": [
+            {
+              "expression": "filed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "eviction_filings_status_idx": {
+          "name": "eviction_filings_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.eviction_response_packets": {
+      "name": "eviction_response_packets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "filing_id": {
+          "name": "filing_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "packet_md": {
+          "name": "packet_md",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt_version": {
+          "name": "prompt_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "generated_by_user_id": {
+          "name": "generated_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "eviction_response_packet_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "response_packets_filing_version_idx": {
+          "name": "response_packets_filing_version_idx",
+          "columns": [
+            {
+              "expression": "filing_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "prompt_version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "response_packets_filing_idx": {
+          "name": "response_packets_filing_idx",
+          "columns": [
+            {
+              "expression": "filing_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "response_packets_status_idx": {
+          "name": "response_packets_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "eviction_response_packets_filing_id_eviction_filings_id_fk": {
+          "name": "eviction_response_packets_filing_id_eviction_filings_id_fk",
+          "tableFrom": "eviction_response_packets",
+          "tableTo": "eviction_filings",
+          "columnsFrom": [
+            "filing_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "eviction_response_packets_generated_by_user_id_users_id_fk": {
+          "name": "eviction_response_packets_generated_by_user_id_users_id_fk",
+          "tableFrom": "eviction_response_packets",
+          "tableTo": "users",
+          "columnsFrom": [
+            "generated_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.health_check": {
+      "name": "health_check",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_memberships": {
+      "name": "org_memberships",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "partner_org_id": {
+          "name": "partner_org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "org_memberships_user_org_idx": {
+          "name": "org_memberships_user_org_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "partner_org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "org_memberships_user_idx": {
+          "name": "org_memberships_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "org_memberships_partner_org_idx": {
+          "name": "org_memberships_partner_org_idx",
+          "columns": [
+            {
+              "expression": "partner_org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "org_memberships_user_id_users_id_fk": {
+          "name": "org_memberships_user_id_users_id_fk",
+          "tableFrom": "org_memberships",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "org_memberships_partner_org_id_partner_orgs_id_fk": {
+          "name": "org_memberships_partner_org_id_partner_orgs_id_fk",
+          "tableFrom": "org_memberships",
+          "tableTo": "partner_orgs",
+          "columnsFrom": [
+            "partner_org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.partner_orgs": {
+      "name": "partner_orgs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "partner_org_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_email": {
+          "name": "contact_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_phone": {
+          "name": "contact_phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "website": {
+          "name": "website",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data_sharing_tier": {
+          "name": "data_sharing_tier",
+          "type": "data_sharing_tier",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "partner_orgs_slug_idx": {
+          "name": "partner_orgs_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.partner_service_events": {
+      "name": "partner_service_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "partner_org_id": {
+          "name": "partner_org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "synthetic_person_ref": {
+          "name": "synthetic_person_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "partner_service_event_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_at": {
+          "name": "event_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "ed_encounter_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'synthetic'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "partner_service_events_person_idx": {
+          "name": "partner_service_events_person_idx",
+          "columns": [
+            {
+              "expression": "synthetic_person_ref",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "partner_service_events_partner_idx": {
+          "name": "partner_service_events_partner_idx",
+          "columns": [
+            {
+              "expression": "partner_org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "partner_service_events_at_idx": {
+          "name": "partner_service_events_at_idx",
+          "columns": [
+            {
+              "expression": "event_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "partner_service_events_partner_org_id_partner_orgs_id_fk": {
+          "name": "partner_service_events_partner_org_id_partner_orgs_id_fk",
+          "tableFrom": "partner_service_events",
+          "tableTo": "partner_orgs",
+          "columnsFrom": [
+            "partner_org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.person_partner_consents": {
+      "name": "person_partner_consents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "synthetic_person_ref": {
+          "name": "synthetic_person_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "partner_org_id": {
+          "name": "partner_org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "granted_at": {
+          "name": "granted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "person_partner_consents_unique_idx": {
+          "name": "person_partner_consents_unique_idx",
+          "columns": [
+            {
+              "expression": "synthetic_person_ref",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "partner_org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "person_partner_consents_partner_org_id_partner_orgs_id_fk": {
+          "name": "person_partner_consents_partner_org_id_partner_orgs_id_fk",
+          "tableFrom": "person_partner_consents",
+          "tableTo": "partner_orgs",
+          "columnsFrom": [
+            "partner_org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rental_assistance_programs": {
+      "name": "rental_assistance_programs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agency": {
+          "name": "agency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "website": {
+          "name": "website",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "eligibility_summary": {
+          "name": "eligibility_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "max_award_cents": {
+          "name": "max_award_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_note": {
+          "name": "source_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "rental_assistance_programs_active_idx": {
+          "name": "rental_assistance_programs_active_idx",
+          "columns": [
+            {
+              "expression": "active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bed_count_updates": {
+      "name": "bed_count_updates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "shelter_id": {
+          "name": "shelter_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_user_id": {
+          "name": "updated_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "previous_occupancy": {
+          "name": "previous_occupancy",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "new_occupancy": {
+          "name": "new_occupancy",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "bed_count_updates_shelter_idx": {
+          "name": "bed_count_updates_shelter_idx",
+          "columns": [
+            {
+              "expression": "shelter_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bed_count_updates_created_idx": {
+          "name": "bed_count_updates_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bed_count_updates_shelter_id_shelters_id_fk": {
+          "name": "bed_count_updates_shelter_id_shelters_id_fk",
+          "tableFrom": "bed_count_updates",
+          "tableTo": "shelters",
+          "columnsFrom": [
+            "shelter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bed_holds": {
+      "name": "bed_holds",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "shelter_id": {
+          "name": "shelter_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "held_by_user_id": {
+          "name": "held_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "person_label": {
+          "name": "person_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "bed_hold_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "released_at": {
+          "name": "released_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "bed_holds_shelter_idx": {
+          "name": "bed_holds_shelter_idx",
+          "columns": [
+            {
+              "expression": "shelter_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bed_holds_status_idx": {
+          "name": "bed_holds_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bed_holds_expires_idx": {
+          "name": "bed_holds_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bed_holds_shelter_id_shelters_id_fk": {
+          "name": "bed_holds_shelter_id_shelters_id_fk",
+          "tableFrom": "bed_holds",
+          "tableTo": "shelters",
+          "columnsFrom": [
+            "shelter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.shelters": {
+      "name": "shelters",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "partner_org_id": {
+          "name": "partner_org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address_line1": {
+          "name": "address_line1",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "city": {
+          "name": "city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "postal_code": {
+          "name": "postal_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_phone": {
+          "name": "contact_phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capacity": {
+          "name": "capacity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_occupancy": {
+          "name": "current_occupancy",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "accepts_men": {
+          "name": "accepts_men",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "accepts_women": {
+          "name": "accepts_women",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "accepts_families": {
+          "name": "accepts_families",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "pet_friendly": {
+          "name": "pet_friendly",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "sud_friendly": {
+          "name": "sud_friendly",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "shelters_slug_idx": {
+          "name": "shelters_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "shelters_partner_org_idx": {
+          "name": "shelters_partner_org_idx",
+          "columns": [
+            {
+              "expression": "partner_org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "shelters_partner_org_id_partner_orgs_id_fk": {
+          "name": "shelters_partner_org_id_partner_orgs_id_fk",
+          "tableFrom": "shelters",
+          "tableTo": "partner_orgs",
+          "columnsFrom": [
+            "partner_org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "shelters_capacity_nonneg": {
+          "name": "shelters_capacity_nonneg",
+          "value": "\"shelters\".\"capacity\" >= 0"
+        },
+        "shelters_occupancy_nonneg": {
+          "name": "shelters_occupancy_nonneg",
+          "value": "\"shelters\".\"current_occupancy\" >= 0"
+        },
+        "shelters_occupancy_le_capacity": {
+          "name": "shelters_occupancy_le_capacity",
+          "value": "\"shelters\".\"current_occupancy\" <= \"shelters\".\"capacity\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.sms_conversations": {
+      "name": "sms_conversations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "from_number": {
+          "name": "from_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "sms_conversation_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'idle'"
+        },
+        "pending_filter": {
+          "name": "pending_filter",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_location": {
+          "name": "last_location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_results": {
+          "name": "last_results",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_hold_id": {
+          "name": "last_hold_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_message_at": {
+          "name": "last_message_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sms_conversations_from_idx": {
+          "name": "sms_conversations_from_idx",
+          "columns": [
+            {
+              "expression": "from_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_conversations_state_idx": {
+          "name": "sms_conversations_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_conversations_expires_idx": {
+          "name": "sms_conversations_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sms_messages": {
+      "name": "sms_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "provider_message_id": {
+          "name": "provider_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "from_number": {
+          "name": "from_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_number": {
+          "name": "to_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "intent": {
+          "name": "intent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reply_body": {
+          "name": "reply_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sms_messages_received_idx": {
+          "name": "sms_messages_received_idx",
+          "columns": [
+            {
+              "expression": "received_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_messages_from_idx": {
+          "name": "sms_messages_from_idx",
+          "columns": [
+            {
+              "expression": "from_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "clerk_user_id": {
+          "name": "clerk_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "users_clerk_user_id_idx": {
+          "name": "users_clerk_user_id_idx",
+          "columns": [
+            {
+              "expression": "clerk_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.bed_hold_status": {
+      "name": "bed_hold_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "released",
+        "expired",
+        "converted"
+      ]
+    },
+    "public.consent_channel": {
+      "name": "consent_channel",
+      "schema": "public",
+      "values": [
+        "sms",
+        "in_person",
+        "web_form",
+        "phone",
+        "paper"
+      ]
+    },
+    "public.consent_type": {
+      "name": "consent_type",
+      "schema": "public",
+      "values": [
+        "phi_share_within_coalition",
+        "sms_communication",
+        "data_for_program_eval"
+      ]
+    },
+    "public.data_sharing_tier": {
+      "name": "data_sharing_tier",
+      "schema": "public",
+      "values": [
+        "none",
+        "aggregate",
+        "individual"
+      ]
+    },
+    "public.ed_encounter_source": {
+      "name": "ed_encounter_source",
+      "schema": "public",
+      "values": [
+        "synthetic",
+        "epic_fhir",
+        "manual"
+      ]
+    },
+    "public.esuc_care_plan_status": {
+      "name": "esuc_care_plan_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "approved",
+        "active",
+        "archived"
+      ]
+    },
+    "public.eviction_case_outcome": {
+      "name": "eviction_case_outcome",
+      "schema": "public",
+      "values": [
+        "dismissed",
+        "judgment_for_plaintiff",
+        "judgment_for_defendant",
+        "settled",
+        "default_judgment",
+        "withdrawn"
+      ]
+    },
+    "public.eviction_cause_type": {
+      "name": "eviction_cause_type",
+      "schema": "public",
+      "values": [
+        "non_payment",
+        "lease_violation",
+        "holdover",
+        "other"
+      ]
+    },
+    "public.eviction_filing_source": {
+      "name": "eviction_filing_source",
+      "schema": "public",
+      "values": [
+        "courtnet",
+        "manual",
+        "synthetic"
+      ]
+    },
+    "public.eviction_filing_status": {
+      "name": "eviction_filing_status",
+      "schema": "public",
+      "values": [
+        "filed",
+        "served",
+        "judgment",
+        "dismissed",
+        "sealed"
+      ]
+    },
+    "public.eviction_response_packet_status": {
+      "name": "eviction_response_packet_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "approved",
+        "filed",
+        "rejected"
+      ]
+    },
+    "public.housing_status": {
+      "name": "housing_status",
+      "schema": "public",
+      "values": [
+        "housed",
+        "doubled_up",
+        "shelter",
+        "unsheltered",
+        "unknown"
+      ]
+    },
+    "public.partner_org_type": {
+      "name": "partner_org_type",
+      "schema": "public",
+      "values": [
+        "hospital",
+        "legal_aid",
+        "shelter",
+        "community_org",
+        "government",
+        "faith_based",
+        "school",
+        "philanthropy",
+        "education",
+        "public_health",
+        "media",
+        "other"
+      ]
+    },
+    "public.partner_service_event_type": {
+      "name": "partner_service_event_type",
+      "schema": "public",
+      "values": [
+        "food_pantry",
+        "shelter_intake",
+        "shelter_bed_night",
+        "utility_assistance",
+        "rent_assistance",
+        "counseling_visit",
+        "medical_visit",
+        "school_attendance_flag",
+        "volunteer_hours",
+        "other"
+      ]
+    },
+    "public.sms_conversation_state": {
+      "name": "sms_conversation_state",
+      "schema": "public",
+      "values": [
+        "idle",
+        "awaiting_location"
+      ]
+    },
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "pending",
+        "attorney",
+        "caseworker",
+        "ed_coordinator",
+        "shelter_staff",
+        "admin"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/migrations/meta/_journal.json
+++ b/drizzle/migrations/meta/_journal.json
@@ -155,6 +155,13 @@
       "when": 1777239126177,
       "tag": "0021_nice_senator_kelly",
       "breakpoints": true
+    },
+    {
+      "idx": 22,
+      "version": "7",
+      "when": 1777239540035,
+      "tag": "0022_woozy_black_panther",
+      "breakpoints": true
     }
   ]
 }

--- a/drizzle/migrations/meta/_journal.json
+++ b/drizzle/migrations/meta/_journal.json
@@ -120,6 +120,13 @@
       "when": 1777232613184,
       "tag": "0016_windy_ironclad",
       "breakpoints": true
+    },
+    {
+      "idx": 17,
+      "version": "7",
+      "when": 1777234082170,
+      "tag": "0017_opposite_nitro",
+      "breakpoints": true
     }
   ]
 }

--- a/drizzle/migrations/meta/_journal.json
+++ b/drizzle/migrations/meta/_journal.json
@@ -148,6 +148,13 @@
       "when": 1777238311241,
       "tag": "0020_quiet_metal_master",
       "breakpoints": true
+    },
+    {
+      "idx": 21,
+      "version": "7",
+      "when": 1777239126177,
+      "tag": "0021_nice_senator_kelly",
+      "breakpoints": true
     }
   ]
 }

--- a/drizzle/migrations/meta/_journal.json
+++ b/drizzle/migrations/meta/_journal.json
@@ -141,6 +141,13 @@
       "when": 1777235054698,
       "tag": "0019_safe_paladin",
       "breakpoints": true
+    },
+    {
+      "idx": 20,
+      "version": "7",
+      "when": 1777238311241,
+      "tag": "0020_quiet_metal_master",
+      "breakpoints": true
     }
   ]
 }

--- a/drizzle/migrations/meta/_journal.json
+++ b/drizzle/migrations/meta/_journal.json
@@ -134,6 +134,13 @@
       "when": 1777234734701,
       "tag": "0018_true_karma",
       "breakpoints": true
+    },
+    {
+      "idx": 19,
+      "version": "7",
+      "when": 1777235054698,
+      "tag": "0019_safe_paladin",
+      "breakpoints": true
     }
   ]
 }

--- a/drizzle/migrations/meta/_journal.json
+++ b/drizzle/migrations/meta/_journal.json
@@ -127,6 +127,13 @@
       "when": 1777234082170,
       "tag": "0017_opposite_nitro",
       "breakpoints": true
+    },
+    {
+      "idx": 18,
+      "version": "7",
+      "when": 1777234734701,
+      "tag": "0018_true_karma",
+      "breakpoints": true
     }
   ]
 }

--- a/drizzle/migrations/meta/_journal.json
+++ b/drizzle/migrations/meta/_journal.json
@@ -162,6 +162,13 @@
       "when": 1777239540035,
       "tag": "0022_woozy_black_panther",
       "breakpoints": true
+    },
+    {
+      "idx": 23,
+      "version": "7",
+      "when": 1777240694967,
+      "tag": "0023_curious_tarot",
+      "breakpoints": true
     }
   ]
 }

--- a/src/app/actions/consent-tokens.ts
+++ b/src/app/actions/consent-tokens.ts
@@ -1,0 +1,48 @@
+'use server';
+
+import { logAuditEvent } from '@/lib/audit';
+import { requireRole } from '@/lib/auth';
+import { CONSENT_TOKEN_TTL_MS, createConsentAccessToken } from '@/lib/dtrs/consent-token';
+import { isValidSyntheticPersonRef } from '@/lib/synthetic-person';
+
+export type MintTokenResult =
+  | { ok: true; url: string; expiresAt: Date }
+  | { ok: false; error: string };
+
+const STAFF_ROLES = ['caseworker', 'shelter_staff', 'admin'] as const;
+
+/**
+ * Mint a fresh access token for a synthetic person ref. Returns the
+ * full URL to hand to the subject (with origin). Only the originating
+ * caseworker (or any staff in `STAFF_ROLES`) can mint; subjects
+ * cannot mint for themselves.
+ */
+export async function mintConsentTokenAction(
+  syntheticPersonRef: string,
+  notes?: string,
+): Promise<MintTokenResult> {
+  const me = await requireRole(STAFF_ROLES);
+
+  if (!isValidSyntheticPersonRef(syntheticPersonRef)) {
+    return { ok: false, error: 'Invalid synthetic-person reference.' };
+  }
+
+  const { token, expiresAt } = await createConsentAccessToken({
+    syntheticPersonRef,
+    issuedByUserId: me.id,
+    notes: notes?.trim() || undefined,
+    ttlMs: CONSENT_TOKEN_TTL_MS,
+  });
+
+  await logAuditEvent({
+    actorUserId: me.id,
+    action: 'consent_token.minted',
+    targetTable: 'consent_access_tokens',
+    metadata: { syntheticPersonRef, ttlHours: CONSENT_TOKEN_TTL_MS / 3_600_000 },
+  });
+
+  // Path-only URL — caller can prepend origin if needed; staff usually
+  // copy/paste into a chat or QR generator.
+  const url = `/p/${syntheticPersonRef}/consent/grant?token=${token}`;
+  return { ok: true, url, expiresAt };
+}

--- a/src/app/actions/consent.ts
+++ b/src/app/actions/consent.ts
@@ -8,6 +8,7 @@ import { type ConsentChannel, type ConsentType, consentChannelEnum } from '@/db/
 import { personPartnerConsents } from '@/db/schema/person-partner-consents';
 import { logAuditEvent } from '@/lib/audit';
 import { CURRENT_CONSENT_VERSION, DATA_CLASSES } from '@/lib/dtrs/consent-text';
+import { redeemConsentAccessToken } from '@/lib/dtrs/consent-token';
 import { rateLimit } from '@/lib/dtrs/rate-limit';
 import { isValidSyntheticPersonRef } from '@/lib/synthetic-person';
 
@@ -70,6 +71,15 @@ export type GrantConsentInput = {
   consentType: ConsentType;
   grantedVia: ConsentChannel;
   signatureText: string;
+  /**
+   * Opaque access token from the URL. Required in non-open-mode prod.
+   * The action calls `redeemConsentAccessToken` and rejects unless the
+   * token is valid AND maps to the same `subjectExternalId`. The page
+   * gate is defense-in-depth — server actions are reachable from any
+   * client capable of crafting a POST, so the action is the auth
+   * boundary, not the page.
+   */
+  accessToken?: string | null;
   scopeDataClasses?: string[] | null;
   scopePartnerIds?: string[] | null;
   expiresAt?: Date | null;
@@ -79,18 +89,30 @@ export type GrantConsentResult = { ok: true; id: string } | { ok: false; error: 
 
 /**
  * Public-surface server action: record a fresh, versioned consent grant
- * (DTRS-001 schema, DTRS-002 form). The subject themselves writes here
- * — no role gate, but inputs are validated and capped, and every grant
- * lands in audit_log so spurious grants are traceable. The opaque
- * subject_external_id is the auth boundary: only the caseworker who
- * shared the link knows the value.
- *
- * Once a one-time-link auth gate ships (#251), this action gets the
- * token check too.
+ * (DTRS-001 schema, DTRS-002 form). Auth: a valid access token from
+ * `consent_access_tokens` whose `synthetic_person_ref` matches
+ * `subjectExternalId`. The token is required in normal operation;
+ * `INDC_CONSENT_OPEN_MODE=1` (dev/demo only) skips the check. The page
+ * render gate at `/p/[ref]/consent/grant` is defense-in-depth — the
+ * action itself is the security boundary because server actions are
+ * reachable from any client.
  */
 export async function grantConsentAction(input: GrantConsentInput): Promise<GrantConsentResult> {
   const subject = input.subjectExternalId.trim();
   if (subject.length === 0) return { ok: false, error: 'Missing subject identifier.' };
+
+  // Auth: a valid access token bound to this subject. Open-mode is the
+  // only way past — explicit env flag, off in prod by definition.
+  const openMode = process.env.INDC_CONSENT_OPEN_MODE === '1';
+  if (!openMode) {
+    if (!input.accessToken) {
+      return { ok: false, error: 'Missing access link. Ask staff for a fresh link.' };
+    }
+    const redeemed = await redeemConsentAccessToken(input.accessToken);
+    if (!redeemed || redeemed.syntheticPersonRef !== subject) {
+      return { ok: false, error: 'This link is no longer valid. Ask staff for a fresh one.' };
+    }
+  }
 
   const limit = rateLimit(`grant:${subject}`, CONSENT_RATE_LIMIT, CONSENT_RATE_WINDOW_MS);
   if (!limit.ok) {

--- a/src/app/actions/consent.ts
+++ b/src/app/actions/consent.ts
@@ -3,8 +3,11 @@
 import { eq } from 'drizzle-orm';
 import { revalidatePath } from 'next/cache';
 import { db } from '@/db/client';
+import { consents } from '@/db/schema/consents';
+import { type ConsentChannel, type ConsentType, consentChannelEnum } from '@/db/schema/enums';
 import { personPartnerConsents } from '@/db/schema/person-partner-consents';
 import { logAuditEvent } from '@/lib/audit';
+import { CURRENT_CONSENT_VERSION, DATA_CLASSES } from '@/lib/dtrs/consent-text';
 import { isValidSyntheticPersonRef } from '@/lib/synthetic-person';
 
 export type ConsentResult = { ok: true } | { ok: false; error: string };
@@ -41,6 +44,114 @@ export async function revokeConsentAction(
   });
 
   revalidatePath(`/p/${syntheticPersonRef}/consent`);
+  return { ok: true };
+}
+
+const VALID_DATA_CLASSES: Set<string> = new Set(DATA_CLASSES.map((d) => d.id as string));
+const VALID_CHANNELS = new Set<ConsentChannel>(consentChannelEnum.enumValues);
+const SIGNATURE_MIN = 1;
+const SIGNATURE_MAX = 80;
+
+export type GrantConsentInput = {
+  subjectExternalId: string;
+  consentType: ConsentType;
+  grantedVia: ConsentChannel;
+  signatureText: string;
+  scopeDataClasses?: string[] | null;
+  scopePartnerIds?: string[] | null;
+  expiresAt?: Date | null;
+};
+
+export type GrantConsentResult = { ok: true; id: string } | { ok: false; error: string };
+
+/**
+ * Public-surface server action: record a fresh, versioned consent grant
+ * (DTRS-001 schema, DTRS-002 form). The subject themselves writes here
+ * — no role gate, but inputs are validated and capped, and every grant
+ * lands in audit_log so spurious grants are traceable. The opaque
+ * subject_external_id is the auth boundary: only the caseworker who
+ * shared the link knows the value.
+ *
+ * Once a one-time-link auth gate ships (#251), this action gets the
+ * token check too.
+ */
+export async function grantConsentAction(input: GrantConsentInput): Promise<GrantConsentResult> {
+  const subject = input.subjectExternalId.trim();
+  if (subject.length === 0) return { ok: false, error: 'Missing subject identifier.' };
+
+  if (!VALID_CHANNELS.has(input.grantedVia)) {
+    return { ok: false, error: 'Invalid consent channel.' };
+  }
+
+  const sig = input.signatureText.trim();
+  if (sig.length < SIGNATURE_MIN || sig.length > SIGNATURE_MAX) {
+    return { ok: false, error: 'Please type your name to sign.' };
+  }
+
+  const dataClasses =
+    input.scopeDataClasses === null
+      ? null
+      : (input.scopeDataClasses ?? []).filter((c) => VALID_DATA_CLASSES.has(c));
+  if (dataClasses && dataClasses.length === 0) {
+    return { ok: false, error: 'Pick at least one kind of info to share.' };
+  }
+
+  const [created] = await db
+    .insert(consents)
+    .values({
+      subjectExternalId: subject,
+      consentType: input.consentType,
+      grantedVia: input.grantedVia,
+      consentVersion: CURRENT_CONSENT_VERSION,
+      signatureText: sig,
+      scopeDataClasses: dataClasses,
+      scopePartnerIds: input.scopePartnerIds ?? null,
+      expiresAt: input.expiresAt ?? null,
+    })
+    .returning({ id: consents.id });
+
+  await logAuditEvent({
+    actorUserId: null,
+    action: 'consent.granted',
+    targetTable: 'consents',
+    targetId: created.id,
+    metadata: {
+      consentType: input.consentType,
+      grantedVia: input.grantedVia,
+      consentVersion: CURRENT_CONSENT_VERSION,
+      hasDataClassScope: dataClasses !== null,
+      hasPartnerScope: input.scopePartnerIds != null,
+      hasExpiry: Boolean(input.expiresAt),
+    },
+  });
+
+  return { ok: true, id: created.id };
+}
+
+export type RevokeVersionedConsentResult = { ok: true } | { ok: false; error: string };
+
+/** Revoke a versioned `consents` row. Idempotent on already-revoked rows. */
+export async function revokeVersionedConsentAction(
+  consentId: string,
+): Promise<RevokeVersionedConsentResult> {
+  const [existing] = await db
+    .select({ id: consents.id, subject: consents.subjectExternalId, revokedAt: consents.revokedAt })
+    .from(consents)
+    .where(eq(consents.id, consentId))
+    .limit(1);
+  if (!existing) return { ok: false, error: 'Consent not found.' };
+  if (existing.revokedAt) return { ok: true };
+
+  await db.update(consents).set({ revokedAt: new Date() }).where(eq(consents.id, consentId));
+
+  await logAuditEvent({
+    actorUserId: null,
+    action: 'consent.revoked',
+    targetTable: 'consents',
+    targetId: consentId,
+    metadata: { subject: existing.subject },
+  });
+
   return { ok: true };
 }
 

--- a/src/app/actions/consent.ts
+++ b/src/app/actions/consent.ts
@@ -8,7 +8,11 @@ import { type ConsentChannel, type ConsentType, consentChannelEnum } from '@/db/
 import { personPartnerConsents } from '@/db/schema/person-partner-consents';
 import { logAuditEvent } from '@/lib/audit';
 import { CURRENT_CONSENT_VERSION, DATA_CLASSES } from '@/lib/dtrs/consent-text';
+import { rateLimit } from '@/lib/dtrs/rate-limit';
 import { isValidSyntheticPersonRef } from '@/lib/synthetic-person';
+
+const CONSENT_RATE_WINDOW_MS = 60_000;
+const CONSENT_RATE_LIMIT = 6; // 6 ops/min per subject is plenty for legit use.
 
 export type ConsentResult = { ok: true } | { ok: false; error: string };
 
@@ -23,6 +27,15 @@ export async function revokeConsentAction(
 ): Promise<ConsentResult> {
   if (!isValidSyntheticPersonRef(syntheticPersonRef))
     return { ok: false, error: 'Invalid identifier.' };
+
+  const limit = rateLimit(
+    `revoke:${syntheticPersonRef}`,
+    CONSENT_RATE_LIMIT,
+    CONSENT_RATE_WINDOW_MS,
+  );
+  if (!limit.ok) {
+    return { ok: false, error: 'Too many attempts. Please wait a minute and try again.' };
+  }
 
   const [updated] = await db
     .update(personPartnerConsents)
@@ -78,6 +91,11 @@ export type GrantConsentResult = { ok: true; id: string } | { ok: false; error: 
 export async function grantConsentAction(input: GrantConsentInput): Promise<GrantConsentResult> {
   const subject = input.subjectExternalId.trim();
   if (subject.length === 0) return { ok: false, error: 'Missing subject identifier.' };
+
+  const limit = rateLimit(`grant:${subject}`, CONSENT_RATE_LIMIT, CONSENT_RATE_WINDOW_MS);
+  if (!limit.ok) {
+    return { ok: false, error: 'Too many attempts. Please wait a minute and try again.' };
+  }
 
   if (!VALID_CHANNELS.has(input.grantedVia)) {
     return { ok: false, error: 'Invalid consent channel.' };
@@ -161,6 +179,15 @@ export async function regrantConsentAction(
 ): Promise<ConsentResult> {
   if (!isValidSyntheticPersonRef(syntheticPersonRef))
     return { ok: false, error: 'Invalid identifier.' };
+
+  const limit = rateLimit(
+    `regrant:${syntheticPersonRef}`,
+    CONSENT_RATE_LIMIT,
+    CONSENT_RATE_WINDOW_MS,
+  );
+  if (!limit.ok) {
+    return { ok: false, error: 'Too many attempts. Please wait a minute and try again.' };
+  }
 
   const [updated] = await db
     .update(personPartnerConsents)

--- a/src/app/actions/coordination.ts
+++ b/src/app/actions/coordination.ts
@@ -1,0 +1,94 @@
+'use server';
+
+import { eq } from 'drizzle-orm';
+import { revalidatePath } from 'next/cache';
+import { db } from '@/db/client';
+import { bedCountUpdates, shelters } from '@/db/schema/shelters';
+import { logAuditEvent } from '@/lib/audit';
+import { requireRole } from '@/lib/auth';
+import { validateBedCount } from '@/lib/coordination/bed-availability';
+
+export type UpdateBedCountResult = { ok: true } | { ok: false; error: string };
+
+const STAFF_ROLES = ['shelter_staff', 'admin'] as const;
+
+const MAX_NOTE_LEN = 280;
+
+/**
+ * Set a shelter's current_occupancy to `newOccupancy` and append the
+ * change to bed_count_updates. The mutation runs in a transaction so
+ * we never end up with a shelters row that disagrees with the audit
+ * log.
+ *
+ * Server-authoritative bounds: clamp to [0, capacity]. The check
+ * constraint on shelters would reject anything else, but explicit
+ * validation gives a useful error to staff instead of a 500.
+ */
+export async function updateBedCountAction(
+  shelterId: string,
+  newOccupancy: number,
+  note: string | null,
+): Promise<UpdateBedCountResult> {
+  const actor = await requireRole(STAFF_ROLES);
+
+  const trimmedNote = note?.trim() ? note.trim().slice(0, MAX_NOTE_LEN) : null;
+
+  const result = await db.transaction(async (tx) => {
+    const [shelter] = await tx
+      .select({
+        id: shelters.id,
+        capacity: shelters.capacity,
+        currentOccupancy: shelters.currentOccupancy,
+        active: shelters.active,
+      })
+      .from(shelters)
+      .where(eq(shelters.id, shelterId))
+      .limit(1);
+    if (!shelter) return { ok: false as const, error: 'Shelter not found.' };
+    if (!shelter.active) return { ok: false as const, error: 'Shelter is inactive.' };
+    const validation = validateBedCount(newOccupancy, shelter.capacity);
+    if (!validation.ok) return { ok: false as const, error: validation.error };
+    if (newOccupancy === shelter.currentOccupancy) {
+      return { ok: true as const, noChange: true, previous: shelter.currentOccupancy };
+    }
+
+    await tx
+      .update(shelters)
+      .set({ currentOccupancy: newOccupancy, updatedAt: new Date() })
+      .where(eq(shelters.id, shelterId));
+
+    await tx.insert(bedCountUpdates).values({
+      shelterId,
+      updatedByUserId: actor.id,
+      previousOccupancy: shelter.currentOccupancy,
+      newOccupancy,
+      note: trimmedNote,
+    });
+
+    return {
+      ok: true as const,
+      noChange: false,
+      previous: shelter.currentOccupancy,
+    };
+  });
+
+  if (!result.ok) return result;
+
+  if (!result.noChange) {
+    await logAuditEvent({
+      actorUserId: actor.id,
+      action: 'shelter.bed_count_updated',
+      targetTable: 'shelters',
+      targetId: shelterId,
+      metadata: {
+        previousOccupancy: result.previous,
+        newOccupancy,
+        hasNote: Boolean(trimmedNote),
+      },
+    });
+  }
+
+  revalidatePath('/app/coalition/beds');
+  revalidatePath('/app/coalition/beds/update');
+  return { ok: true };
+}

--- a/src/app/actions/coordination.ts
+++ b/src/app/actions/coordination.ts
@@ -1,9 +1,9 @@
 'use server';
 
-import { eq } from 'drizzle-orm';
+import { and, count, eq, gt } from 'drizzle-orm';
 import { revalidatePath } from 'next/cache';
 import { db } from '@/db/client';
-import { bedCountUpdates, shelters } from '@/db/schema/shelters';
+import { bedCountUpdates, bedHolds, shelters } from '@/db/schema/shelters';
 import { logAuditEvent } from '@/lib/audit';
 import { requireRole } from '@/lib/auth';
 import { validateBedCount } from '@/lib/coordination/bed-availability';
@@ -11,8 +11,17 @@ import { validateBedCount } from '@/lib/coordination/bed-availability';
 export type UpdateBedCountResult = { ok: true } | { ok: false; error: string };
 
 const STAFF_ROLES = ['shelter_staff', 'admin'] as const;
+const HOLD_ROLES = ['caseworker', 'ed_coordinator', 'shelter_staff', 'admin'] as const;
 
 const MAX_NOTE_LEN = 280;
+const MAX_PERSON_LABEL_LEN = 80;
+/**
+ * Soft-hold lifetime. 90 minutes is the working number from the BACKLOG
+ * AC for COOR-005 — long enough that someone walking in from across town
+ * still has the bed waiting, short enough that no-shows free up beds
+ * within the same intake window.
+ */
+const HOLD_DURATION_MIN = 90;
 
 /**
  * Set a shelter's current_occupancy to `newOccupancy` and append the
@@ -87,6 +96,136 @@ export async function updateBedCountAction(
       },
     });
   }
+
+  revalidatePath('/app/coalition/beds');
+  revalidatePath('/app/coalition/beds/update');
+  return { ok: true };
+}
+
+export type CreateBedHoldResult =
+  | { ok: true; holdId: string; expiresAt: Date }
+  | { ok: false; error: string };
+
+/**
+ * Create a 90-minute soft hold against a shelter bed. The hold reserves
+ * one effective free bed without changing current_occupancy — the bed
+ * isn't physically taken until staff bumps occupancy on arrival.
+ *
+ * Race protection: we count active+unexpired holds inside the
+ * transaction and reject if it would push us above raw free beds. A
+ * concurrent second-clicker gets a friendly error instead of an
+ * overbooked shelter.
+ */
+export async function createBedHoldAction(
+  shelterId: string,
+  personLabel: string,
+  notes: string | null,
+): Promise<CreateBedHoldResult> {
+  const actor = await requireRole(HOLD_ROLES);
+
+  const trimmedLabel = personLabel.trim().slice(0, MAX_PERSON_LABEL_LEN);
+  if (trimmedLabel.length === 0) {
+    return { ok: false, error: 'Hold label is required (e.g., "211 caller #1234").' };
+  }
+  const trimmedNotes = notes?.trim() ? notes.trim().slice(0, MAX_NOTE_LEN) : null;
+
+  const expiresAt = new Date(Date.now() + HOLD_DURATION_MIN * 60_000);
+
+  const result = await db.transaction(async (tx) => {
+    const [shelter] = await tx
+      .select({
+        id: shelters.id,
+        capacity: shelters.capacity,
+        currentOccupancy: shelters.currentOccupancy,
+        active: shelters.active,
+      })
+      .from(shelters)
+      .where(eq(shelters.id, shelterId))
+      .limit(1);
+    if (!shelter) return { ok: false as const, error: 'Shelter not found.' };
+    if (!shelter.active) return { ok: false as const, error: 'Shelter is inactive.' };
+
+    const rawFree = shelter.capacity - shelter.currentOccupancy;
+    if (rawFree <= 0) return { ok: false as const, error: 'No free beds at this shelter.' };
+
+    const [{ value: activeHolds }] = await tx
+      .select({ value: count() })
+      .from(bedHolds)
+      .where(
+        and(
+          eq(bedHolds.shelterId, shelterId),
+          eq(bedHolds.status, 'active'),
+          gt(bedHolds.expiresAt, new Date()),
+        ),
+      );
+
+    if (Number(activeHolds) >= rawFree) {
+      return { ok: false as const, error: 'All free beds are already on hold.' };
+    }
+
+    const [created] = await tx
+      .insert(bedHolds)
+      .values({
+        shelterId,
+        heldByUserId: actor.id,
+        personLabel: trimmedLabel,
+        notes: trimmedNotes,
+        expiresAt,
+      })
+      .returning({ id: bedHolds.id, expiresAt: bedHolds.expiresAt });
+    return { ok: true as const, holdId: created.id, expiresAt: created.expiresAt };
+  });
+
+  if (!result.ok) return result;
+
+  await logAuditEvent({
+    actorUserId: actor.id,
+    action: 'shelter.bed_hold_created',
+    targetTable: 'bed_holds',
+    targetId: result.holdId,
+    metadata: { shelterId, durationMin: HOLD_DURATION_MIN },
+  });
+
+  revalidatePath('/app/coalition/beds');
+  revalidatePath('/app/coalition/beds/update');
+  return result;
+}
+
+export type ReleaseBedHoldResult = { ok: true } | { ok: false; error: string };
+
+const HOLD_TERMINAL_STATUSES = new Set(['released', 'expired', 'converted']);
+
+/**
+ * Manually release a hold (typically: caller said "never mind" or
+ * staff freed the bed). Only flips status from 'active' → 'released';
+ * already-terminal holds return ok without re-flipping.
+ */
+export async function releaseBedHoldAction(holdId: string): Promise<ReleaseBedHoldResult> {
+  const actor = await requireRole(HOLD_ROLES);
+
+  const [hold] = await db
+    .select({ id: bedHolds.id, shelterId: bedHolds.shelterId, status: bedHolds.status })
+    .from(bedHolds)
+    .where(eq(bedHolds.id, holdId))
+    .limit(1);
+  if (!hold) return { ok: false, error: 'Hold not found.' };
+
+  if (HOLD_TERMINAL_STATUSES.has(hold.status)) {
+    return { ok: true };
+  }
+
+  await db
+    .update(bedHolds)
+    .set({ status: 'released', releasedAt: new Date(), updatedAt: new Date() })
+    .where(eq(bedHolds.id, holdId));
+
+  await logAuditEvent({
+    actorUserId: actor.id,
+    action: 'shelter.bed_hold_released',
+    targetTable: 'bed_holds',
+    targetId: holdId,
+    metadata: { shelterId: hold.shelterId, previousStatus: hold.status },
+  });
 
   revalidatePath('/app/coalition/beds');
   revalidatePath('/app/coalition/beds/update');

--- a/src/app/actions/sms.ts
+++ b/src/app/actions/sms.ts
@@ -1,0 +1,35 @@
+'use server';
+
+import { db } from '@/db/client';
+import { smsMessages } from '@/db/schema/sms-messages';
+import { requireRole } from '@/lib/auth';
+import { handleInboundSms } from '@/lib/indc/sms-pipeline';
+
+export type SimulateSmsResult = {
+  ok: true;
+  reply: string;
+  intent: string;
+};
+
+/**
+ * Internal-only "what would the SMS reply be?" helper. Runs the same
+ * pipeline as the Twilio webhook against a typed-in body, lets staff
+ * preview formatting without burning a Twilio segment. Logged like a
+ * real inbound message but with synthetic from/to numbers so it's easy
+ * to filter out.
+ */
+export async function simulateInboundSmsAction(body: string): Promise<SimulateSmsResult> {
+  const actor = await requireRole(['admin', 'shelter_staff', 'caseworker', 'ed_coordinator']);
+  const result = await handleInboundSms(body);
+
+  await db.insert(smsMessages).values({
+    fromNumber: `SIMULATED-${actor.id.slice(0, 8)}`,
+    toNumber: 'SIMULATED-INBOUND',
+    body,
+    intent: result.intent,
+    replyBody: result.reply,
+    metadata: { simulated: true, actorRole: actor.role },
+  });
+
+  return { ok: true, reply: result.reply, intent: result.intent };
+}

--- a/src/app/api/webhooks/twilio/sms/route.ts
+++ b/src/app/api/webhooks/twilio/sms/route.ts
@@ -1,0 +1,88 @@
+import { headers } from 'next/headers';
+import { db } from '@/db/client';
+import { smsMessages } from '@/db/schema/sms-messages';
+import { handleInboundSms } from '@/lib/indc/sms-pipeline';
+import { twimlEmpty, twimlMessage, verifyTwilioSignature } from '@/lib/indc/twilio-signature';
+
+export const dynamic = 'force-dynamic';
+
+/**
+ * Twilio inbound-SMS webhook (INDC-001). Verifies the X-Twilio-Signature
+ * header against TWILIO_AUTH_TOKEN (skipped if no token is configured —
+ * dev mode), runs the parsed-command pipeline, logs the exchange, and
+ * returns inline TwiML so Twilio sends the reply automatically.
+ */
+export async function POST(req: Request) {
+  const authToken = process.env.TWILIO_AUTH_TOKEN;
+  const skipSignature = process.env.INDC_SKIP_TWILIO_SIGNATURE === '1';
+
+  const hdrs = await headers();
+  const signature = hdrs.get('x-twilio-signature') ?? '';
+  const proto = hdrs.get('x-forwarded-proto') ?? 'https';
+  const host = hdrs.get('x-forwarded-host') ?? hdrs.get('host') ?? '';
+  // Twilio signs against the URL it POSTed to — including the path,
+  // excluding any query string.
+  const url = new URL(req.url);
+  const fullUrl = `${proto}://${host}${url.pathname}`;
+
+  const rawBody = await req.text();
+  const params: Record<string, string> = {};
+  for (const [k, v] of new URLSearchParams(rawBody)) params[k] = v;
+
+  if (!skipSignature) {
+    if (!authToken) {
+      return new Response('twilio webhook not configured', { status: 503 });
+    }
+    if (!verifyTwilioSignature(authToken, fullUrl, params, signature)) {
+      console.warn('[twilio sms] signature mismatch', {
+        fullUrl,
+        signaturePresent: Boolean(signature),
+      });
+      return new Response('invalid signature', { status: 403 });
+    }
+  }
+
+  const fromNumber = params.From ?? 'unknown';
+  const toNumber = params.To ?? 'unknown';
+  const body = params.Body ?? '';
+  const messageSid = params.MessageSid ?? null;
+
+  let reply: string;
+  let intent: string;
+  try {
+    const result = await handleInboundSms(body);
+    reply = result.reply;
+    intent = result.intent;
+  } catch (err) {
+    console.error('[twilio sms] pipeline error', err);
+    reply = 'Sorry, something went wrong. Try BED again or call 211.';
+    intent = 'error';
+  }
+
+  try {
+    await db.insert(smsMessages).values({
+      providerMessageId: messageSid,
+      fromNumber,
+      toNumber,
+      body,
+      intent,
+      replyBody: reply,
+    });
+  } catch (err) {
+    console.error('[twilio sms] log insert failed', err);
+  }
+
+  // STOP messages: Twilio handles delivery suppression; reply with empty
+  // TwiML so we don't double-send.
+  if (intent === 'stop') {
+    return new Response(twimlEmpty(), {
+      status: 200,
+      headers: { 'content-type': 'text/xml' },
+    });
+  }
+
+  return new Response(twimlMessage(reply), {
+    status: 200,
+    headers: { 'content-type': 'text/xml' },
+  });
+}

--- a/src/app/api/webhooks/twilio/sms/route.ts
+++ b/src/app/api/webhooks/twilio/sms/route.ts
@@ -1,7 +1,7 @@
 import { headers } from 'next/headers';
 import { db } from '@/db/client';
 import { smsMessages } from '@/db/schema/sms-messages';
-import { handleInboundSms } from '@/lib/indc/sms-pipeline';
+import { handleInboundSmsForNumber } from '@/lib/indc/sms-pipeline';
 import { twimlEmpty, twimlMessage, verifyTwilioSignature } from '@/lib/indc/twilio-signature';
 
 export const dynamic = 'force-dynamic';
@@ -50,7 +50,7 @@ export async function POST(req: Request) {
   let reply: string;
   let intent: string;
   try {
-    const result = await handleInboundSms(body);
+    const result = await handleInboundSmsForNumber(fromNumber, body);
     reply = result.reply;
     intent = result.intent;
   } catch (err) {

--- a/src/app/app/admin/audit/page.tsx
+++ b/src/app/app/admin/audit/page.tsx
@@ -1,0 +1,178 @@
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { actionCountsByDay, listAuditLog } from '@/db/queries/audit-log';
+import { requireRole } from '@/lib/auth';
+
+export const dynamic = 'force-dynamic';
+
+const fmtTime = (d: Date) =>
+  new Intl.DateTimeFormat('en-US', { dateStyle: 'short', timeStyle: 'short' }).format(new Date(d));
+
+const WINDOW_DAYS = 7;
+
+export default async function AuditLogPage({
+  searchParams,
+}: {
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+}) {
+  await requireRole(['admin']);
+  const sp = await searchParams;
+  const action = (Array.isArray(sp.action) ? sp.action[0] : sp.action)?.trim() || undefined;
+  const targetId = (Array.isArray(sp.targetId) ? sp.targetId[0] : sp.targetId)?.trim() || undefined;
+
+  const [rows, byDay] = await Promise.all([
+    listAuditLog({ action, targetId, limit: 200 }),
+    actionCountsByDay(WINDOW_DAYS),
+  ]);
+
+  const dayMap = new Map<string, number>();
+  for (const r of byDay) dayMap.set(r.day, (dayMap.get(r.day) ?? 0) + r.count);
+  const days = Array.from(dayMap.entries()).sort(([a], [b]) => a.localeCompare(b));
+  const peak = days.reduce((m, [, c]) => Math.max(m, c), 0) || 1;
+
+  // Per-action totals across the window for the right-rail breakdown.
+  const actionTotals = new Map<string, number>();
+  for (const r of byDay) actionTotals.set(r.action, (actionTotals.get(r.action) ?? 0) + r.count);
+  const sortedActions = Array.from(actionTotals.entries()).sort(([, a], [, b]) => b - a);
+  const grandTotal = sortedActions.reduce((s, [, c]) => s + c, 0);
+
+  return (
+    <div className="mx-auto max-w-6xl space-y-4 p-4 md:p-6">
+      <header>
+        <h1 className="font-serif text-3xl font-bold text-primary">Audit log</h1>
+        <p className="text-sm text-muted-foreground">
+          Append-only record of every consent grant, role change, hold, AI generation, and PHI
+          access. Last {WINDOW_DAYS} days at a glance; full search below.
+        </p>
+      </header>
+
+      <div className="grid gap-4 md:grid-cols-3">
+        <Card className="md:col-span-2">
+          <CardHeader>
+            <CardTitle className="text-base">Daily volume</CardTitle>
+          </CardHeader>
+          <CardContent>
+            {days.length === 0 ? (
+              <p className="text-sm text-muted-foreground">No events yet.</p>
+            ) : (
+              <div className="grid grid-cols-7 gap-2">
+                {days.map(([day, count]) => (
+                  <div key={day} className="text-center">
+                    <div className="relative mx-auto h-24 w-8 overflow-hidden rounded bg-muted">
+                      <div
+                        className="absolute bottom-0 w-full bg-primary"
+                        style={{ height: `${(count / peak) * 100}%` }}
+                      />
+                    </div>
+                    <p className="mt-1 text-xs text-muted-foreground">{day.slice(5)}</p>
+                    <p className="text-xs font-medium">{count}</p>
+                  </div>
+                ))}
+              </div>
+            )}
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-base">By action</CardTitle>
+          </CardHeader>
+          <CardContent>
+            {sortedActions.length === 0 ? (
+              <p className="text-sm text-muted-foreground">No events.</p>
+            ) : (
+              <ul className="space-y-1 text-xs">
+                {sortedActions.slice(0, 12).map(([action, count]) => (
+                  <li key={action} className="flex justify-between">
+                    <span className="font-mono">{action}</span>
+                    <span className="text-muted-foreground">
+                      {count}
+                      {grandTotal > 0 ? (
+                        <span className="ml-1 text-[10px]">
+                          ({Math.round((count / grandTotal) * 100)}%)
+                        </span>
+                      ) : null}
+                    </span>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </CardContent>
+        </Card>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">Search</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <form className="grid gap-2 md:grid-cols-3" action="/app/admin/audit">
+            <div className="space-y-1">
+              <label htmlFor="action-input" className="text-xs uppercase tracking-wide">
+                Action contains
+              </label>
+              <Input
+                id="action-input"
+                name="action"
+                defaultValue={action ?? ''}
+                placeholder="data.accessed, consent, hold"
+              />
+            </div>
+            <div className="space-y-1 md:col-span-2">
+              <label htmlFor="target-input" className="text-xs uppercase tracking-wide">
+                Target id
+              </label>
+              <Input
+                id="target-input"
+                name="targetId"
+                defaultValue={targetId ?? ''}
+                placeholder="UUID or opaque ref"
+              />
+            </div>
+            <div className="md:col-span-3">
+              <button
+                type="submit"
+                className="rounded-md border border-border bg-card px-3 py-1.5 text-xs hover:bg-muted"
+              >
+                Apply
+              </button>
+            </div>
+          </form>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">
+            Most recent {rows.length === 200 ? `${rows.length}+` : rows.length} events
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          {rows.length === 0 ? (
+            <p className="text-sm text-muted-foreground">
+              No events match. Try widening the search.
+            </p>
+          ) : (
+            <ul className="space-y-1 text-xs">
+              {rows.map((r) => (
+                <li
+                  key={r.id}
+                  className="flex flex-wrap items-baseline justify-between gap-2 rounded bg-muted/40 px-2 py-1"
+                >
+                  <span className="font-mono">
+                    {fmtTime(r.createdAt)} · <strong>{r.action}</strong>
+                    {r.targetTable ? ` · ${r.targetTable}` : ''}
+                  </span>
+                  <span className="text-muted-foreground">
+                    {r.actorEmail ?? <em className="not-italic">system</em>}
+                    {r.actorRole ? ` (${r.actorRole})` : ''}
+                  </span>
+                </li>
+              ))}
+            </ul>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/app/app/cases/filings/[id]/page.tsx
+++ b/src/app/app/cases/filings/[id]/page.tsx
@@ -8,6 +8,8 @@ import { listCaseOutcomes } from '@/db/queries/eviction-case-outcomes';
 import { getFilingById } from '@/db/queries/eviction-filings';
 import { matchAssistancePrograms } from '@/db/queries/rental-assistance';
 import { requireRole, userIsKlaAttorney } from '@/lib/auth';
+import { recordDataAccess } from '@/lib/dtrs/data-access';
+import { redactAddress, viewerCanSeeDvAddresses } from '@/lib/dtrs/dv-blind';
 import { getLatestScore } from '@/lib/eviction/risk-score';
 
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
@@ -29,6 +31,22 @@ export default async function FilingDetailPage({ params }: { params: Promise<{ i
     matchAssistancePrograms(filing),
   ]);
 
+  // DV abuser-blind: filing.dv_flag is the per-record marker; the viewer
+  // role is the second axis. Attorneys + caseworkers see the address;
+  // everyone else sees LOCATION_REDACTED.
+  const showAddress = !filing.dvFlag || viewerCanSeeDvAddresses(me.role);
+  const safeFiling = redactAddress(filing, !showAddress);
+
+  // DTRS-003: log this read. We log AFTER the row is fetched so the
+  // log entry corresponds to a successful access.
+  await recordDataAccess({
+    actorUserId: me.id,
+    resourceType: 'eviction_filings',
+    resourceId: filing.id,
+    purpose: 'attorney_case_detail',
+    metadata: { dvFlag: filing.dvFlag, addressVisible: showAddress },
+  });
+
   return (
     <div className="mx-auto max-w-4xl p-6 space-y-4">
       <div className="text-xs">
@@ -36,7 +54,7 @@ export default async function FilingDetailPage({ params }: { params: Promise<{ i
           ← Back to filings
         </Link>
       </div>
-      <FilingDetail filing={filing} score={score} />
+      <FilingDetail filing={safeFiling} score={score} />
       <div className="rounded-md border border-border bg-card p-4 text-sm">
         <p className="mb-2 font-medium">Response packet</p>
         <p className="mb-3 text-xs text-muted-foreground">

--- a/src/app/app/clients/consent-link/page.tsx
+++ b/src/app/app/clients/consent-link/page.tsx
@@ -1,0 +1,43 @@
+import { ConsentTokenMinter } from '@/components/consent/consent-token-minter';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { requireRole } from '@/lib/auth';
+
+export const dynamic = 'force-dynamic';
+
+export default async function ConsentLinkPage() {
+  await requireRole(['caseworker', 'shelter_staff', 'admin']);
+
+  return (
+    <div className="mx-auto max-w-2xl space-y-4 p-4 md:p-6">
+      <header>
+        <h1 className="font-serif text-3xl font-bold text-primary">Consent link</h1>
+        <p className="text-sm text-muted-foreground">
+          Mint a 24-hour single-resource link a client can use to grant or revoke their sharing
+          settings. The token resolves server-side; nobody can change a client's settings without
+          one.
+        </p>
+      </header>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">Mint a link</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <ConsentTokenMinter />
+        </CardContent>
+      </Card>
+
+      <Card className="border-amber-500/40 bg-amber-500/5">
+        <CardContent className="text-xs">
+          <p className="font-medium">Don't share these links over public channels.</p>
+          <p className="mt-1 text-muted-foreground">
+            A leaked link grants 24h of write access to one client's settings. Hand it to the person
+            directly (printed wallet card, in-shelter QR), or message it on a channel only they can
+            see. If you suspect a leak, mint a new one — older tokens stay valid until their expiry
+            but you can also revoke a token via the database.
+          </p>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/app/app/clients/screener/page.tsx
+++ b/src/app/app/clients/screener/page.tsx
@@ -1,0 +1,30 @@
+import { BenefitsScreener } from '@/components/cwt/benefits-screener';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { requireRole } from '@/lib/auth';
+
+export const dynamic = 'force-dynamic';
+
+export default async function BenefitsScreenerPage() {
+  await requireRole(['caseworker', 'shelter_staff', 'admin']);
+
+  return (
+    <div className="mx-auto max-w-5xl space-y-4 p-4 md:p-6">
+      <header>
+        <h1 className="font-serif text-3xl font-bold text-primary">Benefits screener</h1>
+        <p className="text-sm text-muted-foreground">
+          Quick eligibility screen across SNAP, KCHIP, Medicaid, KTAP, SSI, VA, and LIHEAP. Type the
+          household details on the left; results update live on the right. Nothing is saved.
+        </p>
+      </header>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">Household details</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <BenefitsScreener />
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/app/app/clients/triage/page.tsx
+++ b/src/app/app/clients/triage/page.tsx
@@ -1,0 +1,31 @@
+import { TriageTierTool } from '@/components/cwt/triage-tier';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { requireRole } from '@/lib/auth';
+
+export const dynamic = 'force-dynamic';
+
+export default async function TriageTierPage() {
+  await requireRole(['caseworker', 'shelter_staff', 'admin']);
+
+  return (
+    <div className="mx-auto max-w-5xl space-y-4 p-4 md:p-6">
+      <header>
+        <h1 className="font-serif text-3xl font-bold text-primary">Triage tier</h1>
+        <p className="text-sm text-muted-foreground">
+          Quick rule-based recommendation for a household's housing-stability potential. Each
+          factor's weight is shown so you can argue with the result rather than just accept it.
+          Nothing is saved.
+        </p>
+      </header>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">Household details</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <TriageTierTool />
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/app/app/coalition/beds/page.tsx
+++ b/src/app/app/coalition/beds/page.tsx
@@ -1,22 +1,40 @@
 import { AutoRefresh } from '@/components/coordination/auto-refresh';
 import { BedBoardCard } from '@/components/coordination/bed-board-card';
+import { BedBoardFilters } from '@/components/coordination/bed-board-filters';
 import { Card, CardContent } from '@/components/ui/card';
 import { lastBedCountUpdateByShelter, listActiveShelters } from '@/db/queries/shelters';
 import { requireRole } from '@/lib/auth';
-import { freeBeds } from '@/lib/coordination/bed-availability';
+import {
+  freeBeds,
+  hasActiveFilter,
+  matchesFilter,
+  parseBedFilterParams,
+} from '@/lib/coordination/bed-availability';
 
 export const dynamic = 'force-dynamic';
 
-export default async function BedAvailabilityBoardPage() {
+export default async function BedAvailabilityBoardPage({
+  searchParams,
+}: {
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+}) {
   await requireRole(['attorney', 'caseworker', 'ed_coordinator', 'shelter_staff', 'admin']);
-  const [shelterRows, lastUpdates] = await Promise.all([
+  const params = await searchParams;
+  const filter = parseBedFilterParams(params);
+
+  const [allShelters, lastUpdates] = await Promise.all([
     listActiveShelters(),
     lastBedCountUpdateByShelter(),
   ]);
 
-  const totalCapacity = shelterRows.reduce((sum, s) => sum + s.capacity, 0);
-  const totalOccupied = shelterRows.reduce((sum, s) => sum + s.currentOccupancy, 0);
-  const totalFree = shelterRows.reduce((sum, s) => sum + freeBeds(s), 0);
+  const filtered = allShelters.filter((s) =>
+    matchesFilter(s, filter, `${s.name} ${s.partnerOrg.name}`),
+  );
+
+  const totalCapacity = filtered.reduce((sum, s) => sum + s.capacity, 0);
+  const totalOccupied = filtered.reduce((sum, s) => sum + s.currentOccupancy, 0);
+  const totalFree = filtered.reduce((sum, s) => sum + freeBeds(s), 0);
+  const filterActive = hasActiveFilter(filter);
 
   return (
     <div className="mx-auto max-w-6xl space-y-4 p-4 md:p-6">
@@ -24,17 +42,21 @@ export default async function BedAvailabilityBoardPage() {
         <div>
           <h1 className="font-serif text-3xl font-bold text-primary">Bed availability</h1>
           <p className="text-sm text-muted-foreground">
-            Live across {shelterRows.length} Daviess shelters. Numbers reflect what staff entered
+            Live across {allShelters.length} Daviess shelters. Numbers reflect what staff entered
             most recently in the bed-count update view.
           </p>
         </div>
         <AutoRefresh />
       </header>
 
+      <BedBoardFilters />
+
       <Card>
         <CardContent className="grid grid-cols-3 gap-3 text-center">
           <div>
-            <p className="text-xs uppercase tracking-wide text-muted-foreground">Free beds</p>
+            <p className="text-xs uppercase tracking-wide text-muted-foreground">
+              Free {filterActive ? '(filtered)' : ''}
+            </p>
             <p className="text-2xl font-semibold text-emerald-600 dark:text-emerald-400">
               {totalFree}
             </p>
@@ -50,16 +72,22 @@ export default async function BedAvailabilityBoardPage() {
         </CardContent>
       </Card>
 
-      {shelterRows.length === 0 ? (
+      {allShelters.length === 0 ? (
         <Card>
           <CardContent className="text-sm text-muted-foreground">
             No active shelters. Run <code className="font-mono">pnpm db:seed</code> to load the
             Daviess catalog.
           </CardContent>
         </Card>
+      ) : filtered.length === 0 ? (
+        <Card>
+          <CardContent className="text-sm text-muted-foreground">
+            No shelters match the current filters. Try a different preset or clear filters.
+          </CardContent>
+        </Card>
       ) : (
         <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
-          {shelterRows.map((shelter) => (
+          {filtered.map((shelter) => (
             <BedBoardCard
               key={shelter.id}
               shelter={shelter}

--- a/src/app/app/coalition/beds/page.tsx
+++ b/src/app/app/coalition/beds/page.tsx
@@ -2,10 +2,15 @@ import { AutoRefresh } from '@/components/coordination/auto-refresh';
 import { BedBoardCard } from '@/components/coordination/bed-board-card';
 import { BedBoardFilters } from '@/components/coordination/bed-board-filters';
 import { Card, CardContent } from '@/components/ui/card';
-import { lastBedCountUpdateByShelter, listActiveShelters } from '@/db/queries/shelters';
+import {
+  type BedHoldWithHolder,
+  lastBedCountUpdateByShelter,
+  listActiveHolds,
+  listActiveShelters,
+} from '@/db/queries/shelters';
 import { requireRole } from '@/lib/auth';
 import {
-  freeBeds,
+  effectiveFreeBeds,
   hasActiveFilter,
   matchesFilter,
   parseBedFilterParams,
@@ -13,12 +18,20 @@ import {
 
 export const dynamic = 'force-dynamic';
 
+const HOLD_ROLES = ['caseworker', 'ed_coordinator', 'shelter_staff', 'admin'];
+
 export default async function BedAvailabilityBoardPage({
   searchParams,
 }: {
   searchParams: Promise<Record<string, string | string[] | undefined>>;
 }) {
-  await requireRole(['attorney', 'caseworker', 'ed_coordinator', 'shelter_staff', 'admin']);
+  const me = await requireRole([
+    'attorney',
+    'caseworker',
+    'ed_coordinator',
+    'shelter_staff',
+    'admin',
+  ]);
   const params = await searchParams;
   const filter = parseBedFilterParams(params);
 
@@ -27,14 +40,24 @@ export default async function BedAvailabilityBoardPage({
     lastBedCountUpdateByShelter(),
   ]);
 
+  const holdLists = await Promise.all(allShelters.map((s) => listActiveHolds(s.id)));
+  const holdsByShelter = new Map<string, BedHoldWithHolder[]>(
+    allShelters.map((s, i) => [s.id, holdLists[i]]),
+  );
+
   const filtered = allShelters.filter((s) =>
     matchesFilter(s, filter, `${s.name} ${s.partnerOrg.name}`),
   );
 
   const totalCapacity = filtered.reduce((sum, s) => sum + s.capacity, 0);
   const totalOccupied = filtered.reduce((sum, s) => sum + s.currentOccupancy, 0);
-  const totalFree = filtered.reduce((sum, s) => sum + freeBeds(s), 0);
+  const totalFree = filtered.reduce(
+    (sum, s) => sum + effectiveFreeBeds(s, holdsByShelter.get(s.id)?.length ?? 0),
+    0,
+  );
+  const totalHolds = filtered.reduce((sum, s) => sum + (holdsByShelter.get(s.id)?.length ?? 0), 0);
   const filterActive = hasActiveFilter(filter);
+  const canHold = HOLD_ROLES.includes(me.role);
 
   return (
     <div className="mx-auto max-w-6xl space-y-4 p-4 md:p-6">
@@ -42,8 +65,8 @@ export default async function BedAvailabilityBoardPage({
         <div>
           <h1 className="font-serif text-3xl font-bold text-primary">Bed availability</h1>
           <p className="text-sm text-muted-foreground">
-            Live across {allShelters.length} Daviess shelters. Numbers reflect what staff entered
-            most recently in the bed-count update view.
+            Live across {allShelters.length} Daviess shelters. Free counts subtract active 90-min
+            holds.
           </p>
         </div>
         <AutoRefresh />
@@ -52,7 +75,7 @@ export default async function BedAvailabilityBoardPage({
       <BedBoardFilters />
 
       <Card>
-        <CardContent className="grid grid-cols-3 gap-3 text-center">
+        <CardContent className="grid grid-cols-4 gap-3 text-center">
           <div>
             <p className="text-xs uppercase tracking-wide text-muted-foreground">
               Free {filterActive ? '(filtered)' : ''}
@@ -60,6 +83,10 @@ export default async function BedAvailabilityBoardPage({
             <p className="text-2xl font-semibold text-emerald-600 dark:text-emerald-400">
               {totalFree}
             </p>
+          </div>
+          <div>
+            <p className="text-xs uppercase tracking-wide text-muted-foreground">On hold</p>
+            <p className="text-2xl font-semibold">{totalHolds}</p>
           </div>
           <div>
             <p className="text-xs uppercase tracking-wide text-muted-foreground">Occupied</p>
@@ -92,6 +119,8 @@ export default async function BedAvailabilityBoardPage({
               key={shelter.id}
               shelter={shelter}
               lastUpdatedAt={lastUpdates.get(shelter.id) ?? null}
+              activeHolds={holdsByShelter.get(shelter.id) ?? []}
+              canHold={canHold}
             />
           ))}
         </div>

--- a/src/app/app/coalition/beds/page.tsx
+++ b/src/app/app/coalition/beds/page.tsx
@@ -1,0 +1,73 @@
+import { AutoRefresh } from '@/components/coordination/auto-refresh';
+import { BedBoardCard } from '@/components/coordination/bed-board-card';
+import { Card, CardContent } from '@/components/ui/card';
+import { lastBedCountUpdateByShelter, listActiveShelters } from '@/db/queries/shelters';
+import { requireRole } from '@/lib/auth';
+import { freeBeds } from '@/lib/coordination/bed-availability';
+
+export const dynamic = 'force-dynamic';
+
+export default async function BedAvailabilityBoardPage() {
+  await requireRole(['attorney', 'caseworker', 'ed_coordinator', 'shelter_staff', 'admin']);
+  const [shelterRows, lastUpdates] = await Promise.all([
+    listActiveShelters(),
+    lastBedCountUpdateByShelter(),
+  ]);
+
+  const totalCapacity = shelterRows.reduce((sum, s) => sum + s.capacity, 0);
+  const totalOccupied = shelterRows.reduce((sum, s) => sum + s.currentOccupancy, 0);
+  const totalFree = shelterRows.reduce((sum, s) => sum + freeBeds(s), 0);
+
+  return (
+    <div className="mx-auto max-w-6xl space-y-4 p-4 md:p-6">
+      <header className="flex flex-wrap items-baseline justify-between gap-2">
+        <div>
+          <h1 className="font-serif text-3xl font-bold text-primary">Bed availability</h1>
+          <p className="text-sm text-muted-foreground">
+            Live across {shelterRows.length} Daviess shelters. Numbers reflect what staff entered
+            most recently in the bed-count update view.
+          </p>
+        </div>
+        <AutoRefresh />
+      </header>
+
+      <Card>
+        <CardContent className="grid grid-cols-3 gap-3 text-center">
+          <div>
+            <p className="text-xs uppercase tracking-wide text-muted-foreground">Free beds</p>
+            <p className="text-2xl font-semibold text-emerald-600 dark:text-emerald-400">
+              {totalFree}
+            </p>
+          </div>
+          <div>
+            <p className="text-xs uppercase tracking-wide text-muted-foreground">Occupied</p>
+            <p className="text-2xl font-semibold">{totalOccupied}</p>
+          </div>
+          <div>
+            <p className="text-xs uppercase tracking-wide text-muted-foreground">Capacity</p>
+            <p className="text-2xl font-semibold">{totalCapacity}</p>
+          </div>
+        </CardContent>
+      </Card>
+
+      {shelterRows.length === 0 ? (
+        <Card>
+          <CardContent className="text-sm text-muted-foreground">
+            No active shelters. Run <code className="font-mono">pnpm db:seed</code> to load the
+            Daviess catalog.
+          </CardContent>
+        </Card>
+      ) : (
+        <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+          {shelterRows.map((shelter) => (
+            <BedBoardCard
+              key={shelter.id}
+              shelter={shelter}
+              lastUpdatedAt={lastUpdates.get(shelter.id) ?? null}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/app/coalition/beds/update/page.tsx
+++ b/src/app/app/coalition/beds/update/page.tsx
@@ -1,0 +1,55 @@
+import { BedCountStaffCard } from '@/components/coordination/bed-count-staff-card';
+import { Card, CardContent } from '@/components/ui/card';
+import { lastBedCountUpdateByShelter, listActiveShelters } from '@/db/queries/shelters';
+import { requireRole } from '@/lib/auth';
+
+export const dynamic = 'force-dynamic';
+
+export default async function BedCountUpdatePage() {
+  await requireRole(['shelter_staff', 'admin']);
+  const [shelterRows, lastUpdates] = await Promise.all([
+    listActiveShelters(),
+    lastBedCountUpdateByShelter(),
+  ]);
+
+  return (
+    <div className="mx-auto max-w-3xl space-y-4 p-4 md:p-6">
+      <header>
+        <h1 className="font-serif text-3xl font-bold text-primary">Update bed counts</h1>
+        <p className="text-sm text-muted-foreground">
+          Tap −1 / +1 (or −5 / +5 for fast moves) when a bed turns over. Saves take a second; the
+          live availability board picks up the change automatically.
+        </p>
+      </header>
+
+      {shelterRows.length === 0 ? (
+        <Card>
+          <CardContent className="text-sm text-muted-foreground">
+            No active shelters. Run <code className="font-mono">pnpm db:seed</code> to load the
+            Daviess catalog.
+          </CardContent>
+        </Card>
+      ) : (
+        <div className="grid gap-4 md:grid-cols-2">
+          {shelterRows.map((shelter) => (
+            <BedCountStaffCard
+              key={shelter.id}
+              shelter={shelter}
+              lastUpdatedAt={lastUpdates.get(shelter.id) ?? null}
+            />
+          ))}
+        </div>
+      )}
+
+      <Card className="border-amber-500/40 bg-amber-500/5">
+        <CardContent className="text-xs">
+          <p className="font-medium">Phase-1 scoping note.</p>
+          <p className="mt-1 text-muted-foreground">
+            Every shelter_staff user sees every shelter today. Per-shelter membership scoping (so
+            St. Benedict's staff only see St. Benedict's) ships with COOR-007 onboarding.
+          </p>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/app/app/coalition/sms/handout/page.tsx
+++ b/src/app/app/coalition/sms/handout/page.tsx
@@ -1,0 +1,121 @@
+import { PrintButton } from '@/components/coordination/print-button';
+import { requireRole } from '@/lib/auth';
+
+export const dynamic = 'force-dynamic';
+
+/**
+ * INDC-008 — printable one-pager staff hand to clients. Designed
+ * for letter-paper / 4×6 reprinting. Avoids the app shell so the
+ * page prints clean.
+ */
+export default async function SmsHandoutPage() {
+  await requireRole(['admin', 'shelter_staff', 'caseworker', 'ed_coordinator']);
+  // The actual SMS shortcode / number is configured per environment;
+  // staff printing this should override [SHORTCODE] before laminating.
+  // Phase 1: Twilio long-code; Phase 2 (post-BAA): coalition shortcode.
+  const shortcode = process.env.NEXT_PUBLIC_INDC_SMS_NUMBER ?? '[number TBD]';
+
+  return (
+    <div className="mx-auto max-w-2xl p-8 print:p-0">
+      <div className="space-y-6 rounded-lg border border-border bg-white p-8 text-black shadow-sm print:border-0 print:shadow-none">
+        <header className="space-y-1">
+          <p className="text-xs uppercase tracking-wide text-stone-500">
+            Daviess County Homeless Coalition
+          </p>
+          <h1 className="font-serif text-3xl font-bold">Find a bed by text.</h1>
+          <p className="text-stone-700">Free. Confidential. Local partners. No app to install.</p>
+        </header>
+
+        <section>
+          <p className="text-sm">Text the word below to:</p>
+          <p className="mt-1 font-mono text-2xl font-semibold">{shortcode}</p>
+        </section>
+
+        <section className="space-y-3 rounded-md bg-stone-50 p-4">
+          <h2 className="font-serif text-lg font-semibold">Quick commands</h2>
+          <table className="w-full text-sm">
+            <tbody className="[&_td]:py-1 [&_td:first-child]:font-mono [&_td:first-child]:font-semibold [&_td:first-child]:pr-3">
+              <tr>
+                <td>BED</td>
+                <td>find an open shelter bed</td>
+              </tr>
+              <tr>
+                <td>BED FAMILY</td>
+                <td>only family-accepting shelters</td>
+              </tr>
+              <tr>
+                <td>BED PET</td>
+                <td>only pet-friendly shelters</td>
+              </tr>
+              <tr>
+                <td>BED MEN / WOMEN</td>
+                <td>filter by population</td>
+              </tr>
+              <tr>
+                <td>BED SUD</td>
+                <td>recovery / SUD-friendly</td>
+              </tr>
+              <tr>
+                <td>HOLD 1</td>
+                <td>hold the first bed for 90 minutes</td>
+              </tr>
+              <tr>
+                <td>RELEASE</td>
+                <td>cancel a hold you placed</td>
+              </tr>
+              <tr>
+                <td>FOOD</td>
+                <td>nearby food pantry numbers</td>
+              </tr>
+              <tr>
+                <td>STORY</td>
+                <td>about this service</td>
+              </tr>
+              <tr>
+                <td>HELP</td>
+                <td>show this list again</td>
+              </tr>
+              <tr>
+                <td>STOP</td>
+                <td>opt out of texts</td>
+              </tr>
+            </tbody>
+          </table>
+        </section>
+
+        <section className="space-y-2 text-sm">
+          <h2 className="font-serif text-lg font-semibold">How it works</h2>
+          <ol className="list-decimal space-y-1 pl-5">
+            <li>
+              Text <span className="font-mono font-semibold">BED</span> (or BED FAMILY / BED PET).
+            </li>
+            <li>Reply with a neighborhood, intersection, or ZIP — or ANYWHERE.</li>
+            <li>You'll get up to 3 shelters with current open beds and phone numbers.</li>
+            <li>Reply HOLD &lt;#&gt; to hold the bed for 90 minutes while you walk over.</li>
+          </ol>
+        </section>
+
+        <section className="space-y-1 text-xs text-stone-700">
+          <p>
+            <strong>Privacy.</strong> The coalition stores the messages and your phone number during
+            the pilot to make the service work. We don't share your number with shelters unless you
+            ask us to.
+          </p>
+          <p>
+            <strong>Need a person?</strong> Call <span className="font-mono">211</span> for live
+            referrals 24/7.
+          </p>
+        </section>
+      </div>
+
+      <div className="mt-4 space-y-2 print:hidden">
+        <PrintButton />
+        <p className="text-xs text-muted-foreground">
+          Print this on letter paper, or trim down to a quarter-sheet. Replace
+          <code className="font-mono"> [number TBD]</code> with the real Twilio number once it's
+          provisioned (set <code className="font-mono">NEXT_PUBLIC_INDC_SMS_NUMBER</code>).
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/app/app/coalition/sms/metrics/page.tsx
+++ b/src/app/app/coalition/sms/metrics/page.tsx
@@ -1,0 +1,212 @@
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import {
+  dailyIntentCounts,
+  intentTotals,
+  recentRedactedMessages,
+  uniqueCallerCount,
+} from '@/db/queries/sms-metrics';
+import { requireRole } from '@/lib/auth';
+
+export const dynamic = 'force-dynamic';
+
+const WINDOW_DAYS = 7;
+
+const fmtTime = (d: Date) =>
+  new Intl.DateTimeFormat('en-US', { dateStyle: 'short', timeStyle: 'short' }).format(new Date(d));
+
+/**
+ * INTENT_LABELS keeps the dashboard copy stable even as the pipeline
+ * evolves; unknown intents fall through to their raw key so we can
+ * still see them in the breakdown.
+ */
+const INTENT_LABELS: Record<string, string> = {
+  bed_results: 'Bed list shown',
+  awaiting_location: 'Asked for location',
+  location_received: 'Location received → results',
+  help: 'HELP',
+  food: 'FOOD',
+  story: 'STORY',
+  stop: 'STOP / opt-out',
+  hold_confirmed: 'Hold confirmed',
+  hold_failed: 'Hold failed',
+  release_confirmed: 'Hold released',
+  release_failed: 'Release failed',
+  unknown: 'Unknown / didn\u2019t match',
+  error: 'Pipeline error',
+};
+
+export default async function SmsMetricsPage() {
+  await requireRole(['admin']);
+
+  const [byDay, totals, callers, recent] = await Promise.all([
+    dailyIntentCounts(WINDOW_DAYS),
+    intentTotals(WINDOW_DAYS),
+    uniqueCallerCount(WINDOW_DAYS),
+    recentRedactedMessages(20),
+  ]);
+
+  const totalMessages = totals.reduce((sum, t) => sum + t.count, 0);
+  const beds = totals.find((t) => t.intent === 'bed_results')?.count ?? 0;
+  const askedLocation = totals.find((t) => t.intent === 'awaiting_location')?.count ?? 0;
+  const locationReplies = totals.find((t) => t.intent === 'location_received')?.count ?? 0;
+  const completionRate =
+    askedLocation > 0 ? Math.round((locationReplies / askedLocation) * 100) : null;
+  const unknown = totals.find((t) => t.intent === 'unknown')?.count ?? 0;
+
+  // Build a per-day stack: array of { day, total, byIntent: { intent: count } }
+  const dayMap = new Map<string, Map<string, number>>();
+  for (const r of byDay) {
+    if (!dayMap.has(r.day)) dayMap.set(r.day, new Map());
+    dayMap.get(r.day)!.set(r.intent, r.count);
+  }
+  const days = Array.from(dayMap.entries())
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([day, intents]) => ({
+      day,
+      total: Array.from(intents.values()).reduce((s, n) => s + n, 0),
+      intents: Array.from(intents.entries()).map(([k, v]) => ({ intent: k, count: v })),
+    }));
+  const peakDayCount = days.reduce((m, d) => Math.max(m, d.total), 0) || 1;
+
+  return (
+    <div className="mx-auto max-w-6xl space-y-4 p-4 md:p-6">
+      <header>
+        <h1 className="font-serif text-3xl font-bold text-primary">SMS bed-finder metrics</h1>
+        <p className="text-sm text-muted-foreground">
+          Last {WINDOW_DAYS} days. Phone numbers never leave the database — only counts do.
+          Simulated playground traffic is excluded.
+        </p>
+      </header>
+
+      <div className="grid gap-4 md:grid-cols-4">
+        <Card>
+          <CardContent>
+            <p className="text-xs uppercase tracking-wide text-muted-foreground">Messages</p>
+            <p className="text-3xl font-semibold">{totalMessages}</p>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardContent>
+            <p className="text-xs uppercase tracking-wide text-muted-foreground">Unique callers</p>
+            <p className="text-3xl font-semibold">{callers}</p>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardContent>
+            <p className="text-xs uppercase tracking-wide text-muted-foreground">Bed lists shown</p>
+            <p className="text-3xl font-semibold">{beds + locationReplies}</p>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardContent>
+            <p className="text-xs uppercase tracking-wide text-muted-foreground">
+              Location-prompt completion
+            </p>
+            <p className="text-3xl font-semibold">
+              {completionRate === null ? '—' : `${completionRate}%`}
+            </p>
+            <p className="text-xs text-muted-foreground">
+              {locationReplies} of {askedLocation} prompts answered
+            </p>
+          </CardContent>
+        </Card>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">Daily volume</CardTitle>
+        </CardHeader>
+        <CardContent>
+          {days.length === 0 ? (
+            <p className="text-sm text-muted-foreground">No traffic in the window.</p>
+          ) : (
+            <div className="grid grid-cols-7 gap-2">
+              {days.map((d) => (
+                <div key={d.day} className="text-center">
+                  <div
+                    role="img"
+                    aria-label={`${d.total} messages on ${d.day}`}
+                    className="relative mx-auto h-32 w-8 overflow-hidden rounded bg-muted"
+                  >
+                    <div
+                      className="absolute bottom-0 w-full bg-primary"
+                      style={{ height: `${(d.total / peakDayCount) * 100}%` }}
+                    />
+                  </div>
+                  <p className="mt-1 text-xs text-muted-foreground">{d.day.slice(5)}</p>
+                  <p className="text-xs font-medium">{d.total}</p>
+                </div>
+              ))}
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">Intent breakdown</CardTitle>
+        </CardHeader>
+        <CardContent>
+          {totals.length === 0 ? (
+            <p className="text-sm text-muted-foreground">No traffic in the window.</p>
+          ) : (
+            <ul className="space-y-2">
+              {totals.map((t) => {
+                const pct = totalMessages > 0 ? (t.count / totalMessages) * 100 : 0;
+                return (
+                  <li key={t.intent} className="text-sm">
+                    <div className="flex justify-between">
+                      <span>{INTENT_LABELS[t.intent] ?? t.intent}</span>
+                      <span className="text-muted-foreground">
+                        {t.count} <span className="text-xs">({Math.round(pct)}%)</span>
+                      </span>
+                    </div>
+                    <div className="mt-1 h-1.5 w-full overflow-hidden rounded-full bg-muted">
+                      <div className="h-full bg-primary" style={{ width: `${Math.round(pct)}%` }} />
+                    </div>
+                  </li>
+                );
+              })}
+            </ul>
+          )}
+          {unknown > 0 ? (
+            <p className="mt-3 rounded-md border border-amber-500/40 bg-amber-500/5 p-2 text-xs">
+              <strong>Friction signal:</strong> {unknown} unknown messages in the window —
+              candidates for parser additions or improved help copy.
+            </p>
+          ) : null}
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">Recent traffic (redacted)</CardTitle>
+        </CardHeader>
+        <CardContent>
+          {recent.length === 0 ? (
+            <p className="text-sm text-muted-foreground">No messages yet.</p>
+          ) : (
+            <ul className="space-y-1 text-xs">
+              {recent.map((m) => (
+                <li
+                  key={m.id}
+                  className="flex flex-wrap items-baseline justify-between gap-2 rounded bg-muted/40 px-2 py-1"
+                >
+                  <span className="font-mono text-muted-foreground">
+                    {fmtTime(m.receivedAt)} · …{m.fromLast4} · {m.intent}
+                  </span>
+                  <span className="truncate font-mono">{m.bodyExcerpt}</span>
+                </li>
+              ))}
+            </ul>
+          )}
+          <p className="mt-3 text-xs text-muted-foreground">
+            Phone numbers shown only as last-4 digits. Full numbers stay in the
+            <code className="font-mono"> sms_messages</code> table for audit; this view is for fast
+            triage.
+          </p>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/app/app/coalition/sms/page.tsx
+++ b/src/app/app/coalition/sms/page.tsx
@@ -1,0 +1,42 @@
+import { SmsPlayground } from '@/components/coordination/sms-playground';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { requireRole } from '@/lib/auth';
+
+export const dynamic = 'force-dynamic';
+
+export default async function SmsPlaygroundPage() {
+  await requireRole(['admin', 'shelter_staff', 'caseworker', 'ed_coordinator']);
+
+  return (
+    <div className="mx-auto max-w-3xl space-y-4 p-4 md:p-6">
+      <header>
+        <h1 className="font-serif text-3xl font-bold text-primary">SMS bed-finder</h1>
+        <p className="text-sm text-muted-foreground">
+          Simulate inbound SMS to preview what a caller would see. The same pipeline runs against
+          live Twilio traffic at <code className="font-mono">/api/webhooks/twilio/sms</code>.
+        </p>
+      </header>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">Try a message</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <SmsPlayground />
+        </CardContent>
+      </Card>
+
+      <Card className="border-amber-500/40 bg-amber-500/5">
+        <CardContent className="text-xs">
+          <p className="font-medium">Phase-1 stub.</p>
+          <p className="mt-1 text-muted-foreground">
+            Replies use seeded shelter data. The webhook is wired up but does nothing in production
+            until <code className="font-mono">TWILIO_AUTH_TOKEN</code> is set and a Twilio number is
+            pointed at the route. Enable this for real client traffic only after the HIPAA-eligible
+            Twilio account migration (ESUC-004).
+          </p>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/app/p/[ref]/consent/grant/page.tsx
+++ b/src/app/p/[ref]/consent/grant/page.tsx
@@ -1,0 +1,58 @@
+import { notFound } from 'next/navigation';
+import { ConsentForm } from '@/components/consent/consent-form';
+import { Card, CardContent } from '@/components/ui/card';
+import { type ConsentType, consentTypeEnum } from '@/db/schema/enums';
+import { consentTextFor } from '@/lib/dtrs/consent-text';
+import { isValidSyntheticPersonRef } from '@/lib/synthetic-person';
+
+export const metadata = {
+  title: 'Sharing agreement',
+};
+
+const VALID_TYPES = new Set<ConsentType>(consentTypeEnum.enumValues);
+
+export default async function GrantConsentPage({
+  params,
+  searchParams,
+}: {
+  params: Promise<{ ref: string }>;
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+}) {
+  const { ref } = await params;
+  const sp = await searchParams;
+  if (!isValidSyntheticPersonRef(ref)) notFound();
+
+  const rawType = Array.isArray(sp.type) ? sp.type[0] : sp.type;
+  const consentType: ConsentType =
+    rawType && VALID_TYPES.has(rawType as ConsentType)
+      ? (rawType as ConsentType)
+      : 'phi_share_within_coalition';
+  const copy = consentTextFor(consentType);
+
+  return (
+    <div className="mx-auto max-w-xl space-y-4 p-6">
+      <header>
+        <p className="text-xs text-muted-foreground">
+          Identifier <span className="font-mono">{ref}</span>
+        </p>
+      </header>
+
+      <Card>
+        <CardContent className="pt-6">
+          <ConsentForm subjectExternalId={ref} consentType={consentType} copy={copy} />
+        </CardContent>
+      </Card>
+
+      <Card className="border-amber-500/40 bg-amber-500/5">
+        <CardContent className="text-xs">
+          <p className="font-medium">Phase-1 stub.</p>
+          <p className="mt-1 text-muted-foreground">
+            This page is open to anyone with the URL today. A one-time-link auth gate (#251) is the
+            follow-up that scopes write access to the right person. The wording itself is reviewed
+            in DTRS-005 advisor sessions before any client traffic flows.
+          </p>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/app/p/[ref]/consent/grant/page.tsx
+++ b/src/app/p/[ref]/consent/grant/page.tsx
@@ -3,7 +3,7 @@ import { ConsentForm } from '@/components/consent/consent-form';
 import { Card, CardContent } from '@/components/ui/card';
 import { type ConsentType, consentTypeEnum } from '@/db/schema/enums';
 import { consentTextFor } from '@/lib/dtrs/consent-text';
-import { redeemConsentAccessToken } from '@/lib/dtrs/consent-token';
+import { lookupConsentAccessToken } from '@/lib/dtrs/consent-token';
 import { isValidSyntheticPersonRef } from '@/lib/synthetic-person';
 
 export const metadata = {
@@ -37,10 +37,14 @@ export default async function GrantConsentPage({
   const rawToken = Array.isArray(sp.token) ? sp.token[0] : sp.token;
   const openMode = process.env.INDC_CONSENT_OPEN_MODE === '1';
 
+  // Page render uses LOOKUP (no side effect) — `used_at` is stamped only
+  // when the form is actually submitted via the server action's
+  // redeemConsentAccessToken call. This keeps "viewed but didn't submit"
+  // distinguishable in analytics.
   let authorized = false;
   if (rawToken) {
-    const redeemed = await redeemConsentAccessToken(rawToken);
-    if (redeemed && redeemed.syntheticPersonRef === ref) {
+    const found = await lookupConsentAccessToken(rawToken);
+    if (found && found.syntheticPersonRef === ref) {
       authorized = true;
     }
   } else if (openMode) {
@@ -66,7 +70,12 @@ export default async function GrantConsentPage({
 
       <Card>
         <CardContent className="pt-6">
-          <ConsentForm subjectExternalId={ref} consentType={consentType} copy={copy} />
+          <ConsentForm
+            subjectExternalId={ref}
+            consentType={consentType}
+            copy={copy}
+            accessToken={rawToken ?? null}
+          />
         </CardContent>
       </Card>
 

--- a/src/app/p/[ref]/consent/grant/page.tsx
+++ b/src/app/p/[ref]/consent/grant/page.tsx
@@ -3,6 +3,7 @@ import { ConsentForm } from '@/components/consent/consent-form';
 import { Card, CardContent } from '@/components/ui/card';
 import { type ConsentType, consentTypeEnum } from '@/db/schema/enums';
 import { consentTextFor } from '@/lib/dtrs/consent-text';
+import { redeemConsentAccessToken } from '@/lib/dtrs/consent-token';
 import { isValidSyntheticPersonRef } from '@/lib/synthetic-person';
 
 export const metadata = {
@@ -11,6 +12,17 @@ export const metadata = {
 
 const VALID_TYPES = new Set<ConsentType>(consentTypeEnum.enumValues);
 
+/**
+ * Public consent grant surface. Two access modes:
+ *   1. Token mode (preferred, post-#251): URL has `?token=<opaque>`
+ *      and the token resolves server-side to the ref. Phase-1 prod use.
+ *   2. Open mode (legacy, demo only): no token, but the URL itself
+ *      is the secret. Locked behind INDC_CONSENT_OPEN_MODE=1 so we
+ *      don't accidentally ship open-mode to a real domain.
+ *
+ * If neither path validates, return 404 — don't leak that the route
+ * pattern exists.
+ */
 export default async function GrantConsentPage({
   params,
   searchParams,
@@ -21,6 +33,21 @@ export default async function GrantConsentPage({
   const { ref } = await params;
   const sp = await searchParams;
   if (!isValidSyntheticPersonRef(ref)) notFound();
+
+  const rawToken = Array.isArray(sp.token) ? sp.token[0] : sp.token;
+  const openMode = process.env.INDC_CONSENT_OPEN_MODE === '1';
+
+  let authorized = false;
+  if (rawToken) {
+    const redeemed = await redeemConsentAccessToken(rawToken);
+    if (redeemed && redeemed.syntheticPersonRef === ref) {
+      authorized = true;
+    }
+  } else if (openMode) {
+    authorized = true;
+  }
+
+  if (!authorized) notFound();
 
   const rawType = Array.isArray(sp.type) ? sp.type[0] : sp.type;
   const consentType: ConsentType =
@@ -43,16 +70,18 @@ export default async function GrantConsentPage({
         </CardContent>
       </Card>
 
-      <Card className="border-amber-500/40 bg-amber-500/5">
-        <CardContent className="text-xs">
-          <p className="font-medium">Phase-1 stub.</p>
-          <p className="mt-1 text-muted-foreground">
-            This page is open to anyone with the URL today. A one-time-link auth gate (#251) is the
-            follow-up that scopes write access to the right person. The wording itself is reviewed
-            in DTRS-005 advisor sessions before any client traffic flows.
-          </p>
-        </CardContent>
-      </Card>
+      {openMode ? (
+        <Card className="border-amber-500/40 bg-amber-500/5">
+          <CardContent className="text-xs">
+            <p className="font-medium">Open mode is active.</p>
+            <p className="mt-1 text-muted-foreground">
+              <code className="font-mono">INDC_CONSENT_OPEN_MODE=1</code> is set, so this URL is
+              reachable without a token. Used for staff demos. Disable in any environment that
+              touches real callers.
+            </p>
+          </CardContent>
+        </Card>
+      ) : null}
     </div>
   );
 }

--- a/src/components/app-shell/nav-config.ts
+++ b/src/components/app-shell/nav-config.ts
@@ -66,6 +66,16 @@ export const NAV_ITEMS: NavItem[] = [
     href: '/app/coalition/sms',
     roles: ['admin', 'shelter_staff', 'caseworker', 'ed_coordinator'],
   },
+  {
+    label: 'SMS metrics',
+    href: '/app/coalition/sms/metrics',
+    roles: ['admin'],
+  },
+  {
+    label: 'SMS handout',
+    href: '/app/coalition/sms/handout',
+    roles: ['admin', 'shelter_staff', 'caseworker', 'ed_coordinator'],
+  },
   { label: 'Settings', href: '/app/settings', roles: 'all' },
   { label: 'Admin · Users', href: '/app/admin/users', roles: ['admin'] },
 ];

--- a/src/components/app-shell/nav-config.ts
+++ b/src/components/app-shell/nav-config.ts
@@ -52,6 +52,11 @@ export const NAV_ITEMS: NavItem[] = [
     roles: ['attorney', 'caseworker', 'ed_coordinator', 'shelter_staff', 'admin'],
   },
   {
+    label: 'Bed availability',
+    href: '/app/coalition/beds',
+    roles: ['attorney', 'caseworker', 'ed_coordinator', 'shelter_staff', 'admin'],
+  },
+  {
     label: 'Update beds',
     href: '/app/coalition/beds/update',
     roles: ['shelter_staff', 'admin'],

--- a/src/components/app-shell/nav-config.ts
+++ b/src/components/app-shell/nav-config.ts
@@ -46,6 +46,11 @@ export const NAV_ITEMS: NavItem[] = [
     roles: ['caseworker', 'shelter_staff', 'admin'],
   },
   {
+    label: 'Triage tier',
+    href: '/app/clients/triage',
+    roles: ['caseworker', 'shelter_staff', 'admin'],
+  },
+  {
     label: 'Outcomes',
     href: '/app/metrics',
     roles: ['attorney', 'admin'],

--- a/src/components/app-shell/nav-config.ts
+++ b/src/components/app-shell/nav-config.ts
@@ -41,6 +41,11 @@ export const NAV_ITEMS: NavItem[] = [
     roles: ['caseworker', 'ed_coordinator', 'shelter_staff', 'admin'],
   },
   {
+    label: 'Benefits screener',
+    href: '/app/clients/screener',
+    roles: ['caseworker', 'shelter_staff', 'admin'],
+  },
+  {
     label: 'Outcomes',
     href: '/app/metrics',
     roles: ['attorney', 'admin'],

--- a/src/components/app-shell/nav-config.ts
+++ b/src/components/app-shell/nav-config.ts
@@ -51,6 +51,11 @@ export const NAV_ITEMS: NavItem[] = [
     roles: ['caseworker', 'shelter_staff', 'admin'],
   },
   {
+    label: 'Consent link',
+    href: '/app/clients/consent-link',
+    roles: ['caseworker', 'shelter_staff', 'admin'],
+  },
+  {
     label: 'Outcomes',
     href: '/app/metrics',
     roles: ['attorney', 'admin'],

--- a/src/components/app-shell/nav-config.ts
+++ b/src/components/app-shell/nav-config.ts
@@ -61,6 +61,11 @@ export const NAV_ITEMS: NavItem[] = [
     href: '/app/coalition/beds/update',
     roles: ['shelter_staff', 'admin'],
   },
+  {
+    label: 'SMS bed-finder',
+    href: '/app/coalition/sms',
+    roles: ['admin', 'shelter_staff', 'caseworker', 'ed_coordinator'],
+  },
   { label: 'Settings', href: '/app/settings', roles: 'all' },
   { label: 'Admin · Users', href: '/app/admin/users', roles: ['admin'] },
 ];

--- a/src/components/app-shell/nav-config.ts
+++ b/src/components/app-shell/nav-config.ts
@@ -78,6 +78,7 @@ export const NAV_ITEMS: NavItem[] = [
   },
   { label: 'Settings', href: '/app/settings', roles: 'all' },
   { label: 'Admin · Users', href: '/app/admin/users', roles: ['admin'] },
+  { label: 'Admin · Audit log', href: '/app/admin/audit', roles: ['admin'] },
 ];
 
 export function navItemsForRole(role: UserRole): NavItem[] {

--- a/src/components/app-shell/nav-config.ts
+++ b/src/components/app-shell/nav-config.ts
@@ -51,6 +51,11 @@ export const NAV_ITEMS: NavItem[] = [
     href: '/app/coalition/coordination',
     roles: ['attorney', 'caseworker', 'ed_coordinator', 'shelter_staff', 'admin'],
   },
+  {
+    label: 'Update beds',
+    href: '/app/coalition/beds/update',
+    roles: ['shelter_staff', 'admin'],
+  },
   { label: 'Settings', href: '/app/settings', roles: 'all' },
   { label: 'Admin · Users', href: '/app/admin/users', roles: ['admin'] },
 ];

--- a/src/components/consent/consent-form.tsx
+++ b/src/components/consent/consent-form.tsx
@@ -17,10 +17,13 @@ export function ConsentForm({
   subjectExternalId,
   consentType,
   copy,
+  accessToken,
 }: {
   subjectExternalId: string;
   consentType: ConsentType;
   copy: ConsentCopy;
+  /** Forwarded to the server action — the action is the auth boundary. */
+  accessToken?: string | null;
 }) {
   const sigId = useId();
   const [signature, setSignature] = useState('');
@@ -56,6 +59,7 @@ export function ConsentForm({
         grantedVia: 'web_form',
         signatureText: signature,
         scopeDataClasses: Array.from(checked),
+        accessToken: accessToken ?? null,
       });
       if (!r.ok) {
         setError(r.error);

--- a/src/components/consent/consent-form.tsx
+++ b/src/components/consent/consent-form.tsx
@@ -1,0 +1,147 @@
+'use client';
+
+import { useId, useState, useTransition } from 'react';
+import { grantConsentAction } from '@/app/actions/consent';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import type { ConsentType } from '@/db/schema/enums';
+import { type ConsentCopy, DATA_CLASSES } from '@/lib/dtrs/consent-text';
+
+/**
+ * Plain-language consent form (DTRS-002). Reading-level target: grade 6.
+ * Every label is in `consent-text.ts` so the wording can be reviewed in
+ * lived-experience advisor sessions (DTRS-005) without code changes.
+ */
+export function ConsentForm({
+  subjectExternalId,
+  consentType,
+  copy,
+}: {
+  subjectExternalId: string;
+  consentType: ConsentType;
+  copy: ConsentCopy;
+}) {
+  const sigId = useId();
+  const [signature, setSignature] = useState('');
+  const [checked, setChecked] = useState<Set<string>>(() => new Set(DATA_CLASSES.map((d) => d.id)));
+  const [pending, startTransition] = useTransition();
+  const [error, setError] = useState<string | null>(null);
+  const [submitted, setSubmitted] = useState<boolean>(false);
+
+  const toggle = (id: string) => {
+    setChecked((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  };
+
+  const onSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    setError(null);
+    if (signature.trim().length === 0) {
+      setError('Please type your name on the line below.');
+      return;
+    }
+    if (checked.size === 0) {
+      setError('Pick at least one kind of info to share.');
+      return;
+    }
+    startTransition(async () => {
+      const r = await grantConsentAction({
+        subjectExternalId,
+        consentType,
+        grantedVia: 'web_form',
+        signatureText: signature,
+        scopeDataClasses: Array.from(checked),
+      });
+      if (!r.ok) {
+        setError(r.error);
+        return;
+      }
+      setSubmitted(true);
+    });
+  };
+
+  if (submitted) {
+    return (
+      <div className="rounded-md border border-emerald-500/40 bg-emerald-500/5 p-4 text-sm">
+        <p className="font-semibold text-emerald-700 dark:text-emerald-400">Saved.</p>
+        <p className="mt-1">
+          Thank you, {signature.trim()}. You can change these settings any time at this same link,
+          or by replying STOP to any text we send you.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <form onSubmit={onSubmit} className="space-y-5">
+      <header>
+        <h2 className="font-serif text-2xl font-semibold">{copy.title}</h2>
+        <p className="mt-2 text-base">{copy.intro}</p>
+      </header>
+
+      <div className="rounded-md border border-border bg-muted/20 p-4 text-sm">
+        <ul className="list-disc space-y-1 pl-5">
+          {copy.bullets.map((b) => (
+            <li key={b}>{b}</li>
+          ))}
+        </ul>
+      </div>
+
+      <fieldset className="space-y-2">
+        <legend className="text-sm font-medium">What can we share?</legend>
+        <p className="text-xs text-muted-foreground">
+          Uncheck anything you do not want shared. You can change this later.
+        </p>
+        <div className="space-y-1">
+          {DATA_CLASSES.map((d) => {
+            const id = `data-class-${d.id}`;
+            return (
+              <label
+                key={d.id}
+                htmlFor={id}
+                className="flex cursor-pointer items-center gap-2 rounded p-2 hover:bg-muted/40"
+              >
+                <input
+                  id={id}
+                  type="checkbox"
+                  checked={checked.has(d.id)}
+                  onChange={() => toggle(d.id)}
+                  disabled={pending}
+                  className="h-4 w-4"
+                />
+                <span>{d.label}</span>
+              </label>
+            );
+          })}
+        </div>
+      </fieldset>
+
+      <div className="space-y-1">
+        <Label htmlFor={sigId}>Your name (this counts as your signature)</Label>
+        <Input
+          id={sigId}
+          value={signature}
+          onChange={(e) => setSignature(e.target.value)}
+          placeholder="e.g. Sarah J"
+          maxLength={80}
+          disabled={pending}
+        />
+      </div>
+
+      <p className="text-xs text-muted-foreground">{copy.footer}</p>
+
+      {error ? <p className="text-sm text-destructive">{error}</p> : null}
+
+      <div className="flex flex-wrap gap-2">
+        <Button type="submit" disabled={pending}>
+          {pending ? 'Saving…' : 'I agree'}
+        </Button>
+      </div>
+    </form>
+  );
+}

--- a/src/components/consent/consent-token-minter.tsx
+++ b/src/components/consent/consent-token-minter.tsx
@@ -1,0 +1,82 @@
+'use client';
+
+import { useId, useState, useTransition } from 'react';
+import { mintConsentTokenAction } from '@/app/actions/consent-tokens';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+
+const fmtClock = (d: Date) =>
+  new Intl.DateTimeFormat('en-US', { dateStyle: 'medium', timeStyle: 'short' }).format(new Date(d));
+
+export function ConsentTokenMinter() {
+  const refId = useId();
+  const noteId = useId();
+  const [ref, setRef] = useState('SYN-PERSON-001');
+  const [note, setNote] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [result, setResult] = useState<{ url: string; expiresAt: Date } | null>(null);
+  const [pending, startTransition] = useTransition();
+
+  const onMint = () => {
+    setError(null);
+    startTransition(async () => {
+      const r = await mintConsentTokenAction(ref.trim(), note || undefined);
+      if (!r.ok) {
+        setError(r.error);
+        return;
+      }
+      setResult({ url: r.url, expiresAt: r.expiresAt });
+    });
+  };
+
+  const fullUrl = result
+    ? `${typeof window !== 'undefined' ? window.location.origin : ''}${result.url}`
+    : null;
+
+  return (
+    <div className="space-y-3">
+      <div className="space-y-1">
+        <Label htmlFor={refId}>Synthetic person ref</Label>
+        <Input
+          id={refId}
+          value={ref}
+          onChange={(e) => setRef(e.target.value)}
+          placeholder="SYN-PERSON-001"
+          disabled={pending}
+        />
+      </div>
+      <div className="space-y-1">
+        <Label htmlFor={noteId}>Note (optional)</Label>
+        <Input
+          id={noteId}
+          value={note}
+          onChange={(e) => setNote(e.target.value)}
+          placeholder='e.g. "shared at intake on 2026-04-26"'
+          maxLength={120}
+          disabled={pending}
+        />
+      </div>
+      {error ? <p className="text-sm text-destructive">{error}</p> : null}
+      <Button type="button" disabled={pending || ref.trim().length === 0} onClick={onMint}>
+        {pending ? 'Minting…' : 'Mint 24h link'}
+      </Button>
+
+      {result && fullUrl ? (
+        <div className="space-y-1 rounded-md border border-emerald-500/40 bg-emerald-500/5 p-3 text-sm">
+          <p className="font-semibold text-emerald-700 dark:text-emerald-400">Link minted</p>
+          <p className="break-all font-mono text-xs">{fullUrl}</p>
+          <p className="text-xs text-muted-foreground">Expires {fmtClock(result.expiresAt)}.</p>
+          <Button
+            type="button"
+            size="sm"
+            variant="outline"
+            onClick={() => navigator.clipboard?.writeText(fullUrl)}
+          >
+            Copy
+          </Button>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/src/components/coordination/auto-refresh.tsx
+++ b/src/components/coordination/auto-refresh.tsx
@@ -1,0 +1,33 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { useEffect, useState } from 'react';
+
+const fmtTime = (d: Date) => new Intl.DateTimeFormat('en-US', { timeStyle: 'medium' }).format(d);
+
+/**
+ * Polls `router.refresh()` every `intervalMs` so a server component
+ * page picks up the latest DB state without a manual reload. Pauses
+ * automatically when the tab is hidden — staff often park this on a
+ * back monitor and we don't want to hammer the DB for invisible tabs.
+ */
+export function AutoRefresh({ intervalMs = 60_000 }: { intervalMs?: number }) {
+  const router = useRouter();
+  const [lastRefreshed, setLastRefreshed] = useState<Date>(() => new Date());
+
+  useEffect(() => {
+    const tick = () => {
+      if (document.hidden) return;
+      router.refresh();
+      setLastRefreshed(new Date());
+    };
+    const id = window.setInterval(tick, intervalMs);
+    return () => window.clearInterval(id);
+  }, [router, intervalMs]);
+
+  return (
+    <span className="text-xs text-muted-foreground">
+      Auto-refreshing every {Math.round(intervalMs / 1000)}s · last {fmtTime(lastRefreshed)}
+    </span>
+  );
+}

--- a/src/components/coordination/bed-board-card.tsx
+++ b/src/components/coordination/bed-board-card.tsx
@@ -1,6 +1,7 @@
+import { BedHoldControls } from '@/components/coordination/bed-hold-controls';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import type { ShelterWithOrg } from '@/db/queries/shelters';
-import { freeBeds, occupancyRate } from '@/lib/coordination/bed-availability';
+import type { BedHoldWithHolder, ShelterWithOrg } from '@/db/queries/shelters';
+import { effectiveFreeBeds, freeBeds, occupancyRate } from '@/lib/coordination/bed-availability';
 
 const fmtTime = (d: Date) =>
   new Intl.DateTimeFormat('en-US', { dateStyle: 'medium', timeStyle: 'short' }).format(new Date(d));
@@ -18,11 +19,16 @@ function popChips(shelter: ShelterWithOrg): string[] {
 export function BedBoardCard({
   shelter,
   lastUpdatedAt,
+  activeHolds,
+  canHold,
 }: {
   shelter: ShelterWithOrg;
   lastUpdatedAt: Date | null;
+  activeHolds: BedHoldWithHolder[];
+  canHold: boolean;
 }) {
-  const free = freeBeds(shelter);
+  const rawFree = freeBeds(shelter);
+  const free = effectiveFreeBeds(shelter, activeHolds.length);
   const rate = occupancyRate(shelter);
   const isFull = free === 0;
   const isTight = !isFull && rate >= 0.85;
@@ -47,6 +53,11 @@ export function BedBoardCard({
           <div>
             <p className="text-xs uppercase tracking-wide text-muted-foreground">Free</p>
             <p className={`text-3xl font-semibold ${freeColor}`}>{free}</p>
+            {activeHolds.length > 0 ? (
+              <p className="text-xs text-muted-foreground">
+                {rawFree} unoccupied · {activeHolds.length} on hold
+              </p>
+            ) : null}
           </div>
           <p className="text-sm text-muted-foreground">
             {shelter.currentOccupancy} / {shelter.capacity} occupied
@@ -94,6 +105,14 @@ export function BedBoardCard({
         <p className="text-xs text-muted-foreground">
           {lastUpdatedAt ? `Last update ${fmtTime(lastUpdatedAt)}` : 'No updates yet'}
         </p>
+
+        <BedHoldControls
+          shelterId={shelter.id}
+          shelterName={shelter.name}
+          freeBeds={free}
+          activeHolds={activeHolds}
+          canHold={canHold}
+        />
       </CardContent>
     </Card>
   );

--- a/src/components/coordination/bed-board-card.tsx
+++ b/src/components/coordination/bed-board-card.tsx
@@ -1,0 +1,100 @@
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import type { ShelterWithOrg } from '@/db/queries/shelters';
+import { freeBeds, occupancyRate } from '@/lib/coordination/bed-availability';
+
+const fmtTime = (d: Date) =>
+  new Intl.DateTimeFormat('en-US', { dateStyle: 'medium', timeStyle: 'short' }).format(new Date(d));
+
+function popChips(shelter: ShelterWithOrg): string[] {
+  const chips: string[] = [];
+  if (shelter.acceptsMen) chips.push('Men');
+  if (shelter.acceptsWomen) chips.push('Women');
+  if (shelter.acceptsFamilies) chips.push('Families');
+  if (shelter.petFriendly) chips.push('Pet-friendly');
+  if (shelter.sudFriendly) chips.push('SUD-OK');
+  return chips;
+}
+
+export function BedBoardCard({
+  shelter,
+  lastUpdatedAt,
+}: {
+  shelter: ShelterWithOrg;
+  lastUpdatedAt: Date | null;
+}) {
+  const free = freeBeds(shelter);
+  const rate = occupancyRate(shelter);
+  const isFull = free === 0;
+  const isTight = !isFull && rate >= 0.85;
+  const chips = popChips(shelter);
+
+  // Tailwind class lookup (avoid string-built classes that get tree-shaken).
+  const barColor = isFull ? 'bg-destructive' : isTight ? 'bg-amber-500' : 'bg-emerald-500';
+  const freeColor = isFull
+    ? 'text-destructive'
+    : isTight
+      ? 'text-amber-600 dark:text-amber-400'
+      : 'text-emerald-600 dark:text-emerald-400';
+
+  return (
+    <Card>
+      <CardHeader className="pb-2">
+        <CardTitle className="text-base">{shelter.name}</CardTitle>
+        <p className="text-xs text-muted-foreground">{shelter.partnerOrg.name}</p>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        <div className="flex items-baseline justify-between">
+          <div>
+            <p className="text-xs uppercase tracking-wide text-muted-foreground">Free</p>
+            <p className={`text-3xl font-semibold ${freeColor}`}>{free}</p>
+          </div>
+          <p className="text-sm text-muted-foreground">
+            {shelter.currentOccupancy} / {shelter.capacity} occupied
+          </p>
+        </div>
+
+        <div
+          role="progressbar"
+          aria-label={`${Math.round(rate * 100)}% full`}
+          aria-valuenow={Math.round(rate * 100)}
+          aria-valuemin={0}
+          aria-valuemax={100}
+          className="h-2 overflow-hidden rounded-full bg-muted"
+        >
+          <div
+            className={`h-full ${barColor} transition-all`}
+            style={{ width: `${Math.round(rate * 100)}%` }}
+          />
+        </div>
+
+        {chips.length > 0 ? (
+          <div className="flex flex-wrap gap-1">
+            {chips.map((c) => (
+              <span
+                key={c}
+                className="rounded bg-secondary px-2 py-0.5 text-xs text-secondary-foreground"
+              >
+                {c}
+              </span>
+            ))}
+          </div>
+        ) : null}
+
+        {shelter.contactPhone ? (
+          <p className="text-xs text-muted-foreground">
+            <a href={`tel:${shelter.contactPhone}`} className="hover:underline">
+              {shelter.contactPhone}
+            </a>
+            {shelter.city ? ` · ${shelter.city}` : null}
+          </p>
+        ) : shelter.city ? (
+          <p className="text-xs text-muted-foreground">{shelter.city}</p>
+        ) : null}
+
+        <p className="text-xs text-muted-foreground">
+          {lastUpdatedAt ? `Last update ${fmtTime(lastUpdatedAt)}` : 'No updates yet'}
+        </p>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/coordination/bed-board-filters.tsx
+++ b/src/components/coordination/bed-board-filters.tsx
@@ -1,0 +1,112 @@
+'use client';
+
+import { useRouter, useSearchParams } from 'next/navigation';
+import { useId, useTransition } from 'react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+
+type Preset = { label: string; params: Record<string, string> };
+
+const PRESETS: Preset[] = [
+  { label: 'Open beds now', params: { minFree: '1' } },
+  { label: 'Men', params: { population: 'men' } },
+  { label: 'Women', params: { population: 'women' } },
+  { label: 'Families', params: { population: 'families' } },
+  { label: 'Pet-friendly + family', params: { population: 'families', pet: '1' } },
+  { label: 'SUD-OK', params: { sud: '1' } },
+];
+
+export function BedBoardFilters() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const [pending, startTransition] = useTransition();
+  const queryId = useId();
+
+  const setParams = (next: Record<string, string | null>) => {
+    const usp = new URLSearchParams(searchParams.toString());
+    for (const [k, v] of Object.entries(next)) {
+      if (v === null || v === '') usp.delete(k);
+      else usp.set(k, v);
+    }
+    const qs = usp.toString();
+    startTransition(() => {
+      router.push(qs ? `/app/coalition/beds?${qs}` : '/app/coalition/beds');
+    });
+  };
+
+  const applyPreset = (preset: Preset) => {
+    // Clear existing scoped params, then set the preset's.
+    setParams({
+      population: null,
+      pet: null,
+      sud: null,
+      minFree: null,
+      ...preset.params,
+    });
+  };
+
+  const clearAll = () => {
+    startTransition(() => router.push('/app/coalition/beds'));
+  };
+
+  const onSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    const fd = new FormData(e.currentTarget);
+    const q = String(fd.get('q') ?? '').trim();
+    setParams({ q: q || null });
+  };
+
+  const hasAny = searchParams.toString().length > 0;
+
+  return (
+    <div className="space-y-3">
+      <form onSubmit={onSubmit} className="flex gap-2">
+        <Label htmlFor={queryId} className="sr-only">
+          Search shelters
+        </Label>
+        <Input
+          id={queryId}
+          name="q"
+          defaultValue={searchParams.get('q') ?? ''}
+          placeholder="Search shelter or partner name…"
+          maxLength={64}
+          disabled={pending}
+        />
+        <Button type="submit" variant="outline" disabled={pending}>
+          Search
+        </Button>
+      </form>
+
+      <div className="flex flex-wrap gap-2">
+        {PRESETS.map((p) => {
+          const active = Object.entries(p.params).every(([k, v]) => searchParams.get(k) === v);
+          return (
+            <Button
+              key={p.label}
+              type="button"
+              size="sm"
+              variant={active ? 'default' : 'outline'}
+              disabled={pending}
+              onClick={() => applyPreset(p)}
+            >
+              {p.label}
+            </Button>
+          );
+        })}
+        {hasAny ? (
+          <Button
+            type="button"
+            size="sm"
+            variant="ghost"
+            disabled={pending}
+            onClick={clearAll}
+            className="text-muted-foreground"
+          >
+            Clear filters
+          </Button>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/src/components/coordination/bed-count-staff-card.tsx
+++ b/src/components/coordination/bed-count-staff-card.tsx
@@ -1,0 +1,201 @@
+'use client';
+
+import { useId, useState, useTransition } from 'react';
+import { updateBedCountAction } from '@/app/actions/coordination';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import type { ShelterWithOrg } from '@/db/queries/shelters';
+
+const fmtTime = (d: Date) =>
+  new Intl.DateTimeFormat('en-US', { dateStyle: 'medium', timeStyle: 'short' }).format(new Date(d));
+
+export function BedCountStaffCard({
+  shelter,
+  lastUpdatedAt,
+}: {
+  shelter: ShelterWithOrg;
+  lastUpdatedAt: Date | null;
+}) {
+  const occInputId = useId();
+  const noteInputId = useId();
+  const [draftOccupancy, setDraftOccupancy] = useState<number>(shelter.currentOccupancy);
+  const [note, setNote] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [savedAt, setSavedAt] = useState<Date | null>(null);
+  const [pending, startTransition] = useTransition();
+
+  const free = Math.max(0, shelter.capacity - draftOccupancy);
+  const isAtCapacity = draftOccupancy >= shelter.capacity;
+  const isAtZero = draftOccupancy <= 0;
+  const dirty = draftOccupancy !== shelter.currentOccupancy || note.trim().length > 0;
+
+  const adjust = (delta: number) => {
+    setError(null);
+    setDraftOccupancy((prev) => {
+      const next = prev + delta;
+      if (next < 0) return 0;
+      if (next > shelter.capacity) return shelter.capacity;
+      return next;
+    });
+  };
+
+  const onSave = () => {
+    setError(null);
+    startTransition(async () => {
+      const r = await updateBedCountAction(shelter.id, draftOccupancy, note || null);
+      if (!r.ok) {
+        setError(r.error);
+        return;
+      }
+      setNote('');
+      setSavedAt(new Date());
+    });
+  };
+
+  const onReset = () => {
+    setDraftOccupancy(shelter.currentOccupancy);
+    setNote('');
+    setError(null);
+  };
+
+  return (
+    <Card>
+      <CardHeader className="pb-2">
+        <CardTitle className="text-base">{shelter.name}</CardTitle>
+        <p className="text-xs text-muted-foreground">{shelter.partnerOrg.name}</p>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div className="grid grid-cols-3 gap-2 text-center">
+          <div className="rounded-md border border-border bg-muted/40 p-2">
+            <p className="text-xs uppercase tracking-wide text-muted-foreground">Capacity</p>
+            <p className="text-lg font-semibold">{shelter.capacity}</p>
+          </div>
+          <div className="rounded-md border border-border bg-muted/40 p-2">
+            <p className="text-xs uppercase tracking-wide text-muted-foreground">Occupied</p>
+            <p className="text-lg font-semibold">{draftOccupancy}</p>
+          </div>
+          <div className="rounded-md border border-border bg-muted/40 p-2">
+            <p className="text-xs uppercase tracking-wide text-muted-foreground">Free</p>
+            <p
+              className={`text-lg font-semibold ${
+                free === 0 ? 'text-destructive' : 'text-emerald-600 dark:text-emerald-400'
+              }`}
+            >
+              {free}
+            </p>
+          </div>
+        </div>
+
+        <div className="space-y-2">
+          <Label htmlFor={occInputId} className="text-xs uppercase tracking-wide">
+            New occupancy
+          </Label>
+          <div className="flex flex-wrap items-center gap-2">
+            <Button
+              type="button"
+              variant="outline"
+              size="lg"
+              className="h-12 min-w-12"
+              disabled={pending || isAtZero}
+              onClick={() => adjust(-5)}
+              aria-label="Decrease by 5"
+            >
+              −5
+            </Button>
+            <Button
+              type="button"
+              variant="outline"
+              size="lg"
+              className="h-12 min-w-12"
+              disabled={pending || isAtZero}
+              onClick={() => adjust(-1)}
+              aria-label="Decrease by 1"
+            >
+              −1
+            </Button>
+            <Input
+              id={occInputId}
+              type="number"
+              inputMode="numeric"
+              min={0}
+              max={shelter.capacity}
+              value={draftOccupancy}
+              disabled={pending}
+              onChange={(e) => {
+                const n = Number.parseInt(e.target.value, 10);
+                if (Number.isNaN(n)) return;
+                setError(null);
+                setDraftOccupancy(Math.max(0, Math.min(shelter.capacity, n)));
+              }}
+              className="h-12 w-20 text-center text-lg font-semibold"
+            />
+            <Button
+              type="button"
+              variant="outline"
+              size="lg"
+              className="h-12 min-w-12"
+              disabled={pending || isAtCapacity}
+              onClick={() => adjust(1)}
+              aria-label="Increase by 1"
+            >
+              +1
+            </Button>
+            <Button
+              type="button"
+              variant="outline"
+              size="lg"
+              className="h-12 min-w-12"
+              disabled={pending || isAtCapacity}
+              onClick={() => adjust(5)}
+              aria-label="Increase by 5"
+            >
+              +5
+            </Button>
+          </div>
+        </div>
+
+        <div className="space-y-1">
+          <Label htmlFor={noteInputId} className="text-xs uppercase tracking-wide">
+            Note (optional)
+          </Label>
+          <Input
+            id={noteInputId}
+            value={note}
+            onChange={(e) => setNote(e.target.value)}
+            disabled={pending}
+            placeholder="e.g. early intake, reservation released"
+            maxLength={280}
+          />
+        </div>
+
+        {error ? <p className="text-sm text-destructive">{error}</p> : null}
+
+        <div className="flex items-center justify-between gap-2 text-xs text-muted-foreground">
+          <span>
+            {savedAt
+              ? `Saved ${fmtTime(savedAt)}`
+              : lastUpdatedAt
+                ? `Last updated ${fmtTime(lastUpdatedAt)}`
+                : 'No updates yet'}
+          </span>
+          <div className="flex gap-2">
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              disabled={pending || !dirty}
+              onClick={onReset}
+            >
+              Reset
+            </Button>
+            <Button type="button" size="sm" disabled={pending || !dirty} onClick={onSave}>
+              {pending ? 'Saving…' : 'Save'}
+            </Button>
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/coordination/bed-hold-controls.tsx
+++ b/src/components/coordination/bed-hold-controls.tsx
@@ -1,0 +1,163 @@
+'use client';
+
+import { useId, useState, useTransition } from 'react';
+import { createBedHoldAction, releaseBedHoldAction } from '@/app/actions/coordination';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import type { BedHoldWithHolder } from '@/db/queries/shelters';
+
+const fmtTime = (d: Date) =>
+  new Intl.DateTimeFormat('en-US', { timeStyle: 'short' }).format(new Date(d));
+
+const minutesFromNow = (d: Date): number =>
+  Math.max(0, Math.round((new Date(d).getTime() - Date.now()) / 60_000));
+
+export function BedHoldControls({
+  shelterId,
+  shelterName,
+  freeBeds,
+  activeHolds,
+  canHold,
+}: {
+  shelterId: string;
+  shelterName: string;
+  freeBeds: number;
+  activeHolds: BedHoldWithHolder[];
+  canHold: boolean;
+}) {
+  const labelId = useId();
+  const noteId = useId();
+  const [open, setOpen] = useState(false);
+  const [label, setLabel] = useState('');
+  const [note, setNote] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [pending, startTransition] = useTransition();
+
+  const onCreate = () => {
+    setError(null);
+    startTransition(async () => {
+      const r = await createBedHoldAction(shelterId, label, note || null);
+      if (!r.ok) {
+        setError(r.error);
+        return;
+      }
+      setLabel('');
+      setNote('');
+      setOpen(false);
+    });
+  };
+
+  const onRelease = (id: string) => {
+    setError(null);
+    startTransition(async () => {
+      const r = await releaseBedHoldAction(id);
+      if (!r.ok) setError(r.error);
+    });
+  };
+
+  const cannotCreate = !canHold || freeBeds <= 0;
+
+  return (
+    <div className="space-y-2 border-t border-border pt-3 text-sm">
+      <div className="flex items-center justify-between gap-2">
+        <p className="text-xs uppercase tracking-wide text-muted-foreground">
+          Holds{' '}
+          <span className="text-foreground">
+            {activeHolds.length}
+            {activeHolds.length > 0 ? ' active' : ''}
+          </span>
+        </p>
+        {canHold ? (
+          <Button
+            type="button"
+            size="sm"
+            variant={open ? 'ghost' : 'outline'}
+            disabled={pending || (cannotCreate && !open)}
+            onClick={() => setOpen((v) => !v)}
+            title={cannotCreate ? 'No free beds to hold' : `Hold a bed at ${shelterName}`}
+          >
+            {open ? 'Cancel' : 'Hold a bed'}
+          </Button>
+        ) : null}
+      </div>
+
+      {activeHolds.length > 0 ? (
+        <ul className="space-y-1 text-xs">
+          {activeHolds.map((h) => {
+            const mins = minutesFromNow(h.expiresAt);
+            return (
+              <li
+                key={h.id}
+                className="flex items-center justify-between gap-2 rounded bg-muted/40 px-2 py-1"
+              >
+                <span className="truncate">
+                  <span className="font-medium">{h.personLabel}</span>
+                  <span className="text-muted-foreground">
+                    {' '}
+                    · expires {fmtTime(h.expiresAt)} ({mins}m)
+                  </span>
+                </span>
+                {canHold ? (
+                  <Button
+                    type="button"
+                    size="sm"
+                    variant="ghost"
+                    disabled={pending}
+                    onClick={() => onRelease(h.id)}
+                  >
+                    Release
+                  </Button>
+                ) : null}
+              </li>
+            );
+          })}
+        </ul>
+      ) : null}
+
+      {open ? (
+        <div className="space-y-2 rounded border border-border bg-card p-3">
+          <div className="space-y-1">
+            <Label htmlFor={labelId} className="text-xs uppercase tracking-wide">
+              Hold for
+            </Label>
+            <Input
+              id={labelId}
+              value={label}
+              maxLength={80}
+              disabled={pending}
+              placeholder='e.g. "211 caller #1234"'
+              onChange={(e) => setLabel(e.target.value)}
+            />
+          </div>
+          <div className="space-y-1">
+            <Label htmlFor={noteId} className="text-xs uppercase tracking-wide">
+              Note (optional)
+            </Label>
+            <Input
+              id={noteId}
+              value={note}
+              maxLength={280}
+              disabled={pending}
+              placeholder="walking from downtown, ETA 30 min"
+              onChange={(e) => setNote(e.target.value)}
+            />
+          </div>
+          {error ? <p className="text-xs text-destructive">{error}</p> : null}
+          <div className="flex justify-end">
+            <Button
+              type="button"
+              size="sm"
+              disabled={pending || cannotCreate || label.trim().length === 0}
+              onClick={onCreate}
+            >
+              {pending ? 'Saving…' : 'Hold for 90 min'}
+            </Button>
+          </div>
+        </div>
+      ) : error && activeHolds.length > 0 ? (
+        <p className="text-xs text-destructive">{error}</p>
+      ) : null}
+    </div>
+  );
+}

--- a/src/components/coordination/print-button.tsx
+++ b/src/components/coordination/print-button.tsx
@@ -1,0 +1,11 @@
+'use client';
+
+import { Button } from '@/components/ui/button';
+
+export function PrintButton() {
+  return (
+    <Button type="button" variant="outline" size="sm" onClick={() => window.print()}>
+      Print
+    </Button>
+  );
+}

--- a/src/components/coordination/sms-playground.tsx
+++ b/src/components/coordination/sms-playground.tsx
@@ -1,0 +1,106 @@
+'use client';
+
+import { useState, useTransition } from 'react';
+import { simulateInboundSmsAction } from '@/app/actions/sms';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { SMS_MAX_LEN } from '@/lib/indc/sms-formatter';
+
+const PRESETS = ['BED', 'BED FAMILY', 'BED PET', 'BED MEN', 'BED WOMEN SUD', 'HELP', 'STOP'];
+
+type Sample = {
+  request: string;
+  reply: string;
+  intent: string;
+  at: Date;
+};
+
+export function SmsPlayground() {
+  const [body, setBody] = useState('BED');
+  const [history, setHistory] = useState<Sample[]>([]);
+  const [pending, startTransition] = useTransition();
+  const [error, setError] = useState<string | null>(null);
+
+  const submit = (text: string) => {
+    setError(null);
+    startTransition(async () => {
+      const r = await simulateInboundSmsAction(text);
+      if (!r.ok) {
+        setError('Simulation failed.');
+        return;
+      }
+      setHistory((prev) =>
+        [{ request: text, reply: r.reply, intent: r.intent, at: new Date() }, ...prev].slice(0, 10),
+      );
+    });
+  };
+
+  return (
+    <div className="space-y-3">
+      <form
+        onSubmit={(e) => {
+          e.preventDefault();
+          if (body.trim()) submit(body);
+        }}
+        className="flex gap-2"
+      >
+        <Input
+          value={body}
+          onChange={(e) => setBody(e.target.value)}
+          placeholder="Type a message a caller would send"
+          disabled={pending}
+        />
+        <Button type="submit" disabled={pending || !body.trim()}>
+          {pending ? 'Sending…' : 'Send'}
+        </Button>
+      </form>
+
+      <div className="flex flex-wrap gap-2">
+        {PRESETS.map((p) => (
+          <Button
+            key={p}
+            type="button"
+            size="sm"
+            variant="outline"
+            disabled={pending}
+            onClick={() => {
+              setBody(p);
+              submit(p);
+            }}
+          >
+            {p}
+          </Button>
+        ))}
+      </div>
+
+      {error ? <p className="text-sm text-destructive">{error}</p> : null}
+
+      {history.length === 0 ? (
+        <p className="text-xs text-muted-foreground">
+          Send a message above to preview the reply. Up to 10 most-recent are kept here.
+        </p>
+      ) : (
+        <ul className="space-y-2">
+          {history.map((h) => (
+            <li
+              key={h.at.toISOString()}
+              className="rounded-md border border-border bg-card p-3 text-sm"
+            >
+              <p className="font-mono text-xs text-muted-foreground">
+                {h.intent} · {h.reply.length} / {SMS_MAX_LEN} chars
+              </p>
+              <p className="mt-1">
+                <span className="text-muted-foreground">→ </span>
+                <span className="font-mono text-xs">{h.request}</span>
+              </p>
+              <p className="mt-1">
+                <span className="text-muted-foreground">← </span>
+                <span>{h.reply}</span>
+              </p>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/src/components/cwt/benefits-screener.tsx
+++ b/src/components/cwt/benefits-screener.tsx
@@ -1,0 +1,204 @@
+'use client';
+
+import { useId, useMemo, useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import {
+  type EligibilityMatch,
+  fplPercent,
+  type Household,
+  screenHousehold,
+  totalLikelyMonthlyCents,
+} from '@/lib/cwt/benefits';
+
+const fmtMoney = (cents: number) =>
+  new Intl.NumberFormat('en-US', {
+    style: 'currency',
+    currency: 'USD',
+    maximumFractionDigits: 0,
+  }).format(cents / 100);
+
+const STATUS_BADGE: Record<EligibilityMatch['status'], string> = {
+  likely: 'bg-emerald-600/15 text-emerald-700 dark:text-emerald-400',
+  maybe: 'bg-amber-500/15 text-amber-700 dark:text-amber-400',
+  ineligible: 'bg-muted text-muted-foreground',
+};
+
+export function BenefitsScreener() {
+  const incomeId = useId();
+  const sizeId = useId();
+  const [household, setHousehold] = useState<Household>({
+    monthlyIncomeCents: 100_000,
+    householdSize: 1,
+    hasChildrenUnder18: false,
+    hasPregnantMember: false,
+    isVeteran: false,
+    isDisabled: false,
+    ageOldest: 35,
+    kyResident: true,
+    citizenOrQualified: true,
+  });
+
+  const results = useMemo(() => screenHousehold(household), [household]);
+  const totalLikely = useMemo(() => totalLikelyMonthlyCents(results), [results]);
+  const fplPct = useMemo(
+    () => fplPercent(household.monthlyIncomeCents, household.householdSize),
+    [household.monthlyIncomeCents, household.householdSize],
+  );
+
+  const set =
+    <K extends keyof Household>(key: K) =>
+    (value: Household[K]) => {
+      setHousehold((prev) => ({ ...prev, [key]: value }));
+    };
+
+  return (
+    <div className="grid gap-6 md:grid-cols-2">
+      <section className="space-y-4">
+        <h2 className="font-serif text-lg font-semibold">Household</h2>
+
+        <div className="space-y-1">
+          <Label htmlFor={incomeId}>Monthly income (gross, before deductions)</Label>
+          <Input
+            id={incomeId}
+            type="number"
+            inputMode="numeric"
+            min={0}
+            step={50}
+            value={Math.round(household.monthlyIncomeCents / 100)}
+            onChange={(e) => {
+              const dollars = Number.parseInt(e.target.value, 10);
+              set('monthlyIncomeCents')(Number.isFinite(dollars) ? Math.max(0, dollars) * 100 : 0);
+            }}
+          />
+          <p className="text-xs text-muted-foreground">{fplPct}% of the federal poverty line</p>
+        </div>
+
+        <div className="space-y-1">
+          <Label htmlFor={sizeId}>Household size</Label>
+          <Input
+            id={sizeId}
+            type="number"
+            inputMode="numeric"
+            min={1}
+            max={20}
+            value={household.householdSize}
+            onChange={(e) => {
+              const n = Number.parseInt(e.target.value, 10);
+              if (Number.isInteger(n) && n >= 1 && n <= 20) set('householdSize')(n);
+            }}
+          />
+        </div>
+
+        <div className="space-y-1">
+          <Label>Age of the oldest member</Label>
+          <Input
+            type="number"
+            inputMode="numeric"
+            min={0}
+            max={120}
+            value={household.ageOldest ?? ''}
+            onChange={(e) => {
+              const n = Number.parseInt(e.target.value, 10);
+              set('ageOldest')(Number.isInteger(n) ? n : null);
+            }}
+          />
+        </div>
+
+        <fieldset className="space-y-1">
+          <legend className="text-sm font-medium">Situation</legend>
+          {[
+            { k: 'hasChildrenUnder18', label: 'Children under 18 in household' },
+            { k: 'hasPregnantMember', label: 'Pregnant member' },
+            { k: 'isVeteran', label: 'Veteran' },
+            { k: 'isDisabled', label: 'Disabled or qualifying medical condition' },
+            { k: 'kyResident', label: 'Kentucky resident' },
+            {
+              k: 'citizenOrQualified',
+              label: 'US citizen OR qualified non-citizen (LPR 5+ yrs, refugee, etc.)',
+            },
+          ].map(({ k, label }) => (
+            <label
+              key={k}
+              className="flex items-center gap-2 rounded p-1.5 text-sm hover:bg-muted/40"
+            >
+              <input
+                type="checkbox"
+                checked={Boolean(household[k as keyof Household])}
+                onChange={(e) => {
+                  setHousehold((prev) => ({ ...prev, [k]: e.target.checked }));
+                }}
+                className="h-4 w-4"
+              />
+              {label}
+            </label>
+          ))}
+        </fieldset>
+
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          onClick={() =>
+            setHousehold({
+              monthlyIncomeCents: 100_000,
+              householdSize: 1,
+              hasChildrenUnder18: false,
+              hasPregnantMember: false,
+              isVeteran: false,
+              isDisabled: false,
+              ageOldest: 35,
+              kyResident: true,
+              citizenOrQualified: true,
+            })
+          }
+        >
+          Reset
+        </Button>
+      </section>
+
+      <section className="space-y-3">
+        <div className="flex items-baseline justify-between">
+          <h2 className="font-serif text-lg font-semibold">Likely benefits</h2>
+          {totalLikely > 0 ? (
+            <p className="text-sm">
+              Estimated <strong>{fmtMoney(totalLikely)}/mo</strong>
+            </p>
+          ) : null}
+        </div>
+        <ul className="space-y-2">
+          {results.map((r) => (
+            <li key={r.programId} className="rounded-md border border-border bg-card p-3 text-sm">
+              <div className="flex items-baseline justify-between gap-2">
+                <p className="font-medium">{r.programName}</p>
+                <span className={`rounded px-2 py-0.5 text-xs ${STATUS_BADGE[r.status]}`}>
+                  {r.status}
+                </span>
+              </div>
+              {r.estimatedMonthlyCents !== null ? (
+                <p className="mt-1 text-base font-semibold">
+                  ~{fmtMoney(r.estimatedMonthlyCents)}/mo
+                </p>
+              ) : null}
+              <p className="mt-1 text-muted-foreground">{r.reason}</p>
+              {r.status !== 'ineligible' ? (
+                <p className="mt-2 text-xs">{r.applicationPath}</p>
+              ) : null}
+            </li>
+          ))}
+        </ul>
+
+        <div className="rounded-md border border-amber-500/40 bg-amber-500/5 p-3 text-xs">
+          <p className="font-medium">[SAMPLE] estimates only.</p>
+          <p className="mt-1 text-muted-foreground">
+            Income thresholds and benefit amounts are based on 2024 federal poverty figures and
+            published KY program rules. Actual benefits depend on disregards, deductions, household
+            composition, and current funding. Use these as a starting point — verify with the
+            program before quoting an amount to a client.
+          </p>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/src/components/cwt/triage-tier.tsx
+++ b/src/components/cwt/triage-tier.tsx
@@ -1,0 +1,153 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { recommendTriageTier, type TriageInputs, type TriageTier } from '@/lib/cwt/triage';
+
+const TIER_BADGE: Record<TriageTier, string> = {
+  high: 'bg-emerald-600/15 text-emerald-700 dark:text-emerald-400',
+  medium: 'bg-amber-500/15 text-amber-700 dark:text-amber-400',
+  low: 'bg-destructive/15 text-destructive',
+};
+
+const TIER_LABEL: Record<TriageTier, string> = {
+  high: 'High potential',
+  medium: 'Medium potential',
+  low: 'High intensity needed',
+};
+
+const FIELDS: Array<{ k: keyof TriageInputs; label: string; type: 'bool' | 'count' }> = [
+  {
+    k: 'hasStableIncome',
+    label: 'Stable income source (job, SSI, retirement, etc.)',
+    type: 'bool',
+  },
+  { k: 'hasVoucher', label: 'Active rental-assistance voucher', type: 'bool' },
+  { k: 'isEmployed', label: 'Currently employed (any hours)', type: 'bool' },
+  { k: 'hasCaseworkerRelationship', label: 'Existing caseworker relationship', type: 'bool' },
+  { k: 'inSudTreatment', label: 'Engaged in SUD treatment (when relevant)', type: 'bool' },
+  { k: 'inMentalHealthTreatment', label: 'Engaged in mental-health treatment', type: 'bool' },
+  { k: 'recentEvictionCount', label: 'Evictions in last 24 months', type: 'count' },
+  { k: 'daysUnsheltered', label: 'Days unsheltered in last 12 months', type: 'count' },
+  { k: 'hasChildrenUnder18', label: 'Children under 18 in household', type: 'bool' },
+  { k: 'isDvSurvivor', label: 'DV survivor (routing only — no scoring impact)', type: 'bool' },
+  { k: 'hasId', label: 'Has photo ID', type: 'bool' },
+  { k: 'hasSsn', label: 'Has Social Security card', type: 'bool' },
+  { k: 'hasBirthCert', label: 'Has birth certificate', type: 'bool' },
+];
+
+const blankInputs = (): TriageInputs => ({
+  hasStableIncome: false,
+  hasVoucher: false,
+  isEmployed: false,
+  hasCaseworkerRelationship: false,
+  inSudTreatment: false,
+  inMentalHealthTreatment: false,
+  recentEvictionCount: 0,
+  daysUnsheltered: 0,
+  hasChildrenUnder18: false,
+  isDvSurvivor: false,
+  hasId: false,
+  hasSsn: false,
+  hasBirthCert: false,
+});
+
+export function TriageTierTool() {
+  const [inputs, setInputs] = useState<TriageInputs>(() => blankInputs());
+  const result = useMemo(() => recommendTriageTier(inputs), [inputs]);
+
+  return (
+    <div className="grid gap-6 md:grid-cols-2">
+      <section className="space-y-2">
+        <h2 className="font-serif text-lg font-semibold">Stability factors</h2>
+        <ul className="space-y-1">
+          {FIELDS.map(({ k, label, type }) => (
+            <li key={k} className="rounded p-1.5 hover:bg-muted/40">
+              {type === 'bool' ? (
+                <label className="flex items-center gap-2 text-sm">
+                  <input
+                    type="checkbox"
+                    checked={Boolean(inputs[k])}
+                    onChange={(e) =>
+                      setInputs((prev) => ({ ...prev, [k]: e.target.checked }) as TriageInputs)
+                    }
+                    className="h-4 w-4"
+                  />
+                  {label}
+                </label>
+              ) : (
+                <label className="flex items-center justify-between gap-2 text-sm">
+                  <span>{label}</span>
+                  <input
+                    type="number"
+                    min={0}
+                    max={365}
+                    value={inputs[k] as number}
+                    onChange={(e) => {
+                      const n = Number.parseInt(e.target.value, 10);
+                      setInputs(
+                        (prev) =>
+                          ({ ...prev, [k]: Number.isInteger(n) && n >= 0 ? n : 0 }) as TriageInputs,
+                      );
+                    }}
+                    className="h-9 w-20 rounded-md border border-input bg-background px-2 text-sm"
+                  />
+                </label>
+              )}
+            </li>
+          ))}
+        </ul>
+        <Button type="button" variant="outline" size="sm" onClick={() => setInputs(blankInputs())}>
+          Reset
+        </Button>
+      </section>
+
+      <section className="space-y-3">
+        <div className="flex items-baseline justify-between">
+          <h2 className="font-serif text-lg font-semibold">Recommendation</h2>
+          <span className={`rounded px-2 py-0.5 text-xs font-medium ${TIER_BADGE[result.tier]}`}>
+            {TIER_LABEL[result.tier]}
+          </span>
+        </div>
+        <div className="rounded-md border border-border bg-card p-4">
+          <p className="text-xs uppercase tracking-wide text-muted-foreground">Score</p>
+          <p className="text-3xl font-semibold">{result.score} / 100</p>
+          <p className="mt-3 text-sm">{result.recommendation}</p>
+        </div>
+        <div>
+          <p className="text-xs uppercase tracking-wide text-muted-foreground">Factors</p>
+          <ul className="mt-1 space-y-1 text-sm">
+            {result.factors.length === 0 ? (
+              <li className="text-muted-foreground">No factors triggered yet.</li>
+            ) : (
+              result.factors.map((f) => (
+                <li key={f.label} className="flex items-baseline justify-between gap-2">
+                  <span>{f.label}</span>
+                  <span
+                    className={`font-mono text-xs ${
+                      f.delta > 0
+                        ? 'text-emerald-600 dark:text-emerald-400'
+                        : f.delta < 0
+                          ? 'text-destructive'
+                          : 'text-muted-foreground'
+                    }`}
+                  >
+                    {f.delta > 0 ? `+${f.delta}` : f.delta}
+                  </span>
+                </li>
+              ))
+            )}
+          </ul>
+        </div>
+        <div className="rounded-md border border-amber-500/40 bg-amber-500/5 p-3 text-xs">
+          <p className="font-medium">Rule-based v1.</p>
+          <p className="mt-1 text-muted-foreground">
+            Tier comes from a transparent additive score. Phase 2 replaces this with an ML model
+            trained on labeled outcomes from the pilot. Override the recommendation any time —
+            overrides themselves become training data.
+          </p>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/src/db/queries/audit-log.ts
+++ b/src/db/queries/audit-log.ts
@@ -1,0 +1,78 @@
+import { and, desc, eq, ilike, type SQL, sql } from 'drizzle-orm';
+import { db } from '@/db/client';
+import { type AuditLog, auditLog } from '@/db/schema/audit-log';
+import { users } from '@/db/schema/users';
+
+export type AuditLogRow = AuditLog & {
+  actorEmail: string | null;
+  actorRole: string | null;
+};
+
+export type AuditLogFilter = {
+  /** Substring match against `action` (e.g. 'data.accessed', 'consent'). */
+  action?: string;
+  /** Match against target_id (one resource id). */
+  targetId?: string;
+  /** Match against target_table. */
+  targetTable?: string;
+  limit?: number;
+};
+
+/**
+ * Recent audit-log rows joined with the actor's email/role for display.
+ * Append-only triggers prevent any sneaky UPDATEs slipping past this
+ * read view; what's here is the truth at write time.
+ */
+export async function listAuditLog(filter: AuditLogFilter = {}): Promise<AuditLogRow[]> {
+  const conditions: SQL[] = [];
+  if (filter.action) conditions.push(ilike(auditLog.action, `%${filter.action}%`));
+  if (filter.targetId) conditions.push(eq(auditLog.targetId, filter.targetId));
+  if (filter.targetTable) conditions.push(eq(auditLog.targetTable, filter.targetTable));
+
+  const rows = await db
+    .select({
+      log: auditLog,
+      actorEmail: users.email,
+      actorRole: users.role,
+    })
+    .from(auditLog)
+    .leftJoin(users, eq(auditLog.actorUserId, users.id))
+    .where(conditions.length > 0 ? and(...conditions) : sql`true`)
+    .orderBy(desc(auditLog.createdAt))
+    .limit(filter.limit ?? 100);
+
+  return rows.map((r) => ({
+    ...r.log,
+    actorEmail: r.actorEmail,
+    actorRole: r.actorRole,
+  }));
+}
+
+/**
+ * Per-(action, day) counts over the last `windowDays` days. Used by
+ * the DTRS-003 dashboard headline (\"24 reads, 6 grants, 0 deletes
+ * yesterday\").
+ */
+export type AuditCountByActionDay = {
+  action: string;
+  day: string;
+  count: number;
+};
+
+export async function actionCountsByDay(windowDays = 7): Promise<AuditCountByActionDay[]> {
+  const rows = await db.execute(sql`
+    SELECT
+      action,
+      to_char(date_trunc('day', created_at AT TIME ZONE 'UTC'), 'YYYY-MM-DD') AS day,
+      COUNT(*)::int AS count
+    FROM ${auditLog}
+    WHERE created_at >= now() - (${windowDays} || ' days')::interval
+    GROUP BY 1, 2
+    ORDER BY 2 ASC, 1 ASC
+  `);
+  return (rows as unknown as Array<{ action: string; day: string; count: number }>).map((r) => ({
+    action: r.action,
+    day: r.day,
+    count: Number(r.count),
+  }));
+}

--- a/src/db/queries/shelters.ts
+++ b/src/db/queries/shelters.ts
@@ -1,4 +1,4 @@
-import { and, asc, desc, eq } from 'drizzle-orm';
+import { and, asc, desc, eq, max } from 'drizzle-orm';
 import { db } from '@/db/client';
 import { type PartnerOrg, partnerOrgs } from '@/db/schema/partner-orgs';
 import { type BedCountUpdate, bedCountUpdates, type Shelter, shelters } from '@/db/schema/shelters';
@@ -53,4 +53,20 @@ export async function listRecentBedCountUpdates(
     .where(eq(bedCountUpdates.shelterId, shelterId))
     .orderBy(desc(bedCountUpdates.createdAt))
     .limit(limit);
+}
+
+/**
+ * Map of shelter id → most recent bed_count_updates.created_at. Used by
+ * the staff update UI to show "last updated" alongside each card. Returns
+ * `null` for shelters with no updates yet.
+ */
+export async function lastBedCountUpdateByShelter(): Promise<Map<string, Date | null>> {
+  const rows = await db
+    .select({
+      shelterId: bedCountUpdates.shelterId,
+      lastAt: max(bedCountUpdates.createdAt),
+    })
+    .from(bedCountUpdates)
+    .groupBy(bedCountUpdates.shelterId);
+  return new Map(rows.map((r) => [r.shelterId, r.lastAt ? new Date(r.lastAt) : null]));
 }

--- a/src/db/queries/shelters.ts
+++ b/src/db/queries/shelters.ts
@@ -1,7 +1,15 @@
-import { and, asc, desc, eq, max } from 'drizzle-orm';
+import { and, asc, count, desc, eq, gt, max } from 'drizzle-orm';
 import { db } from '@/db/client';
 import { type PartnerOrg, partnerOrgs } from '@/db/schema/partner-orgs';
-import { type BedCountUpdate, bedCountUpdates, type Shelter, shelters } from '@/db/schema/shelters';
+import {
+  type BedCountUpdate,
+  type BedHold,
+  bedCountUpdates,
+  bedHolds,
+  type Shelter,
+  shelters,
+} from '@/db/schema/shelters';
+import { users } from '@/db/schema/users';
 
 export type ShelterWithOrg = Shelter & { partnerOrg: Pick<PartnerOrg, 'id' | 'name' | 'slug'> };
 
@@ -69,4 +77,43 @@ export async function lastBedCountUpdateByShelter(): Promise<Map<string, Date | 
     .from(bedCountUpdates)
     .groupBy(bedCountUpdates.shelterId);
   return new Map(rows.map((r) => [r.shelterId, r.lastAt ? new Date(r.lastAt) : null]));
+}
+
+/**
+ * Count of active, not-yet-expired holds per shelter. The board uses
+ * this to show effective free beds (capacity − occupancy − holds).
+ */
+export async function activeBedHoldCounts(): Promise<Map<string, number>> {
+  const now = new Date();
+  const rows = await db
+    .select({ shelterId: bedHolds.shelterId, value: count() })
+    .from(bedHolds)
+    .where(and(eq(bedHolds.status, 'active'), gt(bedHolds.expiresAt, now)))
+    .groupBy(bedHolds.shelterId);
+  return new Map(rows.map((r) => [r.shelterId, Number(r.value)]));
+}
+
+export type BedHoldWithHolder = BedHold & {
+  heldBy: { firstName: string | null; lastName: string | null; email: string };
+};
+
+/** Active (status=active AND expires_at > now) holds for one shelter, newest first. */
+export async function listActiveHolds(shelterId: string): Promise<BedHoldWithHolder[]> {
+  const now = new Date();
+  const rows = await db
+    .select({
+      hold: bedHolds,
+      heldBy: { firstName: users.firstName, lastName: users.lastName, email: users.email },
+    })
+    .from(bedHolds)
+    .innerJoin(users, eq(bedHolds.heldByUserId, users.id))
+    .where(
+      and(
+        eq(bedHolds.shelterId, shelterId),
+        eq(bedHolds.status, 'active'),
+        gt(bedHolds.expiresAt, now),
+      ),
+    )
+    .orderBy(desc(bedHolds.createdAt));
+  return rows.map((r) => ({ ...r.hold, heldBy: r.heldBy }));
 }

--- a/src/db/queries/sms-metrics.ts
+++ b/src/db/queries/sms-metrics.ts
@@ -1,0 +1,112 @@
+import { sql } from 'drizzle-orm';
+import { db } from '@/db/client';
+import { smsMessages } from '@/db/schema/sms-messages';
+
+export type DailyIntentCount = {
+  /** UTC date string `YYYY-MM-DD`. */
+  day: string;
+  intent: string;
+  count: number;
+};
+
+export type IntentTotal = { intent: string; count: number };
+
+/**
+ * Aggregate inbound message counts by UTC day × intent for the last
+ * `windowDays` days. Phone numbers are NEVER returned by this query —
+ * the dashboard built on top of it is volume-tracking, not surveillance.
+ *
+ * The simulated playground messages (from_number prefixed
+ * "SIMULATED-") are excluded so dashboard counts reflect real traffic.
+ */
+export async function dailyIntentCounts(windowDays = 7): Promise<DailyIntentCount[]> {
+  const rows = await db.execute(sql`
+    SELECT
+      to_char(date_trunc('day', received_at AT TIME ZONE 'UTC'), 'YYYY-MM-DD') AS day,
+      intent,
+      COUNT(*)::int AS count
+    FROM ${smsMessages}
+    WHERE received_at >= now() - (${windowDays} || ' days')::interval
+      AND from_number NOT LIKE 'SIMULATED-%'
+    GROUP BY 1, 2
+    ORDER BY 1 ASC, 2 ASC
+  `);
+  return (rows as unknown as Array<{ day: string; intent: string; count: number }>).map((r) => ({
+    day: r.day,
+    intent: r.intent,
+    count: Number(r.count),
+  }));
+}
+
+/**
+ * Intent totals across the window. Useful for the headline pie/list:
+ * "of 142 messages this week, 87 were BED, 12 HELP, 4 STOP, 39 unknown".
+ */
+export async function intentTotals(windowDays = 7): Promise<IntentTotal[]> {
+  const rows = await db.execute(sql`
+    SELECT intent, COUNT(*)::int AS count
+    FROM ${smsMessages}
+    WHERE received_at >= now() - (${windowDays} || ' days')::interval
+      AND from_number NOT LIKE 'SIMULATED-%'
+    GROUP BY 1
+    ORDER BY count DESC, intent ASC
+  `);
+  return (rows as unknown as Array<{ intent: string; count: number }>).map((r) => ({
+    intent: r.intent,
+    count: Number(r.count),
+  }));
+}
+
+/**
+ * Count of distinct phone numbers seen in the window. Phone numbers
+ * never leave this query — only the count does.
+ */
+export async function uniqueCallerCount(windowDays = 7): Promise<number> {
+  const rows = await db.execute(sql`
+    SELECT COUNT(DISTINCT from_number)::int AS count
+    FROM ${smsMessages}
+    WHERE received_at >= now() - (${windowDays} || ' days')::interval
+      AND from_number NOT LIKE 'SIMULATED-%'
+  `);
+  const first = (rows as unknown as Array<{ count: number }>)[0];
+  return first ? Number(first.count) : 0;
+}
+
+/**
+ * Lightweight last-N "what just happened" feed for admin debugging.
+ * Phone numbers are returned redacted to last-4 ("…4567") so the page
+ * doesn't accidentally surface PII.
+ */
+export type RecentRedactedMessage = {
+  id: string;
+  receivedAt: Date;
+  fromLast4: string;
+  intent: string;
+  bodyExcerpt: string;
+};
+
+export async function recentRedactedMessages(limit = 20): Promise<RecentRedactedMessage[]> {
+  const rows = await db
+    .select({
+      id: smsMessages.id,
+      receivedAt: smsMessages.receivedAt,
+      fromNumber: smsMessages.fromNumber,
+      intent: smsMessages.intent,
+      body: smsMessages.body,
+    })
+    .from(smsMessages)
+    .orderBy(sql`${smsMessages.receivedAt} DESC`)
+    .limit(limit);
+  return rows.map((r) => {
+    const digits = r.fromNumber.replace(/[^0-9]/g, '');
+    const last4 = digits.slice(-4) || '----';
+    const bodyExcerpt = r.body.length > 80 ? `${r.body.slice(0, 77)}…` : r.body;
+    return {
+      id: r.id,
+      receivedAt: new Date(r.receivedAt),
+      fromLast4: last4,
+      intent: r.intent,
+      bodyExcerpt,
+    };
+  });
+}

--- a/src/db/schema/consent-access-tokens.ts
+++ b/src/db/schema/consent-access-tokens.ts
@@ -1,0 +1,48 @@
+import { index, pgTable, text, timestamp, uniqueIndex, uuid } from 'drizzle-orm/pg-core';
+import { users } from './users';
+
+/**
+ * Single-resource access tokens for the public consent surface
+ * (`/p/[ref]/consent`). The opaque token is what the caseworker hands
+ * the subject — typed into a phone or scanned from a QR code printed
+ * on a wallet card. The token resolves server-side to a
+ * `synthetic_person_ref` and an expiry; without a valid token, the
+ * page returns 404 (don't even acknowledge the URL pattern).
+ *
+ * Single-use is the strict mode but disruptive in practice (caller
+ * loses access after one click). Phase-1 default is "valid until
+ * expiry" — a bounded reuse window where the subject can return to
+ * the same link to check / change settings within (say) 24 hours.
+ *
+ * `used_at` records the first redemption so analytics can answer
+ * "what % of distributed links were ever used?".
+ */
+export const consentAccessTokens = pgTable(
+  'consent_access_tokens',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    /** The opaque random string handed to the subject. URL-safe, ≥32 bytes entropy. */
+    token: text('token').notNull(),
+    /** What ref the token maps to. Opaque per the existing convention. */
+    syntheticPersonRef: text('synthetic_person_ref').notNull(),
+    /** Caseworker who minted this token. NOT the subject. */
+    issuedByUserId: uuid('issued_by_user_id')
+      .notNull()
+      .references(() => users.id, { onDelete: 'restrict' }),
+    expiresAt: timestamp('expires_at', { withTimezone: true }).notNull(),
+    /** When the subject first redeemed the token (i.e. opened the page). */
+    usedAt: timestamp('used_at', { withTimezone: true }),
+    /** Optional: when the issuer revokes a token before expiry (lost wallet card, etc). */
+    revokedAt: timestamp('revoked_at', { withTimezone: true }),
+    notes: text('notes'),
+    createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+  },
+  (t) => [
+    uniqueIndex('consent_access_tokens_token_idx').on(t.token),
+    index('consent_access_tokens_ref_idx').on(t.syntheticPersonRef),
+    index('consent_access_tokens_expires_idx').on(t.expiresAt),
+  ],
+);
+
+export type ConsentAccessToken = typeof consentAccessTokens.$inferSelect;
+export type NewConsentAccessToken = typeof consentAccessTokens.$inferInsert;

--- a/src/db/schema/consents.ts
+++ b/src/db/schema/consents.ts
@@ -1,14 +1,20 @@
-import { index, pgTable, text, timestamp, uuid } from 'drizzle-orm/pg-core';
+import { index, jsonb, pgTable, text, timestamp, uuid } from 'drizzle-orm/pg-core';
 import { consentChannelEnum, consentTypeEnum } from './enums';
 
 /**
  * Consent records for individuals to share PHI within the coalition, receive
- * SMS communication, etc. Phase 0 captures the structure; client linkage
- * (subject_external_id -> a real clients.id) lands in a Phase 1 story when
- * the clients table exists and PHI flows are unlocked post-BAA.
+ * SMS communication, etc. Phase 0 captured the bare shape; DTRS-001 adds
+ * the state machine on top: granted → revoked OR granted → expired,
+ * scoped to specific partner orgs and data classes, versioned by the
+ * consent text the subject saw.
  *
  * Append-only in spirit: revocations are recorded by setting revoked_at,
- * NOT by deleting the row.
+ * NOT by deleting the row. Re-granting after a revocation creates a NEW
+ * row so the historical state is queryable forever.
+ *
+ * State is computed (not stored): see `consentState` in
+ * `src/lib/dtrs/consent.ts`. Storing computed state risks drift between
+ * the column and the wall-clock check against expires_at.
  */
 export const consents = pgTable(
   'consents',
@@ -19,6 +25,27 @@ export const consents = pgTable(
     subjectExternalId: text('subject_external_id').notNull(),
     consentType: consentTypeEnum('consent_type').notNull(),
     grantedVia: consentChannelEnum('granted_via').notNull(),
+    /**
+     * Version of the consent text the subject was shown. Bump
+     * `CURRENT_CONSENT_VERSION` and `consentTextFor(...)` together.
+     * A row whose `consent_version` is older than the current version
+     * is treated as still-valid (we don't auto-revoke) but flagged in
+     * the dashboard as needing a re-prompt.
+     */
+    consentVersion: text('consent_version').notNull().default('2026-04-1'),
+    /** Specific partner orgs this consent covers; null = coalition-wide. */
+    scopePartnerIds: jsonb('scope_partner_ids').$type<string[] | null>(),
+    /**
+     * Data classes the subject opted into; null = all. Phase-1 vocabulary
+     * is intentionally short: 'identity', 'health', 'housing_history',
+     * 'service_events'. Wider taxonomy is a follow-up once the FAG
+     * weighs in (see DTRS-005 advisor session).
+     */
+    scopeDataClasses: jsonb('scope_data_classes').$type<string[] | null>(),
+    /** Plain-language signature text typed by the subject ("Sarah J", "X"). */
+    signatureText: text('signature_text'),
+    /** Optional expiry. null = no expiration; coalition can re-prompt at will. */
+    expiresAt: timestamp('expires_at', { withTimezone: true }),
     grantedAt: timestamp('granted_at', { withTimezone: true }).notNull().defaultNow(),
     revokedAt: timestamp('revoked_at', { withTimezone: true }),
     notes: text('notes'),
@@ -27,6 +54,7 @@ export const consents = pgTable(
   (t) => [
     index('consents_subject_idx').on(t.subjectExternalId),
     index('consents_type_idx').on(t.consentType),
+    index('consents_expires_at_idx').on(t.expiresAt),
   ],
 );
 

--- a/src/db/schema/dv-flags.ts
+++ b/src/db/schema/dv-flags.ts
@@ -1,0 +1,46 @@
+import { index, pgTable, text, timestamp, uniqueIndex, uuid } from 'drizzle-orm/pg-core';
+
+/**
+ * DV abuser-blind registry (DTRS-004). One row per (synthetic_person_ref
+ * OR phone number) that DV-trained staff have flagged as needing
+ * location suppression in coalition queries.
+ *
+ * The threat model: an abuser obtains the survivor's new location
+ * through a coalition partner's data leak (e.g. a leaked spreadsheet,
+ * a screen-shared dashboard). This table is the application-level
+ * choke point. Queries that surface addresses to non-attorney roles
+ * must consult this table and redact. The OASIS shelter's location-
+ * confidential model is the same pattern at the shelter level.
+ *
+ * Identifiers are opaque (`synthetic_person_ref`) or phone numbers in
+ * E.164 form. We never store the survivor's name here — naming would
+ * defeat the purpose. Reasoning behind the flag is captured in
+ * `notes`, encrypted-at-rest by the DB engine.
+ *
+ * Flips:
+ *   - `flag_set_at` is when the survivor was added.
+ *   - `flag_cleared_at` non-null = the flag was lifted (e.g. after
+ *     legal protective order resolution); rows are not deleted so
+ *     audit trail survives.
+ */
+export const dvFlaggedPersons = pgTable(
+  'dv_flagged_persons',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    /** Opaque ref OR E.164 phone number — whichever the partner uses. */
+    subjectIdentifier: text('subject_identifier').notNull(),
+    /** Brief, redacted-by-default justification (audit only). */
+    notes: text('notes'),
+    flagSetAt: timestamp('flag_set_at', { withTimezone: true }).notNull().defaultNow(),
+    flagClearedAt: timestamp('flag_cleared_at', { withTimezone: true }),
+    createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),
+  },
+  (t) => [
+    uniqueIndex('dv_flagged_persons_subject_idx').on(t.subjectIdentifier),
+    index('dv_flagged_persons_set_at_idx').on(t.flagSetAt),
+  ],
+);
+
+export type DvFlaggedPerson = typeof dvFlaggedPersons.$inferSelect;
+export type NewDvFlaggedPerson = typeof dvFlaggedPersons.$inferInsert;

--- a/src/db/schema/enums.ts
+++ b/src/db/schema/enums.ts
@@ -134,6 +134,13 @@ export const bedHoldStatusEnum = pgEnum('bed_hold_status', [
 
 export type BedHoldStatus = (typeof bedHoldStatusEnum.enumValues)[number];
 
+export const smsConversationStateEnum = pgEnum('sms_conversation_state', [
+  'idle',
+  'awaiting_location',
+]);
+
+export type SmsConversationState = (typeof smsConversationStateEnum.enumValues)[number];
+
 export const partnerServiceEventTypeEnum = pgEnum('partner_service_event_type', [
   'food_pantry',
   'shelter_intake',

--- a/src/db/schema/enums.ts
+++ b/src/db/schema/enums.ts
@@ -125,6 +125,15 @@ export const dataSharingTierEnum = pgEnum('data_sharing_tier', ['none', 'aggrega
 
 export type DataSharingTier = (typeof dataSharingTierEnum.enumValues)[number];
 
+export const bedHoldStatusEnum = pgEnum('bed_hold_status', [
+  'active',
+  'released',
+  'expired',
+  'converted',
+]);
+
+export type BedHoldStatus = (typeof bedHoldStatusEnum.enumValues)[number];
+
 export const partnerServiceEventTypeEnum = pgEnum('partner_service_event_type', [
   'food_pantry',
   'shelter_intake',

--- a/src/db/schema/eviction-filings.ts
+++ b/src/db/schema/eviction-filings.ts
@@ -1,4 +1,5 @@
 import {
+  boolean,
   index,
   integer,
   jsonb,
@@ -40,6 +41,14 @@ export const evictionFilings = pgTable(
     status: evictionFilingStatusEnum('status').notNull().default('filed'),
     source: evictionFilingSourceEnum('source').notNull(),
     rawJson: jsonb('raw_json').$type<Record<string, unknown>>(),
+    /**
+     * DV abuser-blind flag (DTRS-004). When true, queries that surface
+     * filings to non-attorney roles must redact the defendant's address
+     * (the platform's threat model is the abuser obtaining the survivor's
+     * new location through a coalition data leak). Toggled by DV-trained
+     * staff during intake; default false.
+     */
+    dvFlag: boolean('dv_flag').notNull().default(false),
     createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
     updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),
   },

--- a/src/db/schema/index.ts
+++ b/src/db/schema/index.ts
@@ -14,5 +14,6 @@ export * from './partner-service-events';
 export * from './person-partner-consents';
 export * from './rental-assistance-programs';
 export * from './shelters';
+export * from './sms-conversations';
 export * from './sms-messages';
 export * from './users';

--- a/src/db/schema/index.ts
+++ b/src/db/schema/index.ts
@@ -1,5 +1,6 @@
 export * from './audit-log';
 export * from './consents';
+export * from './dv-flags';
 export * from './ed-encounters';
 export * from './enums';
 export * from './esuc-care-plans';

--- a/src/db/schema/index.ts
+++ b/src/db/schema/index.ts
@@ -1,4 +1,5 @@
 export * from './audit-log';
+export * from './consent-access-tokens';
 export * from './consents';
 export * from './dv-flags';
 export * from './ed-encounters';

--- a/src/db/schema/index.ts
+++ b/src/db/schema/index.ts
@@ -14,4 +14,5 @@ export * from './partner-service-events';
 export * from './person-partner-consents';
 export * from './rental-assistance-programs';
 export * from './shelters';
+export * from './sms-messages';
 export * from './users';

--- a/src/db/schema/shelters.ts
+++ b/src/db/schema/shelters.ts
@@ -10,6 +10,7 @@ import {
   uniqueIndex,
   uuid,
 } from 'drizzle-orm/pg-core';
+import { bedHoldStatusEnum } from './enums';
 import { partnerOrgs } from './partner-orgs';
 
 /**
@@ -96,3 +97,46 @@ export const bedCountUpdates = pgTable(
 
 export type BedCountUpdate = typeof bedCountUpdates.$inferSelect;
 export type NewBedCountUpdate = typeof bedCountUpdates.$inferInsert;
+
+/**
+ * Soft 90-minute reservation against a shelter bed (COOR-005). A hold
+ * decrements effective free beds (free = capacity − occupancy − active
+ * holds) without touching `current_occupancy` itself — the bed is still
+ * unoccupied until the person arrives and the staff bumps occupancy.
+ *
+ * Identity is opaque on purpose: `personLabel` is whatever the dispatcher
+ * wrote ("211 caller #1234", "Phone: 270-555-0100"). No real PHI lands
+ * here pre-BAA.
+ *
+ * Lifecycle:
+ *  - active   → released   (manual release, person didn't show)
+ *  - active   → expired    (auto-released by Inngest after expires_at)
+ *  - active   → converted  (intake completed; occupancy bumped manually)
+ */
+export const bedHolds = pgTable(
+  'bed_holds',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    shelterId: uuid('shelter_id')
+      .notNull()
+      .references(() => shelters.id, { onDelete: 'cascade' }),
+    /** Internal user who created the hold. */
+    heldByUserId: uuid('held_by_user_id').notNull(),
+    /** Free-text label for the requesting party. NEVER PHI. */
+    personLabel: text('person_label').notNull(),
+    status: bedHoldStatusEnum('status').notNull().default('active'),
+    expiresAt: timestamp('expires_at', { withTimezone: true }).notNull(),
+    releasedAt: timestamp('released_at', { withTimezone: true }),
+    notes: text('notes'),
+    createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),
+  },
+  (t) => [
+    index('bed_holds_shelter_idx').on(t.shelterId),
+    index('bed_holds_status_idx').on(t.status),
+    index('bed_holds_expires_idx').on(t.expiresAt),
+  ],
+);
+
+export type BedHold = typeof bedHolds.$inferSelect;
+export type NewBedHold = typeof bedHolds.$inferInsert;

--- a/src/db/schema/sms-conversations.ts
+++ b/src/db/schema/sms-conversations.ts
@@ -1,0 +1,39 @@
+import { index, jsonb, pgTable, text, timestamp, uniqueIndex, uuid } from 'drizzle-orm/pg-core';
+import type { BedFilter } from '@/lib/coordination/bed-availability';
+import { smsConversationStateEnum } from './enums';
+
+/**
+ * One row per inbound phone number. Tracks the multi-turn state of the
+ * SMS bed-finder (INDC-004): the user's first BED message becomes a
+ * pending filter while we ask "where are you near?", and the reply is
+ * stitched back to the original filter to produce the bed list.
+ *
+ * Conversations time out after 10 minutes of inactivity. The Inngest
+ * cron (sms-conversation-expiry) flips stale rows back to `idle` so
+ * we don't strand users in the awaiting-location state forever.
+ */
+export const smsConversations = pgTable(
+  'sms_conversations',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    fromNumber: text('from_number').notNull(),
+    state: smsConversationStateEnum('state').notNull().default('idle'),
+    /** The most recent BED filter the user expressed; replayed when location arrives. */
+    pendingFilter: jsonb('pending_filter').$type<BedFilter | null>(),
+    /** Captured location text from the last 'awaiting_location' reply. Free-form. */
+    lastLocation: text('last_location'),
+    /** When the conversation auto-expires back to 'idle'. */
+    expiresAt: timestamp('expires_at', { withTimezone: true }).notNull(),
+    lastMessageAt: timestamp('last_message_at', { withTimezone: true }).notNull().defaultNow(),
+    createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),
+  },
+  (t) => [
+    uniqueIndex('sms_conversations_from_idx').on(t.fromNumber),
+    index('sms_conversations_state_idx').on(t.state),
+    index('sms_conversations_expires_idx').on(t.expiresAt),
+  ],
+);
+
+export type SmsConversation = typeof smsConversations.$inferSelect;
+export type NewSmsConversation = typeof smsConversations.$inferInsert;

--- a/src/db/schema/sms-conversations.ts
+++ b/src/db/schema/sms-conversations.ts
@@ -22,6 +22,14 @@ export const smsConversations = pgTable(
     pendingFilter: jsonb('pending_filter').$type<BedFilter | null>(),
     /** Captured location text from the last 'awaiting_location' reply. Free-form. */
     lastLocation: text('last_location'),
+    /**
+     * The shelter ids and display order from the most recent bed-finder
+     * reply, in the same order they appeared. Lets `HOLD <#>` map a
+     * line number back to a shelter without re-running the search.
+     */
+    lastResults: jsonb('last_results').$type<Array<{ shelterId: string; name: string }>>(),
+    /** Most recent active hold the user created via SMS, for RELEASE shortcuts. */
+    lastHoldId: uuid('last_hold_id'),
     /** When the conversation auto-expires back to 'idle'. */
     expiresAt: timestamp('expires_at', { withTimezone: true }).notNull(),
     lastMessageAt: timestamp('last_message_at', { withTimezone: true }).notNull().defaultNow(),

--- a/src/db/schema/sms-messages.ts
+++ b/src/db/schema/sms-messages.ts
@@ -1,0 +1,37 @@
+import { index, jsonb, pgTable, text, timestamp, uuid } from 'drizzle-orm/pg-core';
+
+/**
+ * Append-only log of every inbound SMS the bed-finder webhook handled.
+ * Identifiers are E.164 phone numbers — these ARE potentially identifying
+ * info, so the log is access-restricted in the UI (admin-only) and never
+ * leaves the DB. Body is stored verbatim for debugging the parser.
+ *
+ * Pre-BAA scope: synthetic / staff-test traffic only. When the unhoused-
+ * companion goes live (post-BAA, post-consent flow), we'll either
+ * suppress phone numbers here or run de-identification on the column.
+ */
+export const smsMessages = pgTable(
+  'sms_messages',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    /** Twilio MessageSid — opaque, useful for correlating Twilio logs. */
+    providerMessageId: text('provider_message_id'),
+    fromNumber: text('from_number').notNull(),
+    toNumber: text('to_number').notNull(),
+    body: text('body').notNull(),
+    /** Recognized intent; 'unknown' for messages we couldn't parse. */
+    intent: text('intent').notNull(),
+    /** Reply we sent back inline (TwiML). Useful for debugging. */
+    replyBody: text('reply_body').notNull(),
+    /** Free-form context the formatter / pipeline wrote. Optional. */
+    metadata: jsonb('metadata').$type<Record<string, unknown> | null>(),
+    receivedAt: timestamp('received_at', { withTimezone: true }).notNull().defaultNow(),
+  },
+  (t) => [
+    index('sms_messages_received_idx').on(t.receivedAt),
+    index('sms_messages_from_idx').on(t.fromNumber),
+  ],
+);
+
+export type SmsMessage = typeof smsMessages.$inferSelect;
+export type NewSmsMessage = typeof smsMessages.$inferInsert;

--- a/src/inngest/functions/expire-bed-holds.ts
+++ b/src/inngest/functions/expire-bed-holds.ts
@@ -1,0 +1,35 @@
+import { and, eq, lt } from 'drizzle-orm';
+import { db } from '@/db/client';
+import { bedHolds } from '@/db/schema/shelters';
+import { inngest } from '../client';
+
+/**
+ * Auto-expires soft bed holds whose `expires_at` has passed (COOR-005
+ * AC: "Expires, releases automatically"). Runs every minute so a hold
+ * never lingers visibly past its 90-minute window.
+ *
+ * The board already filters by `expires_at > now()` when computing
+ * effective free beds, so the cron is a tidiness step — it normalizes
+ * the row to status='expired' so the audit trail reflects what
+ * actually happened, and so an admin browsing the table doesn't see
+ * lingering 'active' rows that are functionally dead.
+ */
+export const expireBedHolds = inngest.createFunction(
+  {
+    id: 'expire-bed-holds',
+    retries: 1,
+    triggers: [{ cron: '* * * * *' }], // every minute
+  },
+  async ({ step }) => {
+    const result = await step.run('flip-expired', async () => {
+      const now = new Date();
+      const expired = await db
+        .update(bedHolds)
+        .set({ status: 'expired', updatedAt: now })
+        .where(and(eq(bedHolds.status, 'active'), lt(bedHolds.expiresAt, now)))
+        .returning({ id: bedHolds.id });
+      return { count: expired.length };
+    });
+    return { ok: true, expired: result.count };
+  },
+);

--- a/src/inngest/functions/expire-sms-conversations.ts
+++ b/src/inngest/functions/expire-sms-conversations.ts
@@ -1,0 +1,32 @@
+import { and, eq, lt } from 'drizzle-orm';
+import { db } from '@/db/client';
+import { smsConversations } from '@/db/schema/sms-conversations';
+import { inngest } from '../client';
+
+/**
+ * Sweeps awaiting_location conversations whose TTL has passed back to
+ * idle. Pipeline lazy-expires on read too, so this is a tidiness step
+ * — it keeps the table clean for analytics and prevents a stale
+ * pending_filter from being replayed if a user comes back days later.
+ */
+export const expireSmsConversations = inngest.createFunction(
+  {
+    id: 'expire-sms-conversations',
+    retries: 1,
+    triggers: [{ cron: '*/5 * * * *' }], // every 5 minutes
+  },
+  async ({ step }) => {
+    const result = await step.run('reset-stale', async () => {
+      const now = new Date();
+      const reset = await db
+        .update(smsConversations)
+        .set({ state: 'idle', pendingFilter: null, updatedAt: now })
+        .where(
+          and(eq(smsConversations.state, 'awaiting_location'), lt(smsConversations.expiresAt, now)),
+        )
+        .returning({ id: smsConversations.id });
+      return { count: reset.length };
+    });
+    return { ok: true, reset: result.count };
+  },
+);

--- a/src/inngest/functions/index.ts
+++ b/src/inngest/functions/index.ts
@@ -1,6 +1,13 @@
 import { dailyAttorneyDigest } from './daily-attorney-digest';
 import { dailyCourtnetScrape } from './daily-courtnet-scrape';
 import { dailyHealthPing } from './daily-health-ping';
+import { expireBedHolds } from './expire-bed-holds';
 import { userSignedUp } from './user-signed-up';
 
-export const functions = [dailyHealthPing, userSignedUp, dailyCourtnetScrape, dailyAttorneyDigest];
+export const functions = [
+  dailyHealthPing,
+  userSignedUp,
+  dailyCourtnetScrape,
+  dailyAttorneyDigest,
+  expireBedHolds,
+];

--- a/src/inngest/functions/index.ts
+++ b/src/inngest/functions/index.ts
@@ -2,6 +2,7 @@ import { dailyAttorneyDigest } from './daily-attorney-digest';
 import { dailyCourtnetScrape } from './daily-courtnet-scrape';
 import { dailyHealthPing } from './daily-health-ping';
 import { expireBedHolds } from './expire-bed-holds';
+import { expireSmsConversations } from './expire-sms-conversations';
 import { userSignedUp } from './user-signed-up';
 
 export const functions = [
@@ -10,4 +11,5 @@ export const functions = [
   dailyCourtnetScrape,
   dailyAttorneyDigest,
   expireBedHolds,
+  expireSmsConversations,
 ];

--- a/src/lib/coordination/bed-availability.test.ts
+++ b/src/lib/coordination/bed-availability.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { freeBeds, matchesFilter, occupancyRate } from './bed-availability';
+import { freeBeds, matchesFilter, occupancyRate, validateBedCount } from './bed-availability';
 
 const baseShelter = {
   capacity: 60,
@@ -62,5 +62,30 @@ describe('matchesFilter', () => {
   it('rejects when minFreeBeds is not met', () => {
     expect(matchesFilter({ ...baseShelter, currentOccupancy: 60 }, { minFreeBeds: 1 })).toBe(false);
     expect(matchesFilter({ ...baseShelter, currentOccupancy: 50 }, { minFreeBeds: 1 })).toBe(true);
+  });
+});
+
+describe('validateBedCount', () => {
+  it('accepts integer occupancies in [0, capacity]', () => {
+    expect(validateBedCount(0, 10)).toEqual({ ok: true, value: 0 });
+    expect(validateBedCount(10, 10)).toEqual({ ok: true, value: 10 });
+    expect(validateBedCount(7, 10)).toEqual({ ok: true, value: 7 });
+  });
+
+  it('rejects negative occupancy', () => {
+    const r = validateBedCount(-1, 10);
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toMatch(/whole number/);
+  });
+
+  it('rejects fractional occupancy', () => {
+    const r = validateBedCount(3.5, 10);
+    expect(r.ok).toBe(false);
+  });
+
+  it('rejects occupancy above capacity with the capacity in the message', () => {
+    const r = validateBedCount(11, 10);
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toContain('10');
   });
 });

--- a/src/lib/coordination/bed-availability.test.ts
+++ b/src/lib/coordination/bed-availability.test.ts
@@ -1,5 +1,12 @@
 import { describe, expect, it } from 'vitest';
-import { freeBeds, matchesFilter, occupancyRate, validateBedCount } from './bed-availability';
+import {
+  freeBeds,
+  hasActiveFilter,
+  matchesFilter,
+  occupancyRate,
+  parseBedFilterParams,
+  validateBedCount,
+} from './bed-availability';
 
 const baseShelter = {
   capacity: 60,
@@ -62,6 +69,79 @@ describe('matchesFilter', () => {
   it('rejects when minFreeBeds is not met', () => {
     expect(matchesFilter({ ...baseShelter, currentOccupancy: 60 }, { minFreeBeds: 1 })).toBe(false);
     expect(matchesFilter({ ...baseShelter, currentOccupancy: 50 }, { minFreeBeds: 1 })).toBe(true);
+  });
+});
+
+describe('matchesFilter — query', () => {
+  it('matches case-insensitively against searchableText', () => {
+    expect(matchesFilter(baseShelter, { query: 'BENED' }, 'St. Benedict\u2019s — Owensboro')).toBe(
+      true,
+    );
+  });
+
+  it('rejects when query has no match', () => {
+    expect(matchesFilter(baseShelter, { query: 'zzz' }, 'St. Benedict\u2019s')).toBe(false);
+  });
+
+  it('rejects when searchableText is undefined and query is set', () => {
+    expect(matchesFilter(baseShelter, { query: 'foo' })).toBe(false);
+  });
+
+  it('ignores whitespace-only queries', () => {
+    // parseBedFilterParams strips these; matchesFilter only acts on
+    // non-empty queries (passes when query.trim() is empty).
+    expect(matchesFilter(baseShelter, { query: '   ' })).toBe(true);
+  });
+});
+
+describe('parseBedFilterParams', () => {
+  it('returns empty filter for empty params', () => {
+    expect(parseBedFilterParams({})).toEqual({});
+  });
+
+  it('parses a populated query string', () => {
+    expect(
+      parseBedFilterParams({
+        population: 'families',
+        pet: '1',
+        sud: 'true',
+        minFree: '3',
+        q: '  Boulware ',
+      }),
+    ).toEqual({
+      population: 'families',
+      petFriendly: true,
+      sudFriendly: true,
+      minFreeBeds: 3,
+      query: 'Boulware',
+    });
+  });
+
+  it('drops invalid population values', () => {
+    expect(parseBedFilterParams({ population: 'aliens' }).population).toBeUndefined();
+  });
+
+  it('drops zero / negative / non-numeric minFree', () => {
+    expect(parseBedFilterParams({ minFree: '0' }).minFreeBeds).toBeUndefined();
+    expect(parseBedFilterParams({ minFree: '-2' }).minFreeBeds).toBeUndefined();
+    expect(parseBedFilterParams({ minFree: 'abc' }).minFreeBeds).toBeUndefined();
+  });
+
+  it('caps long search queries to 64 chars', () => {
+    const long = 'a'.repeat(200);
+    expect(parseBedFilterParams({ q: long }).query?.length).toBe(64);
+  });
+});
+
+describe('hasActiveFilter', () => {
+  it('returns false for empty filter', () => {
+    expect(hasActiveFilter({})).toBe(false);
+  });
+
+  it('returns true when any dimension is set', () => {
+    expect(hasActiveFilter({ petFriendly: true })).toBe(true);
+    expect(hasActiveFilter({ query: 'foo' })).toBe(true);
+    expect(hasActiveFilter({ minFreeBeds: 1 })).toBe(true);
   });
 });
 

--- a/src/lib/coordination/bed-availability.test.ts
+++ b/src/lib/coordination/bed-availability.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import {
+  effectiveFreeBeds,
   freeBeds,
   hasActiveFilter,
   matchesFilter,
@@ -29,6 +30,20 @@ describe('freeBeds', () => {
 
   it('returns 0 when at capacity', () => {
     expect(freeBeds({ capacity: 10, currentOccupancy: 10 })).toBe(0);
+  });
+});
+
+describe('effectiveFreeBeds', () => {
+  it('subtracts active holds from raw free', () => {
+    expect(effectiveFreeBeds({ capacity: 10, currentOccupancy: 4 }, 2)).toBe(4);
+  });
+
+  it('clamps to 0 when holds exceed raw free', () => {
+    expect(effectiveFreeBeds({ capacity: 10, currentOccupancy: 8 }, 5)).toBe(0);
+  });
+
+  it('treats negative hold counts as 0', () => {
+    expect(effectiveFreeBeds({ capacity: 10, currentOccupancy: 4 }, -1)).toBe(6);
   });
 });
 

--- a/src/lib/coordination/bed-availability.ts
+++ b/src/lib/coordination/bed-availability.ts
@@ -59,6 +59,19 @@ export function freeBeds(shelter: Pick<Shelter, 'capacity' | 'currentOccupancy'>
   return Math.max(0, shelter.capacity - shelter.currentOccupancy);
 }
 
+/**
+ * Effective free beds, accounting for active soft holds. A hold reserves
+ * a bed for the holder for `expires_at` minutes; until released or
+ * expired it should not be advertised as available. Capped at the raw
+ * free count so a stale hold count never makes free go negative.
+ */
+export function effectiveFreeBeds(
+  shelter: Pick<Shelter, 'capacity' | 'currentOccupancy'>,
+  activeHolds: number,
+): number {
+  return Math.max(0, freeBeds(shelter) - Math.max(0, activeHolds));
+}
+
 /** Occupancy rate as a fraction in [0, 1]. Capacity 0 → 1 (treat as full). */
 export function occupancyRate(shelter: Pick<Shelter, 'capacity' | 'currentOccupancy'>): number {
   if (shelter.capacity <= 0) return 1;

--- a/src/lib/coordination/bed-availability.ts
+++ b/src/lib/coordination/bed-availability.ts
@@ -7,7 +7,52 @@ export type BedFilter = {
   sudFriendly?: boolean;
   /** Minimum free beds the shelter must have right now. */
   minFreeBeds?: number;
+  /** Free-text query — matches shelter or partner-org name (case-insensitive). */
+  query?: string;
 };
+
+const VALID_POPULATIONS = ['men', 'women', 'families'] as const;
+type Population = (typeof VALID_POPULATIONS)[number];
+const isPopulation = (v: unknown): v is Population =>
+  typeof v === 'string' && (VALID_POPULATIONS as readonly string[]).includes(v);
+
+/**
+ * Parses a `URLSearchParams`-shaped record into a BedFilter, dropping
+ * unknown / malformed values. Used by the bed board page to read
+ * filters off the URL on the server side.
+ *
+ * Recognized keys: `population`, `pet=1`, `sud=1`, `minFree`, `q`.
+ */
+export function parseBedFilterParams(
+  params: Record<string, string | string[] | undefined>,
+): BedFilter {
+  const filter: BedFilter = {};
+  const pop = Array.isArray(params.population) ? params.population[0] : params.population;
+  if (isPopulation(pop)) filter.population = pop;
+  const pet = Array.isArray(params.pet) ? params.pet[0] : params.pet;
+  if (pet === '1' || pet === 'true') filter.petFriendly = true;
+  const sud = Array.isArray(params.sud) ? params.sud[0] : params.sud;
+  if (sud === '1' || sud === 'true') filter.sudFriendly = true;
+  const minFreeRaw = Array.isArray(params.minFree) ? params.minFree[0] : params.minFree;
+  if (minFreeRaw) {
+    const n = Number.parseInt(minFreeRaw, 10);
+    if (Number.isInteger(n) && n > 0) filter.minFreeBeds = n;
+  }
+  const q = Array.isArray(params.q) ? params.q[0] : params.q;
+  if (typeof q === 'string' && q.trim().length > 0) filter.query = q.trim().slice(0, 64);
+  return filter;
+}
+
+/** True when at least one filter dimension is populated. */
+export function hasActiveFilter(filter: BedFilter): boolean {
+  return Boolean(
+    filter.population ||
+      filter.petFriendly ||
+      filter.sudFriendly ||
+      filter.minFreeBeds ||
+      filter.query,
+  );
+}
 
 /** Free beds = capacity − current occupancy. Never negative. */
 export function freeBeds(shelter: Pick<Shelter, 'capacity' | 'currentOccupancy'>): number {
@@ -42,7 +87,9 @@ export function validateBedCount(newOccupancy: number, capacity: number): BedCou
 
 /**
  * True iff a shelter satisfies every populated criterion in `filter`.
- * Empty filter matches every active shelter.
+ * Empty filter matches every active shelter. The `query` text dimension
+ * is checked against `searchableText` (shelter name + partner-org name)
+ * when provided — pass `undefined` to skip text matching.
  */
 export function matchesFilter(
   shelter: Pick<
@@ -56,6 +103,7 @@ export function matchesFilter(
     | 'sudFriendly'
   >,
   filter: BedFilter,
+  searchableText?: string,
 ): boolean {
   if (filter.population === 'men' && !shelter.acceptsMen) return false;
   if (filter.population === 'women' && !shelter.acceptsWomen) return false;
@@ -64,6 +112,10 @@ export function matchesFilter(
   if (filter.sudFriendly && !shelter.sudFriendly) return false;
   if (typeof filter.minFreeBeds === 'number' && freeBeds(shelter) < filter.minFreeBeds) {
     return false;
+  }
+  if (filter.query && filter.query.trim().length > 0) {
+    if (!searchableText) return false;
+    if (!searchableText.toLowerCase().includes(filter.query.toLowerCase())) return false;
   }
   return true;
 }

--- a/src/lib/coordination/bed-availability.ts
+++ b/src/lib/coordination/bed-availability.ts
@@ -20,6 +20,26 @@ export function occupancyRate(shelter: Pick<Shelter, 'capacity' | 'currentOccupa
   return Math.min(1, Math.max(0, shelter.currentOccupancy / shelter.capacity));
 }
 
+export type BedCountValidation = { ok: true; value: number } | { ok: false; error: string };
+
+/**
+ * Validates a proposed `newOccupancy` against `capacity`. Mirrors what
+ * the server action accepts; pulled out as a pure function so unit
+ * tests can cover the rule set without spinning up a database.
+ */
+export function validateBedCount(newOccupancy: number, capacity: number): BedCountValidation {
+  if (!Number.isInteger(newOccupancy) || newOccupancy < 0) {
+    return { ok: false, error: 'Bed count must be a whole number ≥ 0.' };
+  }
+  if (capacity < 0) {
+    return { ok: false, error: 'Shelter capacity is invalid.' };
+  }
+  if (newOccupancy > capacity) {
+    return { ok: false, error: `Bed count cannot exceed capacity (${capacity}).` };
+  }
+  return { ok: true, value: newOccupancy };
+}
+
 /**
  * True iff a shelter satisfies every populated criterion in `filter`.
  * Empty filter matches every active shelter.

--- a/src/lib/cwt/benefits.test.ts
+++ b/src/lib/cwt/benefits.test.ts
@@ -1,0 +1,212 @@
+import { describe, expect, it } from 'vitest';
+import {
+  fplMonthlyCents,
+  fplPercent,
+  type Household,
+  screenHousehold,
+  totalLikelyMonthlyCents,
+} from './benefits';
+
+const baseHousehold = (overrides: Partial<Household> = {}): Household => ({
+  monthlyIncomeCents: 100_000, // $1,000 / mo
+  householdSize: 1,
+  hasChildrenUnder18: false,
+  hasPregnantMember: false,
+  isVeteran: false,
+  isDisabled: false,
+  ageOldest: 35,
+  kyResident: true,
+  citizenOrQualified: true,
+  ...overrides,
+});
+
+const findById = (results: ReturnType<typeof screenHousehold>, id: string) =>
+  results.find((r) => r.programId === id);
+
+describe('fplMonthlyCents', () => {
+  it('matches the 2024 HHS table for sizes 1-8', () => {
+    expect(fplMonthlyCents(1)).toBe(125_400);
+    expect(fplMonthlyCents(4)).toBe(257_400);
+    expect(fplMonthlyCents(8)).toBe(433_400);
+  });
+
+  it('extrapolates linearly above 8', () => {
+    expect(fplMonthlyCents(10)).toBe(433_400 + 2 * 44_000);
+  });
+
+  it('clamps non-positive household size to 1', () => {
+    expect(fplMonthlyCents(0)).toBe(125_400);
+  });
+});
+
+describe('fplPercent', () => {
+  it('returns income as percent of FPL with one decimal', () => {
+    // Single household, $1254/mo = 100% FPL.
+    expect(fplPercent(125_400, 1)).toBe(100);
+    // $627/mo single = 50%.
+    expect(fplPercent(62_700, 1)).toBe(50);
+  });
+});
+
+describe('screenHousehold — SNAP', () => {
+  it('marks SNAP likely for low-income KY resident citizen', () => {
+    const r = findById(screenHousehold(baseHousehold()), 'snap');
+    expect(r?.status).toBe('likely');
+    expect(r?.estimatedMonthlyCents).toBeGreaterThan(0);
+  });
+
+  it('marks SNAP ineligible above 130% FPL', () => {
+    const r = findById(screenHousehold(baseHousehold({ monthlyIncomeCents: 200_000 })), 'snap');
+    expect(r?.status).toBe('ineligible');
+  });
+
+  it('marks SNAP ineligible for non-KY resident', () => {
+    const r = findById(screenHousehold(baseHousehold({ kyResident: false })), 'snap');
+    expect(r?.status).toBe('ineligible');
+  });
+
+  it('marks SNAP maybe when citizenship is unclear', () => {
+    const r = findById(screenHousehold(baseHousehold({ citizenOrQualified: false })), 'snap');
+    expect(r?.status).toBe('maybe');
+  });
+});
+
+describe('screenHousehold — KCHIP', () => {
+  it('likely for kid-having low-income KY family', () => {
+    const r = findById(
+      screenHousehold(
+        baseHousehold({
+          householdSize: 4,
+          hasChildrenUnder18: true,
+          monthlyIncomeCents: 250_000,
+        }),
+      ),
+      'kchip',
+    );
+    expect(r?.status).toBe('likely');
+  });
+
+  it('ineligible without a child or pregnancy', () => {
+    const r = findById(screenHousehold(baseHousehold()), 'kchip');
+    expect(r?.status).toBe('ineligible');
+    expect(r?.reason).toMatch(/under 18/);
+  });
+});
+
+describe('screenHousehold — KTAP', () => {
+  it('likely for very-low-income family with kids', () => {
+    const r = findById(
+      screenHousehold(
+        baseHousehold({
+          householdSize: 3,
+          hasChildrenUnder18: true,
+          monthlyIncomeCents: 30_000, // $300 / mo
+        }),
+      ),
+      'ktap',
+    );
+    expect(r?.status).toBe('likely');
+    expect(r?.estimatedMonthlyCents).toBeGreaterThan(0);
+  });
+
+  it('maybe when income is borderline', () => {
+    const r = findById(
+      screenHousehold(
+        baseHousehold({
+          householdSize: 3,
+          hasChildrenUnder18: true,
+          monthlyIncomeCents: 80_000,
+        }),
+      ),
+      'ktap',
+    );
+    expect(r?.status).toBe('maybe');
+  });
+
+  it('ineligible without a child', () => {
+    const r = findById(screenHousehold(baseHousehold()), 'ktap');
+    expect(r?.status).toBe('ineligible');
+  });
+});
+
+describe('screenHousehold — SSI', () => {
+  it('likely for an aged or disabled household member with low income', () => {
+    const r = findById(
+      screenHousehold(baseHousehold({ ageOldest: 70, monthlyIncomeCents: 30_000 })),
+      'ssi',
+    );
+    expect(r?.status).toBe('likely');
+  });
+
+  it('ineligible for under-65 non-disabled', () => {
+    const r = findById(screenHousehold(baseHousehold({ ageOldest: 35 })), 'ssi');
+    expect(r?.status).toBe('ineligible');
+  });
+
+  it('maybe when income near or above SSI FBR', () => {
+    const r = findById(
+      screenHousehold(baseHousehold({ isDisabled: true, monthlyIncomeCents: 100_000 })),
+      'ssi',
+    );
+    expect(r?.status).toBe('maybe');
+  });
+});
+
+describe('screenHousehold — VA', () => {
+  it('marks VA maybe for any veteran', () => {
+    const r = findById(screenHousehold(baseHousehold({ isVeteran: true })), 'va_pension');
+    expect(r?.status).toBe('maybe');
+  });
+
+  it('ineligible for non-veteran', () => {
+    const r = findById(screenHousehold(baseHousehold()), 'va_pension');
+    expect(r?.status).toBe('ineligible');
+  });
+});
+
+describe('screenHousehold — LIHEAP', () => {
+  it('likely for KY resident under 130% FPL', () => {
+    const r = findById(screenHousehold(baseHousehold()), 'liheap');
+    expect(r?.status).toBe('likely');
+  });
+
+  it('ineligible above 130% FPL', () => {
+    const r = findById(screenHousehold(baseHousehold({ monthlyIncomeCents: 200_000 })), 'liheap');
+    expect(r?.status).toBe('ineligible');
+  });
+});
+
+describe('screenHousehold — sort order', () => {
+  it('puts likely first, maybe next, ineligible last', () => {
+    const results = screenHousehold(
+      baseHousehold({
+        householdSize: 4,
+        hasChildrenUnder18: true,
+        monthlyIncomeCents: 100_000,
+      }),
+    );
+    let phase = 0;
+    for (const r of results) {
+      const next = r.status === 'likely' ? 0 : r.status === 'maybe' ? 1 : 2;
+      expect(next).toBeGreaterThanOrEqual(phase);
+      phase = next;
+    }
+  });
+});
+
+describe('totalLikelyMonthlyCents', () => {
+  it('sums only likely matches with estimates', () => {
+    const results = screenHousehold(
+      baseHousehold({
+        householdSize: 3,
+        hasChildrenUnder18: true,
+        monthlyIncomeCents: 30_000,
+      }),
+    );
+    expect(totalLikelyMonthlyCents(results)).toBeGreaterThan(0);
+  });
+
+  it('returns 0 when no estimates', () => {
+    expect(totalLikelyMonthlyCents([])).toBe(0);
+  });
+});

--- a/src/lib/cwt/benefits.ts
+++ b/src/lib/cwt/benefits.ts
@@ -1,0 +1,423 @@
+/**
+ * Benefits eligibility rule engine (CWT-007) + dollar-value estimator
+ * (CWT-008). KY-specific income thresholds. Static rules first; the
+ * vocabulary is intentionally narrow because every program has dozens
+ * of edge cases the legal team will refine over Phase 2.
+ *
+ * Every rule output is marked `[SAMPLE]` in copy until a verification
+ * pass against current KY DCBS / KHC / SSA documentation lands. The
+ * caseworker UI surfaces this prominently so no one acts on a number
+ * before it's been reviewed.
+ *
+ * Federal Poverty Level numbers are 2024 (HHS) — the working set we
+ * have access to today. Bump these when 2025/2026 numbers publish.
+ */
+
+/** Monthly income, in CENTS, that equals 100% of FPL by household size. */
+export const FPL_2024_MONTHLY_CENTS: Record<number, number> = {
+  1: 125_400, // $1,254 / mo
+  2: 169_400,
+  3: 213_400,
+  4: 257_400,
+  5: 301_400,
+  6: 345_400,
+  7: 389_400,
+  8: 433_400,
+};
+
+/** Each additional household member above 8. */
+const FPL_2024_PER_ADDL_CENTS = 44_000;
+
+export function fplMonthlyCents(householdSize: number): number {
+  if (householdSize <= 0) return FPL_2024_MONTHLY_CENTS[1];
+  if (householdSize <= 8) return FPL_2024_MONTHLY_CENTS[householdSize];
+  const over = householdSize - 8;
+  return FPL_2024_MONTHLY_CENTS[8] + over * FPL_2024_PER_ADDL_CENTS;
+}
+
+export function fplPercent(monthlyIncomeCents: number, householdSize: number): number {
+  const baseline = fplMonthlyCents(householdSize);
+  if (baseline <= 0) return 0;
+  return Math.round((monthlyIncomeCents / baseline) * 1000) / 10; // one decimal place
+}
+
+export type Household = {
+  monthlyIncomeCents: number;
+  householdSize: number;
+  hasChildrenUnder18: boolean;
+  hasPregnantMember: boolean;
+  isVeteran: boolean;
+  isDisabled: boolean;
+  /** Age of the oldest household member; affects SSI / Medicare paths. */
+  ageOldest?: number | null;
+  kyResident: boolean;
+  /** US citizen or qualified non-citizen. SNAP / KCHIP gate this. */
+  citizenOrQualified: boolean;
+};
+
+export type ProgramId =
+  | 'snap'
+  | 'kchip'
+  | 'medicaid_adult'
+  | 'ktap'
+  | 'ssi'
+  | 'va_pension'
+  | 'liheap';
+
+export type EligibilityMatch = {
+  programId: ProgramId;
+  programName: string;
+  /** "likely" / "maybe" / "ineligible". Maybe = caseworker should verify. */
+  status: 'likely' | 'maybe' | 'ineligible';
+  /** 1-2 sentences of plain-language reasoning. */
+  reason: string;
+  /** Estimated monthly dollar value (cents). null when not estimable. */
+  estimatedMonthlyCents: number | null;
+  /** How to apply — phone number / website / in-person path. */
+  applicationPath: string;
+  /** Display order priority; lower = surfaced first. */
+  priority: number;
+};
+
+/** SNAP gross-income test: 130% FPL for most households. */
+function evaluateSnap(h: Household): EligibilityMatch {
+  const fplPct = fplPercent(h.monthlyIncomeCents, h.householdSize);
+  if (!h.kyResident) {
+    return mk('snap', 'SNAP food benefits', 'ineligible', 'Must be a Kentucky resident.', null, 5);
+  }
+  if (!h.citizenOrQualified) {
+    return mk(
+      'snap',
+      'SNAP food benefits',
+      'maybe',
+      'Citizenship rules limit SNAP. Some non-citizens still qualify (refugees, lawful permanent residents past 5 years, others). Caseworker should verify.',
+      null,
+      5,
+    );
+  }
+  if (fplPct <= 130) {
+    // SNAP formula (rough): benefit = max − 0.3 × (gross − standard deduction).
+    // 2024 standard deduction for HH ≤ 3 is $198/mo, scaling up. We use a
+    // flat $200 to keep the estimator readable; actuals are off by a few
+    // dollars and the screener marks every output [SAMPLE] anyway.
+    const STD_DEDUCTION_CENTS = 20_000;
+    const max = snapMaxMonthlyCents(h.householdSize);
+    const net = Math.max(0, h.monthlyIncomeCents - STD_DEDUCTION_CENTS);
+    const estimate = Math.max(0, Math.round(max - net * 0.3));
+    return mk(
+      'snap',
+      'SNAP food benefits',
+      'likely',
+      `Income is ${fplPct}% of poverty line — under the 130% gross-income limit for SNAP.`,
+      Math.min(max, estimate),
+      1,
+    );
+  }
+  return mk(
+    'snap',
+    'SNAP food benefits',
+    'ineligible',
+    `Gross income (${fplPct}% FPL) exceeds the 130% SNAP gross-income limit.`,
+    null,
+    5,
+  );
+}
+
+/** Max SNAP allotment by household size (FY2024 CONUS). */
+function snapMaxMonthlyCents(householdSize: number): number {
+  const TABLE: Record<number, number> = {
+    1: 29_100,
+    2: 53_500,
+    3: 76_600,
+    4: 97_300,
+    5: 115_500,
+    6: 138_600,
+    7: 153_200,
+    8: 175_100,
+  };
+  if (householdSize <= 0) return TABLE[1];
+  if (householdSize <= 8) return TABLE[householdSize];
+  return TABLE[8] + (householdSize - 8) * 21_900;
+}
+
+/** KCHIP: KY children's Medicaid, up to 218% FPL. */
+function evaluateKchip(h: Household): EligibilityMatch {
+  if (!h.kyResident) {
+    return mk('kchip', 'KCHIP children\u2019s Medicaid', 'ineligible', 'KY-only program.', null, 7);
+  }
+  if (!h.hasChildrenUnder18 && !h.hasPregnantMember) {
+    return mk(
+      'kchip',
+      'KCHIP children\u2019s Medicaid',
+      'ineligible',
+      'KCHIP covers children under 18 (and pregnant household members). No qualifying member listed.',
+      null,
+      7,
+    );
+  }
+  const fplPct = fplPercent(h.monthlyIncomeCents, h.householdSize);
+  if (fplPct <= 218) {
+    return mk(
+      'kchip',
+      'KCHIP children\u2019s Medicaid',
+      'likely',
+      `Income (${fplPct}% FPL) is within the 218% threshold for KCHIP.`,
+      null,
+      2,
+    );
+  }
+  return mk(
+    'kchip',
+    'KCHIP children\u2019s Medicaid',
+    'ineligible',
+    `Income (${fplPct}% FPL) exceeds the 218% KCHIP threshold.`,
+    null,
+    7,
+  );
+}
+
+/** Adult Medicaid expansion (KY): up to 138% FPL. */
+function evaluateMedicaidAdult(h: Household): EligibilityMatch {
+  if (!h.kyResident) {
+    return mk('medicaid_adult', 'KY Medicaid (adult)', 'ineligible', 'KY-only program.', null, 8);
+  }
+  const fplPct = fplPercent(h.monthlyIncomeCents, h.householdSize);
+  if (fplPct <= 138) {
+    return mk(
+      'medicaid_adult',
+      'KY Medicaid (adult expansion)',
+      'likely',
+      `Income (${fplPct}% FPL) is within the 138% threshold for adult Medicaid.`,
+      null,
+      3,
+    );
+  }
+  return mk(
+    'medicaid_adult',
+    'KY Medicaid (adult expansion)',
+    'ineligible',
+    `Income (${fplPct}% FPL) exceeds the 138% adult Medicaid threshold.`,
+    null,
+    8,
+  );
+}
+
+/** KTAP — KY's TANF: families with children, ~30% FPL after disregards. */
+function evaluateKtap(h: Household): EligibilityMatch {
+  if (!h.kyResident) return mk('ktap', 'KTAP cash assistance', 'ineligible', 'KY-only.', null, 9);
+  if (!h.hasChildrenUnder18) {
+    return mk(
+      'ktap',
+      'KTAP cash assistance',
+      'ineligible',
+      'KTAP requires a dependent child in the household.',
+      null,
+      9,
+    );
+  }
+  const fplPct = fplPercent(h.monthlyIncomeCents, h.householdSize);
+  if (fplPct <= 30) {
+    // Rough KTAP base: $186/mo for 1, $234 for 2, $292 for 3 — rounded.
+    const base = ktapMonthlyCents(h.householdSize);
+    return mk(
+      'ktap',
+      'KTAP cash assistance',
+      'likely',
+      `Income (${fplPct}% FPL) is well below KTAP's working threshold.`,
+      base,
+      4,
+    );
+  }
+  if (fplPct <= 50) {
+    return mk(
+      'ktap',
+      'KTAP cash assistance',
+      'maybe',
+      `Income (${fplPct}% FPL) is borderline. Disregards (childcare, work expenses) may bring it under the limit.`,
+      null,
+      4,
+    );
+  }
+  return mk(
+    'ktap',
+    'KTAP cash assistance',
+    'ineligible',
+    `Income (${fplPct}% FPL) exceeds KTAP's threshold even with typical disregards.`,
+    null,
+    9,
+  );
+}
+
+function ktapMonthlyCents(householdSize: number): number {
+  const TABLE: Record<number, number> = {
+    1: 18_600,
+    2: 23_400,
+    3: 29_200,
+    4: 35_900,
+    5: 41_500,
+    6: 47_000,
+    7: 52_600,
+    8: 58_100,
+  };
+  if (householdSize <= 0) return TABLE[1];
+  if (householdSize <= 8) return TABLE[householdSize];
+  return TABLE[8] + (householdSize - 8) * 5_500;
+}
+
+function evaluateSsi(h: Household): EligibilityMatch {
+  const ageBased = (h.ageOldest ?? 0) >= 65;
+  if (!h.isDisabled && !ageBased) {
+    return mk(
+      'ssi',
+      'SSI (Supplemental Security Income)',
+      'ineligible',
+      'SSI requires either a qualifying disability OR age 65+.',
+      null,
+      10,
+    );
+  }
+  // 2024 SSI federal benefit rate: $943/mo individual.
+  const SSI_FBR_INDIVIDUAL_CENTS = 94_300;
+  if (h.monthlyIncomeCents >= SSI_FBR_INDIVIDUAL_CENTS) {
+    return mk(
+      'ssi',
+      'SSI (Supplemental Security Income)',
+      'maybe',
+      'Income is near or above the SSI federal benefit rate. SSA still applies disregards (first $20 + first $65 of earned income); a caseworker should verify.',
+      null,
+      6,
+    );
+  }
+  // Estimate: FBR minus countable income (rough — SSA disregards $20 unearned + $65 earned + ½ remainder).
+  const countable = Math.max(0, h.monthlyIncomeCents - 2_000);
+  const estimate = Math.max(0, SSI_FBR_INDIVIDUAL_CENTS - countable);
+  return mk(
+    'ssi',
+    'SSI (Supplemental Security Income)',
+    'likely',
+    ageBased ? 'Age 65+ and income below SSI cap.' : 'Disability + income below SSI cap.',
+    estimate,
+    5,
+  );
+}
+
+function evaluateVa(h: Household): EligibilityMatch {
+  if (!h.isVeteran) {
+    return mk(
+      'va_pension',
+      'VA pension / benefits',
+      'ineligible',
+      'VA benefits require veteran status.',
+      null,
+      11,
+    );
+  }
+  return mk(
+    'va_pension',
+    'VA pension / benefits',
+    'maybe',
+    'Several veterans benefits apply (HUD-VASH housing voucher, VA pension, healthcare). Eligibility depends on service period and income; a Veterans Service Officer review is the right next step.',
+    null,
+    6,
+  );
+}
+
+function evaluateLiheap(h: Household): EligibilityMatch {
+  if (!h.kyResident) {
+    return mk('liheap', 'LIHEAP utility assistance', 'ineligible', 'KY-only.', null, 12);
+  }
+  // KY LIHEAP threshold: 130% FPL (winter / summer programs vary slightly).
+  const fplPct = fplPercent(h.monthlyIncomeCents, h.householdSize);
+  if (fplPct <= 130) {
+    return mk(
+      'liheap',
+      'LIHEAP utility assistance',
+      'likely',
+      `Income (${fplPct}% FPL) is within KY LIHEAP's 130% threshold.`,
+      null,
+      3,
+    );
+  }
+  return mk(
+    'liheap',
+    'LIHEAP utility assistance',
+    'ineligible',
+    `Income (${fplPct}% FPL) exceeds the 130% LIHEAP threshold.`,
+    null,
+    11,
+  );
+}
+
+const APPLICATION_PATHS: Record<ProgramId, string> = {
+  snap: 'Apply at benefind.ky.gov or call DCBS at +1-855-306-8959.',
+  kchip: 'Apply at kynect.ky.gov or call +1-855-459-6328.',
+  medicaid_adult: 'Apply at kynect.ky.gov or call +1-855-459-6328.',
+  ktap: 'Apply at benefind.ky.gov or your local DCBS office.',
+  ssi: 'Apply at ssa.gov/benefits/ssi or call +1-800-772-1213.',
+  va_pension: 'Contact a KY Department of Veterans Affairs benefits counselor at +1-502-595-4447.',
+  liheap: 'Apply through Audubon Area Community Services at +1-270-686-1600 (Daviess County).',
+};
+
+const PROGRAM_NAMES: Record<ProgramId, string> = {
+  snap: 'SNAP food benefits',
+  kchip: 'KCHIP children\u2019s Medicaid',
+  medicaid_adult: 'KY Medicaid (adult expansion)',
+  ktap: 'KTAP cash assistance',
+  ssi: 'SSI (Supplemental Security Income)',
+  va_pension: 'VA pension / benefits',
+  liheap: 'LIHEAP utility assistance',
+};
+
+function mk(
+  id: ProgramId,
+  _displayName: string,
+  status: EligibilityMatch['status'],
+  reason: string,
+  estimatedMonthlyCents: number | null,
+  priority: number,
+): EligibilityMatch {
+  return {
+    programId: id,
+    programName: PROGRAM_NAMES[id],
+    status,
+    reason,
+    estimatedMonthlyCents,
+    applicationPath: APPLICATION_PATHS[id],
+    priority,
+  };
+}
+
+/**
+ * Run every program rule against the household. Results are sorted with
+ * 'likely' first, 'maybe' next, ineligible last; ties broken by `priority`.
+ */
+export function screenHousehold(h: Household): EligibilityMatch[] {
+  const results = [
+    evaluateSnap(h),
+    evaluateKchip(h),
+    evaluateMedicaidAdult(h),
+    evaluateKtap(h),
+    evaluateSsi(h),
+    evaluateVa(h),
+    evaluateLiheap(h),
+  ];
+  const statusRank: Record<EligibilityMatch['status'], number> = {
+    likely: 0,
+    maybe: 1,
+    ineligible: 2,
+  };
+  results.sort((a, b) => {
+    if (statusRank[a.status] !== statusRank[b.status]) {
+      return statusRank[a.status] - statusRank[b.status];
+    }
+    return a.priority - b.priority;
+  });
+  return results;
+}
+
+/** Total estimated monthly $ across all 'likely' matches. */
+export function totalLikelyMonthlyCents(matches: EligibilityMatch[]): number {
+  return matches
+    .filter((m) => m.status === 'likely' && m.estimatedMonthlyCents !== null)
+    .reduce((sum, m) => sum + (m.estimatedMonthlyCents ?? 0), 0);
+}

--- a/src/lib/cwt/triage.test.ts
+++ b/src/lib/cwt/triage.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from 'vitest';
+import { recommendTriageTier, type TriageInputs } from './triage';
+
+const baseInputs = (overrides: Partial<TriageInputs> = {}): TriageInputs => ({
+  hasStableIncome: false,
+  hasVoucher: false,
+  isEmployed: false,
+  hasCaseworkerRelationship: false,
+  inSudTreatment: false,
+  inMentalHealthTreatment: false,
+  recentEvictionCount: 0,
+  daysUnsheltered: 0,
+  hasChildrenUnder18: false,
+  isDvSurvivor: false,
+  hasId: false,
+  hasSsn: false,
+  hasBirthCert: false,
+  ...overrides,
+});
+
+describe('recommendTriageTier', () => {
+  it('returns medium tier for the empty/baseline case (score 50)', () => {
+    const r = recommendTriageTier(baseInputs());
+    expect(r.tier).toBe('medium');
+    expect(r.score).toBe(50);
+    expect(r.factors).toEqual([]);
+  });
+
+  it('high tier for stable income + voucher + employed', () => {
+    const r = recommendTriageTier(
+      baseInputs({ hasStableIncome: true, hasVoucher: true, isEmployed: true }),
+    );
+    expect(r.tier).toBe('high');
+    expect(r.score).toBeGreaterThanOrEqual(67);
+  });
+
+  it('low tier for severe instability', () => {
+    const r = recommendTriageTier(baseInputs({ recentEvictionCount: 3, daysUnsheltered: 120 }));
+    expect(r.tier).toBe('low');
+    expect(r.score).toBeLessThanOrEqual(32);
+  });
+
+  it('clamps score to [0, 100]', () => {
+    const veryHigh = recommendTriageTier(
+      baseInputs({
+        hasStableIncome: true,
+        hasVoucher: true,
+        isEmployed: true,
+        hasCaseworkerRelationship: true,
+        inSudTreatment: true,
+        inMentalHealthTreatment: true,
+        hasId: true,
+        hasSsn: true,
+        hasBirthCert: true,
+      }),
+    );
+    expect(veryHigh.score).toBeLessThanOrEqual(100);
+    expect(veryHigh.tier).toBe('high');
+
+    const veryLow = recommendTriageTier(
+      baseInputs({ recentEvictionCount: 5, daysUnsheltered: 365 }),
+    );
+    expect(veryLow.score).toBeGreaterThanOrEqual(0);
+    expect(veryLow.tier).toBe('low');
+  });
+
+  it('records each factor that fires, with non-zero delta', () => {
+    const r = recommendTriageTier(baseInputs({ hasStableIncome: true, recentEvictionCount: 2 }));
+    const labels = r.factors.map((f) => f.label);
+    expect(labels).toContain('Stable income source');
+    expect(labels.some((l) => l.startsWith('2 evictions'))).toBe(true);
+  });
+
+  it('children + DV are surfaced as factors but DV is delta=0 (handling-routing only)', () => {
+    const r = recommendTriageTier(baseInputs({ hasChildrenUnder18: true, isDvSurvivor: true }));
+    const dv = r.factors.find((f) => f.label.includes('DV survivor'));
+    expect(dv?.delta).toBe(0);
+    const kids = r.factors.find((f) => f.label.includes('Children under 18'));
+    expect(kids?.delta).toBeGreaterThan(0);
+  });
+
+  it('returns a tier-appropriate recommendation', () => {
+    const high = recommendTriageTier(baseInputs({ hasVoucher: true, hasStableIncome: true }));
+    expect(high.recommendation).toMatch(/light-touch/);
+    const low = recommendTriageTier(baseInputs({ recentEvictionCount: 3, daysUnsheltered: 120 }));
+    expect(low.recommendation).toMatch(/Recuperative Care|PSH/);
+  });
+});

--- a/src/lib/cwt/triage.ts
+++ b/src/lib/cwt/triage.ts
@@ -1,0 +1,137 @@
+/**
+ * Triage tier recommendation (CWT-009). Rule-based v1; the BACKLOG
+ * explicitly calls this out as a placeholder to be replaced by ML in
+ * Phase 2 once enough labeled outcomes exist. The whole point right
+ * now is consistency — give caseworkers a tier they can argue with,
+ * not predict outcomes precisely.
+ *
+ * Output: tier ∈ {high, medium, low} reflecting "housing-stability
+ * potential" (high = most likely to stabilize quickly with the right
+ * supports; low = needs the most intensive intervention). Score is
+ * 0-100; the tier bands are deliberately wide so a small input change
+ * doesn't flip a tier.
+ *
+ * Every contribution is captured in `factors` so the caseworker UI
+ * can show "this is high tier because: stable income source, prior
+ * housing history, no recent evictions" — explainable by design.
+ */
+
+export type TriageInputs = {
+  /** Stable income source (job, SSI, disability, retirement, etc.). */
+  hasStableIncome: boolean;
+  /** Active rental-assistance voucher in hand. */
+  hasVoucher: boolean;
+  /** Currently employed (any hours). */
+  isEmployed: boolean;
+  /** Existing relationship with a caseworker (current or recent). */
+  hasCaseworkerRelationship: boolean;
+  /** Currently engaged in substance-use treatment, if relevant. */
+  inSudTreatment: boolean;
+  /** Currently engaged in mental-health treatment, if relevant. */
+  inMentalHealthTreatment: boolean;
+  /** Number of evictions in the last 24 months (0 = none). */
+  recentEvictionCount: number;
+  /** Days unsheltered in the last 12 months (0 if always housed/sheltered). */
+  daysUnsheltered: number;
+  /** Children in household — adds urgency, not stability per se. */
+  hasChildrenUnder18: boolean;
+  /** Domestic-violence survivor — DTRS-004 abuser-blind handling already applies. */
+  isDvSurvivor: boolean;
+  /** Documents in hand: ID, SSN, birth certificate. Each ~5 stability points. */
+  hasId: boolean;
+  hasSsn: boolean;
+  hasBirthCert: boolean;
+};
+
+export type TriageFactor = {
+  /** Plain-language label shown in the UI. */
+  label: string;
+  /** +N raises stability tier; -N lowers. */
+  delta: number;
+};
+
+export type TriageTier = 'high' | 'medium' | 'low';
+
+export type TriageResult = {
+  tier: TriageTier;
+  /** 0-100 score; band thresholds are 33 / 67. */
+  score: number;
+  factors: TriageFactor[];
+  /** When tier == 'low', a one-line "what to do next" suggestion. */
+  recommendation: string;
+};
+
+const BASE_SCORE = 50;
+const TIER_LOW_MAX = 32;
+const TIER_HIGH_MIN = 67;
+
+/**
+ * Pure scorer. Each factor pushes the score up or down; the final
+ * tier is just a banding of the clamped score. Deliberately small set
+ * — broader feature space is what Phase 2's ML replacement is for.
+ */
+export function recommendTriageTier(inputs: TriageInputs): TriageResult {
+  const factors: TriageFactor[] = [];
+
+  if (inputs.hasStableIncome) factors.push({ label: 'Stable income source', delta: +12 });
+  if (inputs.hasVoucher) factors.push({ label: 'Active rental-assistance voucher', delta: +18 });
+  if (inputs.isEmployed) factors.push({ label: 'Currently employed', delta: +10 });
+  if (inputs.hasCaseworkerRelationship)
+    factors.push({ label: 'Existing caseworker relationship', delta: +6 });
+  if (inputs.inSudTreatment) factors.push({ label: 'Engaged in SUD treatment', delta: +5 });
+  if (inputs.inMentalHealthTreatment)
+    factors.push({ label: 'Engaged in mental-health treatment', delta: +5 });
+
+  if (inputs.recentEvictionCount === 1)
+    factors.push({ label: '1 eviction in last 24 months', delta: -8 });
+  else if (inputs.recentEvictionCount >= 2)
+    factors.push({
+      label: `${inputs.recentEvictionCount} evictions in last 24 months`,
+      delta: -16,
+    });
+
+  if (inputs.daysUnsheltered >= 30 && inputs.daysUnsheltered < 90)
+    factors.push({ label: '30-89 days unsheltered in last year', delta: -8 });
+  else if (inputs.daysUnsheltered >= 90)
+    factors.push({ label: '90+ days unsheltered in last year', delta: -16 });
+
+  if (inputs.hasChildrenUnder18)
+    factors.push({ label: 'Children under 18 in household — prioritize', delta: +4 });
+
+  if (inputs.isDvSurvivor)
+    factors.push({
+      label: 'DV survivor — route through OASIS + abuser-blind handling',
+      delta: +0,
+    });
+
+  // Documents in hand are small individual signals but additive.
+  let docPoints = 0;
+  if (inputs.hasId) docPoints += 4;
+  if (inputs.hasSsn) docPoints += 4;
+  if (inputs.hasBirthCert) docPoints += 3;
+  if (docPoints > 0) {
+    factors.push({ label: `Vital documents in hand (+${docPoints})`, delta: docPoints });
+  }
+
+  const raw = BASE_SCORE + factors.reduce((sum, f) => sum + f.delta, 0);
+  const score = Math.max(0, Math.min(100, raw));
+
+  let tier: TriageTier;
+  if (score <= TIER_LOW_MAX) tier = 'low';
+  else if (score >= TIER_HIGH_MIN) tier = 'high';
+  else tier = 'medium';
+
+  let recommendation: string;
+  if (tier === 'high') {
+    recommendation =
+      'Likely stabilizes with light-touch support. Connect to KCHIP/SNAP/voucher renewal as needed; check in monthly.';
+  } else if (tier === 'medium') {
+    recommendation =
+      'Moderate intensity. Pair with active caseworker; address top 1-2 documents/income gaps before placement.';
+  } else {
+    recommendation =
+      'High intensity. Recommend Recuperative Care or PSH route (TEAMKY HRSN if eligible); wraparound case management.';
+  }
+
+  return { tier, score, factors, recommendation };
+}

--- a/src/lib/dtrs/consent-text.ts
+++ b/src/lib/dtrs/consent-text.ts
@@ -1,0 +1,79 @@
+/**
+ * Plain-language consent text shown to subjects. Reading-level target:
+ * Flesch-Kincaid grade 6 or below. Reviewed in DTRS-005 advisor sessions
+ * before any client traffic flows.
+ *
+ * Bump `CURRENT_CONSENT_VERSION` (in src/db/schema/consents.ts) every
+ * time the wording materially changes. Old consent rows keep their
+ * version stamp; the dashboard can flag them as "out of date" and the
+ * subject can be re-prompted.
+ */
+
+import type { ConsentType } from '@/db/schema/enums';
+
+export const CURRENT_CONSENT_VERSION = '2026-04-1';
+
+/** Short data-class vocabulary the consent form lets subjects scope. */
+export const DATA_CLASSES = [
+  { id: 'identity', label: 'My name and contact info' },
+  { id: 'health', label: 'My health visits' },
+  { id: 'housing_history', label: 'Where I have stayed' },
+  { id: 'service_events', label: 'Help I have received (food, utility, shelter)' },
+] as const;
+
+export type DataClassId = (typeof DATA_CLASSES)[number]['id'];
+
+export type ConsentCopy = {
+  /** One-line title shown at the top of the form. */
+  title: string;
+  /** 1-3 short sentences explaining what the subject is agreeing to. */
+  intro: string;
+  /** Bullet list of plain-language commitments / rights. */
+  bullets: string[];
+  /** Footer text — opt-out instructions. */
+  footer: string;
+};
+
+const PHI_COPY: ConsentCopy = {
+  title: 'Can we share your info with your case team?',
+  intro:
+    "Saying yes lets the people helping you talk to each other about your situation, so you don't have to repeat your story.",
+  bullets: [
+    'We will only share what you check off below.',
+    'Only people on your case team will see it.',
+    "We won't sell or give it to anyone else.",
+    'You can change your mind any time. Reply STOP or call 270-555-COAL.',
+    "If you don't say yes, you still get help. We just won't share between agencies.",
+  ],
+  footer:
+    'Your name on the line at the bottom counts as your signature, like signing a paper form.',
+};
+
+const SMS_COPY: ConsentCopy = {
+  title: 'Can we text you?',
+  intro: "Saying yes lets us text you about beds, food, and your case. We won't share your number.",
+  bullets: [
+    'We text only about your situation.',
+    "Reply STOP at any time and we won't text again.",
+    'Standard text rates from your phone company may apply.',
+  ],
+  footer: 'Your name on the line below counts as your signature.',
+};
+
+const PROGRAM_EVAL_COPY: ConsentCopy = {
+  title: 'Can we use your info to make this program better?',
+  intro:
+    "We learn what works by looking at the patterns in everyone's stories. Saying yes lets us count what helped without sharing your name.",
+  bullets: [
+    'Your name and contact info are removed before we count.',
+    'We share only the patterns, not the people.',
+    'You can say no and still get every service.',
+  ],
+  footer: 'Your name on the line below counts as your signature.',
+};
+
+export function consentTextFor(consentType: ConsentType): ConsentCopy {
+  if (consentType === 'phi_share_within_coalition') return PHI_COPY;
+  if (consentType === 'sms_communication') return SMS_COPY;
+  return PROGRAM_EVAL_COPY;
+}

--- a/src/lib/dtrs/consent-token.ts
+++ b/src/lib/dtrs/consent-token.ts
@@ -1,0 +1,72 @@
+import { randomBytes } from 'node:crypto';
+import { and, eq, gt, isNull } from 'drizzle-orm';
+import { db } from '@/db/client';
+import { type ConsentAccessToken, consentAccessTokens } from '@/db/schema/consent-access-tokens';
+
+/** Default lifetime: 24 hours. Long enough for shelter outreach, short enough that a found wallet card isn't a forever leak. */
+export const CONSENT_TOKEN_TTL_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * Mint a fresh URL-safe token. ~256 bits of entropy from
+ * `crypto.randomBytes`; URL-safe via `base64url` encoding.
+ */
+export function mintTokenString(): string {
+  return randomBytes(32).toString('base64url');
+}
+
+/**
+ * Server-only: create a new access token row for the given subject.
+ * Returns the token string the caller hands to the subject.
+ */
+export async function createConsentAccessToken(input: {
+  syntheticPersonRef: string;
+  issuedByUserId: string;
+  notes?: string;
+  ttlMs?: number;
+}): Promise<{ token: string; expiresAt: Date }> {
+  const token = mintTokenString();
+  const expiresAt = new Date(Date.now() + (input.ttlMs ?? CONSENT_TOKEN_TTL_MS));
+  await db.insert(consentAccessTokens).values({
+    token,
+    syntheticPersonRef: input.syntheticPersonRef,
+    issuedByUserId: input.issuedByUserId,
+    expiresAt,
+    notes: input.notes ?? null,
+  });
+  return { token, expiresAt };
+}
+
+/**
+ * Look up a token by its opaque string. Returns the row only if it's
+ * unexpired AND not revoked; otherwise null. Side effect: stamps
+ * `used_at` on first redemption so analytics see distinct redeems.
+ */
+export async function redeemConsentAccessToken(
+  rawToken: string,
+): Promise<ConsentAccessToken | null> {
+  const trimmed = rawToken.trim();
+  if (trimmed.length < 32 || trimmed.length > 64) return null;
+
+  const now = new Date();
+  const [row] = await db
+    .select()
+    .from(consentAccessTokens)
+    .where(
+      and(
+        eq(consentAccessTokens.token, trimmed),
+        gt(consentAccessTokens.expiresAt, now),
+        isNull(consentAccessTokens.revokedAt),
+      ),
+    )
+    .limit(1);
+
+  if (!row) return null;
+
+  if (!row.usedAt) {
+    await db
+      .update(consentAccessTokens)
+      .set({ usedAt: now })
+      .where(eq(consentAccessTokens.id, row.id));
+  }
+  return row;
+}

--- a/src/lib/dtrs/consent-token.ts
+++ b/src/lib/dtrs/consent-token.ts
@@ -6,6 +6,9 @@ import { type ConsentAccessToken, consentAccessTokens } from '@/db/schema/consen
 /** Default lifetime: 24 hours. Long enough for shelter outreach, short enough that a found wallet card isn't a forever leak. */
 export const CONSENT_TOKEN_TTL_MS = 24 * 60 * 60 * 1000;
 
+/** randomBytes(32).toString('base64url') is exactly 43 chars. */
+const TOKEN_LEN = 43;
+
 /**
  * Mint a fresh URL-safe token. ~256 bits of entropy from
  * `crypto.randomBytes`; URL-safe via `base64url` encoding.
@@ -37,15 +40,15 @@ export async function createConsentAccessToken(input: {
 }
 
 /**
- * Look up a token by its opaque string. Returns the row only if it's
- * unexpired AND not revoked; otherwise null. Side effect: stamps
- * `used_at` on first redemption so analytics see distinct redeems.
+ * Read-only token validation. Returns the row when the token is valid
+ * (unexpired, unrevoked) — does NOT stamp `used_at`. Used by the page
+ * render path so the page can show a form without consuming the token.
  */
-export async function redeemConsentAccessToken(
+export async function lookupConsentAccessToken(
   rawToken: string,
 ): Promise<ConsentAccessToken | null> {
   const trimmed = rawToken.trim();
-  if (trimmed.length < 32 || trimmed.length > 64) return null;
+  if (trimmed.length !== TOKEN_LEN) return null;
 
   const now = new Date();
   const [row] = await db
@@ -59,14 +62,47 @@ export async function redeemConsentAccessToken(
       ),
     )
     .limit(1);
+  return row ?? null;
+}
 
-  if (!row) return null;
+/**
+ * Atomically redeem a token. Returns the row only if the conditional
+ * UPDATE actually flipped a row from "valid + unused" to "valid +
+ * used_at=now". Concurrent calls collapse: only one redeems, the other
+ * returns null. This is the right primitive for write actions
+ * (grantConsentAction, revokeConsentAction).
+ *
+ * For "is this token currently valid?" without consuming, use
+ * `lookupConsentAccessToken` — that does NOT touch `used_at`.
+ */
+export async function redeemConsentAccessToken(
+  rawToken: string,
+): Promise<ConsentAccessToken | null> {
+  const trimmed = rawToken.trim();
+  if (trimmed.length !== TOKEN_LEN) return null;
 
-  if (!row.usedAt) {
-    await db
-      .update(consentAccessTokens)
-      .set({ usedAt: now })
-      .where(eq(consentAccessTokens.id, row.id));
-  }
-  return row;
+  const now = new Date();
+  // Single UPDATE...RETURNING. Conditional on usedAt IS NULL so the first
+  // concurrent caller wins and the second sees zero rows back.
+  const [redeemed] = await db
+    .update(consentAccessTokens)
+    .set({ usedAt: now })
+    .where(
+      and(
+        eq(consentAccessTokens.token, trimmed),
+        gt(consentAccessTokens.expiresAt, now),
+        isNull(consentAccessTokens.revokedAt),
+        isNull(consentAccessTokens.usedAt),
+      ),
+    )
+    .returning();
+
+  if (redeemed) return redeemed;
+
+  // No update happened — could be: invalid, expired, revoked, OR already
+  // redeemed. For the already-redeemed case (legitimate user re-submitting
+  // within the bounded reuse window), look up the row and return it WITHOUT
+  // re-stamping. Token reuse is intentional during the 24h window — only
+  // analytics need to know "first redemption".
+  return await lookupConsentAccessToken(trimmed);
 }

--- a/src/lib/dtrs/consent.test.ts
+++ b/src/lib/dtrs/consent.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from 'vitest';
+import type { Consent } from '@/db/schema/consents';
+import { consentCovers, consentNeedsRefresh, consentState } from './consent';
+import { CURRENT_CONSENT_VERSION } from './consent-text';
+
+const baseConsent = (overrides: Partial<Consent> = {}): Consent => ({
+  id: '11111111-1111-1111-1111-111111111111',
+  subjectExternalId: 'SYN-PERSON-001',
+  consentType: 'phi_share_within_coalition',
+  grantedVia: 'web_form',
+  consentVersion: CURRENT_CONSENT_VERSION,
+  scopePartnerIds: null,
+  scopeDataClasses: null,
+  signatureText: 'Sarah J',
+  expiresAt: null,
+  grantedAt: new Date('2026-01-01T00:00:00Z'),
+  revokedAt: null,
+  notes: null,
+  createdAt: new Date('2026-01-01T00:00:00Z'),
+  ...overrides,
+});
+
+const NOW = new Date('2026-04-26T12:00:00Z');
+
+describe('consentState', () => {
+  it('returns granted for an open-ended consent', () => {
+    expect(consentState(baseConsent(), NOW)).toBe('granted');
+  });
+
+  it('returns revoked when revoked_at is set, even before any expiry', () => {
+    expect(
+      consentState(
+        baseConsent({
+          revokedAt: new Date('2026-02-01T00:00:00Z'),
+          expiresAt: new Date('2027-01-01T00:00:00Z'),
+        }),
+        NOW,
+      ),
+    ).toBe('revoked');
+  });
+
+  it('returns expired when expires_at has passed', () => {
+    const c = baseConsent({ expiresAt: new Date('2026-04-01T00:00:00Z') });
+    expect(consentState(c, NOW)).toBe('expired');
+  });
+
+  it('still granted when expires_at is in the future', () => {
+    const c = baseConsent({ expiresAt: new Date('2027-01-01T00:00:00Z') });
+    expect(consentState(c, NOW)).toBe('granted');
+  });
+
+  it('revoked beats expired even if both timestamps are past', () => {
+    expect(
+      consentState(
+        baseConsent({
+          revokedAt: new Date('2026-03-01T00:00:00Z'),
+          expiresAt: new Date('2026-02-01T00:00:00Z'),
+        }),
+        NOW,
+      ),
+    ).toBe('revoked');
+  });
+});
+
+describe('consentCovers', () => {
+  it('null scopes mean coalition-wide', () => {
+    expect(consentCovers({ partnerOrgIds: null, dataClasses: null }, 'org1', 'health')).toBe(true);
+  });
+
+  it('rejects non-listed partners', () => {
+    const scope = { partnerOrgIds: ['org1'], dataClasses: null };
+    expect(consentCovers(scope, 'org2', 'identity')).toBe(false);
+  });
+
+  it('rejects non-listed data classes', () => {
+    const scope = { partnerOrgIds: null, dataClasses: ['identity'] };
+    expect(consentCovers(scope, 'org1', 'health')).toBe(false);
+  });
+
+  it('matches when both lists include the request', () => {
+    const scope = { partnerOrgIds: ['org1', 'org2'], dataClasses: ['identity', 'health'] };
+    expect(consentCovers(scope, 'org2', 'health')).toBe(true);
+  });
+});
+
+describe('consentNeedsRefresh', () => {
+  it('returns false for the current version', () => {
+    expect(consentNeedsRefresh(baseConsent())).toBe(false);
+  });
+
+  it('returns true for an older version', () => {
+    expect(consentNeedsRefresh(baseConsent({ consentVersion: '2025-01-1' }))).toBe(true);
+  });
+});

--- a/src/lib/dtrs/consent.ts
+++ b/src/lib/dtrs/consent.ts
@@ -1,0 +1,54 @@
+import type { Consent } from '@/db/schema/consents';
+import { CURRENT_CONSENT_VERSION } from './consent-text';
+
+export type ConsentState = 'granted' | 'revoked' | 'expired';
+
+/**
+ * Compute the live state of a consent record. Stored fields are the
+ * source of truth (granted_at, revoked_at, expires_at); the state is
+ * derived at read time so wall-clock changes (TTL passing) flip the
+ * label without a write.
+ *
+ * Order matters: revoked beats expired beats granted. A subject who
+ * revokes mid-window stays revoked even after the original window
+ * passes.
+ */
+export function consentState(c: Consent, now: Date = new Date()): ConsentState {
+  if (c.revokedAt) return 'revoked';
+  if (c.expiresAt && new Date(c.expiresAt).getTime() <= now.getTime()) return 'expired';
+  return 'granted';
+}
+
+export type ConsentScope = {
+  partnerOrgIds: string[] | null;
+  dataClasses: string[] | null;
+};
+
+/**
+ * True iff a consent in `granted` state covers the (partner_org, data_class)
+ * being requested. `null` scopes mean "any" — that's the default for
+ * coalition-wide consents that don't single out specific partners or data.
+ *
+ * Callers asking "can partner X see data class Y about subject Z?" should:
+ *   1. fetch consents WHERE subject_external_id = Z and consent_type = …
+ *   2. filter to consentState === 'granted'
+ *   3. check at least one row covers (X, Y) via this helper.
+ */
+export function consentCovers(
+  scope: ConsentScope,
+  partnerOrgId: string,
+  dataClass: string,
+): boolean {
+  const partnerOk = scope.partnerOrgIds === null || scope.partnerOrgIds.includes(partnerOrgId);
+  const classOk = scope.dataClasses === null || scope.dataClasses.includes(dataClass);
+  return partnerOk && classOk;
+}
+
+/**
+ * True if the consent text the subject saw is older than the current
+ * version. Doesn't invalidate the consent — surfaced in the dashboard
+ * as a re-prompt candidate.
+ */
+export function consentNeedsRefresh(c: Consent): boolean {
+  return c.consentVersion !== CURRENT_CONSENT_VERSION;
+}

--- a/src/lib/dtrs/data-access.ts
+++ b/src/lib/dtrs/data-access.ts
@@ -1,0 +1,75 @@
+import { logAuditEvent } from '@/lib/audit';
+
+/**
+ * Record-access audit (DTRS-003). Writes a row to audit_log every
+ * time a user views or computes against a piece of identifiable data,
+ * so the DTRS-015 annual independent audit can answer "who saw what,
+ * when?" The append-only trigger on audit_log is the durability
+ * guarantee.
+ *
+ * Conventions:
+ *   - `purpose` is a free-form short string the calling page chose.
+ *     Example: 'attorney_case_detail', 'caseworker_intake_view',
+ *     'ed_coordinator_queue'. Not enforced — meaningful copy beats
+ *     locked-down enums when investigating an incident.
+ *   - This is intentionally a fire-and-forget thunk style: errors
+ *     log to the server console but never throw, so a transient DB
+ *     hiccup doesn't 500 a read view.
+ */
+export async function recordDataAccess(input: {
+  actorUserId: string | null;
+  /** Logical table or domain ('eviction_filings', 'ed_encounters'). */
+  resourceType: string;
+  /** Primary key OR opaque subject identifier; whichever the page reads. */
+  resourceId: string;
+  /** Free-form short string describing why the read happened. */
+  purpose: string;
+  /** Optional structured context (filter, page, etc). */
+  metadata?: Record<string, unknown>;
+}): Promise<void> {
+  try {
+    await logAuditEvent({
+      actorUserId: input.actorUserId,
+      action: 'data.accessed',
+      targetTable: input.resourceType,
+      targetId: input.resourceId,
+      metadata: { purpose: input.purpose, ...input.metadata },
+    });
+  } catch (err) {
+    console.error('[recordDataAccess] failed', err);
+  }
+}
+
+/**
+ * Record an AI-generation event (DTRS-003 explicitly calls this out).
+ * Goes through the same audit_log table so a single query gives you
+ * "every read + every AI write touching subject X".
+ *
+ * The `model` and `prompt_version` fields are how the DTRS-015 audit
+ * answers "did the AI see PHI it shouldn't have?" — the prompt
+ * version pins the system-prompt text used at generation time.
+ */
+export async function recordAiGeneration(input: {
+  actorUserId: string | null;
+  resourceType: string;
+  resourceId: string;
+  model: string;
+  promptVersion: string;
+  metadata?: Record<string, unknown>;
+}): Promise<void> {
+  try {
+    await logAuditEvent({
+      actorUserId: input.actorUserId,
+      action: 'ai.generated',
+      targetTable: input.resourceType,
+      targetId: input.resourceId,
+      metadata: {
+        model: input.model,
+        promptVersion: input.promptVersion,
+        ...input.metadata,
+      },
+    });
+  } catch (err) {
+    console.error('[recordAiGeneration] failed', err);
+  }
+}

--- a/src/lib/dtrs/dv-blind.test.ts
+++ b/src/lib/dtrs/dv-blind.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest';
+import { REDACTED_PLACEHOLDER, redactAddress, viewerCanSeeDvAddresses } from './dv-blind';
+
+describe('viewerCanSeeDvAddresses', () => {
+  it('attorney + caseworker can see the un-redacted address', () => {
+    expect(viewerCanSeeDvAddresses('attorney')).toBe(true);
+    expect(viewerCanSeeDvAddresses('caseworker')).toBe(true);
+  });
+
+  it('shelter staff and ed coordinator cannot', () => {
+    expect(viewerCanSeeDvAddresses('shelter_staff')).toBe(false);
+    expect(viewerCanSeeDvAddresses('ed_coordinator')).toBe(false);
+  });
+
+  it('admin cannot — administrative access is not the same as case-bound need', () => {
+    expect(viewerCanSeeDvAddresses('admin')).toBe(false);
+  });
+
+  it('pending users cannot', () => {
+    expect(viewerCanSeeDvAddresses('pending')).toBe(false);
+  });
+});
+
+describe('redactAddress', () => {
+  it('passes through when redact=false', () => {
+    const before = { addressLine1: '123 Main St', city: 'Owensboro', state: 'KY' };
+    expect(redactAddress(before, false)).toEqual(before);
+  });
+
+  it('replaces structured address fields when redact=true', () => {
+    const before = {
+      addressLine1: '123 Main St',
+      city: 'Owensboro',
+      state: 'KY',
+      postalCode: '42301',
+    };
+    const after = redactAddress(before, true);
+    expect(after.addressLine1).toBe(REDACTED_PLACEHOLDER);
+    expect(after.city).toBeNull();
+    expect(after.state).toBeNull();
+    expect(after.postalCode).toBeNull();
+  });
+
+  it('replaces eviction-filing defendant_address when redact=true', () => {
+    const before = { defendantAddress: '123 Main St', plaintiff: 'Mock LLC' };
+    const after = redactAddress(before, true);
+    expect(after.defendantAddress).toBe(REDACTED_PLACEHOLDER);
+    expect(after.plaintiff).toBe('Mock LLC');
+  });
+
+  it('does not touch non-address fields', () => {
+    const before = { addressLine1: '123 Main St', name: 'Anywhere Shelter' } as {
+      addressLine1?: string | null;
+      name: string;
+    };
+    const after = redactAddress(before, true);
+    expect(after.name).toBe('Anywhere Shelter');
+  });
+
+  it('returns the input object reference when redact=false (no-clone)', () => {
+    const before = { addressLine1: '123 Main St' };
+    expect(redactAddress(before, false)).toBe(before);
+  });
+});

--- a/src/lib/dtrs/dv-blind.ts
+++ b/src/lib/dtrs/dv-blind.ts
@@ -1,0 +1,87 @@
+import { and, eq, inArray, isNull } from 'drizzle-orm';
+import { db } from '@/db/client';
+import { dvFlaggedPersons } from '@/db/schema/dv-flags';
+import type { UserRole } from '@/db/schema/enums';
+
+/**
+ * Roles allowed to see un-redacted location/address data on DV-flagged
+ * subjects. Attorneys actively defending a survivor in court need the
+ * address; everyone else gets redacted. DV-trained caseworkers also
+ * keep access — they're who set the flag in the first place.
+ *
+ * A future enhancement (post-DTRS-005 advisor session) is to make this
+ * per-flag rather than per-role: a survivor could opt to share their
+ * address with one specific caseworker and no one else.
+ */
+const DV_ADDRESS_VIEW_ROLES: ReadonlySet<UserRole> = new Set(['attorney', 'caseworker']);
+
+export const REDACTED_PLACEHOLDER = 'LOCATION_REDACTED';
+
+export function viewerCanSeeDvAddresses(role: UserRole): boolean {
+  return DV_ADDRESS_VIEW_ROLES.has(role);
+}
+
+/**
+ * Returns the set of subject identifiers (synthetic_person_ref OR
+ * phone OR — in eviction-filings — defendant name+address pair) that
+ * are currently DV-flagged. "Currently" = flag_cleared_at IS NULL.
+ *
+ * Pass an empty `candidates` to skip the round-trip; the function
+ * short-circuits to an empty Set.
+ */
+export async function dvFlaggedSubset(candidates: readonly string[]): Promise<Set<string>> {
+  if (candidates.length === 0) return new Set();
+  const rows = await db
+    .select({ subject: dvFlaggedPersons.subjectIdentifier })
+    .from(dvFlaggedPersons)
+    .where(
+      and(
+        inArray(dvFlaggedPersons.subjectIdentifier, candidates as string[]),
+        isNull(dvFlaggedPersons.flagClearedAt),
+      ),
+    );
+  return new Set(rows.map((r) => r.subject));
+}
+
+/**
+ * One-off check by subject identifier. Use the bulk variant in
+ * `dvFlaggedSubset` for any list view; this helper is for single
+ * record reads (e.g. a case detail page).
+ */
+export async function isDvFlagged(subjectIdentifier: string): Promise<boolean> {
+  const [row] = await db
+    .select({ id: dvFlaggedPersons.id })
+    .from(dvFlaggedPersons)
+    .where(
+      and(
+        eq(dvFlaggedPersons.subjectIdentifier, subjectIdentifier),
+        isNull(dvFlaggedPersons.flagClearedAt),
+      ),
+    )
+    .limit(1);
+  return Boolean(row);
+}
+
+/**
+ * Pure helper. Given a record with optional address fields, replace
+ * them with the redacted placeholder when `redact` is true. Used in
+ * page-level rendering and tested with shared fixtures.
+ */
+export function redactAddress<
+  T extends {
+    addressLine1?: string | null;
+    city?: string | null;
+    state?: string | null;
+    postalCode?: string | null;
+    defendantAddress?: string | null;
+  },
+>(record: T, redact: boolean): T {
+  if (!redact) return record;
+  const next: T = { ...record };
+  if ('addressLine1' in next) next.addressLine1 = REDACTED_PLACEHOLDER;
+  if ('city' in next) next.city = null;
+  if ('state' in next) next.state = null;
+  if ('postalCode' in next) next.postalCode = null;
+  if ('defendantAddress' in next) next.defendantAddress = REDACTED_PLACEHOLDER;
+  return next;
+}

--- a/src/lib/dtrs/rate-limit.test.ts
+++ b/src/lib/dtrs/rate-limit.test.ts
@@ -1,0 +1,26 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { _resetRateLimitBucketsForTests, rateLimit } from './rate-limit';
+
+afterEach(() => {
+  _resetRateLimitBucketsForTests();
+});
+
+describe('rateLimit', () => {
+  it('allows up to `limit` operations within the window', () => {
+    expect(rateLimit('a', 3, 60_000)).toEqual({ ok: true, remaining: 2 });
+    expect(rateLimit('a', 3, 60_000)).toEqual({ ok: true, remaining: 1 });
+    expect(rateLimit('a', 3, 60_000)).toEqual({ ok: true, remaining: 0 });
+  });
+
+  it('rejects beyond the limit and reports retryAfter', () => {
+    rateLimit('b', 1, 60_000);
+    const r = rateLimit('b', 1, 60_000);
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.retryAfterMs).toBeGreaterThan(0);
+  });
+
+  it('keys are independent', () => {
+    rateLimit('c', 1, 60_000);
+    expect(rateLimit('d', 1, 60_000).ok).toBe(true);
+  });
+});

--- a/src/lib/dtrs/rate-limit.ts
+++ b/src/lib/dtrs/rate-limit.ts
@@ -1,0 +1,45 @@
+/**
+ * In-memory token-bucket rate limiter for the public consent surface.
+ *
+ * The Phase-1 deployment is a single Next.js process behind Vercel /
+ * Railway, so an in-process Map is sufficient. When the surface
+ * scales out (multiple workers, edge caching), this module gets
+ * swapped for a Redis / Upstash backend. Until then the same shape
+ * means the swap is a one-line change.
+ *
+ * The keying is intentional: a `synthetic_person_ref` IS the auth
+ * boundary in Phase 1, so the bucket is per-ref. Once token auth is
+ * required (this PR), we can also key on token to make brute-force
+ * exponentially harder.
+ */
+
+type Bucket = { count: number; resetAt: number };
+
+const buckets = new Map<string, Bucket>();
+
+export type RateLimitResult = { ok: true; remaining: number } | { ok: false; retryAfterMs: number };
+
+/**
+ * Allow up to `limit` operations per `windowMs` for a given `key`.
+ * Returns the result and decrements the bucket atomically (single-
+ * threaded JS — Node event loop guarantees the read-modify-write
+ * doesn't tear).
+ */
+export function rateLimit(key: string, limit: number, windowMs: number): RateLimitResult {
+  const now = Date.now();
+  const existing = buckets.get(key);
+  if (!existing || existing.resetAt <= now) {
+    buckets.set(key, { count: 1, resetAt: now + windowMs });
+    return { ok: true, remaining: limit - 1 };
+  }
+  if (existing.count >= limit) {
+    return { ok: false, retryAfterMs: Math.max(0, existing.resetAt - now) };
+  }
+  existing.count += 1;
+  return { ok: true, remaining: limit - existing.count };
+}
+
+/** Test/dev hook — only for vitest. */
+export function _resetRateLimitBucketsForTests(): void {
+  buckets.clear();
+}

--- a/src/lib/eviction/docket-ranking.test.ts
+++ b/src/lib/eviction/docket-ranking.test.ts
@@ -16,6 +16,7 @@ const baseFiling = (overrides: Partial<EvictionFiling> = {}): EvictionFiling => 
   status: 'filed',
   source: 'synthetic',
   rawJson: null,
+  dvFlag: false,
   createdAt: new Date(),
   updatedAt: new Date(),
   ...overrides,

--- a/src/lib/eviction/packet-pdf.test.ts
+++ b/src/lib/eviction/packet-pdf.test.ts
@@ -23,6 +23,7 @@ const filing: EvictionFiling = {
   status: 'filed',
   source: 'synthetic',
   rawJson: null,
+  dvFlag: false,
   createdAt: new Date(),
   updatedAt: new Date(),
 };

--- a/src/lib/eviction/upsert.test.ts
+++ b/src/lib/eviction/upsert.test.ts
@@ -16,6 +16,7 @@ const baseExisting: EvictionFiling = {
   status: 'filed',
   source: 'synthetic',
   rawJson: null,
+  dvFlag: false,
   createdAt: new Date(),
   updatedAt: new Date(),
 };

--- a/src/lib/indc/bed-finder.test.ts
+++ b/src/lib/indc/bed-finder.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest';
+import type { ShelterWithOrg } from '@/db/queries/shelters';
+import { findOpenBeds } from './bed-finder';
+
+const baseShelter = (overrides: Partial<ShelterWithOrg>): ShelterWithOrg => ({
+  id: 'sh1',
+  partnerOrgId: 'org1',
+  name: 'Shelter One',
+  slug: 'shelter-one',
+  addressLine1: null,
+  city: null,
+  state: null,
+  postalCode: null,
+  contactPhone: null,
+  capacity: 20,
+  currentOccupancy: 10,
+  acceptsMen: true,
+  acceptsWomen: true,
+  acceptsFamilies: false,
+  petFriendly: false,
+  sudFriendly: false,
+  active: true,
+  notes: null,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+  partnerOrg: { id: 'org1', name: 'Org One', slug: 'org-one' },
+  ...overrides,
+});
+
+describe('findOpenBeds', () => {
+  it('returns empty when no shelters have free beds', () => {
+    expect(
+      findOpenBeds({
+        shelters: [baseShelter({ currentOccupancy: 20 })],
+        filter: { minFreeBeds: 1 },
+      }),
+    ).toEqual([]);
+  });
+
+  it('ranks by free beds descending then name ascending', () => {
+    const shelters = [
+      baseShelter({ id: 'a', name: 'Alpha', currentOccupancy: 18 }), // 2 free
+      baseShelter({ id: 'b', name: 'Bravo', currentOccupancy: 5 }), // 15 free
+      baseShelter({ id: 'c', name: 'Charlie', currentOccupancy: 5 }), // 15 free
+    ];
+    const result = findOpenBeds({ shelters, filter: {} });
+    expect(result.map((r) => r.shelter.id)).toEqual(['b', 'c', 'a']);
+    expect(result[0].freeBeds).toBe(15);
+  });
+
+  it('subtracts active holds from free count', () => {
+    const shelters = [baseShelter({ id: 'a', currentOccupancy: 5 })]; // raw 15 free
+    const result = findOpenBeds({
+      shelters,
+      filter: {},
+      activeHoldsByShelter: new Map([['a', 4]]),
+    });
+    expect(result[0].freeBeds).toBe(11);
+  });
+
+  it('respects population filter', () => {
+    const shelters = [
+      baseShelter({ id: 'a', acceptsFamilies: false, currentOccupancy: 5 }),
+      baseShelter({ id: 'b', acceptsFamilies: true, currentOccupancy: 5 }),
+    ];
+    const result = findOpenBeds({ shelters, filter: { population: 'families' } });
+    expect(result.map((r) => r.shelter.id)).toEqual(['b']);
+  });
+
+  it('caps to limit', () => {
+    const shelters = Array.from({ length: 5 }, (_, i) =>
+      baseShelter({ id: `s${i}`, name: `Shelter ${i}`, currentOccupancy: 5 + i }),
+    );
+    expect(findOpenBeds({ shelters, filter: {}, limit: 2 })).toHaveLength(2);
+  });
+});

--- a/src/lib/indc/bed-finder.ts
+++ b/src/lib/indc/bed-finder.ts
@@ -1,0 +1,49 @@
+import type { ShelterWithOrg } from '@/db/queries/shelters';
+import {
+  type BedFilter,
+  effectiveFreeBeds,
+  matchesFilter,
+} from '@/lib/coordination/bed-availability';
+
+export type BedFinderResult = {
+  shelter: ShelterWithOrg;
+  freeBeds: number;
+};
+
+export type BedFinderInput = {
+  shelters: readonly ShelterWithOrg[];
+  /** Map of shelter id → active hold count. Defaults to 0 per shelter. */
+  activeHoldsByShelter?: Map<string, number>;
+  filter: BedFilter;
+  /** Maximum results to return; SMS replies cap at 3 to fit in one segment. */
+  limit?: number;
+};
+
+/**
+ * Returns the top `limit` shelters that satisfy the filter and have at
+ * least one effective free bed (capacity − occupied − holds), ranked
+ * by free beds descending then name ascending.
+ *
+ * Pure function — caller fetches the data; this just ranks.
+ */
+export function findOpenBeds(input: BedFinderInput): BedFinderResult[] {
+  const limit = input.limit ?? 3;
+  const holds = input.activeHoldsByShelter ?? new Map<string, number>();
+
+  const candidates: BedFinderResult[] = [];
+  for (const shelter of input.shelters) {
+    const free = effectiveFreeBeds(shelter, holds.get(shelter.id) ?? 0);
+    if (free <= 0) continue;
+    if (!matchesFilter(shelter, input.filter, `${shelter.name} ${shelter.partnerOrg.name}`)) {
+      continue;
+    }
+    candidates.push({ shelter, freeBeds: free });
+  }
+
+  candidates.sort((a, b) => {
+    if (b.freeBeds !== a.freeBeds) return b.freeBeds - a.freeBeds;
+    return a.shelter.name.localeCompare(b.shelter.name);
+  });
+
+  return candidates.slice(0, limit);
+}

--- a/src/lib/indc/sms-bed-holds.ts
+++ b/src/lib/indc/sms-bed-holds.ts
@@ -1,0 +1,142 @@
+import { and, count, eq, gt } from 'drizzle-orm';
+import { db } from '@/db/client';
+import { bedHolds, shelters } from '@/db/schema/shelters';
+import { logAuditEvent } from '@/lib/audit';
+
+/**
+ * Sentinel "user id" written into bed_holds.held_by_user_id when a hold
+ * is created from an SMS conversation rather than a signed-in coalition
+ * user. The bed_holds.held_by_user_id column is a uuid (not a FK), so
+ * this opaque marker is structurally fine; downstream UIs check for
+ * the prefix to render \"placed via SMS\" instead of looking up a name.
+ */
+export const SMS_HELD_BY_SENTINEL = '00000000-0000-0000-0000-00000000515d'; // last bytes spell "SMS" approximately
+export const HOLD_DURATION_MIN_SMS = 90;
+const PHONE_LABEL_MAX_LEN = 24;
+
+export type CreateSmsHoldResult =
+  | { ok: true; holdId: string; expiresAt: Date }
+  | { ok: false; error: string };
+
+/**
+ * Creates a 90-minute hold on behalf of an SMS caller. Same race-safe
+ * count check as the staff-side action; person_label is a redacted
+ * version of the caller's number (E.164 last-4) so staff can identify
+ * the caller without storing the full number on the hold row.
+ */
+export async function createBedHoldFromSms(
+  shelterId: string,
+  fromNumber: string,
+): Promise<CreateSmsHoldResult> {
+  const expiresAt = new Date(Date.now() + HOLD_DURATION_MIN_SMS * 60_000);
+  // E.164 numbers like "+15551234567" → "SMS caller …4567" — keeps
+  // staff context without the full number on the bed_holds row.
+  const last4 = fromNumber.replace(/[^0-9]/g, '').slice(-4) || 'unknown';
+  const personLabel = `SMS caller …${last4}`.slice(0, PHONE_LABEL_MAX_LEN);
+
+  const result = await db.transaction(async (tx) => {
+    const [shelter] = await tx
+      .select({
+        id: shelters.id,
+        capacity: shelters.capacity,
+        currentOccupancy: shelters.currentOccupancy,
+        active: shelters.active,
+        name: shelters.name,
+        contactPhone: shelters.contactPhone,
+      })
+      .from(shelters)
+      .where(eq(shelters.id, shelterId))
+      .limit(1);
+    if (!shelter) return { ok: false as const, error: 'shelter not found' };
+    if (!shelter.active) return { ok: false as const, error: 'shelter is inactive' };
+
+    const rawFree = shelter.capacity - shelter.currentOccupancy;
+    if (rawFree <= 0) return { ok: false as const, error: 'no free beds' };
+
+    const [{ value: activeHolds }] = await tx
+      .select({ value: count() })
+      .from(bedHolds)
+      .where(
+        and(
+          eq(bedHolds.shelterId, shelterId),
+          eq(bedHolds.status, 'active'),
+          gt(bedHolds.expiresAt, new Date()),
+        ),
+      );
+    if (Number(activeHolds) >= rawFree) {
+      return { ok: false as const, error: 'all free beds are already on hold' };
+    }
+
+    const [created] = await tx
+      .insert(bedHolds)
+      .values({
+        shelterId,
+        heldByUserId: SMS_HELD_BY_SENTINEL,
+        personLabel,
+        expiresAt,
+      })
+      .returning({ id: bedHolds.id, expiresAt: bedHolds.expiresAt });
+    return { ok: true as const, holdId: created.id, expiresAt: created.expiresAt };
+  });
+
+  if (!result.ok) return result;
+
+  await logAuditEvent({
+    actorUserId: null,
+    action: 'shelter.bed_hold_created_via_sms',
+    targetTable: 'bed_holds',
+    targetId: result.holdId,
+    metadata: { shelterId, last4 },
+  });
+
+  return result;
+}
+
+export type ReleaseSmsHoldResult = { ok: true; shelterName: string } | { ok: false; error: string };
+
+/**
+ * Releases a hold the SMS caller previously placed. Caller-scoped:
+ * we look up the hold by id AND verify it was created via SMS
+ * (`held_by_user_id = SMS_HELD_BY_SENTINEL`) so a leaked id can't be
+ * used to release a staff-created hold.
+ */
+export async function releaseBedHoldFromSms(holdId: string): Promise<ReleaseSmsHoldResult> {
+  const [hold] = await db
+    .select({
+      id: bedHolds.id,
+      shelterId: bedHolds.shelterId,
+      heldByUserId: bedHolds.heldByUserId,
+      status: bedHolds.status,
+    })
+    .from(bedHolds)
+    .where(eq(bedHolds.id, holdId))
+    .limit(1);
+  if (!hold) return { ok: false, error: 'hold not found' };
+  if (hold.heldByUserId !== SMS_HELD_BY_SENTINEL) {
+    return { ok: false, error: 'hold not owned by this SMS conversation' };
+  }
+  if (hold.status !== 'active') {
+    return { ok: false, error: 'hold already closed' };
+  }
+
+  const [shelter] = await db
+    .select({ name: shelters.name })
+    .from(shelters)
+    .where(eq(shelters.id, hold.shelterId))
+    .limit(1);
+
+  await db
+    .update(bedHolds)
+    .set({ status: 'released', releasedAt: new Date(), updatedAt: new Date() })
+    .where(eq(bedHolds.id, holdId));
+
+  await logAuditEvent({
+    actorUserId: null,
+    action: 'shelter.bed_hold_released_via_sms',
+    targetTable: 'bed_holds',
+    targetId: holdId,
+    metadata: { shelterId: hold.shelterId },
+  });
+
+  return { ok: true, shelterName: shelter?.name ?? 'shelter' };
+}

--- a/src/lib/indc/sms-conversation.test.ts
+++ b/src/lib/indc/sms-conversation.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import { isLocationSkip, normalizeLocation } from './sms-conversation';
+
+describe('isLocationSkip', () => {
+  it.each([
+    'ANYWHERE',
+    'anywhere',
+    'Any',
+    'SKIP',
+    'whatever',
+    'NEAR',
+  ])('recognizes %s as skip', (token) => {
+    expect(isLocationSkip(token)).toBe(true);
+  });
+
+  it('looks at the first token only', () => {
+    expect(isLocationSkip('ANYWHERE downtown')).toBe(true);
+  });
+
+  it('rejects normal location text', () => {
+    expect(isLocationSkip('downtown')).toBe(false);
+    expect(isLocationSkip('42301')).toBe(false);
+    expect(isLocationSkip('')).toBe(false);
+  });
+});
+
+describe('normalizeLocation', () => {
+  it('trims and collapses whitespace', () => {
+    expect(normalizeLocation('  downtown   owensboro  ')).toBe('downtown owensboro');
+  });
+
+  it('caps to 80 chars', () => {
+    expect(normalizeLocation('a'.repeat(200)).length).toBe(80);
+  });
+});

--- a/src/lib/indc/sms-conversation.ts
+++ b/src/lib/indc/sms-conversation.ts
@@ -68,15 +68,21 @@ export async function setAwaitingLocation(
 
 export async function markIdle(
   fromNumber: string,
-  capturedLocation?: string | null,
+  opts: {
+    capturedLocation?: string | null;
+    lastResults?: Array<{ shelterId: string; name: string }> | null;
+  } = {},
 ): Promise<void> {
   const now = new Date();
   const expiresAt = new Date(now.getTime() + CONVERSATION_TTL_MS);
+  const lastLocation = opts.capturedLocation ?? null;
+  const lastResults = opts.lastResults ?? null;
   const values: NewSmsConversation = {
     fromNumber,
     state: 'idle',
     pendingFilter: null,
-    lastLocation: capturedLocation ?? null,
+    lastLocation,
+    lastResults,
     lastMessageAt: now,
     expiresAt,
   };
@@ -88,12 +94,22 @@ export async function markIdle(
       set: {
         state: 'idle',
         pendingFilter: null,
-        lastLocation: capturedLocation ?? null,
+        lastLocation,
+        lastResults,
         lastMessageAt: now,
         expiresAt,
         updatedAt: now,
       },
     });
+}
+
+export async function setLastHoldId(fromNumber: string, holdId: string | null): Promise<void> {
+  const now = new Date();
+  const expiresAt = new Date(now.getTime() + CONVERSATION_TTL_MS);
+  await db
+    .update(smsConversations)
+    .set({ lastHoldId: holdId, lastMessageAt: now, expiresAt, updatedAt: now })
+    .where(eq(smsConversations.fromNumber, fromNumber));
 }
 
 export async function clearConversation(fromNumber: string): Promise<void> {

--- a/src/lib/indc/sms-conversation.ts
+++ b/src/lib/indc/sms-conversation.ts
@@ -1,0 +1,134 @@
+import { eq } from 'drizzle-orm';
+import { db } from '@/db/client';
+import {
+  type NewSmsConversation,
+  type SmsConversation,
+  smsConversations,
+} from '@/db/schema/sms-conversations';
+import type { BedFilter } from '@/lib/coordination/bed-availability';
+
+/** Conversation TTL: 10 minutes of silence rolls the user back to idle. */
+export const CONVERSATION_TTL_MS = 10 * 60 * 1000;
+
+const isExpired = (row: SmsConversation): boolean =>
+  new Date(row.expiresAt).getTime() <= Date.now();
+
+export async function getConversation(fromNumber: string): Promise<SmsConversation | null> {
+  const [row] = await db
+    .select()
+    .from(smsConversations)
+    .where(eq(smsConversations.fromNumber, fromNumber))
+    .limit(1);
+  if (!row) return null;
+  if (isExpired(row)) {
+    // Lazy-expire on read so a caller after the TTL gets a clean slate
+    // even if the cron hasn't fired yet.
+    await db
+      .update(smsConversations)
+      .set({
+        state: 'idle',
+        pendingFilter: null,
+        updatedAt: new Date(),
+      })
+      .where(eq(smsConversations.id, row.id));
+    return { ...row, state: 'idle', pendingFilter: null };
+  }
+  return row;
+}
+
+export async function setAwaitingLocation(
+  fromNumber: string,
+  filter: BedFilter,
+): Promise<SmsConversation> {
+  const now = new Date();
+  const expiresAt = new Date(now.getTime() + CONVERSATION_TTL_MS);
+  const values: NewSmsConversation = {
+    fromNumber,
+    state: 'awaiting_location',
+    pendingFilter: filter,
+    lastMessageAt: now,
+    expiresAt,
+  };
+  const [row] = await db
+    .insert(smsConversations)
+    .values(values)
+    .onConflictDoUpdate({
+      target: smsConversations.fromNumber,
+      set: {
+        state: 'awaiting_location',
+        pendingFilter: filter,
+        lastMessageAt: now,
+        expiresAt,
+        updatedAt: now,
+      },
+    })
+    .returning();
+  return row;
+}
+
+export async function markIdle(
+  fromNumber: string,
+  capturedLocation?: string | null,
+): Promise<void> {
+  const now = new Date();
+  const expiresAt = new Date(now.getTime() + CONVERSATION_TTL_MS);
+  const values: NewSmsConversation = {
+    fromNumber,
+    state: 'idle',
+    pendingFilter: null,
+    lastLocation: capturedLocation ?? null,
+    lastMessageAt: now,
+    expiresAt,
+  };
+  await db
+    .insert(smsConversations)
+    .values(values)
+    .onConflictDoUpdate({
+      target: smsConversations.fromNumber,
+      set: {
+        state: 'idle',
+        pendingFilter: null,
+        lastLocation: capturedLocation ?? null,
+        lastMessageAt: now,
+        expiresAt,
+        updatedAt: now,
+      },
+    });
+}
+
+export async function clearConversation(fromNumber: string): Promise<void> {
+  const now = new Date();
+  const expiresAt = new Date(now.getTime() + CONVERSATION_TTL_MS);
+  const values: NewSmsConversation = {
+    fromNumber,
+    state: 'idle',
+    pendingFilter: null,
+    lastMessageAt: now,
+    expiresAt,
+  };
+  await db
+    .insert(smsConversations)
+    .values(values)
+    .onConflictDoUpdate({
+      target: smsConversations.fromNumber,
+      set: { state: 'idle', pendingFilter: null, lastMessageAt: now, expiresAt, updatedAt: now },
+    });
+}
+
+const SKIP_TOKENS = new Set(['ANYWHERE', 'ANY', 'SKIP', 'WHATEVER', 'NEAR']);
+
+/**
+ * Returns true if the location body is a "doesn't matter" answer. The
+ * pipeline treats this as: keep the original filter, drop location.
+ */
+export function isLocationSkip(body: string): boolean {
+  const head = body.trim().toUpperCase().split(/\s+/)[0];
+  return SKIP_TOKENS.has(head);
+}
+
+const LOCATION_MAX_LEN = 80;
+
+/** Tidy a location string for storage / inclusion in replies. */
+export function normalizeLocation(body: string): string {
+  return body.trim().replace(/\s+/g, ' ').slice(0, LOCATION_MAX_LEN);
+}

--- a/src/lib/indc/sms-formatter.test.ts
+++ b/src/lib/indc/sms-formatter.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest';
+import type { ShelterWithOrg } from '@/db/queries/shelters';
+import type { BedFinderResult } from './bed-finder';
+import { formatBedResults, SMS_MAX_LEN, smsHelp, smsStop, smsUnknown } from './sms-formatter';
+
+const shelter = (name: string, phone: string | null = '+1-270-555-0100'): ShelterWithOrg => ({
+  id: name,
+  partnerOrgId: 'org1',
+  name,
+  slug: name.toLowerCase(),
+  addressLine1: null,
+  city: 'Owensboro',
+  state: 'KY',
+  postalCode: null,
+  contactPhone: phone,
+  capacity: 20,
+  currentOccupancy: 5,
+  acceptsMen: true,
+  acceptsWomen: true,
+  acceptsFamilies: false,
+  petFriendly: false,
+  sudFriendly: false,
+  active: true,
+  notes: null,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+  partnerOrg: { id: 'org1', name: 'Org', slug: 'org' },
+});
+
+const result = (name: string, free: number): BedFinderResult => ({
+  shelter: shelter(name),
+  freeBeds: free,
+});
+
+describe('formatBedResults', () => {
+  it('renders the no-match copy for empty results', () => {
+    const r = formatBedResults([], {});
+    expect(r).toContain('No open beds');
+    expect(r.length).toBeLessThanOrEqual(SMS_MAX_LEN);
+  });
+
+  it('describes the active filter in the header', () => {
+    const r = formatBedResults([result('Boulware', 5)], {
+      population: 'families',
+      petFriendly: true,
+    });
+    expect(r).toMatch(/families/);
+    expect(r).toMatch(/pet-friendly/);
+  });
+
+  it('renders multiple results pluralized', () => {
+    const r = formatBedResults([result('Boulware', 1), result('St Benedicts', 7)], {});
+    expect(r).toMatch(/Boulware — 1 bed/);
+    expect(r).toMatch(/St Benedicts — 7 beds/);
+  });
+
+  it('stays within SMS_MAX_LEN', () => {
+    const many = Array.from({ length: 10 }, (_, i) => result(`Shelter ${i}`, 9 - i));
+    const r = formatBedResults(many, {});
+    expect(r.length).toBeLessThanOrEqual(SMS_MAX_LEN);
+  });
+
+  it('includes hold + help footer', () => {
+    const r = formatBedResults([result('Boulware', 5)], {});
+    expect(r).toContain('HOLD');
+    expect(r).toContain('HELP');
+  });
+});
+
+describe('canned replies', () => {
+  it('all stay within SMS_MAX_LEN', () => {
+    expect(smsHelp().length).toBeLessThanOrEqual(SMS_MAX_LEN);
+    expect(smsStop().length).toBeLessThanOrEqual(SMS_MAX_LEN);
+    expect(smsUnknown().length).toBeLessThanOrEqual(SMS_MAX_LEN);
+  });
+});

--- a/src/lib/indc/sms-formatter.test.ts
+++ b/src/lib/indc/sms-formatter.test.ts
@@ -4,9 +4,16 @@ import type { BedFinderResult } from './bed-finder';
 import {
   formatBedResults,
   SMS_MAX_LEN,
+  smsFood,
   smsHelp,
+  smsHoldConfirmed,
+  smsHoldFailed,
+  smsHoldReleased,
   smsLocationPrompt,
+  smsNoActiveHold,
+  smsNoHoldContext,
   smsStop,
+  smsStory,
   smsUnknown,
 } from './sms-formatter';
 
@@ -76,14 +83,52 @@ describe('formatBedResults', () => {
 
 describe('canned replies', () => {
   it('all stay within SMS_MAX_LEN', () => {
-    expect(smsHelp().length).toBeLessThanOrEqual(SMS_MAX_LEN);
-    expect(smsStop().length).toBeLessThanOrEqual(SMS_MAX_LEN);
-    expect(smsUnknown().length).toBeLessThanOrEqual(SMS_MAX_LEN);
-    expect(smsLocationPrompt().length).toBeLessThanOrEqual(SMS_MAX_LEN);
+    for (const reply of [
+      smsHelp(),
+      smsStop(),
+      smsUnknown(),
+      smsLocationPrompt(),
+      smsFood(),
+      smsStory(),
+      smsNoActiveHold(),
+      smsNoHoldContext(),
+    ]) {
+      expect(reply.length).toBeLessThanOrEqual(SMS_MAX_LEN);
+    }
   });
 
   it('location prompt mentions ANYWHERE escape hatch', () => {
     expect(smsLocationPrompt()).toMatch(/ANYWHERE/);
+  });
+
+  it('food reply names actual coalition partners', () => {
+    expect(smsFood()).toMatch(/Catholic Charities/);
+    expect(smsFood()).toMatch(/Boulware/);
+  });
+});
+
+describe('hold reply formatters', () => {
+  it('confirms a hold with shelter name + clock + phone', () => {
+    const expires = new Date('2026-04-26T15:30:00Z');
+    const reply = smsHoldConfirmed('Boulware Mission', '+1-270-683-1505', expires);
+    expect(reply).toContain('Boulware Mission');
+    expect(reply).toContain('270-683-1505');
+    expect(reply).toMatch(/RELEASE/);
+    expect(reply.length).toBeLessThanOrEqual(SMS_MAX_LEN);
+  });
+
+  it('drops phone fragment cleanly when shelter has no phone', () => {
+    const reply = smsHoldConfirmed('Anon Shelter', null, new Date());
+    expect(reply).not.toMatch(/Call/);
+  });
+
+  it('hold-released reply names the shelter', () => {
+    expect(smsHoldReleased('Daniel Pitino')).toContain('Daniel Pitino');
+  });
+
+  it('hold-failed reply ≤ SMS_MAX_LEN even with long reason', () => {
+    const reply = smsHoldFailed('a'.repeat(400));
+    expect(reply.length).toBeLessThanOrEqual(SMS_MAX_LEN);
   });
 });
 

--- a/src/lib/indc/sms-formatter.test.ts
+++ b/src/lib/indc/sms-formatter.test.ts
@@ -1,7 +1,14 @@
 import { describe, expect, it } from 'vitest';
 import type { ShelterWithOrg } from '@/db/queries/shelters';
 import type { BedFinderResult } from './bed-finder';
-import { formatBedResults, SMS_MAX_LEN, smsHelp, smsStop, smsUnknown } from './sms-formatter';
+import {
+  formatBedResults,
+  SMS_MAX_LEN,
+  smsHelp,
+  smsLocationPrompt,
+  smsStop,
+  smsUnknown,
+} from './sms-formatter';
 
 const shelter = (name: string, phone: string | null = '+1-270-555-0100'): ShelterWithOrg => ({
   id: name,
@@ -72,5 +79,22 @@ describe('canned replies', () => {
     expect(smsHelp().length).toBeLessThanOrEqual(SMS_MAX_LEN);
     expect(smsStop().length).toBeLessThanOrEqual(SMS_MAX_LEN);
     expect(smsUnknown().length).toBeLessThanOrEqual(SMS_MAX_LEN);
+    expect(smsLocationPrompt().length).toBeLessThanOrEqual(SMS_MAX_LEN);
+  });
+
+  it('location prompt mentions ANYWHERE escape hatch', () => {
+    expect(smsLocationPrompt()).toMatch(/ANYWHERE/);
+  });
+});
+
+describe('formatBedResults — location label', () => {
+  it('includes "near <loc>" in the header when supplied', () => {
+    const r = formatBedResults([result('Boulware', 5)], {}, '42301');
+    expect(r).toMatch(/near 42301/);
+  });
+
+  it('skips "near" label when null', () => {
+    const r = formatBedResults([result('Boulware', 5)], {}, null);
+    expect(r).not.toMatch(/near/);
   });
 });

--- a/src/lib/indc/sms-formatter.ts
+++ b/src/lib/indc/sms-formatter.ts
@@ -35,14 +35,32 @@ function formatShelterLine(idx: number, r: BedFinderResult): string {
   return `${idx}. ${r.shelter.name} — ${free}.${phone}`;
 }
 
+const LOCATION_PROMPT =
+  'Where are you near? Reply with a neighborhood, intersection, or ZIP — or ANYWHERE for any open bed.';
+
+/**
+ * The "where are you?" prompt shown after the first BED message
+ * (INDC-004). Stays well under SMS_MAX_LEN.
+ */
+export function smsLocationPrompt(): string {
+  return LOCATION_PROMPT;
+}
+
 /**
  * Format a list of bed-finder results as a body that fits in
- * `SMS_MAX_LEN`. Drops trailing matches if they don't fit.
+ * `SMS_MAX_LEN`. Drops trailing matches if they don't fit. The optional
+ * `nearLocation` is appended to the header when provided so the user
+ * sees the location they gave reflected back.
  */
-export function formatBedResults(results: BedFinderResult[], filter: BedFilter): string {
+export function formatBedResults(
+  results: BedFinderResult[],
+  filter: BedFilter,
+  nearLocation?: string | null,
+): string {
   if (results.length === 0) return NO_MATCH_REPLY;
 
-  const header = `Open beds${describeFilter(filter)}:`;
+  const near = nearLocation ? ` near ${nearLocation}` : '';
+  const header = `Open beds${describeFilter(filter)}${near}:`;
   const footer = ' Reply HOLD <#> to hold, HELP for options.';
   const fixed = `${header}${footer}`;
   const budget = SMS_MAX_LEN - fixed.length;
@@ -60,10 +78,8 @@ export function formatBedResults(results: BedFinderResult[], filter: BedFilter):
   if (lines.length === 0) {
     // Even one line didn't fit. Bail to a tiny fallback.
     const top = results[0];
-    return `${top.shelter.name}: ${top.freeBeds} free.${top.shelter.contactPhone ? ` ${top.shelter.contactPhone}` : ''}`.slice(
-      0,
-      SMS_MAX_LEN,
-    );
+    const phone = top.shelter.contactPhone ? ` ${top.shelter.contactPhone}` : '';
+    return `${top.shelter.name}: ${top.freeBeds} free.${phone}`.slice(0, SMS_MAX_LEN);
   }
 
   return `${header} ${lines.join(' ')}${footer}`;

--- a/src/lib/indc/sms-formatter.ts
+++ b/src/lib/indc/sms-formatter.ts
@@ -1,0 +1,82 @@
+import type { BedFilter } from '@/lib/coordination/bed-availability';
+import type { BedFinderResult } from './bed-finder';
+
+/**
+ * SMS replies cap at 320 chars (two GSM segments — keeps cost predictable
+ * and avoids carrier-side concatenation surprises). The formatter trims
+ * matches until the body fits.
+ */
+export const SMS_MAX_LEN = 320;
+
+const HELP_REPLY =
+  'Coalition bed-finder. Reply BED for an open shelter bed. Add MEN, WOMEN, FAMILY, PET, or SUD to filter (e.g. BED FAMILY PET). HELP repeats this. STOP to opt out.';
+
+const STOP_REPLY = "You're opted out. Reply START to opt back in.";
+
+const UNKNOWN_REPLY =
+  "Sorry, didn't catch that. Reply BED for an open shelter bed, or HELP for options.";
+
+const NO_MATCH_REPLY =
+  'No open beds match right now. Try BED for any open bed, or call 211 for live help.';
+
+function describeFilter(filter: BedFilter): string {
+  const parts: string[] = [];
+  if (filter.population === 'men') parts.push('men');
+  if (filter.population === 'women') parts.push('women');
+  if (filter.population === 'families') parts.push('families');
+  if (filter.petFriendly) parts.push('pet-friendly');
+  if (filter.sudFriendly) parts.push('SUD-OK');
+  return parts.length > 0 ? ` (${parts.join(', ')})` : '';
+}
+
+function formatShelterLine(idx: number, r: BedFinderResult): string {
+  const phone = r.shelter.contactPhone ? ` ${r.shelter.contactPhone}` : '';
+  const free = r.freeBeds === 1 ? '1 bed' : `${r.freeBeds} beds`;
+  return `${idx}. ${r.shelter.name} — ${free}.${phone}`;
+}
+
+/**
+ * Format a list of bed-finder results as a body that fits in
+ * `SMS_MAX_LEN`. Drops trailing matches if they don't fit.
+ */
+export function formatBedResults(results: BedFinderResult[], filter: BedFilter): string {
+  if (results.length === 0) return NO_MATCH_REPLY;
+
+  const header = `Open beds${describeFilter(filter)}:`;
+  const footer = ' Reply HOLD <#> to hold, HELP for options.';
+  const fixed = `${header}${footer}`;
+  const budget = SMS_MAX_LEN - fixed.length;
+
+  const lines: string[] = [];
+  let used = 0;
+  for (let i = 0; i < results.length; i++) {
+    const line = formatShelterLine(i + 1, results[i]);
+    // +1 for the leading space we'll join with.
+    if (used + line.length + 1 > budget) break;
+    lines.push(line);
+    used += line.length + 1;
+  }
+
+  if (lines.length === 0) {
+    // Even one line didn't fit. Bail to a tiny fallback.
+    const top = results[0];
+    return `${top.shelter.name}: ${top.freeBeds} free.${top.shelter.contactPhone ? ` ${top.shelter.contactPhone}` : ''}`.slice(
+      0,
+      SMS_MAX_LEN,
+    );
+  }
+
+  return `${header} ${lines.join(' ')}${footer}`;
+}
+
+export function smsHelp(): string {
+  return HELP_REPLY;
+}
+
+export function smsStop(): string {
+  return STOP_REPLY;
+}
+
+export function smsUnknown(): string {
+  return UNKNOWN_REPLY;
+}

--- a/src/lib/indc/sms-formatter.ts
+++ b/src/lib/indc/sms-formatter.ts
@@ -9,7 +9,7 @@ import type { BedFinderResult } from './bed-finder';
 export const SMS_MAX_LEN = 320;
 
 const HELP_REPLY =
-  'Coalition bed-finder. Reply BED for an open shelter bed. Add MEN, WOMEN, FAMILY, PET, or SUD to filter (e.g. BED FAMILY PET). HELP repeats this. STOP to opt out.';
+  'Coalition bed-finder. BED (+ MEN/WOMEN/FAMILY/PET/SUD) for an open bed. HOLD <#> to hold one. FOOD for pantries. STORY about this service. STOP to opt out.';
 
 const STOP_REPLY = "You're opted out. Reply START to opt back in.";
 
@@ -18,6 +18,17 @@ const UNKNOWN_REPLY =
 
 const NO_MATCH_REPLY =
   'No open beds match right now. Try BED for any open bed, or call 211 for live help.';
+
+const FOOD_REPLY =
+  'Food in Daviess Co: Catholic Charities Feeding Our Friends 270-683-1545. St Benedicts day meals 270-686-8410. Boulware Mission daily meals 270-683-1505. Call 211 for current hours.';
+
+const STORY_REPLY =
+  'This is the Daviess coalition bed-finder. Free, confidential, run with local partners. Texts go to staff during pilot; only HELP/STOP messages and bed counts are kept. Reply BED to start.';
+
+const NO_HOLD_CONTEXT_REPLY =
+  'No recent bed list to hold against. Reply BED first, then HOLD <#> against the list we send back.';
+
+const NO_ACTIVE_HOLD_REPLY = 'No active hold to release. Reply BED to look for a new bed.';
 
 function describeFilter(filter: BedFilter): string {
   const parts: string[] = [];
@@ -95,4 +106,53 @@ export function smsStop(): string {
 
 export function smsUnknown(): string {
   return UNKNOWN_REPLY;
+}
+
+export function smsFood(): string {
+  return FOOD_REPLY;
+}
+
+export function smsStory(): string {
+  return STORY_REPLY;
+}
+
+export function smsNoHoldContext(): string {
+  return NO_HOLD_CONTEXT_REPLY;
+}
+
+export function smsNoActiveHold(): string {
+  return NO_ACTIVE_HOLD_REPLY;
+}
+
+const fmtClock = (d: Date) =>
+  new Intl.DateTimeFormat('en-US', { timeStyle: 'short' }).format(new Date(d));
+
+/**
+ * Inline confirmation for a hold a caller just placed via SMS. Includes
+ * the shelter name, expiry clock, and a one-tap call link. The caller
+ * can text RELEASE to undo.
+ */
+export function smsHoldConfirmed(
+  shelterName: string,
+  phone: string | null,
+  expiresAt: Date,
+): string {
+  const callPart = phone ? ` Call ${phone} or` : '';
+  return `Bed held at ${shelterName} until ${fmtClock(expiresAt)}.${callPart} walk in to take it. Reply RELEASE to cancel.`.slice(
+    0,
+    SMS_MAX_LEN,
+  );
+}
+
+export function smsHoldReleased(shelterName: string): string {
+  return `Hold at ${shelterName} released. Reply BED to look for another open bed.`.slice(
+    0,
+    SMS_MAX_LEN,
+  );
+}
+
+export function smsHoldFailed(reason: string): string {
+  // Reason copy should already be user-safe — we cap to MAX_LEN as a
+  // defense against an unexpectedly long server message.
+  return `Couldn't hold a bed: ${reason} Reply BED to try again.`.slice(0, SMS_MAX_LEN);
 }

--- a/src/lib/indc/sms-parser.test.ts
+++ b/src/lib/indc/sms-parser.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+import { parseSmsCommand } from './sms-parser';
+
+describe('parseSmsCommand', () => {
+  it('treats bare BED as a request for any open bed', () => {
+    expect(parseSmsCommand('BED')).toEqual({ kind: 'bed', filter: { minFreeBeds: 1 } });
+  });
+
+  it('handles lowercase + leading whitespace', () => {
+    expect(parseSmsCommand('   bed family ')).toEqual({
+      kind: 'bed',
+      filter: { minFreeBeds: 1, population: 'families' },
+    });
+  });
+
+  it('stacks population + pet + sud modifiers', () => {
+    expect(parseSmsCommand('BED WOMEN PET SUD')).toEqual({
+      kind: 'bed',
+      filter: { minFreeBeds: 1, population: 'women', petFriendly: true, sudFriendly: true },
+    });
+  });
+
+  it('accepts BEDS and SHELTER as synonyms', () => {
+    expect(parseSmsCommand('BEDS').kind).toBe('bed');
+    expect(parseSmsCommand('SHELTER').kind).toBe('bed');
+  });
+
+  it('first population token wins when conflicting', () => {
+    expect(parseSmsCommand('BED MEN WOMEN')).toEqual({
+      kind: 'bed',
+      filter: { minFreeBeds: 1, population: 'men' },
+    });
+  });
+
+  it('ignores unknown modifier tokens but stays a BED command', () => {
+    const result = parseSmsCommand('BED ASAP PLEASE');
+    expect(result).toEqual({ kind: 'bed', filter: { minFreeBeds: 1 } });
+  });
+
+  it('recognizes STOP variants', () => {
+    expect(parseSmsCommand('STOP').kind).toBe('stop');
+    expect(parseSmsCommand('UNSUBSCRIBE').kind).toBe('stop');
+    expect(parseSmsCommand('cancel').kind).toBe('stop');
+  });
+
+  it('recognizes HELP variants', () => {
+    expect(parseSmsCommand('HELP').kind).toBe('help');
+    expect(parseSmsCommand('?').kind).toBe('help');
+  });
+
+  it('returns unknown for empty / unrecognized input', () => {
+    expect(parseSmsCommand('').kind).toBe('unknown');
+    expect(parseSmsCommand('hello there').kind).toBe('unknown');
+  });
+});

--- a/src/lib/indc/sms-parser.test.ts
+++ b/src/lib/indc/sms-parser.test.ts
@@ -37,15 +37,39 @@ describe('parseSmsCommand', () => {
     expect(result).toEqual({ kind: 'bed', filter: { minFreeBeds: 1 } });
   });
 
-  it('recognizes STOP variants', () => {
+  it('recognizes STOP variants (CANCEL routed to release instead)', () => {
     expect(parseSmsCommand('STOP').kind).toBe('stop');
     expect(parseSmsCommand('UNSUBSCRIBE').kind).toBe('stop');
-    expect(parseSmsCommand('cancel').kind).toBe('stop');
+    expect(parseSmsCommand('quit').kind).toBe('stop');
   });
 
   it('recognizes HELP variants', () => {
     expect(parseSmsCommand('HELP').kind).toBe('help');
     expect(parseSmsCommand('?').kind).toBe('help');
+  });
+
+  it('recognizes shorthand info commands', () => {
+    expect(parseSmsCommand('FOOD').kind).toBe('food');
+    expect(parseSmsCommand('hungry').kind).toBe('food');
+    expect(parseSmsCommand('STORY').kind).toBe('story');
+    expect(parseSmsCommand('about').kind).toBe('story');
+  });
+
+  it('parses HOLD with numeric arg into 0-indexed resultIndex', () => {
+    expect(parseSmsCommand('HOLD 1')).toEqual({ kind: 'hold', resultIndex: 0 });
+    expect(parseSmsCommand('HOLD 3')).toEqual({ kind: 'hold', resultIndex: 2 });
+    expect(parseSmsCommand('hold #2')).toEqual({ kind: 'hold', resultIndex: 1 });
+  });
+
+  it('defaults bare HOLD to slot 1', () => {
+    expect(parseSmsCommand('HOLD')).toEqual({ kind: 'hold', resultIndex: 0 });
+    expect(parseSmsCommand('RESERVE')).toEqual({ kind: 'hold', resultIndex: 0 });
+  });
+
+  it('routes RELEASE / CANCEL / NEVERMIND to release', () => {
+    expect(parseSmsCommand('RELEASE').kind).toBe('release');
+    expect(parseSmsCommand('cancel').kind).toBe('release');
+    expect(parseSmsCommand('Nevermind').kind).toBe('release');
   });
 
   it('returns unknown for empty / unrecognized input', () => {

--- a/src/lib/indc/sms-parser.ts
+++ b/src/lib/indc/sms-parser.ts
@@ -1,0 +1,73 @@
+import type { BedFilter } from '@/lib/coordination/bed-availability';
+
+/**
+ * Inbound SMS commands the bed-finder understands. Every command maps
+ * to a single intent; modifiers stack inside `BED ...`. Examples:
+ *   BED                → find any open bed
+ *   BED FAMILY         → family-accepting + open
+ *   BED PET            → pet-friendly + open
+ *   BED MEN PET        → men + pet-friendly + open
+ *   BED WOMEN SUD      → women + SUD-friendly + open
+ *   HELP               → help text
+ *   STOP / END / QUIT  → opt-out (Twilio handles delivery; we still log it)
+ */
+export type ParsedSmsCommand =
+  | { kind: 'bed'; filter: BedFilter }
+  | { kind: 'help' }
+  | { kind: 'stop' }
+  | { kind: 'unknown'; raw: string };
+
+const STOP_WORDS = new Set(['STOP', 'STOPALL', 'UNSUBSCRIBE', 'CANCEL', 'END', 'QUIT']);
+const HELP_WORDS = new Set(['HELP', 'INFO', '?']);
+
+const POPULATION_TOKENS: Record<string, NonNullable<BedFilter['population']>> = {
+  MEN: 'men',
+  MAN: 'men',
+  MALE: 'men',
+  WOMEN: 'women',
+  WOMAN: 'women',
+  FEMALE: 'women',
+  FAMILY: 'families',
+  FAMILIES: 'families',
+  KIDS: 'families',
+  CHILDREN: 'families',
+};
+
+const PET_TOKENS = new Set(['PET', 'PETS', 'DOG', 'CAT', 'PETFRIENDLY']);
+const SUD_TOKENS = new Set(['SUD', 'SOBER', 'RECOVERY', 'DRUGS', 'CLEAN']);
+
+export function parseSmsCommand(raw: string): ParsedSmsCommand {
+  const trimmed = raw.trim();
+  if (!trimmed) return { kind: 'unknown', raw };
+
+  const tokens = trimmed.toUpperCase().split(/\s+/).filter(Boolean);
+  if (tokens.length === 0) return { kind: 'unknown', raw };
+
+  const head = tokens[0];
+
+  if (STOP_WORDS.has(head)) return { kind: 'stop' };
+  if (HELP_WORDS.has(head)) return { kind: 'help' };
+
+  if (head === 'BED' || head === 'BEDS' || head === 'SHELTER') {
+    const filter: BedFilter = { minFreeBeds: 1 };
+    for (const t of tokens.slice(1)) {
+      const pop = POPULATION_TOKENS[t];
+      if (pop && !filter.population) {
+        filter.population = pop;
+        continue;
+      }
+      if (PET_TOKENS.has(t)) {
+        filter.petFriendly = true;
+        continue;
+      }
+      if (SUD_TOKENS.has(t)) {
+        filter.sudFriendly = true;
+      }
+      // Unknown modifiers are ignored — we still treat the message as
+      // a BED request rather than rejecting on a typo.
+    }
+    return { kind: 'bed', filter };
+  }
+
+  return { kind: 'unknown', raw };
+}

--- a/src/lib/indc/sms-parser.ts
+++ b/src/lib/indc/sms-parser.ts
@@ -13,12 +13,20 @@ import type { BedFilter } from '@/lib/coordination/bed-availability';
  */
 export type ParsedSmsCommand =
   | { kind: 'bed'; filter: BedFilter }
+  | { kind: 'food' }
+  | { kind: 'story' }
+  | { kind: 'hold'; resultIndex: number }
+  | { kind: 'release' }
   | { kind: 'help' }
   | { kind: 'stop' }
   | { kind: 'unknown'; raw: string };
 
-const STOP_WORDS = new Set(['STOP', 'STOPALL', 'UNSUBSCRIBE', 'CANCEL', 'END', 'QUIT']);
+const STOP_WORDS = new Set(['STOP', 'STOPALL', 'UNSUBSCRIBE', 'END', 'QUIT']);
 const HELP_WORDS = new Set(['HELP', 'INFO', '?']);
+const FOOD_WORDS = new Set(['FOOD', 'EAT', 'PANTRY', 'MEAL', 'MEALS', 'HUNGRY']);
+const STORY_WORDS = new Set(['STORY', 'ABOUT', 'WHO', 'WHAT']);
+const HOLD_WORDS = new Set(['HOLD', 'RESERVE', 'CONFIRM']);
+const RELEASE_WORDS = new Set(['RELEASE', 'CANCEL', 'NEVERMIND']);
 
 const POPULATION_TOKENS: Record<string, NonNullable<BedFilter['population']>> = {
   MEN: 'men',
@@ -47,6 +55,22 @@ export function parseSmsCommand(raw: string): ParsedSmsCommand {
 
   if (STOP_WORDS.has(head)) return { kind: 'stop' };
   if (HELP_WORDS.has(head)) return { kind: 'help' };
+  if (FOOD_WORDS.has(head)) return { kind: 'food' };
+  if (STORY_WORDS.has(head)) return { kind: 'story' };
+
+  if (HOLD_WORDS.has(head)) {
+    // Accept `HOLD 1`, `HOLD #2`, `RESERVE 3`. Default to slot 1 when
+    // unspecified — the most-recent top result.
+    const arg = tokens[1];
+    let n = 1;
+    if (arg) {
+      const cleaned = arg.replace(/[^0-9]/g, '');
+      const parsed = Number.parseInt(cleaned, 10);
+      if (Number.isInteger(parsed) && parsed >= 1) n = parsed;
+    }
+    return { kind: 'hold', resultIndex: n - 1 };
+  }
+  if (RELEASE_WORDS.has(head)) return { kind: 'release' };
 
   if (head === 'BED' || head === 'BEDS' || head === 'SHELTER') {
     const filter: BedFilter = { minFreeBeds: 1 };

--- a/src/lib/indc/sms-pipeline.ts
+++ b/src/lib/indc/sms-pipeline.ts
@@ -1,31 +1,92 @@
 import { activeBedHoldCounts, listActiveShelters } from '@/db/queries/shelters';
+import type { BedFilter } from '@/lib/coordination/bed-availability';
 import { findOpenBeds } from './bed-finder';
-import { formatBedResults, smsHelp, smsStop, smsUnknown } from './sms-formatter';
+import {
+  clearConversation,
+  getConversation,
+  isLocationSkip,
+  markIdle,
+  normalizeLocation,
+  setAwaitingLocation,
+} from './sms-conversation';
+import { formatBedResults, smsHelp, smsLocationPrompt, smsStop, smsUnknown } from './sms-formatter';
 import { parseSmsCommand } from './sms-parser';
 
 export type SmsHandleResult = {
   /** Reply body to return to the caller (≤ SMS_MAX_LEN). */
   reply: string;
   /** What kind of intent we recognized; useful for logs / tests. */
-  intent: 'bed' | 'help' | 'stop' | 'unknown';
+  intent:
+    | 'bed_results'
+    | 'awaiting_location'
+    | 'help'
+    | 'stop'
+    | 'unknown'
+    | 'location_received'
+    | 'error';
 };
 
+async function bedResults(filter: BedFilter, nearLocation: string | null): Promise<string> {
+  const [shelters, holdCounts] = await Promise.all([listActiveShelters(), activeBedHoldCounts()]);
+  const matches = findOpenBeds({ shelters, activeHoldsByShelter: holdCounts, filter });
+  return formatBedResults(matches, filter, nearLocation);
+}
+
 /**
- * End-to-end "inbound message text → reply text" function. Pulls live
- * shelter + hold data from the DB; pure-ish in that everything else is
- * deterministic given that data.
+ * Stateful end-to-end SMS handler. The `fromNumber` keys the conversation
+ * state so multi-turn flows ("BED FAMILY" → "where are you?" → "42301"
+ * → results) work correctly. Pass an anonymous / empty fromNumber to
+ * disable conversation state (the playground uses this — it operates
+ * stateless against the same logic).
+ */
+export async function handleInboundSmsForNumber(
+  fromNumber: string,
+  body: string,
+): Promise<SmsHandleResult> {
+  const cmd = parseSmsCommand(body);
+  const stateful = Boolean(fromNumber && fromNumber.trim().length > 0);
+
+  if (cmd.kind === 'help') {
+    if (stateful) await clearConversation(fromNumber);
+    return { reply: smsHelp(), intent: 'help' };
+  }
+  if (cmd.kind === 'stop') {
+    if (stateful) await clearConversation(fromNumber);
+    return { reply: smsStop(), intent: 'stop' };
+  }
+
+  // Stateful BED command: park the filter and ask for location.
+  if (cmd.kind === 'bed' && stateful) {
+    await setAwaitingLocation(fromNumber, cmd.filter);
+    return { reply: smsLocationPrompt(), intent: 'awaiting_location' };
+  }
+
+  // Stateless BED (playground): immediate results, no location prompt.
+  if (cmd.kind === 'bed') {
+    return { reply: await bedResults(cmd.filter, null), intent: 'bed_results' };
+  }
+
+  // From here cmd.kind === 'unknown'. Conversation context decides
+  // whether the body is a location reply or a true unknown.
+  if (!stateful) {
+    return { reply: smsUnknown(), intent: 'unknown' };
+  }
+
+  const convo = await getConversation(fromNumber);
+  if (convo?.state === 'awaiting_location' && convo.pendingFilter) {
+    const nearLocation = isLocationSkip(body) ? null : normalizeLocation(body);
+    const reply = await bedResults(convo.pendingFilter, nearLocation);
+    await markIdle(fromNumber, nearLocation);
+    return { reply, intent: 'location_received' };
+  }
+
+  return { reply: smsUnknown(), intent: 'unknown' };
+}
+
+/**
+ * Stateless variant — used by the admin playground so testing the
+ * formatter doesn't pollute real users' conversation state.
  */
 export async function handleInboundSms(body: string): Promise<SmsHandleResult> {
-  const cmd = parseSmsCommand(body);
-  if (cmd.kind === 'help') return { reply: smsHelp(), intent: 'help' };
-  if (cmd.kind === 'stop') return { reply: smsStop(), intent: 'stop' };
-  if (cmd.kind === 'unknown') return { reply: smsUnknown(), intent: 'unknown' };
-
-  const [shelters, holdCounts] = await Promise.all([listActiveShelters(), activeBedHoldCounts()]);
-  const matches = findOpenBeds({
-    shelters,
-    activeHoldsByShelter: holdCounts,
-    filter: cmd.filter,
-  });
-  return { reply: formatBedResults(matches, cmd.filter), intent: 'bed' };
+  return handleInboundSmsForNumber('', body);
 }

--- a/src/lib/indc/sms-pipeline.ts
+++ b/src/lib/indc/sms-pipeline.ts
@@ -1,6 +1,11 @@
 import { activeBedHoldCounts, listActiveShelters } from '@/db/queries/shelters';
-import type { BedFilter } from '@/lib/coordination/bed-availability';
-import { findOpenBeds } from './bed-finder';
+import {
+  type BedFilter,
+  effectiveFreeBeds,
+  matchesFilter,
+} from '@/lib/coordination/bed-availability';
+import { type BedFinderResult, findOpenBeds } from './bed-finder';
+import { createBedHoldFromSms, releaseBedHoldFromSms } from './sms-bed-holds';
 import {
   clearConversation,
   getConversation,
@@ -8,36 +13,60 @@ import {
   markIdle,
   normalizeLocation,
   setAwaitingLocation,
+  setLastHoldId,
 } from './sms-conversation';
-import { formatBedResults, smsHelp, smsLocationPrompt, smsStop, smsUnknown } from './sms-formatter';
+import {
+  formatBedResults,
+  smsFood,
+  smsHelp,
+  smsHoldConfirmed,
+  smsHoldFailed,
+  smsHoldReleased,
+  smsLocationPrompt,
+  smsNoActiveHold,
+  smsNoHoldContext,
+  smsStop,
+  smsStory,
+  smsUnknown,
+} from './sms-formatter';
 import { parseSmsCommand } from './sms-parser';
+
+export type SmsHandleIntent =
+  | 'bed_results'
+  | 'awaiting_location'
+  | 'location_received'
+  | 'help'
+  | 'stop'
+  | 'food'
+  | 'story'
+  | 'hold_confirmed'
+  | 'hold_failed'
+  | 'release_confirmed'
+  | 'release_failed'
+  | 'unknown'
+  | 'error';
 
 export type SmsHandleResult = {
   /** Reply body to return to the caller (≤ SMS_MAX_LEN). */
   reply: string;
   /** What kind of intent we recognized; useful for logs / tests. */
-  intent:
-    | 'bed_results'
-    | 'awaiting_location'
-    | 'help'
-    | 'stop'
-    | 'unknown'
-    | 'location_received'
-    | 'error';
+  intent: SmsHandleIntent;
 };
 
-async function bedResults(filter: BedFilter, nearLocation: string | null): Promise<string> {
+async function bedResults(
+  filter: BedFilter,
+  nearLocation: string | null,
+): Promise<{ reply: string; results: BedFinderResult[] }> {
   const [shelters, holdCounts] = await Promise.all([listActiveShelters(), activeBedHoldCounts()]);
   const matches = findOpenBeds({ shelters, activeHoldsByShelter: holdCounts, filter });
-  return formatBedResults(matches, filter, nearLocation);
+  return { reply: formatBedResults(matches, filter, nearLocation), results: matches };
 }
 
 /**
  * Stateful end-to-end SMS handler. The `fromNumber` keys the conversation
  * state so multi-turn flows ("BED FAMILY" → "where are you?" → "42301"
- * → results) work correctly. Pass an anonymous / empty fromNumber to
- * disable conversation state (the playground uses this — it operates
- * stateless against the same logic).
+ * → results, then HOLD <#> against the result list) work correctly.
+ * Pass an empty fromNumber to disable conversation state (playground).
  */
 export async function handleInboundSmsForNumber(
   fromNumber: string,
@@ -54,6 +83,8 @@ export async function handleInboundSmsForNumber(
     if (stateful) await clearConversation(fromNumber);
     return { reply: smsStop(), intent: 'stop' };
   }
+  if (cmd.kind === 'food') return { reply: smsFood(), intent: 'food' };
+  if (cmd.kind === 'story') return { reply: smsStory(), intent: 'story' };
 
   // Stateful BED command: park the filter and ask for location.
   if (cmd.kind === 'bed' && stateful) {
@@ -63,24 +94,84 @@ export async function handleInboundSmsForNumber(
 
   // Stateless BED (playground): immediate results, no location prompt.
   if (cmd.kind === 'bed') {
-    return { reply: await bedResults(cmd.filter, null), intent: 'bed_results' };
+    const { reply } = await bedResults(cmd.filter, null);
+    return { reply, intent: 'bed_results' };
   }
 
-  // From here cmd.kind === 'unknown'. Conversation context decides
-  // whether the body is a location reply or a true unknown.
+  if (cmd.kind === 'hold' && stateful) {
+    return await handleHold(fromNumber, cmd.resultIndex);
+  }
+
+  if (cmd.kind === 'release' && stateful) {
+    return await handleRelease(fromNumber);
+  }
+
+  // From here cmd.kind === 'unknown' (or hold/release in stateless mode).
   if (!stateful) {
     return { reply: smsUnknown(), intent: 'unknown' };
   }
 
   const convo = await getConversation(fromNumber);
-  if (convo?.state === 'awaiting_location' && convo.pendingFilter) {
+  if (cmd.kind === 'unknown' && convo?.state === 'awaiting_location' && convo.pendingFilter) {
     const nearLocation = isLocationSkip(body) ? null : normalizeLocation(body);
-    const reply = await bedResults(convo.pendingFilter, nearLocation);
-    await markIdle(fromNumber, nearLocation);
+    const { reply, results } = await bedResults(convo.pendingFilter, nearLocation);
+    await markIdle(fromNumber, {
+      capturedLocation: nearLocation,
+      lastResults: results.map((r) => ({ shelterId: r.shelter.id, name: r.shelter.name })),
+    });
     return { reply, intent: 'location_received' };
   }
 
   return { reply: smsUnknown(), intent: 'unknown' };
+}
+
+async function handleHold(fromNumber: string, resultIndex: number): Promise<SmsHandleResult> {
+  const convo = await getConversation(fromNumber);
+  const list = convo?.lastResults ?? [];
+  if (list.length === 0) {
+    return { reply: smsNoHoldContext(), intent: 'hold_failed' };
+  }
+  const target = list[Math.max(0, Math.min(resultIndex, list.length - 1))];
+  if (!target) {
+    return { reply: smsNoHoldContext(), intent: 'hold_failed' };
+  }
+  // Re-verify there's still an open bed against current data, since
+  // the list might be a few minutes stale by the time HOLD arrives.
+  const [shelters, holdCounts] = await Promise.all([listActiveShelters(), activeBedHoldCounts()]);
+  const shelter = shelters.find((s) => s.id === target.shelterId);
+  if (!shelter) {
+    return { reply: smsHoldFailed('that shelter is no longer listed.'), intent: 'hold_failed' };
+  }
+  const free = effectiveFreeBeds(shelter, holdCounts.get(shelter.id) ?? 0);
+  if (free <= 0 || !matchesFilter(shelter, { minFreeBeds: 1 })) {
+    return {
+      reply: smsHoldFailed(`${shelter.name} just filled up.`),
+      intent: 'hold_failed',
+    };
+  }
+
+  const created = await createBedHoldFromSms(target.shelterId, fromNumber);
+  if (!created.ok) {
+    return { reply: smsHoldFailed(`${created.error}.`), intent: 'hold_failed' };
+  }
+  await setLastHoldId(fromNumber, created.holdId);
+  return {
+    reply: smsHoldConfirmed(shelter.name, shelter.contactPhone, created.expiresAt),
+    intent: 'hold_confirmed',
+  };
+}
+
+async function handleRelease(fromNumber: string): Promise<SmsHandleResult> {
+  const convo = await getConversation(fromNumber);
+  const lastHoldId = convo?.lastHoldId;
+  if (!lastHoldId) return { reply: smsNoActiveHold(), intent: 'release_failed' };
+
+  const released = await releaseBedHoldFromSms(lastHoldId);
+  if (!released.ok) {
+    return { reply: smsNoActiveHold(), intent: 'release_failed' };
+  }
+  await setLastHoldId(fromNumber, null);
+  return { reply: smsHoldReleased(released.shelterName), intent: 'release_confirmed' };
 }
 
 /**

--- a/src/lib/indc/sms-pipeline.ts
+++ b/src/lib/indc/sms-pipeline.ts
@@ -1,0 +1,31 @@
+import { activeBedHoldCounts, listActiveShelters } from '@/db/queries/shelters';
+import { findOpenBeds } from './bed-finder';
+import { formatBedResults, smsHelp, smsStop, smsUnknown } from './sms-formatter';
+import { parseSmsCommand } from './sms-parser';
+
+export type SmsHandleResult = {
+  /** Reply body to return to the caller (≤ SMS_MAX_LEN). */
+  reply: string;
+  /** What kind of intent we recognized; useful for logs / tests. */
+  intent: 'bed' | 'help' | 'stop' | 'unknown';
+};
+
+/**
+ * End-to-end "inbound message text → reply text" function. Pulls live
+ * shelter + hold data from the DB; pure-ish in that everything else is
+ * deterministic given that data.
+ */
+export async function handleInboundSms(body: string): Promise<SmsHandleResult> {
+  const cmd = parseSmsCommand(body);
+  if (cmd.kind === 'help') return { reply: smsHelp(), intent: 'help' };
+  if (cmd.kind === 'stop') return { reply: smsStop(), intent: 'stop' };
+  if (cmd.kind === 'unknown') return { reply: smsUnknown(), intent: 'unknown' };
+
+  const [shelters, holdCounts] = await Promise.all([listActiveShelters(), activeBedHoldCounts()]);
+  const matches = findOpenBeds({
+    shelters,
+    activeHoldsByShelter: holdCounts,
+    filter: cmd.filter,
+  });
+  return { reply: formatBedResults(matches, cmd.filter), intent: 'bed' };
+}

--- a/src/lib/indc/twilio-signature.test.ts
+++ b/src/lib/indc/twilio-signature.test.ts
@@ -1,0 +1,55 @@
+import { createHmac } from 'node:crypto';
+import { describe, expect, it } from 'vitest';
+import { twimlEmpty, twimlMessage, verifyTwilioSignature } from './twilio-signature';
+
+const sign = (token: string, url: string, params: Record<string, string>) => {
+  const sortedKeys = Object.keys(params).sort();
+  let canonical = url;
+  for (const k of sortedKeys) canonical += k + params[k];
+  return createHmac('sha1', token).update(canonical, 'utf-8').digest('base64');
+};
+
+describe('verifyTwilioSignature', () => {
+  const token = 'test_auth_token';
+  const url = 'https://example.test/api/webhooks/twilio/sms';
+  const params = { From: '+15551234567', To: '+15557654321', Body: 'BED FAMILY' };
+
+  it('accepts a valid signature', () => {
+    const sig = sign(token, url, params);
+    expect(verifyTwilioSignature(token, url, params, sig)).toBe(true);
+  });
+
+  it('rejects when the body has been tampered with', () => {
+    const sig = sign(token, url, params);
+    expect(verifyTwilioSignature(token, url, { ...params, Body: 'BED PET' }, sig)).toBe(false);
+  });
+
+  it('rejects when the signature header is empty', () => {
+    expect(verifyTwilioSignature(token, url, params, '')).toBe(false);
+  });
+
+  it('rejects when the auth token is empty', () => {
+    const sig = sign(token, url, params);
+    expect(verifyTwilioSignature('', url, params, sig)).toBe(false);
+  });
+
+  it('is param-order independent', () => {
+    const reordered = { Body: params.Body, To: params.To, From: params.From };
+    const sig = sign(token, url, reordered);
+    expect(verifyTwilioSignature(token, url, params, sig)).toBe(true);
+  });
+});
+
+describe('twimlMessage', () => {
+  it('XML-escapes the body', () => {
+    const xml = twimlMessage('Bed at <St. Mary\'s> & "Boulware"');
+    expect(xml).toContain('&lt;St. Mary');
+    expect(xml).toContain('&apos;');
+    expect(xml).toContain('&amp;');
+    expect(xml).toContain('&quot;Boulware&quot;');
+  });
+
+  it('twimlEmpty is a valid empty Response', () => {
+    expect(twimlEmpty()).toMatch(/<Response\s*\/>/);
+  });
+});

--- a/src/lib/indc/twilio-signature.ts
+++ b/src/lib/indc/twilio-signature.ts
@@ -1,0 +1,57 @@
+import { createHmac, timingSafeEqual } from 'node:crypto';
+
+/**
+ * Verifies the X-Twilio-Signature header against the documented algorithm:
+ *
+ *   base64(HMAC-SHA1(authToken, fullUrl + sortedParams))
+ *
+ * `fullUrl` must include the protocol, host, and path (no query). The
+ * `params` map is the form-encoded body keys, sorted alphabetically and
+ * concatenated as `key + value` pairs (no separators). See
+ * https://www.twilio.com/docs/usage/webhooks/webhooks-security
+ *
+ * This is a clean-room implementation so we don't take a dependency on
+ * the full `twilio` SDK just to verify a signature.
+ */
+export function verifyTwilioSignature(
+  authToken: string,
+  fullUrl: string,
+  params: Record<string, string>,
+  signatureHeader: string,
+): boolean {
+  if (!authToken || !signatureHeader) return false;
+
+  const sortedKeys = Object.keys(params).sort();
+  let canonical = fullUrl;
+  for (const k of sortedKeys) canonical += k + params[k];
+
+  const expected = createHmac('sha1', authToken).update(canonical, 'utf-8').digest('base64');
+
+  // timingSafeEqual requires equal-length buffers — guard explicitly.
+  if (expected.length !== signatureHeader.length) return false;
+  try {
+    return timingSafeEqual(Buffer.from(expected), Buffer.from(signatureHeader));
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * TwiML <Response><Message> wrapper. Twilio expects an XML body when
+ * replying inline to an inbound webhook, OR a 204 with an out-of-band
+ * SMS sent via the REST API. We use the inline TwiML form — simplest,
+ * no API calls, signed by the request itself.
+ */
+export function twimlMessage(body: string): string {
+  const escaped = body
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;');
+  return `<?xml version="1.0" encoding="UTF-8"?>\n<Response><Message>${escaped}</Message></Response>`;
+}
+
+export function twimlEmpty(): string {
+  return '<?xml version="1.0" encoding="UTF-8"?>\n<Response/>';
+}


### PR DESCRIPTION
**Recovery PR.** This rolls up all 13 stacked PRs (#255-#267) into one merge after the GitHub stacked-PR auto-base-flip went sideways. All commits are preserved per-feature; review each as a separate commit in this PR.

Closes #45, #46, #47, #49, #50, #51, #52, #53, #55, #56, #57, #58, #62, #63, #64, #65, #66, #67, #68, #69, #70, #251.

## Why one PR
The original plan was 13 stacked PRs. After #254 (COOR-001) merged, `gh pr merge --squash` for the chain pushed squash commits onto stacked source branches instead of main. Recovery: rebase the tip onto main (auto-skipped the duplicate COOR-001 commit) and merge as one. Per-feature history preserved in the commit log.

## Includes
- **Sprint COOR-002…005** (#255–#258): bed-count update UI; live availability board with auto-refresh + filters/search; 90-min soft holds with Inngest auto-expirer.
- **Sprint INDC-001…009** (#259–#262): Twilio webhook + signature verification; bed-finder pipeline (parser, finder, formatter); multi-turn conversation state with location prompt; FOOD/STORY shorthand + HOLD/RELEASE flow; SMS observability dashboard + admin handout.
- **Sprint DTRS-001…005** (#263, #264): consent state machine with versioning + scoping; plain-language consent form; per-record audit + DV abuser-blind helper; advisor-review doc.
- **Sprint CWT-007…009** (#265, #266): benefits eligibility rule engine (SNAP/KCHIP/Medicaid/KTAP/SSI/VA/LIHEAP) + dollar estimator; rule-based triage tier recommendation.
- **Follow-up #251** (#267): one-time-link auth on the consent surface + rate limiter; **post-review fixes** for token enforcement on the action and prod guard on the Twilio signature bypass.

## Code-review fixes (already applied as fix commits)
- #259: prod guard on `INDC_SKIP_TWILIO_SIGNATURE=1` (refused outside development).
- #267: `grantConsentAction` now requires + atomically redeems an access token; page render uses non-consuming lookup; token length tightened to exactly 43 chars.

Non-blocking review findings tracked separately in #268, #269, #270.

## Verification
- `pnpm typecheck` clean
- `pnpm exec vitest run` → 189/189 passing (17 test files)
- `pnpm build` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)