### PR TITLE
feat(OPRT-006): public outcome dashboard

### DIFF
--- a/src/app/outcomes/page.tsx
+++ b/src/app/outcomes/page.tsx
@@ -1,0 +1,187 @@
+import Link from 'next/link';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import {
+  getCoalitionAggregate,
+  getGovernanceCounts,
+  listLastNQuarters,
+  listQuarterlyEvictionAggregates,
+} from '@/db/queries/public-outcomes';
+
+export const dynamic = 'force-dynamic';
+
+export const metadata = {
+  title: 'Outcomes — Daviess Coalition',
+  description:
+    'Public outcome dashboard for the Daviess County homelessness-response coalition. Quarterly aggregate counts only — no individual data.',
+};
+
+const fmt = (n: number | null) =>
+  n === null ? <span className="text-muted-foreground">— suppressed</span> : n.toLocaleString();
+
+export default async function PublicOutcomesPage() {
+  const quarters = listLastNQuarters(new Date(), 4);
+  const [eviction, coalition, governance] = await Promise.all([
+    listQuarterlyEvictionAggregates(quarters),
+    getCoalitionAggregate(90),
+    getGovernanceCounts(),
+  ]);
+
+  return (
+    <main className="mx-auto max-w-5xl space-y-6 p-6 md:p-8">
+      <header className="space-y-2">
+        <p className="text-xs uppercase tracking-wide text-muted-foreground">
+          Daviess County Homelessness-Response Coalition
+        </p>
+        <h1 className="font-serif text-4xl font-bold text-primary">Outcomes</h1>
+        <p className="text-sm text-muted-foreground">
+          Quarterly aggregate counts of what the coalition has done. No individual data; cells with
+          fewer than five people are suppressed so no number traces back to a small handful of
+          identifiable people.
+        </p>
+      </header>
+
+      <section className="space-y-3">
+        <h2 className="font-serif text-2xl font-semibold">Coalition at a glance</h2>
+        <div className="grid gap-3 md:grid-cols-3">
+          <Card>
+            <CardContent>
+              <p className="text-xs uppercase tracking-wide text-muted-foreground">
+                Partner organizations
+              </p>
+              <p className="text-3xl font-semibold">{coalition.partnerCount}</p>
+              <p className="text-xs text-muted-foreground">
+                {coalition.partnersSharing} actively sharing data
+              </p>
+            </CardContent>
+          </Card>
+          <Card>
+            <CardContent>
+              <p className="text-xs uppercase tracking-wide text-muted-foreground">
+                Shelter capacity (coalition)
+              </p>
+              <p className="text-3xl font-semibold">{coalition.totalShelterCapacity}</p>
+              <p className="text-xs text-muted-foreground">
+                across {coalition.shelterCount} shelters
+              </p>
+            </CardContent>
+          </Card>
+          <Card>
+            <CardContent>
+              <p className="text-xs uppercase tracking-wide text-muted-foreground">
+                Service events (last {coalition.rollingWindowDays} days)
+              </p>
+              <p className="text-3xl font-semibold">{fmt(coalition.serviceEventsRolling)}</p>
+              <p className="text-xs text-muted-foreground">
+                across {fmt(coalition.uniquePeopleRolling)} people
+              </p>
+            </CardContent>
+          </Card>
+        </div>
+      </section>
+
+      <section className="space-y-3">
+        <h2 className="font-serif text-2xl font-semibold">Eviction defense by quarter</h2>
+        <div className="overflow-x-auto rounded-md border border-border">
+          <table className="w-full text-sm">
+            <thead className="bg-muted/40 text-left text-xs uppercase tracking-wide text-muted-foreground">
+              <tr>
+                <th scope="col" className="px-3 py-2">
+                  Quarter
+                </th>
+                <th scope="col" className="px-3 py-2 text-right">
+                  Filings
+                </th>
+                <th scope="col" className="px-3 py-2 text-right">
+                  Response packets
+                </th>
+                <th scope="col" className="px-3 py-2 text-right">
+                  Outcomes
+                </th>
+                <th scope="col" className="px-3 py-2 text-right">
+                  Default judgments
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              {eviction.map((e) => (
+                <tr key={e.quarter.label} className="border-t border-border">
+                  <td className="px-3 py-2 font-mono text-xs">{e.quarter.label}</td>
+                  <td className="px-3 py-2 text-right">{fmt(e.filingsIngested)}</td>
+                  <td className="px-3 py-2 text-right">{fmt(e.filingsWithPacket)}</td>
+                  <td className="px-3 py-2 text-right">{fmt(e.outcomesRecorded)}</td>
+                  <td className="px-3 py-2 text-right">{fmt(e.defaultJudgments)}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+        <p className="text-xs text-muted-foreground">
+          Filings are public court records. Response packets and outcomes are coalition-tracked
+          aggregates of what happened after legal aid intervention.
+        </p>
+      </section>
+
+      <section className="space-y-3">
+        <h2 className="font-serif text-2xl font-semibold">Data trust governance</h2>
+        <div className="grid gap-3 md:grid-cols-3">
+          <Card>
+            <CardContent>
+              <p className="text-xs uppercase tracking-wide text-muted-foreground">
+                Consent grants
+              </p>
+              <p className="text-3xl font-semibold">{fmt(governance.consentGrants90d)}</p>
+              <p className="text-xs text-muted-foreground">last 90 days</p>
+            </CardContent>
+          </Card>
+          <Card>
+            <CardContent>
+              <p className="text-xs uppercase tracking-wide text-muted-foreground">
+                Consent revocations
+              </p>
+              <p className="text-3xl font-semibold">{fmt(governance.consentRevocations90d)}</p>
+              <p className="text-xs text-muted-foreground">last 90 days</p>
+            </CardContent>
+          </Card>
+          <Card>
+            <CardContent>
+              <p className="text-xs uppercase tracking-wide text-muted-foreground">
+                Per-record accesses logged
+              </p>
+              <p className="text-3xl font-semibold">{fmt(governance.dataAccessEvents90d)}</p>
+              <p className="text-xs text-muted-foreground">last 90 days, audit-trail</p>
+            </CardContent>
+          </Card>
+        </div>
+        <p className="text-xs text-muted-foreground">
+          Consent and access counts are part of the coalition's transparency commitment. Every
+          record access is logged in an append-only audit trail; revocations are honored
+          immediately.
+        </p>
+      </section>
+
+      <Card className="border-amber-500/40 bg-amber-500/5">
+        <CardHeader>
+          <CardTitle className="text-base">About this dashboard</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-2 text-xs text-muted-foreground">
+          <p>
+            Built per OPRT-006 in the coalition's engineering backlog. Updated every page load
+            against the live database. No personally identifying information is exposed; cells below
+            the suppression threshold (5) are shown as <span className="font-mono">—</span>.
+          </p>
+          <p>
+            Source code is open. The data trust governance described above is documented in the
+            pilot report; partner organizations participate via signed MOUs.
+          </p>
+          <p>
+            Questions or corrections:{' '}
+            <Link href="/" className="underline hover:text-foreground">
+              return to the coalition home page
+            </Link>{' '}
+            for contact info.
+          </p>
+        </CardContent>
+      </Card>
+    </main>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -7,38 +7,59 @@ export default async function Home() {
   const { userId } = await auth();
 
   return (
-    <main className="flex min-h-screen flex-col items-center justify-center gap-8 bg-background p-8">
-      <div className="max-w-2xl text-center space-y-4">
-        <h1 className="text-4xl font-bold tracking-tight">Daviess Coalition Platform</h1>
+    <main className="mx-auto flex min-h-screen max-w-3xl flex-col items-center justify-center gap-8 p-8">
+      <div className="text-center space-y-3">
+        <p className="text-xs uppercase tracking-wide text-muted-foreground">
+          Daviess County, Kentucky
+        </p>
+        <h1 className="font-serif text-4xl font-bold tracking-tight">Daviess Coalition Platform</h1>
         <p className="text-lg text-muted-foreground">
-          AI-powered tooling to address homelessness in Daviess County, Kentucky — eviction defense,
-          ED super-utilizer care coordination, caseworker tools, and an SMS companion for unhoused
+          AI-powered tooling for the county homelessness-response coalition — eviction defense, ED
+          super-utilizer care coordination, caseworker tools, and an SMS bed-finder for unhoused
           individuals.
         </p>
       </div>
 
-      <Card className="max-w-2xl w-full">
-        <CardHeader>
-          <CardTitle>Phase 0 — Foundation</CardTitle>
-          <CardDescription>This is a scaffold. Real surfaces ship in Phase 1.</CardDescription>
-        </CardHeader>
-        <CardContent className="flex gap-3">
-          {userId ? (
-            <Link href="/app/dashboard">
-              <Button>Open dashboard</Button>
+      <div className="grid w-full gap-4 md:grid-cols-2">
+        <Card>
+          <CardHeader>
+            <CardTitle>For coalition partners</CardTitle>
+            <CardDescription>
+              Sign in for attorney, caseworker, ED coordinator, shelter staff, or admin tools.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="flex gap-2">
+            {userId ? (
+              <Link href="/app/dashboard">
+                <Button>Open dashboard</Button>
+              </Link>
+            ) : (
+              <>
+                <Link href="/sign-in">
+                  <Button>Sign in</Button>
+                </Link>
+                <Link href="/sign-up">
+                  <Button variant="outline">Create account</Button>
+                </Link>
+              </>
+            )}
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>For everyone else</CardTitle>
+            <CardDescription>
+              Quarterly outcomes, governance counts, and what the coalition has done so far.
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <Link href="/outcomes">
+              <Button variant="outline">View outcomes →</Button>
             </Link>
-          ) : (
-            <>
-              <Link href="/sign-in">
-                <Button>Sign in</Button>
-              </Link>
-              <Link href="/sign-up">
-                <Button variant="outline">Create account</Button>
-              </Link>
-            </>
-          )}
-        </CardContent>
-      </Card>
+          </CardContent>
+        </Card>
+      </div>
     </main>
   );
 }

--- a/src/db/queries/public-outcomes.test.ts
+++ b/src/db/queries/public-outcomes.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest';
+import { listLastNQuarters, quarterFromDate } from './public-outcomes';
+
+describe('quarterFromDate', () => {
+  it('Q1 covers Jan–Mar', () => {
+    expect(quarterFromDate(new Date('2026-01-15T12:00:00Z'))).toEqual({
+      year: 2026,
+      quarter: 1,
+      label: '2026 Q1',
+    });
+    expect(quarterFromDate(new Date('2026-03-31T23:00:00Z'))).toEqual({
+      year: 2026,
+      quarter: 1,
+      label: '2026 Q1',
+    });
+  });
+
+  it('Q4 covers Oct–Dec', () => {
+    expect(quarterFromDate(new Date('2026-10-01T00:00:00Z'))).toEqual({
+      year: 2026,
+      quarter: 4,
+      label: '2026 Q4',
+    });
+    expect(quarterFromDate(new Date('2026-12-31T23:00:00Z'))).toEqual({
+      year: 2026,
+      quarter: 4,
+      label: '2026 Q4',
+    });
+  });
+});
+
+describe('listLastNQuarters', () => {
+  it('returns N quarters ending with the current one, oldest first', () => {
+    const out = listLastNQuarters(new Date('2026-04-26T12:00:00Z'), 4);
+    expect(out.map((q) => q.label)).toEqual(['2025 Q3', '2025 Q4', '2026 Q1', '2026 Q2']);
+  });
+
+  it('rolls over the year boundary correctly', () => {
+    const out = listLastNQuarters(new Date('2026-02-15T12:00:00Z'), 5);
+    expect(out.map((q) => q.label)).toEqual([
+      '2025 Q1',
+      '2025 Q2',
+      '2025 Q3',
+      '2025 Q4',
+      '2026 Q1',
+    ]);
+  });
+
+  it('N=1 returns just the current quarter', () => {
+    const out = listLastNQuarters(new Date('2026-04-26T12:00:00Z'), 1);
+    expect(out.map((q) => q.label)).toEqual(['2026 Q2']);
+  });
+});

--- a/src/db/queries/public-outcomes.ts
+++ b/src/db/queries/public-outcomes.ts
@@ -1,0 +1,181 @@
+import { sql } from 'drizzle-orm';
+import { db } from '@/db/client';
+import { auditLog } from '@/db/schema/audit-log';
+import { evictionCaseOutcomes } from '@/db/schema/eviction-case-outcomes';
+import { evictionFilings } from '@/db/schema/eviction-filings';
+import { evictionResponsePackets } from '@/db/schema/eviction-response-packets';
+import { partnerOrgs } from '@/db/schema/partner-orgs';
+import { partnerServiceEvents } from '@/db/schema/partner-service-events';
+import { shelters } from '@/db/schema/shelters';
+
+/**
+ * OPRT-006 public outcome dashboard data layer. Every query returns
+ * coalition-level AGGREGATE counts only — never per-person, never
+ * per-shelter address, never anything that could identify a subject
+ * or a survivor. The threshold rule we follow: any cell smaller
+ * than 5 is suppressed (returned as null), so no count traces back
+ * to a small handful of identifiable people.
+ *
+ * Quarter labelling follows calendar quarters in UTC.
+ */
+
+export type Quarter = { year: number; quarter: 1 | 2 | 3 | 4; label: string };
+
+export function quarterFromDate(d: Date): Quarter {
+  const year = d.getUTCFullYear();
+  const month = d.getUTCMonth(); // 0-11
+  const quarter = (Math.floor(month / 3) + 1) as 1 | 2 | 3 | 4;
+  return { year, quarter, label: `${year} Q${quarter}` };
+}
+
+export function listLastNQuarters(now: Date, n: number): Quarter[] {
+  const cur = quarterFromDate(now);
+  const out: Quarter[] = [];
+  let year = cur.year;
+  let quarter: number = cur.quarter;
+  for (let i = 0; i < n; i++) {
+    out.push({ year, quarter: quarter as 1 | 2 | 3 | 4, label: `${year} Q${quarter}` });
+    quarter -= 1;
+    if (quarter === 0) {
+      quarter = 4;
+      year -= 1;
+    }
+  }
+  return out.reverse();
+}
+
+const SUPPRESSION_THRESHOLD = 5;
+
+/** Returns the count if ≥ threshold, else null. */
+function suppress(value: number): number | null {
+  return value >= SUPPRESSION_THRESHOLD ? value : null;
+}
+
+export type QuarterlyEvictionAggregate = {
+  quarter: Quarter;
+  /** Filings ingested. null if below the suppression threshold. */
+  filingsIngested: number | null;
+  /** Filings (in this quarter) that received a response packet. */
+  filingsWithPacket: number | null;
+  /** Outcomes recorded in this quarter (filed, dismissed, etc.). */
+  outcomesRecorded: number | null;
+  /** Default-judgment outcomes in this quarter — the avoid-this metric. */
+  defaultJudgments: number | null;
+};
+
+export async function listQuarterlyEvictionAggregates(
+  quarters: Quarter[],
+): Promise<QuarterlyEvictionAggregate[]> {
+  const out: QuarterlyEvictionAggregate[] = [];
+  for (const q of quarters) {
+    const start = new Date(Date.UTC(q.year, (q.quarter - 1) * 3, 1));
+    const end = new Date(Date.UTC(q.year, q.quarter * 3, 1));
+
+    const [filingsRow] = await db.execute<{ count: number }>(sql`
+      SELECT COUNT(*)::int AS count FROM ${evictionFilings}
+      WHERE filed_at >= ${start} AND filed_at < ${end}
+    `);
+    const [packetsRow] = await db.execute<{ count: number }>(sql`
+      SELECT COUNT(DISTINCT ${evictionResponsePackets.filingId})::int AS count
+      FROM ${evictionResponsePackets}
+      INNER JOIN ${evictionFilings} ON ${evictionFilings.id} = ${evictionResponsePackets.filingId}
+      WHERE ${evictionFilings.filedAt} >= ${start} AND ${evictionFilings.filedAt} < ${end}
+    `);
+    const [outcomesRow] = await db.execute<{ count: number }>(sql`
+      SELECT COUNT(*)::int AS count FROM ${evictionCaseOutcomes}
+      WHERE created_at >= ${start} AND created_at < ${end}
+    `);
+    const [defaultRow] = await db.execute<{ count: number }>(sql`
+      SELECT COUNT(*)::int AS count FROM ${evictionCaseOutcomes}
+      WHERE outcome = 'default_judgment' AND created_at >= ${start} AND created_at < ${end}
+    `);
+
+    out.push({
+      quarter: q,
+      filingsIngested: suppress(Number(filingsRow.count)),
+      filingsWithPacket: suppress(Number(packetsRow.count)),
+      outcomesRecorded: suppress(Number(outcomesRow.count)),
+      defaultJudgments: suppress(Number(defaultRow.count)),
+    });
+  }
+  return out;
+}
+
+export type CoalitionAggregate = {
+  /** Total active partner orgs in the directory (no suppression — names are public). */
+  partnerCount: number;
+  /** Number of partners with data_sharing_tier != 'none'. */
+  partnersSharing: number;
+  /** Active shelters listed. Public; not suppressed. */
+  shelterCount: number;
+  /** Sum of capacity across shelters. */
+  totalShelterCapacity: number;
+  /** Cross-org touchpoints (events) in the last `windowDays` days. Suppressed if low. */
+  serviceEventsRolling: number | null;
+  /** Distinct opaque persons touched in the same window. Suppressed if low. */
+  uniquePeopleRolling: number | null;
+  rollingWindowDays: number;
+};
+
+export async function getCoalitionAggregate(rollingWindowDays = 90): Promise<CoalitionAggregate> {
+  const since = new Date();
+  since.setUTCDate(since.getUTCDate() - rollingWindowDays);
+
+  const [partners] = await db.execute<{ count: number; sharing: number }>(sql`
+    SELECT
+      COUNT(*) FILTER (WHERE active = true)::int AS count,
+      COUNT(*) FILTER (WHERE active = true AND data_sharing_tier <> 'none')::int AS sharing
+    FROM ${partnerOrgs}
+  `);
+  const [shelterRow] = await db.execute<{ count: number; capacity: number }>(sql`
+    SELECT
+      COUNT(*) FILTER (WHERE active = true)::int AS count,
+      COALESCE(SUM(capacity) FILTER (WHERE active = true), 0)::int AS capacity
+    FROM ${shelters}
+  `);
+  const [eventsRow] = await db.execute<{ events: number; people: number }>(sql`
+    SELECT
+      COUNT(*)::int AS events,
+      COUNT(DISTINCT synthetic_person_ref)::int AS people
+    FROM ${partnerServiceEvents}
+    WHERE event_at >= ${since}
+  `);
+
+  return {
+    partnerCount: Number(partners.count),
+    partnersSharing: Number(partners.sharing),
+    shelterCount: Number(shelterRow.count),
+    totalShelterCapacity: Number(shelterRow.capacity),
+    serviceEventsRolling: suppress(Number(eventsRow.events)),
+    uniquePeopleRolling: suppress(Number(eventsRow.people)),
+    rollingWindowDays,
+  };
+}
+
+export type GovernanceCounts = {
+  /** Consent grants in the last 90 days. Suppressed if low. */
+  consentGrants90d: number | null;
+  /** Consent revocations in the last 90 days. Suppressed if low. */
+  consentRevocations90d: number | null;
+  /** Per-record data-access events logged in the last 90 days. */
+  dataAccessEvents90d: number | null;
+};
+
+export async function getGovernanceCounts(): Promise<GovernanceCounts> {
+  const since = new Date();
+  since.setUTCDate(since.getUTCDate() - 90);
+
+  const [row] = await db.execute<{ grants: number; revocations: number; access: number }>(sql`
+    SELECT
+      COUNT(*) FILTER (WHERE action = 'consent.granted')::int AS grants,
+      COUNT(*) FILTER (WHERE action = 'consent.revoked')::int AS revocations,
+      COUNT(*) FILTER (WHERE action = 'data.accessed')::int AS access
+    FROM ${auditLog}
+    WHERE created_at >= ${since}
+  `);
+  return {
+    consentGrants90d: suppress(Number(row.grants)),
+    consentRevocations90d: suppress(Number(row.revocations)),
+    dataAccessEvents90d: suppress(Number(row.access)),
+  };
+}


### PR DESCRIPTION
Closes #146.

Public, no-auth-required dashboard at `/outcomes` showing the coalition's quarterly aggregate counts. Every cell with fewer than 5 subjects is suppressed (rendered as `—`) so no number traces back to a small handful of identifiable people.

## Three sections

- **Coalition at a glance** — partner-org count, partners actively sharing data, shelter capacity coalition-wide, 90-day rolling count of service events + distinct opaque persons touched.
- **Eviction defense by quarter** — 4 quarters of filings ingested, response packets drafted, outcomes recorded, and default-judgment count (the avoid-this metric).
- **Data trust governance** — 90-day counts of consent grants / revocations / per-record data-access events.

## Implementation

- `src/db/queries/public-outcomes.ts` aggregates everything into a public-safe surface. No row-level data, only counts. `quarterFromDate` / `listLastNQuarters` helpers are pure and unit-tested.
- Suppression is at the **query layer** (server-side) with a single `SUPPRESSION_THRESHOLD = 5` constant. Any cell below the threshold returns null and the UI renders an em-dash.
- Marketing root (`/`) updated to point public visitors to `/outcomes` alongside the partner sign-in flow.
- 5 new tests, 194 total passing.

## Verification
- Typecheck clean, build clean
- 194/194 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)