### PR TITLE
feat(DTRS-013): quarterly transparency report (downloadable + print)

### DIFF
--- a/src/app/outcomes/page.tsx
+++ b/src/app/outcomes/page.tsx
@@ -100,6 +100,9 @@ export default async function PublicOutcomesPage() {
                 <th scope="col" className="px-3 py-2 text-right">
                   Default judgments
                 </th>
+                <th scope="col" className="px-3 py-2 text-right">
+                  Report
+                </th>
               </tr>
             </thead>
             <tbody>
@@ -110,6 +113,14 @@ export default async function PublicOutcomesPage() {
                   <td className="px-3 py-2 text-right">{fmt(e.filingsWithPacket)}</td>
                   <td className="px-3 py-2 text-right">{fmt(e.outcomesRecorded)}</td>
                   <td className="px-3 py-2 text-right">{fmt(e.defaultJudgments)}</td>
+                  <td className="px-3 py-2 text-right">
+                    <Link
+                      href={`/outcomes/q/${e.quarter.year}/${e.quarter.quarter}`}
+                      className="text-xs text-primary hover:underline"
+                    >
+                      View →
+                    </Link>
+                  </td>
                 </tr>
               ))}
             </tbody>

--- a/src/app/outcomes/q/[year]/[quarter]/markdown/route.ts
+++ b/src/app/outcomes/q/[year]/[quarter]/markdown/route.ts
@@ -1,0 +1,53 @@
+import { notFound } from 'next/navigation';
+import {
+  getCoalitionAggregate,
+  getGovernanceCountsForQuarter,
+  listQuarterlyEvictionAggregates,
+  type Quarter,
+} from '@/db/queries/public-outcomes';
+import { renderTransparencyReport } from '@/lib/dtrs/transparency-report';
+
+export const dynamic = 'force-dynamic';
+
+function parseQuarter(yearRaw: string, quarterRaw: string): Quarter | null {
+  const year = Number.parseInt(yearRaw, 10);
+  const quarterNum = Number.parseInt(quarterRaw.replace(/^q/i, ''), 10);
+  if (!Number.isInteger(year) || year < 2024 || year > 2100) return null;
+  if (![1, 2, 3, 4].includes(quarterNum)) return null;
+  return { year, quarter: quarterNum as 1 | 2 | 3 | 4, label: `${year} Q${quarterNum}` };
+}
+
+export async function GET(
+  req: Request,
+  { params }: { params: Promise<{ year: string; quarter: string }> },
+) {
+  const { year, quarter: q } = await params;
+  const quarter = parseQuarter(year, q);
+  if (!quarter) notFound();
+
+  const url = new URL(req.url);
+  const isDownload = url.searchParams.get('download') === '1';
+
+  const [eviction, coalitionSnapshot, governanceForQuarter] = await Promise.all([
+    listQuarterlyEvictionAggregates([quarter]),
+    getCoalitionAggregate(90),
+    getGovernanceCountsForQuarter(quarter),
+  ]);
+
+  const markdown = renderTransparencyReport({
+    quarter,
+    evictionForQuarter: eviction[0],
+    coalitionSnapshot,
+    governanceForQuarter,
+    generatedAt: new Date(),
+  });
+
+  const filename = `daviess-coalition-${quarter.year}-Q${quarter.quarter}.md`;
+  const headers = new Headers({
+    'content-type': 'text/markdown; charset=utf-8',
+  });
+  if (isDownload) {
+    headers.set('content-disposition', `attachment; filename="${filename}"`);
+  }
+  return new Response(markdown, { status: 200, headers });
+}

--- a/src/app/outcomes/q/[year]/[quarter]/page.tsx
+++ b/src/app/outcomes/q/[year]/[quarter]/page.tsx
@@ -1,0 +1,202 @@
+import Link from 'next/link';
+import { notFound } from 'next/navigation';
+import { PrintButton } from '@/components/coordination/print-button';
+import { Card, CardContent } from '@/components/ui/card';
+import {
+  getCoalitionAggregate,
+  getGovernanceCountsForQuarter,
+  listQuarterlyEvictionAggregates,
+  type Quarter,
+} from '@/db/queries/public-outcomes';
+import { renderTransparencyReport } from '@/lib/dtrs/transparency-report';
+
+export const dynamic = 'force-dynamic';
+
+const fmt = (n: number | null) =>
+  n === null ? <span className="text-muted-foreground">— suppressed</span> : n.toLocaleString();
+
+const fmtPct = (a: number | null, b: number | null) =>
+  a === null || b === null || b === 0 ? '—' : `${Math.round((a / b) * 100)}%`;
+
+function parseQuarter(yearRaw: string, quarterRaw: string): Quarter | null {
+  const year = Number.parseInt(yearRaw, 10);
+  const quarterNum = Number.parseInt(quarterRaw.replace(/^q/i, ''), 10);
+  if (!Number.isInteger(year) || year < 2024 || year > 2100) return null;
+  if (![1, 2, 3, 4].includes(quarterNum)) return null;
+  return { year, quarter: quarterNum as 1 | 2 | 3 | 4, label: `${year} Q${quarterNum}` };
+}
+
+export const metadata = {
+  title: 'Quarterly transparency report — Daviess Coalition',
+};
+
+export default async function QuarterlyReportPage({
+  params,
+}: {
+  params: Promise<{ year: string; quarter: string }>;
+}) {
+  const { year, quarter: q } = await params;
+  const quarter = parseQuarter(year, q);
+  if (!quarter) notFound();
+
+  const [eviction, coalitionSnapshot, governanceForQuarter] = await Promise.all([
+    listQuarterlyEvictionAggregates([quarter]),
+    getCoalitionAggregate(90),
+    getGovernanceCountsForQuarter(quarter),
+  ]);
+  const evictionForQuarter = eviction[0];
+  const generatedAt = new Date();
+
+  const repRate = fmtPct(evictionForQuarter.filingsWithPacket, evictionForQuarter.filingsIngested);
+
+  // The Markdown report is the canonical form — staff copy/paste it
+  // into newsletters, funder updates, etc. Surface it as a "view raw"
+  // link below the rendered HTML version.
+  const markdown = renderTransparencyReport({
+    quarter,
+    evictionForQuarter,
+    coalitionSnapshot,
+    governanceForQuarter,
+    generatedAt,
+  });
+
+  return (
+    <main className="mx-auto max-w-3xl space-y-6 p-6 md:p-8 print:max-w-none print:p-0">
+      <div className="text-xs print:hidden">
+        <Link href="/outcomes" className="text-muted-foreground hover:underline">
+          ← Back to outcomes
+        </Link>
+      </div>
+
+      <header className="space-y-2">
+        <p className="text-xs uppercase tracking-wide text-muted-foreground">
+          Daviess County Homelessness-Response Coalition
+        </p>
+        <h1 className="font-serif text-4xl font-bold text-primary">
+          {quarter.label} Transparency Report
+        </h1>
+        <p className="text-sm text-muted-foreground">
+          Generated {generatedAt.toISOString().slice(0, 10)} from live coalition data. Aggregate-
+          only; cells with fewer than 5 subjects are suppressed.
+        </p>
+      </header>
+
+      <section className="space-y-3">
+        <h2 className="font-serif text-2xl font-semibold">Coalition snapshot</h2>
+        <ul className="grid gap-2 text-sm md:grid-cols-2">
+          <li>
+            <strong>{coalitionSnapshot.partnerCount}</strong> partner organizations active
+          </li>
+          <li>
+            <strong>{coalitionSnapshot.partnersSharing}</strong> partners actively sharing data
+          </li>
+          <li>
+            <strong>{coalitionSnapshot.shelterCount}</strong> shelters listed
+          </li>
+          <li>
+            <strong>{coalitionSnapshot.totalShelterCapacity}</strong> coalition-wide beds
+          </li>
+          <li>
+            Service events (rolling {coalitionSnapshot.rollingWindowDays}d):{' '}
+            <strong>{fmt(coalitionSnapshot.serviceEventsRolling)}</strong>
+          </li>
+          <li>
+            Distinct people (rolling): <strong>{fmt(coalitionSnapshot.uniquePeopleRolling)}</strong>
+          </li>
+        </ul>
+      </section>
+
+      <section className="space-y-3">
+        <h2 className="font-serif text-2xl font-semibold">Eviction defense</h2>
+        <table className="w-full text-sm">
+          <tbody>
+            <tr className="border-b border-border">
+              <td className="py-2 text-muted-foreground">Filings ingested</td>
+              <td className="py-2 text-right">{fmt(evictionForQuarter.filingsIngested)}</td>
+            </tr>
+            <tr className="border-b border-border">
+              <td className="py-2 text-muted-foreground">Filings with response packet</td>
+              <td className="py-2 text-right">{fmt(evictionForQuarter.filingsWithPacket)}</td>
+            </tr>
+            <tr className="border-b border-border">
+              <td className="py-2 text-muted-foreground">Representation rate</td>
+              <td className="py-2 text-right">{repRate}</td>
+            </tr>
+            <tr className="border-b border-border">
+              <td className="py-2 text-muted-foreground">Outcomes recorded</td>
+              <td className="py-2 text-right">{fmt(evictionForQuarter.outcomesRecorded)}</td>
+            </tr>
+            <tr>
+              <td className="py-2 text-muted-foreground">Default judgments</td>
+              <td className="py-2 text-right">{fmt(evictionForQuarter.defaultJudgments)}</td>
+            </tr>
+          </tbody>
+        </table>
+        <p className="text-xs text-muted-foreground">
+          Filings are public Daviess District Court records. Response packets are AI-drafted answers
+          reviewed by a Kentucky Legal Aid attorney before filing. Default judgments — when a tenant
+          doesn't respond at all — are the avoid-this metric.
+        </p>
+      </section>
+
+      <section className="space-y-3">
+        <h2 className="font-serif text-2xl font-semibold">Data trust governance</h2>
+        <table className="w-full text-sm">
+          <tbody>
+            <tr className="border-b border-border">
+              <td className="py-2 text-muted-foreground">Consent grants</td>
+              <td className="py-2 text-right">{fmt(governanceForQuarter.consentGrants)}</td>
+            </tr>
+            <tr className="border-b border-border">
+              <td className="py-2 text-muted-foreground">Consent revocations</td>
+              <td className="py-2 text-right">{fmt(governanceForQuarter.consentRevocations)}</td>
+            </tr>
+            <tr>
+              <td className="py-2 text-muted-foreground">Per-record accesses logged</td>
+              <td className="py-2 text-right">{fmt(governanceForQuarter.dataAccessEvents)}</td>
+            </tr>
+          </tbody>
+        </table>
+        <p className="text-xs text-muted-foreground">
+          Every consent grant + revocation is timestamped. Every per-record access by coalition
+          staff lands in an append-only audit trail. Revocations are honored immediately.
+        </p>
+      </section>
+
+      <section className="space-y-3 rounded-md border border-border bg-muted/20 p-4 text-xs print:hidden">
+        <h2 className="font-serif text-base font-semibold">Share this report</h2>
+        <div className="flex flex-wrap items-center gap-2">
+          <PrintButton />
+          <Link
+            href={`/outcomes/q/${quarter.year}/${quarter.quarter}/markdown`}
+            className="rounded-md border border-border bg-card px-3 py-1.5 hover:bg-muted"
+          >
+            View as Markdown
+          </Link>
+          <Link
+            href={`/outcomes/q/${quarter.year}/${quarter.quarter}/markdown?download=1`}
+            className="rounded-md border border-border bg-card px-3 py-1.5 hover:bg-muted"
+          >
+            Download .md
+          </Link>
+        </div>
+        <p className="text-muted-foreground">
+          The Markdown form is the canonical output for newsletters, funder updates, and pastes into
+          Notion / Google Docs. It contains the same data shown above with no extra chrome.
+        </p>
+      </section>
+
+      <Card className="border-amber-500/40 bg-amber-500/5 print:hidden">
+        <CardContent className="text-xs text-muted-foreground">
+          Built per DTRS-013 in the coalition's engineering backlog. Data is recomputed on every
+          page load against the live database — no caching, no stale numbers. The coalition's
+          quarterly report cadence is non-binding; this URL works for any quarter that has recorded
+          data.
+        </CardContent>
+      </Card>
+
+      {/* Hidden by default — present so /markdown can fetch the same component if it ever wants. */}
+      <noscript style={{ display: 'none' }}>{markdown}</noscript>
+    </main>
+  );
+}

--- a/src/db/queries/public-outcomes.ts
+++ b/src/db/queries/public-outcomes.ts
@@ -179,3 +179,30 @@ export async function getGovernanceCounts(): Promise<GovernanceCounts> {
     dataAccessEvents90d: suppress(Number(row.access)),
   };
 }
+
+export type GovernanceCountsForQuarter = {
+  consentGrants: number | null;
+  consentRevocations: number | null;
+  dataAccessEvents: number | null;
+};
+
+/** Quarter-scoped variant of governance counts for the transparency report. */
+export async function getGovernanceCountsForQuarter(
+  q: Quarter,
+): Promise<GovernanceCountsForQuarter> {
+  const start = new Date(Date.UTC(q.year, (q.quarter - 1) * 3, 1));
+  const end = new Date(Date.UTC(q.year, q.quarter * 3, 1));
+  const [row] = await db.execute<{ grants: number; revocations: number; access: number }>(sql`
+    SELECT
+      COUNT(*) FILTER (WHERE action = 'consent.granted')::int AS grants,
+      COUNT(*) FILTER (WHERE action = 'consent.revoked')::int AS revocations,
+      COUNT(*) FILTER (WHERE action = 'data.accessed')::int AS access
+    FROM ${auditLog}
+    WHERE created_at >= ${start} AND created_at < ${end}
+  `);
+  return {
+    consentGrants: suppress(Number(row.grants)),
+    consentRevocations: suppress(Number(row.revocations)),
+    dataAccessEvents: suppress(Number(row.access)),
+  };
+}

--- a/src/lib/dtrs/transparency-report.test.ts
+++ b/src/lib/dtrs/transparency-report.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'vitest';
+import type {
+  CoalitionAggregate,
+  GovernanceCountsForQuarter,
+  Quarter,
+  QuarterlyEvictionAggregate,
+} from '@/db/queries/public-outcomes';
+import { renderTransparencyReport } from './transparency-report';
+
+type Input = {
+  quarter: Quarter;
+  evictionForQuarter: QuarterlyEvictionAggregate;
+  coalitionSnapshot: CoalitionAggregate;
+  governanceForQuarter: GovernanceCountsForQuarter;
+  generatedAt: Date;
+};
+
+const baseInput = (): Input => ({
+  quarter: { year: 2026, quarter: 2, label: '2026 Q2' },
+  evictionForQuarter: {
+    quarter: { year: 2026, quarter: 2, label: '2026 Q2' },
+    filingsIngested: 142,
+    filingsWithPacket: 87,
+    outcomesRecorded: 56,
+    defaultJudgments: 8,
+  },
+  coalitionSnapshot: {
+    partnerCount: 25,
+    partnersSharing: 7,
+    shelterCount: 6,
+    totalShelterCapacity: 220,
+    serviceEventsRolling: 312,
+    uniquePeopleRolling: 89,
+    rollingWindowDays: 90,
+  },
+  governanceForQuarter: {
+    consentGrants: 22,
+    consentRevocations: 3,
+    dataAccessEvents: 481,
+  },
+  generatedAt: new Date('2026-04-26T12:00:00Z'),
+});
+
+describe('renderTransparencyReport', () => {
+  it('renders headline counts and the representation rate', () => {
+    const md = renderTransparencyReport(baseInput());
+    expect(md).toContain('# Daviess Coalition — 2026 Q2 Transparency Report');
+    expect(md).toContain('Filings ingested | 142');
+    expect(md).toContain('Filings with response packet | 87');
+    // 87/142 ≈ 61%
+    expect(md).toMatch(/Representation rate \| 61%/);
+    expect(md).toContain('Default-judgment outcomes | 8');
+  });
+
+  it('shows suppressed cells as the placeholder copy', () => {
+    const input = baseInput();
+    input.evictionForQuarter = {
+      ...input.evictionForQuarter,
+      defaultJudgments: null,
+      filingsWithPacket: null,
+    };
+    const md = renderTransparencyReport(input);
+    expect(md).toMatch(/Default-judgment outcomes \| — suppressed/);
+    // No representation rate when numerator is suppressed
+    expect(md).toMatch(/Representation rate \| —/);
+  });
+
+  it('includes the generated date in YYYY-MM-DD form', () => {
+    const md = renderTransparencyReport(baseInput());
+    expect(md).toContain('Generated 2026-04-26');
+  });
+
+  it('always closes with the read-this-report explainer', () => {
+    const md = renderTransparencyReport(baseInput());
+    expect(md).toContain('How to read this report');
+    expect(md).toContain('— End of report —');
+  });
+});

--- a/src/lib/dtrs/transparency-report.ts
+++ b/src/lib/dtrs/transparency-report.ts
@@ -1,0 +1,78 @@
+import type {
+  CoalitionAggregate,
+  GovernanceCountsForQuarter,
+  Quarter,
+  QuarterlyEvictionAggregate,
+} from '@/db/queries/public-outcomes';
+
+const fmt = (n: number | null): string => (n === null ? '— suppressed (n<5)' : String(n));
+
+const fmtPct = (a: number | null, b: number | null): string => {
+  if (a === null || b === null || b === 0) return '—';
+  return `${Math.round((a / b) * 100)}%`;
+};
+
+/**
+ * Render the quarterly transparency report as Markdown. Public-safe by
+ * construction — every input is already aggregate (no row-level data;
+ * <5 cells are suppressed at the query layer).
+ *
+ * The output is intentionally plain Markdown so it's printable, can be
+ * pasted into a coalition newsletter, and renders cleanly in any GitHub
+ * / Notion / Google Doc target.
+ */
+export function renderTransparencyReport(input: {
+  quarter: Quarter;
+  evictionForQuarter: QuarterlyEvictionAggregate;
+  coalitionSnapshot: CoalitionAggregate;
+  governanceForQuarter: GovernanceCountsForQuarter;
+  generatedAt: Date;
+}): string {
+  const { quarter, evictionForQuarter, coalitionSnapshot, governanceForQuarter, generatedAt } =
+    input;
+  const repRate = fmtPct(evictionForQuarter.filingsWithPacket, evictionForQuarter.filingsIngested);
+  return `# Daviess Coalition — ${quarter.label} Transparency Report
+
+_Generated ${generatedAt.toISOString().slice(0, 10)} from live coalition data. Cells with fewer than 5 subjects are suppressed (rendered as "—") so no figure traces back to a small handful of identifiable people._
+
+## Coalition snapshot
+
+- **Partner organizations**: ${coalitionSnapshot.partnerCount} active
+- **Partners actively sharing data**: ${coalitionSnapshot.partnersSharing}
+- **Shelters listed**: ${coalitionSnapshot.shelterCount}
+- **Total shelter capacity (coalition-wide)**: ${coalitionSnapshot.totalShelterCapacity} beds
+- **Service events recorded (rolling ${coalitionSnapshot.rollingWindowDays}-day window)**: ${fmt(coalitionSnapshot.serviceEventsRolling)}
+- **Distinct opaque persons touched (rolling window)**: ${fmt(coalitionSnapshot.uniquePeopleRolling)}
+
+## Eviction defense — ${quarter.label}
+
+| Metric | Value |
+|---|---|
+| Filings ingested | ${fmt(evictionForQuarter.filingsIngested)} |
+| Filings with response packet | ${fmt(evictionForQuarter.filingsWithPacket)} |
+| Representation rate | ${repRate} |
+| Outcomes recorded | ${fmt(evictionForQuarter.outcomesRecorded)} |
+| Default-judgment outcomes | ${fmt(evictionForQuarter.defaultJudgments)} |
+
+Filings are public Daviess District Court records. Response packets are AI-drafted answers reviewed by a Kentucky Legal Aid attorney before filing. Default judgments are the avoid-this metric — they happen when a tenant doesn't respond at all and lose by default.
+
+## Data trust governance — ${quarter.label}
+
+| Metric | Value |
+|---|---|
+| Consent grants | ${fmt(governanceForQuarter.consentGrants)} |
+| Consent revocations | ${fmt(governanceForQuarter.consentRevocations)} |
+| Per-record accesses logged | ${fmt(governanceForQuarter.dataAccessEvents)} |
+
+Every consent grant and revocation is timestamped. Every per-record access by a coalition staff member is logged in an append-only audit trail. Revocations are honored immediately; the data trust steward can audit any access at any time.
+
+## How to read this report
+
+- **Aggregate-only.** No personal data is exposed. The platform never identifies a specific person in this report; only counts.
+- **Suppression.** Counts below 5 are hidden so a small group can't be re-identified by combining cells.
+- **Append-only audit.** Consent and access counts come from a tamper-evident log enforced at the database layer.
+- **Open-source.** The platform code, data model, and this report generator are all public. Anyone with technical chops can audit the math.
+
+— End of report —
+`;
+}


### PR DESCRIPTION
Closes #143.

Pairs with the public outcomes dashboard (OPRT-006). Generates a single-quarter transparency report with the same suppression rules (no cell <5), available three ways:

- **Public HTML page** at `/outcomes/q/[year]/[quarter]` — print-friendly (chrome hidden via `print:*` utility classes), with Print and Download .md buttons.
- **Markdown response** at `/outcomes/q/[year]/[quarter]/markdown` — the canonical form for newsletters, funder updates, paste-into-Notion. `?download=1` sets a `Content-Disposition: attachment` header.
- **Per-quarter "View →" links** from the main `/outcomes` dashboard's eviction-by-quarter table.

## Implementation
- New `getGovernanceCountsForQuarter(q)` query alongside the existing 90-day rolling variant.
- `renderTransparencyReport` in `src/lib/dtrs/transparency-report.ts` produces the Markdown body. 4 unit tests cover headline counts, suppression placeholders, generated-date format, and the closing explainer.
- All inputs to the renderer are already aggregate (no row data; <5 cells suppressed at the query layer).

## Verification
- Typecheck clean, build clean
- 198/198 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)