### PR TITLE
feat(CWT-014): override tracking on triage recommendations

### DIFF
--- a/drizzle/migrations/0024_modern_hellcat.sql
+++ b/drizzle/migrations/0024_modern_hellcat.sql
@@ -1,0 +1,17 @@
+CREATE TYPE "public"."triage_tier" AS ENUM('high', 'medium', 'low');--> statement-breakpoint
+CREATE TABLE "triage_overrides" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"actor_user_id" uuid NOT NULL,
+	"recommended_tier" "triage_tier" NOT NULL,
+	"recommended_score" integer NOT NULL,
+	"chosen_tier" "triage_tier" NOT NULL,
+	"override_reason" text,
+	"inputs_snapshot" jsonb NOT NULL,
+	"recommended_factors" jsonb NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "triage_overrides" ADD CONSTRAINT "triage_overrides_actor_user_id_users_id_fk" FOREIGN KEY ("actor_user_id") REFERENCES "public"."users"("id") ON DELETE restrict ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "triage_overrides_actor_idx" ON "triage_overrides" USING btree ("actor_user_id");--> statement-breakpoint
+CREATE INDEX "triage_overrides_created_idx" ON "triage_overrides" USING btree ("created_at");--> statement-breakpoint
+CREATE INDEX "triage_overrides_recommended_idx" ON "triage_overrides" USING btree ("recommended_tier");

--- a/drizzle/migrations/meta/0024_snapshot.json
+++ b/drizzle/migrations/meta/0024_snapshot.json
@@ -1,0 +1,3013 @@
+{
+  "id": "6735f13e-9441-404c-9e6c-920eb12826f8",
+  "prevId": "418b7757-36d7-4726-b9a4-5ef97a04d9bf",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.audit_log": {
+      "name": "audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_table": {
+          "name": "target_table",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "audit_log_actor_idx": {
+          "name": "audit_log_actor_idx",
+          "columns": [
+            {
+              "expression": "actor_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_log_action_idx": {
+          "name": "audit_log_action_idx",
+          "columns": [
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_log_created_at_idx": {
+          "name": "audit_log_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audit_log_actor_user_id_users_id_fk": {
+          "name": "audit_log_actor_user_id_users_id_fk",
+          "tableFrom": "audit_log",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.consent_access_tokens": {
+      "name": "consent_access_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "synthetic_person_ref": {
+          "name": "synthetic_person_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issued_by_user_id": {
+          "name": "issued_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "consent_access_tokens_token_idx": {
+          "name": "consent_access_tokens_token_idx",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "consent_access_tokens_ref_idx": {
+          "name": "consent_access_tokens_ref_idx",
+          "columns": [
+            {
+              "expression": "synthetic_person_ref",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "consent_access_tokens_expires_idx": {
+          "name": "consent_access_tokens_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "consent_access_tokens_issued_by_user_id_users_id_fk": {
+          "name": "consent_access_tokens_issued_by_user_id_users_id_fk",
+          "tableFrom": "consent_access_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "issued_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.consents": {
+      "name": "consents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "subject_external_id": {
+          "name": "subject_external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consent_type": {
+          "name": "consent_type",
+          "type": "consent_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "granted_via": {
+          "name": "granted_via",
+          "type": "consent_channel",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consent_version": {
+          "name": "consent_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'2026-04-1'"
+        },
+        "scope_partner_ids": {
+          "name": "scope_partner_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope_data_classes": {
+          "name": "scope_data_classes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "signature_text": {
+          "name": "signature_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "granted_at": {
+          "name": "granted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "consents_subject_idx": {
+          "name": "consents_subject_idx",
+          "columns": [
+            {
+              "expression": "subject_external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "consents_type_idx": {
+          "name": "consents_type_idx",
+          "columns": [
+            {
+              "expression": "consent_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "consents_expires_at_idx": {
+          "name": "consents_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.dv_flagged_persons": {
+      "name": "dv_flagged_persons",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "subject_identifier": {
+          "name": "subject_identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "flag_set_at": {
+          "name": "flag_set_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "flag_cleared_at": {
+          "name": "flag_cleared_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "dv_flagged_persons_subject_idx": {
+          "name": "dv_flagged_persons_subject_idx",
+          "columns": [
+            {
+              "expression": "subject_identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dv_flagged_persons_set_at_idx": {
+          "name": "dv_flagged_persons_set_at_idx",
+          "columns": [
+            {
+              "expression": "flag_set_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ed_encounters": {
+      "name": "ed_encounters",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encounter_external_id": {
+          "name": "encounter_external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "arrived_at": {
+          "name": "arrived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discharged_at": {
+          "name": "discharged_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chief_complaint": {
+          "name": "chief_complaint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "disposition": {
+          "name": "disposition",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "housing_status": {
+          "name": "housing_status",
+          "type": "housing_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unknown'"
+        },
+        "charge_cents": {
+          "name": "charge_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_json": {
+          "name": "raw_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "ed_encounter_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'synthetic'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ed_encounters_external_idx": {
+          "name": "ed_encounters_external_idx",
+          "columns": [
+            {
+              "expression": "encounter_external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ed_encounters_patient_idx": {
+          "name": "ed_encounters_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ed_encounters_arrived_idx": {
+          "name": "ed_encounters_arrived_idx",
+          "columns": [
+            {
+              "expression": "arrived_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ed_encounters_housing_idx": {
+          "name": "ed_encounters_housing_idx",
+          "columns": [
+            {
+              "expression": "housing_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.esuc_care_plans": {
+      "name": "esuc_care_plans",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plan_md": {
+          "name": "plan_md",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt_version": {
+          "name": "prompt_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "generated_by_user_id": {
+          "name": "generated_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "esuc_care_plan_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "care_plans_patient_version_idx": {
+          "name": "care_plans_patient_version_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "prompt_version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "care_plans_patient_idx": {
+          "name": "care_plans_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "care_plans_status_idx": {
+          "name": "care_plans_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "esuc_care_plans_generated_by_user_id_users_id_fk": {
+          "name": "esuc_care_plans_generated_by_user_id_users_id_fk",
+          "tableFrom": "esuc_care_plans",
+          "tableTo": "users",
+          "columnsFrom": [
+            "generated_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.eviction_case_outcomes": {
+      "name": "eviction_case_outcomes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "filing_id": {
+          "name": "filing_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "eviction_case_outcome",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recorded_by_user_id": {
+          "name": "recorded_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "case_outcomes_filing_idx": {
+          "name": "case_outcomes_filing_idx",
+          "columns": [
+            {
+              "expression": "filing_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "case_outcomes_outcome_idx": {
+          "name": "case_outcomes_outcome_idx",
+          "columns": [
+            {
+              "expression": "outcome",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "case_outcomes_created_at_idx": {
+          "name": "case_outcomes_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "eviction_case_outcomes_filing_id_eviction_filings_id_fk": {
+          "name": "eviction_case_outcomes_filing_id_eviction_filings_id_fk",
+          "tableFrom": "eviction_case_outcomes",
+          "tableTo": "eviction_filings",
+          "columnsFrom": [
+            "filing_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "eviction_case_outcomes_recorded_by_user_id_users_id_fk": {
+          "name": "eviction_case_outcomes_recorded_by_user_id_users_id_fk",
+          "tableFrom": "eviction_case_outcomes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "recorded_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.eviction_filing_risk_scores": {
+      "name": "eviction_filing_risk_scores",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "filing_id": {
+          "name": "filing_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rationale": {
+          "name": "rationale",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model_version": {
+          "name": "model_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "risk_scores_filing_version_idx": {
+          "name": "risk_scores_filing_version_idx",
+          "columns": [
+            {
+              "expression": "filing_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "model_version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "risk_scores_filing_idx": {
+          "name": "risk_scores_filing_idx",
+          "columns": [
+            {
+              "expression": "filing_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "risk_scores_score_idx": {
+          "name": "risk_scores_score_idx",
+          "columns": [
+            {
+              "expression": "score",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "eviction_filing_risk_scores_filing_id_eviction_filings_id_fk": {
+          "name": "eviction_filing_risk_scores_filing_id_eviction_filings_id_fk",
+          "tableFrom": "eviction_filing_risk_scores",
+          "tableTo": "eviction_filings",
+          "columnsFrom": [
+            "filing_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.eviction_filings": {
+      "name": "eviction_filings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "case_number": {
+          "name": "case_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filed_at": {
+          "name": "filed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "court_division": {
+          "name": "court_division",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plaintiff": {
+          "name": "plaintiff",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "defendant_first_name": {
+          "name": "defendant_first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "defendant_last_name": {
+          "name": "defendant_last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "defendant_address": {
+          "name": "defendant_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cause_type": {
+          "name": "cause_type",
+          "type": "eviction_cause_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_claimed_cents": {
+          "name": "amount_claimed_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "eviction_filing_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'filed'"
+        },
+        "source": {
+          "name": "source",
+          "type": "eviction_filing_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "raw_json": {
+          "name": "raw_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dv_flag": {
+          "name": "dv_flag",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "eviction_filings_case_source_idx": {
+          "name": "eviction_filings_case_source_idx",
+          "columns": [
+            {
+              "expression": "case_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "eviction_filings_filed_at_idx": {
+          "name": "eviction_filings_filed_at_idx",
+          "columns": [
+            {
+              "expression": "filed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "eviction_filings_status_idx": {
+          "name": "eviction_filings_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.eviction_response_packets": {
+      "name": "eviction_response_packets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "filing_id": {
+          "name": "filing_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "packet_md": {
+          "name": "packet_md",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt_version": {
+          "name": "prompt_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "generated_by_user_id": {
+          "name": "generated_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "eviction_response_packet_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "response_packets_filing_version_idx": {
+          "name": "response_packets_filing_version_idx",
+          "columns": [
+            {
+              "expression": "filing_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "prompt_version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "response_packets_filing_idx": {
+          "name": "response_packets_filing_idx",
+          "columns": [
+            {
+              "expression": "filing_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "response_packets_status_idx": {
+          "name": "response_packets_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "eviction_response_packets_filing_id_eviction_filings_id_fk": {
+          "name": "eviction_response_packets_filing_id_eviction_filings_id_fk",
+          "tableFrom": "eviction_response_packets",
+          "tableTo": "eviction_filings",
+          "columnsFrom": [
+            "filing_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "eviction_response_packets_generated_by_user_id_users_id_fk": {
+          "name": "eviction_response_packets_generated_by_user_id_users_id_fk",
+          "tableFrom": "eviction_response_packets",
+          "tableTo": "users",
+          "columnsFrom": [
+            "generated_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.health_check": {
+      "name": "health_check",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_memberships": {
+      "name": "org_memberships",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "partner_org_id": {
+          "name": "partner_org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "org_memberships_user_org_idx": {
+          "name": "org_memberships_user_org_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "partner_org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "org_memberships_user_idx": {
+          "name": "org_memberships_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "org_memberships_partner_org_idx": {
+          "name": "org_memberships_partner_org_idx",
+          "columns": [
+            {
+              "expression": "partner_org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "org_memberships_user_id_users_id_fk": {
+          "name": "org_memberships_user_id_users_id_fk",
+          "tableFrom": "org_memberships",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "org_memberships_partner_org_id_partner_orgs_id_fk": {
+          "name": "org_memberships_partner_org_id_partner_orgs_id_fk",
+          "tableFrom": "org_memberships",
+          "tableTo": "partner_orgs",
+          "columnsFrom": [
+            "partner_org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.partner_orgs": {
+      "name": "partner_orgs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "partner_org_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_email": {
+          "name": "contact_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_phone": {
+          "name": "contact_phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "website": {
+          "name": "website",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data_sharing_tier": {
+          "name": "data_sharing_tier",
+          "type": "data_sharing_tier",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "partner_orgs_slug_idx": {
+          "name": "partner_orgs_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.partner_service_events": {
+      "name": "partner_service_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "partner_org_id": {
+          "name": "partner_org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "synthetic_person_ref": {
+          "name": "synthetic_person_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "partner_service_event_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_at": {
+          "name": "event_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "ed_encounter_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'synthetic'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "partner_service_events_person_idx": {
+          "name": "partner_service_events_person_idx",
+          "columns": [
+            {
+              "expression": "synthetic_person_ref",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "partner_service_events_partner_idx": {
+          "name": "partner_service_events_partner_idx",
+          "columns": [
+            {
+              "expression": "partner_org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "partner_service_events_at_idx": {
+          "name": "partner_service_events_at_idx",
+          "columns": [
+            {
+              "expression": "event_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "partner_service_events_partner_org_id_partner_orgs_id_fk": {
+          "name": "partner_service_events_partner_org_id_partner_orgs_id_fk",
+          "tableFrom": "partner_service_events",
+          "tableTo": "partner_orgs",
+          "columnsFrom": [
+            "partner_org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.person_partner_consents": {
+      "name": "person_partner_consents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "synthetic_person_ref": {
+          "name": "synthetic_person_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "partner_org_id": {
+          "name": "partner_org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "granted_at": {
+          "name": "granted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "person_partner_consents_unique_idx": {
+          "name": "person_partner_consents_unique_idx",
+          "columns": [
+            {
+              "expression": "synthetic_person_ref",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "partner_org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "person_partner_consents_partner_org_id_partner_orgs_id_fk": {
+          "name": "person_partner_consents_partner_org_id_partner_orgs_id_fk",
+          "tableFrom": "person_partner_consents",
+          "tableTo": "partner_orgs",
+          "columnsFrom": [
+            "partner_org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rental_assistance_programs": {
+      "name": "rental_assistance_programs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agency": {
+          "name": "agency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "website": {
+          "name": "website",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "eligibility_summary": {
+          "name": "eligibility_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "max_award_cents": {
+          "name": "max_award_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_note": {
+          "name": "source_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "rental_assistance_programs_active_idx": {
+          "name": "rental_assistance_programs_active_idx",
+          "columns": [
+            {
+              "expression": "active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bed_count_updates": {
+      "name": "bed_count_updates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "shelter_id": {
+          "name": "shelter_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_user_id": {
+          "name": "updated_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "previous_occupancy": {
+          "name": "previous_occupancy",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "new_occupancy": {
+          "name": "new_occupancy",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "bed_count_updates_shelter_idx": {
+          "name": "bed_count_updates_shelter_idx",
+          "columns": [
+            {
+              "expression": "shelter_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bed_count_updates_created_idx": {
+          "name": "bed_count_updates_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bed_count_updates_shelter_id_shelters_id_fk": {
+          "name": "bed_count_updates_shelter_id_shelters_id_fk",
+          "tableFrom": "bed_count_updates",
+          "tableTo": "shelters",
+          "columnsFrom": [
+            "shelter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bed_holds": {
+      "name": "bed_holds",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "shelter_id": {
+          "name": "shelter_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "held_by_user_id": {
+          "name": "held_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "person_label": {
+          "name": "person_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "bed_hold_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "released_at": {
+          "name": "released_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "bed_holds_shelter_idx": {
+          "name": "bed_holds_shelter_idx",
+          "columns": [
+            {
+              "expression": "shelter_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bed_holds_status_idx": {
+          "name": "bed_holds_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bed_holds_expires_idx": {
+          "name": "bed_holds_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bed_holds_shelter_id_shelters_id_fk": {
+          "name": "bed_holds_shelter_id_shelters_id_fk",
+          "tableFrom": "bed_holds",
+          "tableTo": "shelters",
+          "columnsFrom": [
+            "shelter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.shelters": {
+      "name": "shelters",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "partner_org_id": {
+          "name": "partner_org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address_line1": {
+          "name": "address_line1",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "city": {
+          "name": "city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "postal_code": {
+          "name": "postal_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_phone": {
+          "name": "contact_phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capacity": {
+          "name": "capacity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_occupancy": {
+          "name": "current_occupancy",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "accepts_men": {
+          "name": "accepts_men",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "accepts_women": {
+          "name": "accepts_women",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "accepts_families": {
+          "name": "accepts_families",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "pet_friendly": {
+          "name": "pet_friendly",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "sud_friendly": {
+          "name": "sud_friendly",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "shelters_slug_idx": {
+          "name": "shelters_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "shelters_partner_org_idx": {
+          "name": "shelters_partner_org_idx",
+          "columns": [
+            {
+              "expression": "partner_org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "shelters_partner_org_id_partner_orgs_id_fk": {
+          "name": "shelters_partner_org_id_partner_orgs_id_fk",
+          "tableFrom": "shelters",
+          "tableTo": "partner_orgs",
+          "columnsFrom": [
+            "partner_org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "shelters_capacity_nonneg": {
+          "name": "shelters_capacity_nonneg",
+          "value": "\"shelters\".\"capacity\" >= 0"
+        },
+        "shelters_occupancy_nonneg": {
+          "name": "shelters_occupancy_nonneg",
+          "value": "\"shelters\".\"current_occupancy\" >= 0"
+        },
+        "shelters_occupancy_le_capacity": {
+          "name": "shelters_occupancy_le_capacity",
+          "value": "\"shelters\".\"current_occupancy\" <= \"shelters\".\"capacity\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.sms_conversations": {
+      "name": "sms_conversations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "from_number": {
+          "name": "from_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "sms_conversation_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'idle'"
+        },
+        "pending_filter": {
+          "name": "pending_filter",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_location": {
+          "name": "last_location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_results": {
+          "name": "last_results",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_hold_id": {
+          "name": "last_hold_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_message_at": {
+          "name": "last_message_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sms_conversations_from_idx": {
+          "name": "sms_conversations_from_idx",
+          "columns": [
+            {
+              "expression": "from_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_conversations_state_idx": {
+          "name": "sms_conversations_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_conversations_expires_idx": {
+          "name": "sms_conversations_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sms_messages": {
+      "name": "sms_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "provider_message_id": {
+          "name": "provider_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "from_number": {
+          "name": "from_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_number": {
+          "name": "to_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "intent": {
+          "name": "intent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reply_body": {
+          "name": "reply_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sms_messages_received_idx": {
+          "name": "sms_messages_received_idx",
+          "columns": [
+            {
+              "expression": "received_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_messages_from_idx": {
+          "name": "sms_messages_from_idx",
+          "columns": [
+            {
+              "expression": "from_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.triage_overrides": {
+      "name": "triage_overrides",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recommended_tier": {
+          "name": "recommended_tier",
+          "type": "triage_tier",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recommended_score": {
+          "name": "recommended_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chosen_tier": {
+          "name": "chosen_tier",
+          "type": "triage_tier",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "override_reason": {
+          "name": "override_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "inputs_snapshot": {
+          "name": "inputs_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recommended_factors": {
+          "name": "recommended_factors",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "triage_overrides_actor_idx": {
+          "name": "triage_overrides_actor_idx",
+          "columns": [
+            {
+              "expression": "actor_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "triage_overrides_created_idx": {
+          "name": "triage_overrides_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "triage_overrides_recommended_idx": {
+          "name": "triage_overrides_recommended_idx",
+          "columns": [
+            {
+              "expression": "recommended_tier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "triage_overrides_actor_user_id_users_id_fk": {
+          "name": "triage_overrides_actor_user_id_users_id_fk",
+          "tableFrom": "triage_overrides",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "clerk_user_id": {
+          "name": "clerk_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "users_clerk_user_id_idx": {
+          "name": "users_clerk_user_id_idx",
+          "columns": [
+            {
+              "expression": "clerk_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.bed_hold_status": {
+      "name": "bed_hold_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "released",
+        "expired",
+        "converted"
+      ]
+    },
+    "public.consent_channel": {
+      "name": "consent_channel",
+      "schema": "public",
+      "values": [
+        "sms",
+        "in_person",
+        "web_form",
+        "phone",
+        "paper"
+      ]
+    },
+    "public.consent_type": {
+      "name": "consent_type",
+      "schema": "public",
+      "values": [
+        "phi_share_within_coalition",
+        "sms_communication",
+        "data_for_program_eval"
+      ]
+    },
+    "public.data_sharing_tier": {
+      "name": "data_sharing_tier",
+      "schema": "public",
+      "values": [
+        "none",
+        "aggregate",
+        "individual"
+      ]
+    },
+    "public.ed_encounter_source": {
+      "name": "ed_encounter_source",
+      "schema": "public",
+      "values": [
+        "synthetic",
+        "epic_fhir",
+        "manual"
+      ]
+    },
+    "public.esuc_care_plan_status": {
+      "name": "esuc_care_plan_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "approved",
+        "active",
+        "archived"
+      ]
+    },
+    "public.eviction_case_outcome": {
+      "name": "eviction_case_outcome",
+      "schema": "public",
+      "values": [
+        "dismissed",
+        "judgment_for_plaintiff",
+        "judgment_for_defendant",
+        "settled",
+        "default_judgment",
+        "withdrawn"
+      ]
+    },
+    "public.eviction_cause_type": {
+      "name": "eviction_cause_type",
+      "schema": "public",
+      "values": [
+        "non_payment",
+        "lease_violation",
+        "holdover",
+        "other"
+      ]
+    },
+    "public.eviction_filing_source": {
+      "name": "eviction_filing_source",
+      "schema": "public",
+      "values": [
+        "courtnet",
+        "manual",
+        "synthetic"
+      ]
+    },
+    "public.eviction_filing_status": {
+      "name": "eviction_filing_status",
+      "schema": "public",
+      "values": [
+        "filed",
+        "served",
+        "judgment",
+        "dismissed",
+        "sealed"
+      ]
+    },
+    "public.eviction_response_packet_status": {
+      "name": "eviction_response_packet_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "approved",
+        "filed",
+        "rejected"
+      ]
+    },
+    "public.housing_status": {
+      "name": "housing_status",
+      "schema": "public",
+      "values": [
+        "housed",
+        "doubled_up",
+        "shelter",
+        "unsheltered",
+        "unknown"
+      ]
+    },
+    "public.partner_org_type": {
+      "name": "partner_org_type",
+      "schema": "public",
+      "values": [
+        "hospital",
+        "legal_aid",
+        "shelter",
+        "community_org",
+        "government",
+        "faith_based",
+        "school",
+        "philanthropy",
+        "education",
+        "public_health",
+        "media",
+        "other"
+      ]
+    },
+    "public.partner_service_event_type": {
+      "name": "partner_service_event_type",
+      "schema": "public",
+      "values": [
+        "food_pantry",
+        "shelter_intake",
+        "shelter_bed_night",
+        "utility_assistance",
+        "rent_assistance",
+        "counseling_visit",
+        "medical_visit",
+        "school_attendance_flag",
+        "volunteer_hours",
+        "other"
+      ]
+    },
+    "public.sms_conversation_state": {
+      "name": "sms_conversation_state",
+      "schema": "public",
+      "values": [
+        "idle",
+        "awaiting_location"
+      ]
+    },
+    "public.triage_tier": {
+      "name": "triage_tier",
+      "schema": "public",
+      "values": [
+        "high",
+        "medium",
+        "low"
+      ]
+    },
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "pending",
+        "attorney",
+        "caseworker",
+        "ed_coordinator",
+        "shelter_staff",
+        "admin"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/migrations/meta/_journal.json
+++ b/drizzle/migrations/meta/_journal.json
@@ -169,6 +169,13 @@
       "when": 1777240694967,
       "tag": "0023_curious_tarot",
       "breakpoints": true
+    },
+    {
+      "idx": 24,
+      "version": "7",
+      "when": 1777247227040,
+      "tag": "0024_modern_hellcat",
+      "breakpoints": true
     }
   ]
 }

--- a/src/app/actions/triage.ts
+++ b/src/app/actions/triage.ts
@@ -1,0 +1,73 @@
+'use server';
+
+import { db } from '@/db/client';
+import { triageOverrides } from '@/db/schema/triage-overrides';
+import { logAuditEvent } from '@/lib/audit';
+import { requireRole } from '@/lib/auth';
+import { recommendTriageTier, type TriageInputs, type TriageTier } from '@/lib/cwt/triage';
+
+export type RecordTriageOverrideResult =
+  | { ok: true; id: string; isOverride: boolean }
+  | { ok: false; error: string };
+
+const ROLES = ['caseworker', 'shelter_staff', 'admin'] as const;
+
+const REASON_MAX = 280;
+
+/**
+ * Record what the caseworker did with a triage recommendation:
+ * either confirmed it (chosen === recommended) or overrode it
+ * (chosen !== recommended, with a required rationale). Both cases
+ * land in the same table; the dashboard reports override rate by
+ * dividing chosen != recommended by total rows.
+ *
+ * Re-runs the rule engine server-side so a hand-edited client request
+ * can't claim a different recommendation than the one the engine
+ * actually produced for those inputs.
+ */
+export async function recordTriageOverrideAction(
+  inputs: TriageInputs,
+  chosen: TriageTier,
+  reason: string | null,
+): Promise<RecordTriageOverrideResult> {
+  const actor = await requireRole(ROLES);
+
+  const recommendation = recommendTriageTier(inputs);
+  const isOverride = chosen !== recommendation.tier;
+
+  if (isOverride) {
+    const trimmed = (reason ?? '').trim();
+    if (trimmed.length === 0) {
+      return { ok: false, error: 'Please write a brief reason for the override.' };
+    }
+  }
+
+  const trimmedReason = reason?.trim() ? reason.trim().slice(0, REASON_MAX) : null;
+
+  const [created] = await db
+    .insert(triageOverrides)
+    .values({
+      actorUserId: actor.id,
+      recommendedTier: recommendation.tier,
+      recommendedScore: recommendation.score,
+      chosenTier: chosen,
+      overrideReason: trimmedReason,
+      inputsSnapshot: inputs as unknown as Record<string, unknown>,
+      recommendedFactors: recommendation.factors,
+    })
+    .returning({ id: triageOverrides.id });
+
+  await logAuditEvent({
+    actorUserId: actor.id,
+    action: isOverride ? 'triage.overridden' : 'triage.confirmed',
+    targetTable: 'triage_overrides',
+    targetId: created.id,
+    metadata: {
+      recommendedTier: recommendation.tier,
+      chosenTier: chosen,
+      recommendedScore: recommendation.score,
+    },
+  });
+
+  return { ok: true, id: created.id, isOverride };
+}

--- a/src/app/app/admin/triage-overrides/page.tsx
+++ b/src/app/app/admin/triage-overrides/page.tsx
@@ -1,0 +1,143 @@
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { getTriageOverrideStats, listRecentTriageOverrides } from '@/db/queries/triage-overrides';
+import { requireRole } from '@/lib/auth';
+
+export const dynamic = 'force-dynamic';
+
+const fmtTime = (d: Date) =>
+  new Intl.DateTimeFormat('en-US', { dateStyle: 'short', timeStyle: 'short' }).format(new Date(d));
+
+const TIER_BADGE: Record<string, string> = {
+  high: 'bg-emerald-600/15 text-emerald-700 dark:text-emerald-400',
+  medium: 'bg-amber-500/15 text-amber-700 dark:text-amber-400',
+  low: 'bg-destructive/15 text-destructive',
+};
+
+export default async function TriageOverridesPage() {
+  await requireRole(['admin']);
+  const [stats, rows] = await Promise.all([
+    getTriageOverrideStats(),
+    listRecentTriageOverrides(50),
+  ]);
+
+  return (
+    <div className="mx-auto max-w-5xl space-y-4 p-4 md:p-6">
+      <header>
+        <h1 className="font-serif text-3xl font-bold text-primary">Triage overrides</h1>
+        <p className="text-sm text-muted-foreground">
+          Caseworker decisions on the rule-based triage recommendation. Each row is a confirmation
+          (chose what the engine recommended) or an override (chose something else, with a reason).
+          Overrides are the highest-signal training data for the Phase-2 ML replacement.
+        </p>
+      </header>
+
+      <div className="grid gap-3 md:grid-cols-3">
+        <Card>
+          <CardContent>
+            <p className="text-xs uppercase tracking-wide text-muted-foreground">
+              Decisions logged
+            </p>
+            <p className="text-3xl font-semibold">{stats.total}</p>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardContent>
+            <p className="text-xs uppercase tracking-wide text-muted-foreground">
+              Overrides (chosen ≠ recommended)
+            </p>
+            <p className="text-3xl font-semibold">{stats.overrides}</p>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardContent>
+            <p className="text-xs uppercase tracking-wide text-muted-foreground">Override rate</p>
+            <p className="text-3xl font-semibold">{Math.round(stats.overrideRate * 100)}%</p>
+          </CardContent>
+        </Card>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">Transitions</CardTitle>
+        </CardHeader>
+        <CardContent>
+          {stats.transitions.length === 0 ? (
+            <p className="text-sm text-muted-foreground">
+              No decisions logged yet. Caseworkers record decisions on{' '}
+              <code className="font-mono">/app/clients/triage</code>.
+            </p>
+          ) : (
+            <ul className="space-y-1 text-sm">
+              {stats.transitions.map((t) => (
+                <li
+                  key={`${t.recommended}->${t.chosen}`}
+                  className="flex items-baseline justify-between gap-2"
+                >
+                  <span>
+                    <span
+                      className={`rounded px-2 py-0.5 text-xs ${TIER_BADGE[t.recommended] ?? 'bg-muted'}`}
+                    >
+                      {t.recommended}
+                    </span>
+                    <span className="mx-2 text-muted-foreground">→</span>
+                    <span
+                      className={`rounded px-2 py-0.5 text-xs ${TIER_BADGE[t.chosen] ?? 'bg-muted'}`}
+                    >
+                      {t.chosen}
+                    </span>
+                    {t.recommended === t.chosen ? (
+                      <span className="ml-2 text-xs text-muted-foreground">(confirmed)</span>
+                    ) : null}
+                  </span>
+                  <span className="font-mono text-xs">{t.count}</span>
+                </li>
+              ))}
+            </ul>
+          )}
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">Most recent decisions</CardTitle>
+        </CardHeader>
+        <CardContent>
+          {rows.length === 0 ? (
+            <p className="text-sm text-muted-foreground">No decisions logged yet.</p>
+          ) : (
+            <ul className="space-y-2 text-sm">
+              {rows.map((r) => {
+                const isOverride = r.recommendedTier !== r.chosenTier;
+                return (
+                  <li key={r.id} className="rounded-md border border-border bg-card p-3 text-xs">
+                    <div className="flex flex-wrap items-baseline justify-between gap-2">
+                      <span className="font-mono text-muted-foreground">
+                        {fmtTime(r.createdAt)} · {r.actorEmail ?? 'unknown'}
+                      </span>
+                      <span className={isOverride ? 'text-destructive' : 'text-muted-foreground'}>
+                        {isOverride ? 'OVERRIDE' : 'confirmed'}
+                      </span>
+                    </div>
+                    <p className="mt-1">
+                      Engine recommended{' '}
+                      <span className={`rounded px-2 py-0.5 ${TIER_BADGE[r.recommendedTier]}`}>
+                        {r.recommendedTier}
+                      </span>{' '}
+                      (score {r.recommendedScore}) · caseworker chose{' '}
+                      <span className={`rounded px-2 py-0.5 ${TIER_BADGE[r.chosenTier]}`}>
+                        {r.chosenTier}
+                      </span>
+                    </p>
+                    {r.overrideReason ? (
+                      <p className="mt-1 text-muted-foreground italic">"{r.overrideReason}"</p>
+                    ) : null}
+                  </li>
+                );
+              })}
+            </ul>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/components/app-shell/nav-config.ts
+++ b/src/components/app-shell/nav-config.ts
@@ -94,6 +94,7 @@ export const NAV_ITEMS: NavItem[] = [
   { label: 'Settings', href: '/app/settings', roles: 'all' },
   { label: 'Admin · Users', href: '/app/admin/users', roles: ['admin'] },
   { label: 'Admin · Audit log', href: '/app/admin/audit', roles: ['admin'] },
+  { label: 'Admin · Triage overrides', href: '/app/admin/triage-overrides', roles: ['admin'] },
 ];
 
 export function navItemsForRole(role: UserRole): NavItem[] {

--- a/src/components/cwt/triage-tier.tsx
+++ b/src/components/cwt/triage-tier.tsx
@@ -1,7 +1,10 @@
 'use client';
 
-import { useMemo, useState } from 'react';
+import { useId, useMemo, useState, useTransition } from 'react';
+import { recordTriageOverrideAction } from '@/app/actions/triage';
 import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
 import { recommendTriageTier, type TriageInputs, type TriageTier } from '@/lib/cwt/triage';
 
 const TIER_BADGE: Record<TriageTier, string> = {
@@ -55,6 +58,31 @@ const blankInputs = (): TriageInputs => ({
 export function TriageTierTool() {
   const [inputs, setInputs] = useState<TriageInputs>(() => blankInputs());
   const result = useMemo(() => recommendTriageTier(inputs), [inputs]);
+  const [chosen, setChosen] = useState<TriageTier | null>(null);
+  const [reason, setReason] = useState('');
+  const [pending, startTransition] = useTransition();
+  const [recordError, setRecordError] = useState<string | null>(null);
+  const [savedAt, setSavedAt] = useState<{ at: Date; isOverride: boolean } | null>(null);
+  const reasonId = useId();
+
+  const submit = (chosenTier: TriageTier) => {
+    setRecordError(null);
+    setChosen(chosenTier);
+    const isOverride = chosenTier !== result.tier;
+    if (isOverride && reason.trim().length === 0) {
+      setRecordError('Please write a brief reason for the override.');
+      return;
+    }
+    startTransition(async () => {
+      const r = await recordTriageOverrideAction(inputs, chosenTier, reason || null);
+      if (!r.ok) {
+        setRecordError(r.error);
+        return;
+      }
+      setSavedAt({ at: new Date(), isOverride: r.isOverride });
+      setReason('');
+    });
+  };
 
   return (
     <div className="grid gap-6 md:grid-cols-2">
@@ -143,9 +171,60 @@ export function TriageTierTool() {
           <p className="font-medium">Rule-based v1.</p>
           <p className="mt-1 text-muted-foreground">
             Tier comes from a transparent additive score. Phase 2 replaces this with an ML model
-            trained on labeled outcomes from the pilot. Override the recommendation any time —
-            overrides themselves become training data.
+            trained on labeled outcomes from the pilot. Confirm or override below — both go into the
+            audit trail and become training data.
           </p>
+        </div>
+
+        <div className="space-y-3 rounded-md border border-border bg-card p-3 text-sm">
+          <p className="text-xs uppercase tracking-wide text-muted-foreground">
+            Record your decision
+          </p>
+          {savedAt ? (
+            <p className="text-emerald-700 dark:text-emerald-400">
+              {savedAt.isOverride ? 'Override' : 'Confirmation'} saved at{' '}
+              {new Intl.DateTimeFormat('en-US', { timeStyle: 'short' }).format(savedAt.at)}.
+            </p>
+          ) : null}
+          <div>
+            <Label htmlFor={reasonId} className="text-xs uppercase tracking-wide">
+              Reason (required when overriding)
+            </Label>
+            <Input
+              id={reasonId}
+              value={reason}
+              onChange={(e) => setReason(e.target.value)}
+              maxLength={280}
+              placeholder="e.g. recent eviction not in record yet"
+              disabled={pending}
+            />
+          </div>
+          {recordError ? <p className="text-xs text-destructive">{recordError}</p> : null}
+          <div className="flex flex-wrap gap-2">
+            <Button
+              type="button"
+              size="sm"
+              variant={chosen === result.tier ? 'default' : 'outline'}
+              disabled={pending}
+              onClick={() => submit(result.tier)}
+            >
+              Confirm {TIER_LABEL[result.tier]}
+            </Button>
+            {(['high', 'medium', 'low'] as const)
+              .filter((t) => t !== result.tier)
+              .map((t) => (
+                <Button
+                  key={t}
+                  type="button"
+                  size="sm"
+                  variant="ghost"
+                  disabled={pending}
+                  onClick={() => submit(t)}
+                >
+                  Override → {TIER_LABEL[t]}
+                </Button>
+              ))}
+          </div>
         </div>
       </section>
     </div>

--- a/src/db/queries/triage-overrides.ts
+++ b/src/db/queries/triage-overrides.ts
@@ -1,0 +1,61 @@
+import { desc, eq, sql } from 'drizzle-orm';
+import { db } from '@/db/client';
+import { type TriageOverride, triageOverrides } from '@/db/schema/triage-overrides';
+import { users } from '@/db/schema/users';
+
+export type TriageOverrideRow = TriageOverride & { actorEmail: string | null };
+
+export async function listRecentTriageOverrides(limit = 50): Promise<TriageOverrideRow[]> {
+  const rows = await db
+    .select({
+      override: triageOverrides,
+      actorEmail: users.email,
+    })
+    .from(triageOverrides)
+    .leftJoin(users, eq(triageOverrides.actorUserId, users.id))
+    .orderBy(desc(triageOverrides.createdAt))
+    .limit(limit);
+  return rows.map((r) => ({ ...r.override, actorEmail: r.actorEmail }));
+}
+
+export type TriageOverrideStats = {
+  total: number;
+  overrides: number;
+  /** overrides / total. 0 when total === 0. */
+  overrideRate: number;
+  /** Counts of (recommendedTier → chosenTier) pairs. */
+  transitions: Array<{ recommended: string; chosen: string; count: number }>;
+};
+
+export async function getTriageOverrideStats(): Promise<TriageOverrideStats> {
+  const [totals] = await db.execute<{ total: number; overrides: number }>(sql`
+    SELECT
+      COUNT(*)::int AS total,
+      COUNT(*) FILTER (WHERE recommended_tier <> chosen_tier)::int AS overrides
+    FROM ${triageOverrides}
+  `);
+  const transitions = await db.execute<{ recommended: string; chosen: string; count: number }>(sql`
+    SELECT recommended_tier AS recommended, chosen_tier AS chosen, COUNT(*)::int AS count
+    FROM ${triageOverrides}
+    GROUP BY 1, 2
+    ORDER BY count DESC
+  `);
+  const total = Number(totals.total);
+  const overrides = Number(totals.overrides);
+  return {
+    total,
+    overrides,
+    overrideRate: total > 0 ? overrides / total : 0,
+    transitions: (
+      transitions as unknown as Array<{
+        recommended: string;
+        chosen: string;
+        count: number;
+      }>
+    ).map((r) => ({
+      recommended: r.recommended,
+      chosen: r.chosen,
+      count: Number(r.count),
+    })),
+  };
+}

--- a/src/db/schema/enums.ts
+++ b/src/db/schema/enums.ts
@@ -141,6 +141,10 @@ export const smsConversationStateEnum = pgEnum('sms_conversation_state', [
 
 export type SmsConversationState = (typeof smsConversationStateEnum.enumValues)[number];
 
+export const triageTierEnum = pgEnum('triage_tier', ['high', 'medium', 'low']);
+
+export type TriageTierEnum = (typeof triageTierEnum.enumValues)[number];
+
 export const partnerServiceEventTypeEnum = pgEnum('partner_service_event_type', [
   'food_pantry',
   'shelter_intake',

--- a/src/db/schema/index.ts
+++ b/src/db/schema/index.ts
@@ -18,4 +18,5 @@ export * from './rental-assistance-programs';
 export * from './shelters';
 export * from './sms-conversations';
 export * from './sms-messages';
+export * from './triage-overrides';
 export * from './users';

--- a/src/db/schema/triage-overrides.ts
+++ b/src/db/schema/triage-overrides.ts
@@ -1,0 +1,47 @@
+import { index, integer, jsonb, pgTable, text, timestamp, uuid } from 'drizzle-orm/pg-core';
+import { triageTierEnum } from './enums';
+import { users } from './users';
+
+/**
+ * CWT-014: caseworker overrides on the rule-based triage
+ * recommendation. Captured as a signal for Phase-2 ML retraining
+ * and as an explainable audit trail of "the system said X but the
+ * caseworker chose Y because Z."
+ *
+ * Stores the recommendation context (inputs + computed score + tier)
+ * and what the caseworker actually picked. No client-identifying
+ * data — `inputs_snapshot` carries household details (income,
+ * household size, flags) but no name / address / synthetic_person_ref.
+ */
+export const triageOverrides = pgTable(
+  'triage_overrides',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    /** Caseworker / admin who recorded the override. */
+    actorUserId: uuid('actor_user_id')
+      .notNull()
+      .references(() => users.id, { onDelete: 'restrict' }),
+    /** Rule-engine output at the time of the override. */
+    recommendedTier: triageTierEnum('recommended_tier').notNull(),
+    recommendedScore: integer('recommended_score').notNull(),
+    /** Tier the caseworker chose instead. May equal recommended (a confirm). */
+    chosenTier: triageTierEnum('chosen_tier').notNull(),
+    /** Free-form rationale; required when chosen != recommended. */
+    overrideReason: text('override_reason'),
+    /** Snapshot of TriageInputs at decision time, for retraining context. */
+    inputsSnapshot: jsonb('inputs_snapshot').$type<Record<string, unknown>>().notNull(),
+    /** Snapshot of factors[] from recommendTriageTier output. */
+    recommendedFactors: jsonb('recommended_factors')
+      .$type<Array<{ label: string; delta: number }>>()
+      .notNull(),
+    createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+  },
+  (t) => [
+    index('triage_overrides_actor_idx').on(t.actorUserId),
+    index('triage_overrides_created_idx').on(t.createdAt),
+    index('triage_overrides_recommended_idx').on(t.recommendedTier),
+  ],
+);
+
+export type TriageOverride = typeof triageOverrides.$inferSelect;
+export type NewTriageOverride = typeof triageOverrides.$inferInsert;


### PR DESCRIPTION
Closes #92.

Caseworker decisions on the rule-based triage tool now land in a new `triage_overrides` table — both **confirmations** (engine recommended X, caseworker chose X) and **overrides** (chose Y instead, with a required reason). Phase 2 ML retraining feeds off this audit trail.

## Changes
- **`triage_overrides` table** — `recommended_tier` + `score`, `chosen_tier`, `override_reason`, full `inputs_snapshot` (jsonb of `TriageInputs`) and `recommended_factors` so a future model has the entire decision context.
- **`recordTriageOverrideAction`** re-runs the rule engine server-side so a hand-edited request can't lie about what the engine produced for the inputs it claimed.
- **`TriageTierTool`** grows a "Record your decision" panel: confirm-the-recommended button + per-other-tier override buttons, reason field (required when overriding).
- **`/app/admin/triage-overrides`** — admin-only browse: total / overrides / override-rate headline, transitions table (recommended → chosen), recent decisions feed with reason quotes.
- Audit log gets `triage.confirmed` / `triage.overridden` events.

## Verification
- Typecheck clean, build clean
- 194/194 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)