### PR TITLE
fix(#268): push DV-blind redaction into the query layer

### DIFF
--- a/src/app/app/cases/filings/[id]/page.tsx
+++ b/src/app/app/cases/filings/[id]/page.tsx
@@ -5,11 +5,11 @@ import { CaseOutcomePanel } from '@/components/eviction/case-outcome-panel';
 import { FilingDetail } from '@/components/eviction/filing-detail';
 import { RentalAssistancePanel } from '@/components/eviction/rental-assistance-panel';
 import { listCaseOutcomes } from '@/db/queries/eviction-case-outcomes';
-import { getFilingById } from '@/db/queries/eviction-filings';
+import { getFilingByIdForViewer } from '@/db/queries/eviction-filings';
 import { matchAssistancePrograms } from '@/db/queries/rental-assistance';
 import { requireRole, userIsKlaAttorney } from '@/lib/auth';
 import { recordDataAccess } from '@/lib/dtrs/data-access';
-import { redactAddress, viewerCanSeeDvAddresses } from '@/lib/dtrs/dv-blind';
+import { viewerCanSeeDvAddresses } from '@/lib/dtrs/dv-blind';
 import { getLatestScore } from '@/lib/eviction/risk-score';
 
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
@@ -21,7 +21,11 @@ export default async function FilingDetailPage({ params }: { params: Promise<{ i
   // Cheap shape check before hitting the DB — pg would 22P02 on a malformed UUID
   if (!UUID_RE.test(id)) notFound();
 
-  const filing = await getFilingById(id);
+  // DV abuser-blind: redaction is baked into the query (#268). The
+  // returned row has address fields nulled / replaced with
+  // LOCATION_REDACTED for non-permitted viewers, no per-page work
+  // required.
+  const filing = await getFilingByIdForViewer(id, me.role);
   if (!filing) notFound();
 
   const [score, outcomes, canRecord, assistancePrograms] = await Promise.all([
@@ -31,12 +35,6 @@ export default async function FilingDetailPage({ params }: { params: Promise<{ i
     matchAssistancePrograms(filing),
   ]);
 
-  // DV abuser-blind: filing.dv_flag is the per-record marker; the viewer
-  // role is the second axis. Attorneys + caseworkers see the address;
-  // everyone else sees LOCATION_REDACTED.
-  const showAddress = !filing.dvFlag || viewerCanSeeDvAddresses(me.role);
-  const safeFiling = redactAddress(filing, !showAddress);
-
   // DTRS-003: log this read. We log AFTER the row is fetched so the
   // log entry corresponds to a successful access.
   await recordDataAccess({
@@ -44,7 +42,10 @@ export default async function FilingDetailPage({ params }: { params: Promise<{ i
     resourceType: 'eviction_filings',
     resourceId: filing.id,
     purpose: 'attorney_case_detail',
-    metadata: { dvFlag: filing.dvFlag, addressVisible: showAddress },
+    metadata: {
+      dvFlag: filing.dvFlag,
+      addressVisible: !filing.dvFlag || viewerCanSeeDvAddresses(me.role),
+    },
   });
 
   return (
@@ -54,7 +55,7 @@ export default async function FilingDetailPage({ params }: { params: Promise<{ i
           ← Back to filings
         </Link>
       </div>
-      <FilingDetail filing={safeFiling} score={score} />
+      <FilingDetail filing={filing} score={score} />
       <div className="rounded-md border border-border bg-card p-4 text-sm">
         <p className="mb-2 font-medium">Response packet</p>
         <p className="mb-3 text-xs text-muted-foreground">

--- a/src/app/app/cases/filings/page.tsx
+++ b/src/app/app/cases/filings/page.tsx
@@ -2,7 +2,7 @@ import { CaseFilingsRoles } from '@/components/eviction/case-filings-roles';
 import { FilingsTable } from '@/components/eviction/filings-table';
 import { SourceFilter } from '@/components/eviction/source-filter';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
-import { listRecentFilings } from '@/db/queries/eviction-filings';
+import { listRecentFilingsForViewer } from '@/db/queries/eviction-filings';
 import type { EvictionFilingSource } from '@/db/schema/enums';
 import { requireRole } from '@/lib/auth';
 
@@ -13,11 +13,11 @@ export default async function FilingsPage({
 }: {
   searchParams: Promise<{ source?: string }>;
 }) {
-  await requireRole(CaseFilingsRoles);
+  const me = await requireRole(CaseFilingsRoles);
 
   const params = await searchParams;
   const source = ALLOWED_SOURCES.find((s) => s === params.source);
-  const filings = await listRecentFilings({ limit: 50, source });
+  const filings = await listRecentFilingsForViewer({ limit: 50, source }, me.role);
 
   return (
     <div className="mx-auto max-w-6xl p-6 space-y-4">

--- a/src/app/app/cases/queue/page.tsx
+++ b/src/app/app/cases/queue/page.tsx
@@ -2,7 +2,7 @@ import Link from 'next/link';
 import { DocketFilters, type DocketFilterValues } from '@/components/eviction/docket-filters';
 import { DocketTable } from '@/components/eviction/docket-table';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
-import { listRankedDocket } from '@/db/queries/eviction-filings';
+import { listRankedDocketForViewer } from '@/db/queries/eviction-filings';
 import type { EvictionCauseType, EvictionFilingStatus } from '@/db/schema/enums';
 import { requireKlaAttorney } from '@/lib/auth';
 
@@ -32,7 +32,7 @@ export default async function DocketQueuePage({
     min_score?: string;
   }>;
 }) {
-  await requireKlaAttorney();
+  const me = await requireKlaAttorney();
 
   const params = await searchParams;
   const status = ALLOWED_STATUSES.find((s) => s === params.status);
@@ -43,7 +43,10 @@ export default async function DocketQueuePage({
   const values: DocketFilterValues = { search, status, cause, minScore };
   const filtersActive = Boolean(search || status || cause || typeof minScore === 'number');
 
-  const rows = await listRankedDocket({ limit: 50, status, cause, minScore, search });
+  const rows = await listRankedDocketForViewer(
+    { limit: 50, status, cause, minScore, search },
+    me.role,
+  );
 
   return (
     <div className="mx-auto max-w-6xl p-6 space-y-4">

--- a/src/app/app/clients/page.tsx
+++ b/src/app/app/clients/page.tsx
@@ -1,6 +1,6 @@
 import Link from 'next/link';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import { listCrossOrgTouchpoints } from '@/db/queries/partner-service-events';
+import { listCrossOrgTouchpointsForViewer } from '@/db/queries/partner-service-events';
 import { requireRole } from '@/lib/auth';
 
 export const dynamic = 'force-dynamic';
@@ -9,8 +9,8 @@ const fmtDateTime = (d: Date) =>
   new Intl.DateTimeFormat('en-US', { dateStyle: 'medium' }).format(new Date(d));
 
 export default async function ClientsPage() {
-  await requireRole(['caseworker', 'ed_coordinator', 'shelter_staff', 'admin']);
-  const touchpoints = await listCrossOrgTouchpoints({ windowDays: 14, limit: 8 });
+  const me = await requireRole(['caseworker', 'ed_coordinator', 'shelter_staff', 'admin']);
+  const touchpoints = await listCrossOrgTouchpointsForViewer({ windowDays: 14, limit: 8 }, me.role);
 
   return (
     <div className="mx-auto max-w-5xl space-y-4 p-6">

--- a/src/app/app/coalition/coordination/page.tsx
+++ b/src/app/app/coalition/coordination/page.tsx
@@ -1,5 +1,5 @@
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import { listCrossOrgTouchpoints } from '@/db/queries/partner-service-events';
+import { listCrossOrgTouchpointsForViewer } from '@/db/queries/partner-service-events';
 import { requireRole } from '@/lib/auth';
 
 const WINDOW_DAYS = 14;
@@ -13,8 +13,17 @@ export default async function CrossOrgCoordinationPage() {
   // exactly the lens ed_coordinator and shelter_staff need — gating
   // it away from them would be schema theatre when the platform's
   // whole point is multi-disciplinary coordination.
-  await requireRole(['attorney', 'caseworker', 'ed_coordinator', 'shelter_staff', 'admin']);
-  const rows = await listCrossOrgTouchpoints({ windowDays: WINDOW_DAYS, limit: 50 });
+  const me = await requireRole([
+    'attorney',
+    'caseworker',
+    'ed_coordinator',
+    'shelter_staff',
+    'admin',
+  ]);
+  const rows = await listCrossOrgTouchpointsForViewer(
+    { windowDays: WINDOW_DAYS, limit: 50 },
+    me.role,
+  );
   const crossOrg = rows.filter((r) => r.uniqueOrgs >= 2);
 
   return (

--- a/src/db/queries/eviction-filings.ts
+++ b/src/db/queries/eviction-filings.ts
@@ -5,9 +5,11 @@ import type {
   EvictionCauseType,
   EvictionFilingSource,
   EvictionFilingStatus,
+  UserRole,
 } from '@/db/schema/enums';
 import { evictionFilingRiskScores } from '@/db/schema/eviction-filing-risk-scores';
 import { type EvictionFiling, evictionFilings } from '@/db/schema/eviction-filings';
+import { redactAddress, viewerCanSeeDvAddresses } from '@/lib/dtrs/dv-blind';
 import type { RankedDocketRow } from '@/lib/eviction/docket-ranking';
 
 /**
@@ -28,6 +30,34 @@ export async function listRecentFilings(
 export async function getFilingById(id: string): Promise<EvictionFiling | null> {
   const rows = await db.select().from(evictionFilings).where(eq(evictionFilings.id, id)).limit(1);
   return rows[0] ?? null;
+}
+
+/**
+ * Viewer-aware variants — DTRS-004 redaction baked into the query
+ * layer (issue #268). Every consumer of these helpers gets a row
+ * whose address fields are either real or `LOCATION_REDACTED`,
+ * decided server-side based on the caller's role and the row's
+ * `dv_flag`. New surfaces that fetch through these are safe by
+ * construction. The raw helpers above remain available for
+ * audit / admin use cases that need the un-redacted row.
+ */
+export async function getFilingByIdForViewer(
+  id: string,
+  viewerRole: UserRole,
+): Promise<EvictionFiling | null> {
+  const row = await getFilingById(id);
+  if (!row) return null;
+  const redact = row.dvFlag && !viewerCanSeeDvAddresses(viewerRole);
+  return redactAddress(row, redact);
+}
+
+export async function listRecentFilingsForViewer(
+  opts: { limit?: number; source?: EvictionFilingSource },
+  viewerRole: UserRole,
+): Promise<EvictionFiling[]> {
+  const rows = await listRecentFilings(opts);
+  if (viewerCanSeeDvAddresses(viewerRole)) return rows;
+  return rows.map((f) => (f.dvFlag ? redactAddress(f, true) : f));
 }
 
 /**
@@ -91,4 +121,19 @@ export async function listRankedDocket(
       desc(evictionFilings.filedAt),
     )
     .limit(limit);
+}
+
+/**
+ * Viewer-aware ranked docket. Mirrors `listRankedDocket` but redacts
+ * the embedded filing address for DV-flagged rows when the viewer
+ * lacks the permission. Same shape as the underlying type so the UI
+ * doesn't have to branch.
+ */
+export async function listRankedDocketForViewer(
+  opts: ListRankedDocketOpts,
+  viewerRole: UserRole,
+): Promise<RankedDocketRow[]> {
+  const rows = await listRankedDocket(opts);
+  if (viewerCanSeeDvAddresses(viewerRole)) return rows;
+  return rows.map((r) => (r.filing.dvFlag ? { ...r, filing: redactAddress(r.filing, true) } : r));
 }

--- a/src/db/queries/partner-service-events.ts
+++ b/src/db/queries/partner-service-events.ts
@@ -1,7 +1,9 @@
 import { count, desc, eq, gte, sql } from 'drizzle-orm';
 import { db } from '@/db/client';
+import type { UserRole } from '@/db/schema/enums';
 import { partnerOrgs } from '@/db/schema/partner-orgs';
 import { partnerServiceEvents } from '@/db/schema/partner-service-events';
+import { dvFlaggedSubset, viewerCanSeeDvAddresses } from '@/lib/dtrs/dv-blind';
 
 export interface PersonAggregate {
   syntheticPersonRef: string;
@@ -57,4 +59,25 @@ export async function listCrossOrgTouchpoints(
         : new Date(r.latestEventAt as unknown as string),
     orgNames: r.orgNames ?? [],
   }));
+}
+
+/**
+ * Viewer-aware variant. DV-flagged refs are HIDDEN from viewers who
+ * can't see addresses (DTRS-004 threat model: an abuser browsing the
+ * coordination view to find their survivor's location). The listing
+ * page renders attorneys and caseworkers see the survivor's row;
+ * shelter staff and ED coordinators see the cross-org pattern with
+ * the survivor's row absent — they still get the rest of the
+ * coalition view.
+ */
+export async function listCrossOrgTouchpointsForViewer(
+  opts: { windowDays?: number; limit?: number },
+  viewerRole: UserRole,
+): Promise<PersonAggregate[]> {
+  const all = await listCrossOrgTouchpoints(opts);
+  if (viewerCanSeeDvAddresses(viewerRole)) return all;
+
+  const refs = all.map((r) => r.syntheticPersonRef);
+  const flagged = await dvFlaggedSubset(refs);
+  return all.filter((r) => !flagged.has(r.syntheticPersonRef));
 }


### PR DESCRIPTION
Closes #268.

The audit follow-up to PR #264. DTRS-004 originally hung redaction on a single page (the filing detail view). That worked because no other surface rendered the address — but the design assumed every future surface would remember to apply the gate. This refactor makes redaction **safe-by-construction at the query layer**.

## New viewer-aware helpers

**`src/db/queries/eviction-filings.ts`**
- `getFilingByIdForViewer(id, role)` — returns the row with address fields nulled / replaced with `LOCATION_REDACTED` for non-permitted viewers.
- `listRecentFilingsForViewer(opts, role)` — same for the recent-filings list.
- `listRankedDocketForViewer(opts, role)` — same for the KLA docket; preserves the join shape so the UI doesn't branch.

**`src/db/queries/partner-service-events.ts`**
- `listCrossOrgTouchpointsForViewer(opts, role)` — DV-flagged refs are **hidden entirely** from non-permitted viewers (the threat model is an abuser browsing the coordination view to find a survivor's location, not just an address).

## Consumer rewires
- `/app/cases/filings/[id]` — drops the in-page `redactAddress` call; the query already returns a safe row.
- `/app/cases/filings` — uses `listRecentFilingsForViewer`.
- `/app/cases/queue` (KLA daily docket) — uses `listRankedDocketForViewer`.
- `/app/clients` — uses `listCrossOrgTouchpointsForViewer`.
- `/app/coalition/coordination` — same.

The raw `getFilingById` / `listRecentFilings` / `listRankedDocket` / `listCrossOrgTouchpoints` helpers stay available for audit / admin use cases that legitimately need un-redacted rows.

## Verification
- `pnpm typecheck` clean
- `pnpm exec vitest run` → 189/189 passing
- `pnpm build` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)