### PR TITLE
feat(PCYI-001): quarterly Fiscal Court brief generator

### DIFF
--- a/src/app/outcomes/fiscal-court/[year]/[quarter]/markdown/route.ts
+++ b/src/app/outcomes/fiscal-court/[year]/[quarter]/markdown/route.ts
@@ -1,0 +1,49 @@
+import { notFound } from 'next/navigation';
+import {
+  getCoalitionAggregate,
+  getGovernanceCountsForQuarter,
+  listQuarterlyEvictionAggregates,
+  type Quarter,
+} from '@/db/queries/public-outcomes';
+import { renderFiscalCourtBrief } from '@/lib/dtrs/fiscal-court-brief';
+
+export const dynamic = 'force-dynamic';
+
+function parseQuarter(yearRaw: string, quarterRaw: string): Quarter | null {
+  const year = Number.parseInt(yearRaw, 10);
+  const quarterNum = Number.parseInt(quarterRaw.replace(/^q/i, ''), 10);
+  if (!Number.isInteger(year) || year < 2024 || year > 2100) return null;
+  if (![1, 2, 3, 4].includes(quarterNum)) return null;
+  return { year, quarter: quarterNum as 1 | 2 | 3 | 4, label: `${year} Q${quarterNum}` };
+}
+
+export async function GET(
+  req: Request,
+  { params }: { params: Promise<{ year: string; quarter: string }> },
+) {
+  const { year, quarter: q } = await params;
+  const quarter = parseQuarter(year, q);
+  if (!quarter) notFound();
+
+  const url = new URL(req.url);
+  const isDownload = url.searchParams.get('download') === '1';
+
+  const [eviction, coalitionSnapshot, governanceForQuarter] = await Promise.all([
+    listQuarterlyEvictionAggregates([quarter]),
+    getCoalitionAggregate(90),
+    getGovernanceCountsForQuarter(quarter),
+  ]);
+
+  const markdown = renderFiscalCourtBrief({
+    quarter,
+    evictionForQuarter: eviction[0],
+    coalitionSnapshot,
+    governanceForQuarter,
+    generatedAt: new Date(),
+  });
+
+  const filename = `daviess-fiscal-court-brief-${quarter.year}-Q${quarter.quarter}.md`;
+  const headers = new Headers({ 'content-type': 'text/markdown; charset=utf-8' });
+  if (isDownload) headers.set('content-disposition', `attachment; filename="${filename}"`);
+  return new Response(markdown, { status: 200, headers });
+}

--- a/src/app/outcomes/fiscal-court/[year]/[quarter]/page.tsx
+++ b/src/app/outcomes/fiscal-court/[year]/[quarter]/page.tsx
@@ -1,0 +1,95 @@
+import Link from 'next/link';
+import { notFound } from 'next/navigation';
+import ReactMarkdown from 'react-markdown';
+import { PrintButton } from '@/components/coordination/print-button';
+import { Card, CardContent } from '@/components/ui/card';
+import {
+  getCoalitionAggregate,
+  getGovernanceCountsForQuarter,
+  listQuarterlyEvictionAggregates,
+  type Quarter,
+} from '@/db/queries/public-outcomes';
+import { renderFiscalCourtBrief } from '@/lib/dtrs/fiscal-court-brief';
+
+export const dynamic = 'force-dynamic';
+
+function parseQuarter(yearRaw: string, quarterRaw: string): Quarter | null {
+  const year = Number.parseInt(yearRaw, 10);
+  const quarterNum = Number.parseInt(quarterRaw.replace(/^q/i, ''), 10);
+  if (!Number.isInteger(year) || year < 2024 || year > 2100) return null;
+  if (![1, 2, 3, 4].includes(quarterNum)) return null;
+  return { year, quarter: quarterNum as 1 | 2 | 3 | 4, label: `${year} Q${quarterNum}` };
+}
+
+export const metadata = {
+  title: 'Fiscal Court brief — Daviess Coalition',
+};
+
+export default async function FiscalCourtBriefPage({
+  params,
+}: {
+  params: Promise<{ year: string; quarter: string }>;
+}) {
+  const { year, quarter: q } = await params;
+  const quarter = parseQuarter(year, q);
+  if (!quarter) notFound();
+
+  const [eviction, coalitionSnapshot, governanceForQuarter] = await Promise.all([
+    listQuarterlyEvictionAggregates([quarter]),
+    getCoalitionAggregate(90),
+    getGovernanceCountsForQuarter(quarter),
+  ]);
+
+  const markdown = renderFiscalCourtBrief({
+    quarter,
+    evictionForQuarter: eviction[0],
+    coalitionSnapshot,
+    governanceForQuarter,
+    generatedAt: new Date(),
+  });
+
+  return (
+    <main className="mx-auto max-w-3xl space-y-4 p-6 md:p-8 print:max-w-none print:p-0">
+      <div className="text-xs print:hidden">
+        <Link href="/outcomes" className="text-muted-foreground hover:underline">
+          ← Back to outcomes
+        </Link>
+      </div>
+
+      <article className="prose prose-sm max-w-none dark:prose-invert print:prose-xs">
+        <ReactMarkdown>{markdown}</ReactMarkdown>
+      </article>
+
+      <section className="space-y-3 rounded-md border border-border bg-muted/20 p-4 text-xs print:hidden">
+        <h2 className="font-serif text-base font-semibold">Share this brief</h2>
+        <div className="flex flex-wrap items-center gap-2">
+          <PrintButton />
+          <Link
+            href={`/outcomes/fiscal-court/${quarter.year}/${quarter.quarter}/markdown`}
+            className="rounded-md border border-border bg-card px-3 py-1.5 hover:bg-muted"
+          >
+            View as Markdown
+          </Link>
+          <Link
+            href={`/outcomes/fiscal-court/${quarter.year}/${quarter.quarter}/markdown?download=1`}
+            className="rounded-md border border-border bg-card px-3 py-1.5 hover:bg-muted"
+          >
+            Download .md
+          </Link>
+        </div>
+        <p className="text-muted-foreground">
+          The Markdown form fits in a county-meeting handout or a coalition newsletter. Print
+          renders to a single sheet of letter paper at default browser settings.
+        </p>
+      </section>
+
+      <Card className="border-amber-500/40 bg-amber-500/5 print:hidden">
+        <CardContent className="text-xs text-muted-foreground">
+          Built per PCYI-001. Pairs with the public transparency report (DTRS-013, at{' '}
+          <code className="font-mono">/outcomes/q/[year]/[quarter]</code>) — same data, different
+          framing for a different audience.
+        </CardContent>
+      </Card>
+    </main>
+  );
+}

--- a/src/app/outcomes/page.tsx
+++ b/src/app/outcomes/page.tsx
@@ -118,7 +118,14 @@ export default async function PublicOutcomesPage() {
                       href={`/outcomes/q/${e.quarter.year}/${e.quarter.quarter}`}
                       className="text-xs text-primary hover:underline"
                     >
-                      View →
+                      Public →
+                    </Link>
+                    <span className="mx-1 text-muted-foreground">·</span>
+                    <Link
+                      href={`/outcomes/fiscal-court/${e.quarter.year}/${e.quarter.quarter}`}
+                      className="text-xs text-primary hover:underline"
+                    >
+                      Fiscal Court →
                     </Link>
                   </td>
                 </tr>

--- a/src/lib/dtrs/fiscal-court-brief.test.ts
+++ b/src/lib/dtrs/fiscal-court-brief.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest';
+import type {
+  CoalitionAggregate,
+  GovernanceCountsForQuarter,
+  Quarter,
+  QuarterlyEvictionAggregate,
+} from '@/db/queries/public-outcomes';
+import { renderFiscalCourtBrief } from './fiscal-court-brief';
+
+type Input = {
+  quarter: Quarter;
+  evictionForQuarter: QuarterlyEvictionAggregate;
+  coalitionSnapshot: CoalitionAggregate;
+  governanceForQuarter: GovernanceCountsForQuarter;
+  generatedAt: Date;
+};
+
+const baseInput = (): Input => ({
+  quarter: { year: 2026, quarter: 2, label: '2026 Q2' },
+  evictionForQuarter: {
+    quarter: { year: 2026, quarter: 2, label: '2026 Q2' },
+    filingsIngested: 142,
+    filingsWithPacket: 87,
+    outcomesRecorded: 56,
+    defaultJudgments: 8,
+  },
+  coalitionSnapshot: {
+    partnerCount: 25,
+    partnersSharing: 7,
+    shelterCount: 6,
+    totalShelterCapacity: 220,
+    serviceEventsRolling: 312,
+    uniquePeopleRolling: 89,
+    rollingWindowDays: 90,
+  },
+  governanceForQuarter: {
+    consentGrants: 22,
+    consentRevocations: 3,
+    dataAccessEvents: 481,
+  },
+  generatedAt: new Date('2026-04-26T12:00:00Z'),
+});
+
+describe('renderFiscalCourtBrief', () => {
+  it('leads with the headline number when packets are above suppression threshold', () => {
+    const md = renderFiscalCourtBrief(baseInput());
+    expect(md).toContain('# Daviess County Fiscal Court Brief — 2026 Q2');
+    expect(md).toContain('87 Daviess households received an attorney-reviewed response');
+  });
+
+  it('uses the suppressed-headline copy when packets is null', () => {
+    const input = baseInput();
+    input.evictionForQuarter = { ...input.evictionForQuarter, filingsWithPacket: null };
+    const md = renderFiscalCourtBrief(input);
+    expect(md).toMatch(/A small number of households/);
+    expect(md).toContain('count suppressed for privacy');
+  });
+
+  it('names the six anchor shelters', () => {
+    const md = renderFiscalCourtBrief(baseInput());
+    expect(md).toMatch(/Boulware/);
+    expect(md).toMatch(/St\. Benedict's/);
+    expect(md).toMatch(/Daniel Pitino/);
+    expect(md).toMatch(/CrossRoads/);
+    expect(md).toMatch(/OASIS/);
+    expect(md).toMatch(/St\. Joseph/);
+  });
+
+  it('always includes "What\'s working" and "What\'s needed" sections', () => {
+    const md = renderFiscalCourtBrief(baseInput());
+    expect(md).toContain("## What's working");
+    expect(md).toContain("## What's needed");
+  });
+});

--- a/src/lib/dtrs/fiscal-court-brief.ts
+++ b/src/lib/dtrs/fiscal-court-brief.ts
@@ -1,0 +1,111 @@
+import type {
+  CoalitionAggregate,
+  GovernanceCountsForQuarter,
+  Quarter,
+  QuarterlyEvictionAggregate,
+} from '@/db/queries/public-outcomes';
+
+const fmt = (n: number | null): string => (n === null ? '—' : String(n));
+
+/**
+ * PCYI-001: 1-page Fiscal Court brief. Audience is the Daviess County
+ * Fiscal Court (Judge-Executive + 3 commissioners) plus the Steering
+ * Committee. Different framing than the public transparency report:
+ * tighter, action-oriented, with a "what's working / what's needed"
+ * structure that supports future appropriation requests.
+ *
+ * One page constraint — keep paragraphs short, lead with the headline
+ * number for each pillar.
+ *
+ * Suppression rule (n<5 → null) is inherited from the upstream queries;
+ * the renderer just translates null to em-dash.
+ */
+export function renderFiscalCourtBrief(input: {
+  quarter: Quarter;
+  evictionForQuarter: QuarterlyEvictionAggregate;
+  coalitionSnapshot: CoalitionAggregate;
+  governanceForQuarter: GovernanceCountsForQuarter;
+  generatedAt: Date;
+}): string {
+  const { quarter, evictionForQuarter, coalitionSnapshot, governanceForQuarter, generatedAt } =
+    input;
+
+  const filings = evictionForQuarter.filingsIngested;
+  const packets = evictionForQuarter.filingsWithPacket;
+  const defaults = evictionForQuarter.defaultJudgments;
+
+  // Headline: how many households did the coalition reach with legal
+  // help this quarter? (Filings with response packets is the proxy.)
+  const reachHeadline =
+    packets === null
+      ? 'A small number of households received drafted-and-reviewed legal responses this quarter (count suppressed for privacy).'
+      : `${packets} Daviess households received an attorney-reviewed response to an eviction filing this quarter.`;
+
+  return `# Daviess County Fiscal Court Brief — ${quarter.label}
+
+**To:** Judge-Executive + Fiscal Court commissioners
+**From:** Daviess County Homelessness-Response Coalition
+**Generated:** ${generatedAt.toISOString().slice(0, 10)} from live coalition data
+
+---
+
+## ${quarter.label} headline
+
+${reachHeadline} Coalition partners — ${coalitionSnapshot.partnerCount} organizations across legal aid, healthcare, shelters, and faith-based services — coordinated through a shared platform that records every consent grant and every record access in an append-only audit trail.
+
+## Eviction defense
+
+| Metric | This quarter |
+|---|---|
+| Court filings ingested | ${fmt(filings)} |
+| Filings receiving response packet | ${fmt(packets)} |
+| Default-judgment outcomes (the avoid-this metric) | ${fmt(defaults)} |
+
+Filings come from the public Daviess District Court docket. Response packets are AI-drafted answers reviewed and approved by a Kentucky Legal Aid attorney before filing — the AI does the bulk drafting work; the attorney owns the legal product. Default judgments happen when a tenant doesn't respond at all, and result almost automatically in eviction. Reducing them is the platform's primary win condition.
+
+## Shelter capacity
+
+| Metric | Today |
+|---|---|
+| Active coalition shelters | ${coalitionSnapshot.shelterCount} |
+| Coalition-wide bed capacity | ${coalitionSnapshot.totalShelterCapacity} |
+
+Shelter staff update bed counts in real time; the SMS bed-finder lets unhoused individuals text for an open bed and place a 90-minute soft hold. Coordination across the six anchor shelters (Boulware, St. Benedict's, Daniel Pitino, CrossRoads, OASIS, St. Joseph) is consolidated rather than each provider operating in isolation.
+
+## Coordination signal
+
+Across the rolling ${coalitionSnapshot.rollingWindowDays}-day window:
+
+- ${fmt(coalitionSnapshot.serviceEventsRolling)} service events recorded across coalition partners
+- ${fmt(coalitionSnapshot.uniquePeopleRolling)} distinct opaque persons touched by 1+ partner
+
+The coordination view shows when one person is asking multiple agencies for help in the same week — the kind of signal that would otherwise be invisible. Each entry is opaque (no names) until the subject explicitly grants cross-org consent.
+
+## Data trust governance — ${quarter.label}
+
+| Metric | This quarter |
+|---|---|
+| Consent grants recorded | ${fmt(governanceForQuarter.consentGrants)} |
+| Consent revocations honored | ${fmt(governanceForQuarter.consentRevocations)} |
+| Per-record accesses logged (audit) | ${fmt(governanceForQuarter.dataAccessEvents)} |
+
+Every consent decision is timestamped. Every data access by coalition staff lands in an append-only audit log enforced at the database layer (not just in code). DV-survivor records have location-suppression applied at the query layer — an abuser browsing the system can't find a survivor's address through any coalition surface.
+
+## What's working
+
+- Cross-org coordination is happening through one platform rather than six.
+- Eviction-defense response time is measured, not assumed.
+- Privacy-respecting governance is a built-in feature, not a policy doc.
+
+## What's needed
+
+- Continued county recognition of the coalition's value as a coordination layer.
+- Anchor partner participation across all six shelters (some still onboarding).
+- Verification of benefits-program data (current DCBS / KHC / SSA thresholds) before next public push.
+- BAA closure with Owensboro Health to unlock the ED super-utilizer pillar.
+
+---
+
+_This brief is regenerated on every page load against live data; for any quarter, visit the Coalition's outcomes page or contact the coordinator for the latest figures._
+`;
+}


### PR DESCRIPTION
Closes #163.

1-page brief targeting the Daviess County Fiscal Court (Judge-Executive + commissioners) plus the Steering Committee. Same data as the public transparency report (DTRS-013, #276), different framing — tighter, action-oriented, with explicit **What's working / What's needed** sections that support future appropriation requests.

## Surfaces
- `/outcomes/fiscal-court/[year]/[quarter]` — public HTML, prose-styled via `react-markdown`, print-friendly so it fits one letter-paper sheet at default browser settings.
- `/outcomes/fiscal-court/[year]/[quarter]/markdown` — canonical `.md` output (with optional `?download=1` attachment header).
- `/outcomes` table now offers per-quarter **Public →** and **Fiscal Court →** links side-by-side.

## Implementation
- `renderFiscalCourtBrief` in `src/lib/dtrs/fiscal-court-brief.ts`. 4 unit tests cover headline copy (with + without suppression), all-six anchor-shelter mention, and required sections.
- Reuses the existing OPRT-006 query layer (`getCoalitionAggregate`, `listQuarterlyEvictionAggregates`, `getGovernanceCountsForQuarter`). Same n<5 suppression rule.

## Verification
- 202/202 tests passing, typecheck + build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)