### PR TITLE
feat(OPRT-004): Frontline Advisory Group registry + compensation tracker

### DIFF
--- a/drizzle/migrations/0028_complex_true_believers.sql
+++ b/drizzle/migrations/0028_complex_true_believers.sql
@@ -1,0 +1,38 @@
+CREATE TYPE "public"."fag_member_status" AS ENUM('active', 'paused', 'ended');--> statement-breakpoint
+CREATE TYPE "public"."fag_payout_status" AS ENUM('unpaid', 'paid', 'voided');--> statement-breakpoint
+CREATE TABLE "fag_compensation_entries" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"member_id" uuid NOT NULL,
+	"occurred_on" date NOT NULL,
+	"description" text NOT NULL,
+	"hours_tenths" integer NOT NULL,
+	"hourly_rate_cents" integer NOT NULL,
+	"total_cents" integer NOT NULL,
+	"status" "fag_payout_status" DEFAULT 'unpaid' NOT NULL,
+	"paid_at" timestamp with time zone,
+	"paid_by_user_id" uuid,
+	"notes" text,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "fag_members" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"full_name" text NOT NULL,
+	"role" text NOT NULL,
+	"contact_phone" text,
+	"contact_email" text,
+	"hourly_rate_cents" integer DEFAULT 10000 NOT NULL,
+	"status" "fag_member_status" DEFAULT 'active' NOT NULL,
+	"notes" text,
+	"onboarded_on" date,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "fag_compensation_entries" ADD CONSTRAINT "fag_compensation_entries_member_id_fag_members_id_fk" FOREIGN KEY ("member_id") REFERENCES "public"."fag_members"("id") ON DELETE restrict ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "fag_compensation_entries" ADD CONSTRAINT "fag_compensation_entries_paid_by_user_id_users_id_fk" FOREIGN KEY ("paid_by_user_id") REFERENCES "public"."users"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "fag_compensation_member_idx" ON "fag_compensation_entries" USING btree ("member_id");--> statement-breakpoint
+CREATE INDEX "fag_compensation_status_idx" ON "fag_compensation_entries" USING btree ("status");--> statement-breakpoint
+CREATE INDEX "fag_compensation_occurred_idx" ON "fag_compensation_entries" USING btree ("occurred_on");--> statement-breakpoint
+CREATE INDEX "fag_members_status_idx" ON "fag_members" USING btree ("status");

--- a/drizzle/migrations/meta/0028_snapshot.json
+++ b/drizzle/migrations/meta/0028_snapshot.json
@@ -1,0 +1,3762 @@
+{
+  "id": "57fc8329-e091-40f4-9a38-aa1f214269ec",
+  "prevId": "3b1510d1-1f2a-4937-bc95-363a6c996f07",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.audit_log": {
+      "name": "audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_table": {
+          "name": "target_table",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "audit_log_actor_idx": {
+          "name": "audit_log_actor_idx",
+          "columns": [
+            {
+              "expression": "actor_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_log_action_idx": {
+          "name": "audit_log_action_idx",
+          "columns": [
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_log_created_at_idx": {
+          "name": "audit_log_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audit_log_actor_user_id_users_id_fk": {
+          "name": "audit_log_actor_user_id_users_id_fk",
+          "tableFrom": "audit_log",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.client_documents": {
+      "name": "client_documents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "synthetic_person_ref": {
+          "name": "synthetic_person_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "client_document_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_md": {
+          "name": "content_md",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "extracted_fields": {
+          "name": "extracted_fields",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extraction_notes": {
+          "name": "extraction_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extraction_model": {
+          "name": "extraction_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "client_document_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'uploaded'"
+        },
+        "uploaded_by_user_id": {
+          "name": "uploaded_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "client_documents_kind_idx": {
+          "name": "client_documents_kind_idx",
+          "columns": [
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "client_documents_status_idx": {
+          "name": "client_documents_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "client_documents_uploaded_by_idx": {
+          "name": "client_documents_uploaded_by_idx",
+          "columns": [
+            {
+              "expression": "uploaded_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "client_documents_synthetic_ref_idx": {
+          "name": "client_documents_synthetic_ref_idx",
+          "columns": [
+            {
+              "expression": "synthetic_person_ref",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "client_documents_uploaded_by_user_id_users_id_fk": {
+          "name": "client_documents_uploaded_by_user_id_users_id_fk",
+          "tableFrom": "client_documents",
+          "tableTo": "users",
+          "columnsFrom": [
+            "uploaded_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.comms_advisories": {
+      "name": "comms_advisories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body_md": {
+          "name": "body_md",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "spokesperson_name": {
+          "name": "spokesperson_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "spokesperson_contact": {
+          "name": "spokesperson_contact",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "posted_by_user_id": {
+          "name": "posted_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ended_by_user_id": {
+          "name": "ended_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "comms_advisories_active_idx": {
+          "name": "comms_advisories_active_idx",
+          "columns": [
+            {
+              "expression": "active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "comms_advisories_created_idx": {
+          "name": "comms_advisories_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "comms_advisories_posted_by_user_id_users_id_fk": {
+          "name": "comms_advisories_posted_by_user_id_users_id_fk",
+          "tableFrom": "comms_advisories",
+          "tableTo": "users",
+          "columnsFrom": [
+            "posted_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "comms_advisories_ended_by_user_id_users_id_fk": {
+          "name": "comms_advisories_ended_by_user_id_users_id_fk",
+          "tableFrom": "comms_advisories",
+          "tableTo": "users",
+          "columnsFrom": [
+            "ended_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.consent_access_tokens": {
+      "name": "consent_access_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "synthetic_person_ref": {
+          "name": "synthetic_person_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issued_by_user_id": {
+          "name": "issued_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "consent_access_tokens_token_idx": {
+          "name": "consent_access_tokens_token_idx",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "consent_access_tokens_ref_idx": {
+          "name": "consent_access_tokens_ref_idx",
+          "columns": [
+            {
+              "expression": "synthetic_person_ref",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "consent_access_tokens_expires_idx": {
+          "name": "consent_access_tokens_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "consent_access_tokens_issued_by_user_id_users_id_fk": {
+          "name": "consent_access_tokens_issued_by_user_id_users_id_fk",
+          "tableFrom": "consent_access_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "issued_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.consents": {
+      "name": "consents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "subject_external_id": {
+          "name": "subject_external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consent_type": {
+          "name": "consent_type",
+          "type": "consent_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "granted_via": {
+          "name": "granted_via",
+          "type": "consent_channel",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consent_version": {
+          "name": "consent_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'2026-04-1'"
+        },
+        "scope_partner_ids": {
+          "name": "scope_partner_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope_data_classes": {
+          "name": "scope_data_classes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "signature_text": {
+          "name": "signature_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "granted_at": {
+          "name": "granted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "consents_subject_idx": {
+          "name": "consents_subject_idx",
+          "columns": [
+            {
+              "expression": "subject_external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "consents_type_idx": {
+          "name": "consents_type_idx",
+          "columns": [
+            {
+              "expression": "consent_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "consents_expires_at_idx": {
+          "name": "consents_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.dv_flagged_persons": {
+      "name": "dv_flagged_persons",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "subject_identifier": {
+          "name": "subject_identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "flag_set_at": {
+          "name": "flag_set_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "flag_cleared_at": {
+          "name": "flag_cleared_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "dv_flagged_persons_subject_idx": {
+          "name": "dv_flagged_persons_subject_idx",
+          "columns": [
+            {
+              "expression": "subject_identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dv_flagged_persons_set_at_idx": {
+          "name": "dv_flagged_persons_set_at_idx",
+          "columns": [
+            {
+              "expression": "flag_set_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ed_encounters": {
+      "name": "ed_encounters",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encounter_external_id": {
+          "name": "encounter_external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "arrived_at": {
+          "name": "arrived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discharged_at": {
+          "name": "discharged_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chief_complaint": {
+          "name": "chief_complaint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "disposition": {
+          "name": "disposition",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "housing_status": {
+          "name": "housing_status",
+          "type": "housing_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unknown'"
+        },
+        "charge_cents": {
+          "name": "charge_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_json": {
+          "name": "raw_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "ed_encounter_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'synthetic'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ed_encounters_external_idx": {
+          "name": "ed_encounters_external_idx",
+          "columns": [
+            {
+              "expression": "encounter_external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ed_encounters_patient_idx": {
+          "name": "ed_encounters_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ed_encounters_arrived_idx": {
+          "name": "ed_encounters_arrived_idx",
+          "columns": [
+            {
+              "expression": "arrived_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ed_encounters_housing_idx": {
+          "name": "ed_encounters_housing_idx",
+          "columns": [
+            {
+              "expression": "housing_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.esuc_care_plans": {
+      "name": "esuc_care_plans",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plan_md": {
+          "name": "plan_md",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt_version": {
+          "name": "prompt_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "generated_by_user_id": {
+          "name": "generated_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "esuc_care_plan_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "care_plans_patient_version_idx": {
+          "name": "care_plans_patient_version_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "prompt_version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "care_plans_patient_idx": {
+          "name": "care_plans_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "care_plans_status_idx": {
+          "name": "care_plans_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "esuc_care_plans_generated_by_user_id_users_id_fk": {
+          "name": "esuc_care_plans_generated_by_user_id_users_id_fk",
+          "tableFrom": "esuc_care_plans",
+          "tableTo": "users",
+          "columnsFrom": [
+            "generated_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.eviction_case_outcomes": {
+      "name": "eviction_case_outcomes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "filing_id": {
+          "name": "filing_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "eviction_case_outcome",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recorded_by_user_id": {
+          "name": "recorded_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "case_outcomes_filing_idx": {
+          "name": "case_outcomes_filing_idx",
+          "columns": [
+            {
+              "expression": "filing_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "case_outcomes_outcome_idx": {
+          "name": "case_outcomes_outcome_idx",
+          "columns": [
+            {
+              "expression": "outcome",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "case_outcomes_created_at_idx": {
+          "name": "case_outcomes_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "eviction_case_outcomes_filing_id_eviction_filings_id_fk": {
+          "name": "eviction_case_outcomes_filing_id_eviction_filings_id_fk",
+          "tableFrom": "eviction_case_outcomes",
+          "tableTo": "eviction_filings",
+          "columnsFrom": [
+            "filing_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "eviction_case_outcomes_recorded_by_user_id_users_id_fk": {
+          "name": "eviction_case_outcomes_recorded_by_user_id_users_id_fk",
+          "tableFrom": "eviction_case_outcomes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "recorded_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.eviction_filing_risk_scores": {
+      "name": "eviction_filing_risk_scores",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "filing_id": {
+          "name": "filing_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rationale": {
+          "name": "rationale",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model_version": {
+          "name": "model_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "risk_scores_filing_version_idx": {
+          "name": "risk_scores_filing_version_idx",
+          "columns": [
+            {
+              "expression": "filing_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "model_version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "risk_scores_filing_idx": {
+          "name": "risk_scores_filing_idx",
+          "columns": [
+            {
+              "expression": "filing_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "risk_scores_score_idx": {
+          "name": "risk_scores_score_idx",
+          "columns": [
+            {
+              "expression": "score",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "eviction_filing_risk_scores_filing_id_eviction_filings_id_fk": {
+          "name": "eviction_filing_risk_scores_filing_id_eviction_filings_id_fk",
+          "tableFrom": "eviction_filing_risk_scores",
+          "tableTo": "eviction_filings",
+          "columnsFrom": [
+            "filing_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.eviction_filings": {
+      "name": "eviction_filings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "case_number": {
+          "name": "case_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filed_at": {
+          "name": "filed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "court_division": {
+          "name": "court_division",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plaintiff": {
+          "name": "plaintiff",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "defendant_first_name": {
+          "name": "defendant_first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "defendant_last_name": {
+          "name": "defendant_last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "defendant_address": {
+          "name": "defendant_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cause_type": {
+          "name": "cause_type",
+          "type": "eviction_cause_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_claimed_cents": {
+          "name": "amount_claimed_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "eviction_filing_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'filed'"
+        },
+        "source": {
+          "name": "source",
+          "type": "eviction_filing_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "raw_json": {
+          "name": "raw_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dv_flag": {
+          "name": "dv_flag",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "eviction_filings_case_source_idx": {
+          "name": "eviction_filings_case_source_idx",
+          "columns": [
+            {
+              "expression": "case_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "eviction_filings_filed_at_idx": {
+          "name": "eviction_filings_filed_at_idx",
+          "columns": [
+            {
+              "expression": "filed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "eviction_filings_status_idx": {
+          "name": "eviction_filings_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.eviction_response_packets": {
+      "name": "eviction_response_packets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "filing_id": {
+          "name": "filing_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "packet_md": {
+          "name": "packet_md",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt_version": {
+          "name": "prompt_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "generated_by_user_id": {
+          "name": "generated_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "eviction_response_packet_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "response_packets_filing_version_idx": {
+          "name": "response_packets_filing_version_idx",
+          "columns": [
+            {
+              "expression": "filing_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "prompt_version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "response_packets_filing_idx": {
+          "name": "response_packets_filing_idx",
+          "columns": [
+            {
+              "expression": "filing_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "response_packets_status_idx": {
+          "name": "response_packets_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "eviction_response_packets_filing_id_eviction_filings_id_fk": {
+          "name": "eviction_response_packets_filing_id_eviction_filings_id_fk",
+          "tableFrom": "eviction_response_packets",
+          "tableTo": "eviction_filings",
+          "columnsFrom": [
+            "filing_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "eviction_response_packets_generated_by_user_id_users_id_fk": {
+          "name": "eviction_response_packets_generated_by_user_id_users_id_fk",
+          "tableFrom": "eviction_response_packets",
+          "tableTo": "users",
+          "columnsFrom": [
+            "generated_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.fag_compensation_entries": {
+      "name": "fag_compensation_entries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "member_id": {
+          "name": "member_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurred_on": {
+          "name": "occurred_on",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hours_tenths": {
+          "name": "hours_tenths",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hourly_rate_cents": {
+          "name": "hourly_rate_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_cents": {
+          "name": "total_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "fag_payout_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unpaid'"
+        },
+        "paid_at": {
+          "name": "paid_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "paid_by_user_id": {
+          "name": "paid_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "fag_compensation_member_idx": {
+          "name": "fag_compensation_member_idx",
+          "columns": [
+            {
+              "expression": "member_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "fag_compensation_status_idx": {
+          "name": "fag_compensation_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "fag_compensation_occurred_idx": {
+          "name": "fag_compensation_occurred_idx",
+          "columns": [
+            {
+              "expression": "occurred_on",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "fag_compensation_entries_member_id_fag_members_id_fk": {
+          "name": "fag_compensation_entries_member_id_fag_members_id_fk",
+          "tableFrom": "fag_compensation_entries",
+          "tableTo": "fag_members",
+          "columnsFrom": [
+            "member_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "fag_compensation_entries_paid_by_user_id_users_id_fk": {
+          "name": "fag_compensation_entries_paid_by_user_id_users_id_fk",
+          "tableFrom": "fag_compensation_entries",
+          "tableTo": "users",
+          "columnsFrom": [
+            "paid_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.fag_members": {
+      "name": "fag_members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "full_name": {
+          "name": "full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_phone": {
+          "name": "contact_phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_email": {
+          "name": "contact_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hourly_rate_cents": {
+          "name": "hourly_rate_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 10000
+        },
+        "status": {
+          "name": "status",
+          "type": "fag_member_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onboarded_on": {
+          "name": "onboarded_on",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "fag_members_status_idx": {
+          "name": "fag_members_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.health_check": {
+      "name": "health_check",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_memberships": {
+      "name": "org_memberships",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "partner_org_id": {
+          "name": "partner_org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "org_memberships_user_org_idx": {
+          "name": "org_memberships_user_org_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "partner_org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "org_memberships_user_idx": {
+          "name": "org_memberships_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "org_memberships_partner_org_idx": {
+          "name": "org_memberships_partner_org_idx",
+          "columns": [
+            {
+              "expression": "partner_org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "org_memberships_user_id_users_id_fk": {
+          "name": "org_memberships_user_id_users_id_fk",
+          "tableFrom": "org_memberships",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "org_memberships_partner_org_id_partner_orgs_id_fk": {
+          "name": "org_memberships_partner_org_id_partner_orgs_id_fk",
+          "tableFrom": "org_memberships",
+          "tableTo": "partner_orgs",
+          "columnsFrom": [
+            "partner_org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.partner_orgs": {
+      "name": "partner_orgs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "partner_org_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_email": {
+          "name": "contact_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_phone": {
+          "name": "contact_phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "website": {
+          "name": "website",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data_sharing_tier": {
+          "name": "data_sharing_tier",
+          "type": "data_sharing_tier",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "partner_orgs_slug_idx": {
+          "name": "partner_orgs_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.partner_service_events": {
+      "name": "partner_service_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "partner_org_id": {
+          "name": "partner_org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "synthetic_person_ref": {
+          "name": "synthetic_person_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "partner_service_event_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_at": {
+          "name": "event_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "ed_encounter_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'synthetic'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "partner_service_events_person_idx": {
+          "name": "partner_service_events_person_idx",
+          "columns": [
+            {
+              "expression": "synthetic_person_ref",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "partner_service_events_partner_idx": {
+          "name": "partner_service_events_partner_idx",
+          "columns": [
+            {
+              "expression": "partner_org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "partner_service_events_at_idx": {
+          "name": "partner_service_events_at_idx",
+          "columns": [
+            {
+              "expression": "event_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "partner_service_events_partner_org_id_partner_orgs_id_fk": {
+          "name": "partner_service_events_partner_org_id_partner_orgs_id_fk",
+          "tableFrom": "partner_service_events",
+          "tableTo": "partner_orgs",
+          "columnsFrom": [
+            "partner_org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.person_partner_consents": {
+      "name": "person_partner_consents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "synthetic_person_ref": {
+          "name": "synthetic_person_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "partner_org_id": {
+          "name": "partner_org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "granted_at": {
+          "name": "granted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "person_partner_consents_unique_idx": {
+          "name": "person_partner_consents_unique_idx",
+          "columns": [
+            {
+              "expression": "synthetic_person_ref",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "partner_org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "person_partner_consents_partner_org_id_partner_orgs_id_fk": {
+          "name": "person_partner_consents_partner_org_id_partner_orgs_id_fk",
+          "tableFrom": "person_partner_consents",
+          "tableTo": "partner_orgs",
+          "columnsFrom": [
+            "partner_org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rental_assistance_programs": {
+      "name": "rental_assistance_programs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agency": {
+          "name": "agency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "website": {
+          "name": "website",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "eligibility_summary": {
+          "name": "eligibility_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "max_award_cents": {
+          "name": "max_award_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_note": {
+          "name": "source_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "rental_assistance_programs_active_idx": {
+          "name": "rental_assistance_programs_active_idx",
+          "columns": [
+            {
+              "expression": "active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bed_count_updates": {
+      "name": "bed_count_updates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "shelter_id": {
+          "name": "shelter_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_user_id": {
+          "name": "updated_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "previous_occupancy": {
+          "name": "previous_occupancy",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "new_occupancy": {
+          "name": "new_occupancy",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "bed_count_updates_shelter_idx": {
+          "name": "bed_count_updates_shelter_idx",
+          "columns": [
+            {
+              "expression": "shelter_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bed_count_updates_created_idx": {
+          "name": "bed_count_updates_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bed_count_updates_shelter_id_shelters_id_fk": {
+          "name": "bed_count_updates_shelter_id_shelters_id_fk",
+          "tableFrom": "bed_count_updates",
+          "tableTo": "shelters",
+          "columnsFrom": [
+            "shelter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bed_holds": {
+      "name": "bed_holds",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "shelter_id": {
+          "name": "shelter_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "held_by_user_id": {
+          "name": "held_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "person_label": {
+          "name": "person_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "bed_hold_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "released_at": {
+          "name": "released_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "bed_holds_shelter_idx": {
+          "name": "bed_holds_shelter_idx",
+          "columns": [
+            {
+              "expression": "shelter_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bed_holds_status_idx": {
+          "name": "bed_holds_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bed_holds_expires_idx": {
+          "name": "bed_holds_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bed_holds_shelter_id_shelters_id_fk": {
+          "name": "bed_holds_shelter_id_shelters_id_fk",
+          "tableFrom": "bed_holds",
+          "tableTo": "shelters",
+          "columnsFrom": [
+            "shelter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.shelters": {
+      "name": "shelters",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "partner_org_id": {
+          "name": "partner_org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address_line1": {
+          "name": "address_line1",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "city": {
+          "name": "city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "postal_code": {
+          "name": "postal_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_phone": {
+          "name": "contact_phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capacity": {
+          "name": "capacity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_occupancy": {
+          "name": "current_occupancy",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "accepts_men": {
+          "name": "accepts_men",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "accepts_women": {
+          "name": "accepts_women",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "accepts_families": {
+          "name": "accepts_families",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "pet_friendly": {
+          "name": "pet_friendly",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "sud_friendly": {
+          "name": "sud_friendly",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "shelters_slug_idx": {
+          "name": "shelters_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "shelters_partner_org_idx": {
+          "name": "shelters_partner_org_idx",
+          "columns": [
+            {
+              "expression": "partner_org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "shelters_partner_org_id_partner_orgs_id_fk": {
+          "name": "shelters_partner_org_id_partner_orgs_id_fk",
+          "tableFrom": "shelters",
+          "tableTo": "partner_orgs",
+          "columnsFrom": [
+            "partner_org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "shelters_capacity_nonneg": {
+          "name": "shelters_capacity_nonneg",
+          "value": "\"shelters\".\"capacity\" >= 0"
+        },
+        "shelters_occupancy_nonneg": {
+          "name": "shelters_occupancy_nonneg",
+          "value": "\"shelters\".\"current_occupancy\" >= 0"
+        },
+        "shelters_occupancy_le_capacity": {
+          "name": "shelters_occupancy_le_capacity",
+          "value": "\"shelters\".\"current_occupancy\" <= \"shelters\".\"capacity\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.sms_conversations": {
+      "name": "sms_conversations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "from_number": {
+          "name": "from_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "sms_conversation_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'idle'"
+        },
+        "pending_filter": {
+          "name": "pending_filter",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_location": {
+          "name": "last_location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_results": {
+          "name": "last_results",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_hold_id": {
+          "name": "last_hold_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_message_at": {
+          "name": "last_message_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sms_conversations_from_idx": {
+          "name": "sms_conversations_from_idx",
+          "columns": [
+            {
+              "expression": "from_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_conversations_state_idx": {
+          "name": "sms_conversations_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_conversations_expires_idx": {
+          "name": "sms_conversations_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sms_messages": {
+      "name": "sms_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "provider_message_id": {
+          "name": "provider_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "from_number": {
+          "name": "from_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_number": {
+          "name": "to_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "intent": {
+          "name": "intent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reply_body": {
+          "name": "reply_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sms_messages_received_idx": {
+          "name": "sms_messages_received_idx",
+          "columns": [
+            {
+              "expression": "received_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_messages_from_idx": {
+          "name": "sms_messages_from_idx",
+          "columns": [
+            {
+              "expression": "from_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.steering_meetings": {
+      "name": "steering_meetings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "held_on": {
+          "name": "held_on",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attendees": {
+          "name": "attendees",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agenda_md": {
+          "name": "agenda_md",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "decisions_md": {
+          "name": "decisions_md",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "action_items_md": {
+          "name": "action_items_md",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "posted_at": {
+          "name": "posted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "steering_meetings_held_on_idx": {
+          "name": "steering_meetings_held_on_idx",
+          "columns": [
+            {
+              "expression": "held_on",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "steering_meetings_created_by_idx": {
+          "name": "steering_meetings_created_by_idx",
+          "columns": [
+            {
+              "expression": "created_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "steering_meetings_created_by_user_id_users_id_fk": {
+          "name": "steering_meetings_created_by_user_id_users_id_fk",
+          "tableFrom": "steering_meetings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.triage_overrides": {
+      "name": "triage_overrides",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recommended_tier": {
+          "name": "recommended_tier",
+          "type": "triage_tier",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recommended_score": {
+          "name": "recommended_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chosen_tier": {
+          "name": "chosen_tier",
+          "type": "triage_tier",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "override_reason": {
+          "name": "override_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "inputs_snapshot": {
+          "name": "inputs_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recommended_factors": {
+          "name": "recommended_factors",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "triage_overrides_actor_idx": {
+          "name": "triage_overrides_actor_idx",
+          "columns": [
+            {
+              "expression": "actor_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "triage_overrides_created_idx": {
+          "name": "triage_overrides_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "triage_overrides_recommended_idx": {
+          "name": "triage_overrides_recommended_idx",
+          "columns": [
+            {
+              "expression": "recommended_tier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "triage_overrides_actor_user_id_users_id_fk": {
+          "name": "triage_overrides_actor_user_id_users_id_fk",
+          "tableFrom": "triage_overrides",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "clerk_user_id": {
+          "name": "clerk_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "users_clerk_user_id_idx": {
+          "name": "users_clerk_user_id_idx",
+          "columns": [
+            {
+              "expression": "clerk_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.bed_hold_status": {
+      "name": "bed_hold_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "released",
+        "expired",
+        "converted"
+      ]
+    },
+    "public.client_document_kind": {
+      "name": "client_document_kind",
+      "schema": "public",
+      "values": [
+        "photo_id",
+        "ssn_card",
+        "birth_certificate",
+        "dd_214",
+        "lease",
+        "paystub",
+        "court_record",
+        "other"
+      ]
+    },
+    "public.client_document_status": {
+      "name": "client_document_status",
+      "schema": "public",
+      "values": [
+        "uploaded",
+        "extracting",
+        "extracted",
+        "failed"
+      ]
+    },
+    "public.consent_channel": {
+      "name": "consent_channel",
+      "schema": "public",
+      "values": [
+        "sms",
+        "in_person",
+        "web_form",
+        "phone",
+        "paper"
+      ]
+    },
+    "public.consent_type": {
+      "name": "consent_type",
+      "schema": "public",
+      "values": [
+        "phi_share_within_coalition",
+        "sms_communication",
+        "data_for_program_eval"
+      ]
+    },
+    "public.data_sharing_tier": {
+      "name": "data_sharing_tier",
+      "schema": "public",
+      "values": [
+        "none",
+        "aggregate",
+        "individual"
+      ]
+    },
+    "public.ed_encounter_source": {
+      "name": "ed_encounter_source",
+      "schema": "public",
+      "values": [
+        "synthetic",
+        "epic_fhir",
+        "manual"
+      ]
+    },
+    "public.esuc_care_plan_status": {
+      "name": "esuc_care_plan_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "approved",
+        "active",
+        "archived"
+      ]
+    },
+    "public.eviction_case_outcome": {
+      "name": "eviction_case_outcome",
+      "schema": "public",
+      "values": [
+        "dismissed",
+        "judgment_for_plaintiff",
+        "judgment_for_defendant",
+        "settled",
+        "default_judgment",
+        "withdrawn"
+      ]
+    },
+    "public.eviction_cause_type": {
+      "name": "eviction_cause_type",
+      "schema": "public",
+      "values": [
+        "non_payment",
+        "lease_violation",
+        "holdover",
+        "other"
+      ]
+    },
+    "public.eviction_filing_source": {
+      "name": "eviction_filing_source",
+      "schema": "public",
+      "values": [
+        "courtnet",
+        "manual",
+        "synthetic"
+      ]
+    },
+    "public.eviction_filing_status": {
+      "name": "eviction_filing_status",
+      "schema": "public",
+      "values": [
+        "filed",
+        "served",
+        "judgment",
+        "dismissed",
+        "sealed"
+      ]
+    },
+    "public.eviction_response_packet_status": {
+      "name": "eviction_response_packet_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "approved",
+        "filed",
+        "rejected"
+      ]
+    },
+    "public.fag_member_status": {
+      "name": "fag_member_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "paused",
+        "ended"
+      ]
+    },
+    "public.fag_payout_status": {
+      "name": "fag_payout_status",
+      "schema": "public",
+      "values": [
+        "unpaid",
+        "paid",
+        "voided"
+      ]
+    },
+    "public.housing_status": {
+      "name": "housing_status",
+      "schema": "public",
+      "values": [
+        "housed",
+        "doubled_up",
+        "shelter",
+        "unsheltered",
+        "unknown"
+      ]
+    },
+    "public.partner_org_type": {
+      "name": "partner_org_type",
+      "schema": "public",
+      "values": [
+        "hospital",
+        "legal_aid",
+        "shelter",
+        "community_org",
+        "government",
+        "faith_based",
+        "school",
+        "philanthropy",
+        "education",
+        "public_health",
+        "media",
+        "other"
+      ]
+    },
+    "public.partner_service_event_type": {
+      "name": "partner_service_event_type",
+      "schema": "public",
+      "values": [
+        "food_pantry",
+        "shelter_intake",
+        "shelter_bed_night",
+        "utility_assistance",
+        "rent_assistance",
+        "counseling_visit",
+        "medical_visit",
+        "school_attendance_flag",
+        "volunteer_hours",
+        "other"
+      ]
+    },
+    "public.sms_conversation_state": {
+      "name": "sms_conversation_state",
+      "schema": "public",
+      "values": [
+        "idle",
+        "awaiting_location"
+      ]
+    },
+    "public.triage_tier": {
+      "name": "triage_tier",
+      "schema": "public",
+      "values": [
+        "high",
+        "medium",
+        "low"
+      ]
+    },
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "pending",
+        "attorney",
+        "caseworker",
+        "ed_coordinator",
+        "shelter_staff",
+        "admin"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/migrations/meta/_journal.json
+++ b/drizzle/migrations/meta/_journal.json
@@ -197,6 +197,13 @@
       "when": 1777248849242,
       "tag": "0027_sleepy_landau",
       "breakpoints": true
+    },
+    {
+      "idx": 28,
+      "version": "7",
+      "when": 1777249184720,
+      "tag": "0028_complex_true_believers",
+      "breakpoints": true
     }
   ]
 }

--- a/src/app/actions/fag.ts
+++ b/src/app/actions/fag.ts
@@ -1,0 +1,200 @@
+'use server';
+
+import { eq } from 'drizzle-orm';
+import { revalidatePath } from 'next/cache';
+import { db } from '@/db/client';
+import { type FagMemberStatus, fagMemberStatusEnum } from '@/db/schema/enums';
+import { fagCompensationEntries, fagMembers } from '@/db/schema/fag-members';
+import { logAuditEvent } from '@/lib/audit';
+import { requireRole } from '@/lib/auth';
+
+export type SaveMemberInput = {
+  id?: string;
+  fullName: string;
+  role: string;
+  contactPhone?: string | null;
+  contactEmail?: string | null;
+  hourlyRateCents: number;
+  status: FagMemberStatus;
+  notes?: string | null;
+  onboardedOn?: string | null; // YYYY-MM-DD
+};
+
+export type SaveMemberResult = { ok: true; id: string } | { ok: false; error: string };
+
+const ROLES = ['admin'] as const;
+const VALID_STATUSES = new Set<FagMemberStatus>(fagMemberStatusEnum.enumValues);
+
+const NAME_MAX = 80;
+const ROLE_MAX = 60;
+const NOTES_MAX = 500;
+const RATE_MAX_CENTS = 100_000; // $1,000/hr cap; sanity bound
+
+export async function saveFagMemberAction(input: SaveMemberInput): Promise<SaveMemberResult> {
+  const actor = await requireRole(ROLES);
+
+  const fullName = input.fullName.trim().slice(0, NAME_MAX);
+  if (fullName.length === 0) return { ok: false, error: 'Name is required.' };
+  const role = input.role.trim().slice(0, ROLE_MAX);
+  if (role.length === 0) return { ok: false, error: 'Role label is required.' };
+  if (!VALID_STATUSES.has(input.status)) return { ok: false, error: 'Invalid status.' };
+  if (
+    !Number.isInteger(input.hourlyRateCents) ||
+    input.hourlyRateCents < 0 ||
+    input.hourlyRateCents > RATE_MAX_CENTS
+  ) {
+    return { ok: false, error: 'Hourly rate must be 0 – $1,000/hr.' };
+  }
+  const notes = input.notes?.trim().slice(0, NOTES_MAX) || null;
+  const phone = input.contactPhone?.trim() || null;
+  const email = input.contactEmail?.trim() || null;
+  const onboardedOn = input.onboardedOn?.trim() || null;
+
+  if (input.id) {
+    const [updated] = await db
+      .update(fagMembers)
+      .set({
+        fullName,
+        role,
+        contactPhone: phone,
+        contactEmail: email,
+        hourlyRateCents: input.hourlyRateCents,
+        status: input.status,
+        notes,
+        onboardedOn,
+        updatedAt: new Date(),
+      })
+      .where(eq(fagMembers.id, input.id))
+      .returning({ id: fagMembers.id });
+    if (!updated) return { ok: false, error: 'Member not found.' };
+    await logAuditEvent({
+      actorUserId: actor.id,
+      action: 'fag_member.updated',
+      targetTable: 'fag_members',
+      targetId: updated.id,
+    });
+    revalidatePath('/app/coalition/fag');
+    revalidatePath(`/app/coalition/fag/${updated.id}`);
+    return { ok: true, id: updated.id };
+  }
+
+  const [created] = await db
+    .insert(fagMembers)
+    .values({
+      fullName,
+      role,
+      contactPhone: phone,
+      contactEmail: email,
+      hourlyRateCents: input.hourlyRateCents,
+      status: input.status,
+      notes,
+      onboardedOn,
+    })
+    .returning({ id: fagMembers.id });
+  await logAuditEvent({
+    actorUserId: actor.id,
+    action: 'fag_member.created',
+    targetTable: 'fag_members',
+    targetId: created.id,
+  });
+  revalidatePath('/app/coalition/fag');
+  return { ok: true, id: created.id };
+}
+
+export type AddEntryInput = {
+  memberId: string;
+  occurredOn: string; // YYYY-MM-DD
+  description: string;
+  hoursTenths: number; // 1.5h = 15
+  hourlyRateCents?: number; // override; defaults to member's current rate
+  notes?: string | null;
+};
+
+export type AddEntryResult =
+  | { ok: true; id: string; totalCents: number }
+  | { ok: false; error: string };
+
+const DESC_MAX = 200;
+const HOURS_MAX_TENTHS = 24 * 10; // 24 hours/day cap
+
+const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+
+export async function addFagCompensationEntryAction(input: AddEntryInput): Promise<AddEntryResult> {
+  const actor = await requireRole(ROLES);
+
+  if (!DATE_RE.test(input.occurredOn)) return { ok: false, error: 'Date must be YYYY-MM-DD.' };
+  const description = input.description.trim().slice(0, DESC_MAX);
+  if (description.length === 0) return { ok: false, error: 'Description is required.' };
+  if (
+    !Number.isInteger(input.hoursTenths) ||
+    input.hoursTenths <= 0 ||
+    input.hoursTenths > HOURS_MAX_TENTHS
+  ) {
+    return { ok: false, error: 'Hours must be > 0 and ≤ 24.' };
+  }
+
+  const [member] = await db
+    .select({ id: fagMembers.id, hourlyRateCents: fagMembers.hourlyRateCents })
+    .from(fagMembers)
+    .where(eq(fagMembers.id, input.memberId))
+    .limit(1);
+  if (!member) return { ok: false, error: 'Member not found.' };
+
+  const rate = input.hourlyRateCents ?? member.hourlyRateCents;
+  if (!Number.isInteger(rate) || rate < 0 || rate > RATE_MAX_CENTS) {
+    return { ok: false, error: 'Invalid hourly rate.' };
+  }
+
+  // hoursTenths × cents-per-hour ÷ 10 = cents owed.
+  const totalCents = Math.round((input.hoursTenths * rate) / 10);
+
+  const [created] = await db
+    .insert(fagCompensationEntries)
+    .values({
+      memberId: member.id,
+      occurredOn: input.occurredOn,
+      description,
+      hoursTenths: input.hoursTenths,
+      hourlyRateCents: rate,
+      totalCents,
+      notes: input.notes?.trim().slice(0, NOTES_MAX) || null,
+    })
+    .returning({ id: fagCompensationEntries.id });
+
+  await logAuditEvent({
+    actorUserId: actor.id,
+    action: 'fag_compensation.created',
+    targetTable: 'fag_compensation_entries',
+    targetId: created.id,
+    metadata: { memberId: member.id, totalCents },
+  });
+
+  revalidatePath(`/app/coalition/fag/${member.id}`);
+  revalidatePath('/app/coalition/fag');
+  return { ok: true, id: created.id, totalCents };
+}
+
+export type MarkPaidResult = { ok: true } | { ok: false; error: string };
+
+export async function markFagEntryPaidAction(entryId: string): Promise<MarkPaidResult> {
+  const actor = await requireRole(ROLES);
+
+  const [updated] = await db
+    .update(fagCompensationEntries)
+    .set({ status: 'paid', paidAt: new Date(), paidByUserId: actor.id, updatedAt: new Date() })
+    .where(eq(fagCompensationEntries.id, entryId))
+    .returning({ id: fagCompensationEntries.id, memberId: fagCompensationEntries.memberId });
+  if (!updated) return { ok: false, error: 'Entry not found.' };
+
+  await logAuditEvent({
+    actorUserId: actor.id,
+    action: 'fag_compensation.paid',
+    targetTable: 'fag_compensation_entries',
+    targetId: updated.id,
+    metadata: { memberId: updated.memberId },
+  });
+
+  revalidatePath(`/app/coalition/fag/${updated.memberId}`);
+  revalidatePath('/app/coalition/fag');
+  return { ok: true };
+}

--- a/src/app/app/coalition/fag/[id]/page.tsx
+++ b/src/app/app/coalition/fag/[id]/page.tsx
@@ -1,0 +1,186 @@
+import Link from 'next/link';
+import { notFound } from 'next/navigation';
+import { FagEntryForm } from '@/components/coalition/fag-entry-form';
+import { FagMarkPaidButton } from '@/components/coalition/fag-mark-paid-button';
+import { FagMemberForm } from '@/components/coalition/fag-member-form';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { getFagMemberById, listEntriesForMember } from '@/db/queries/fag';
+import { requireRole } from '@/lib/auth';
+
+export const dynamic = 'force-dynamic';
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+const fmtMoney = (cents: number) =>
+  new Intl.NumberFormat('en-US', {
+    style: 'currency',
+    currency: 'USD',
+    maximumFractionDigits: 2,
+  }).format(cents / 100);
+
+const fmtDate = (iso: string) =>
+  new Intl.DateTimeFormat('en-US', { dateStyle: 'medium' }).format(new Date(iso));
+
+const fmtTime = (d: Date) =>
+  new Intl.DateTimeFormat('en-US', { dateStyle: 'short', timeStyle: 'short' }).format(new Date(d));
+
+export default async function FagMemberDetailPage({ params }: { params: Promise<{ id: string }> }) {
+  await requireRole(['admin']);
+  const { id } = await params;
+  if (!UUID_RE.test(id)) notFound();
+
+  const member = await getFagMemberById(id);
+  if (!member) notFound();
+  const entries = await listEntriesForMember(id);
+
+  const totalPaid = entries
+    .filter((e) => e.status === 'paid')
+    .reduce((sum, e) => sum + e.totalCents, 0);
+  const totalUnpaid = entries
+    .filter((e) => e.status === 'unpaid')
+    .reduce((sum, e) => sum + e.totalCents, 0);
+
+  return (
+    <div className="mx-auto max-w-3xl space-y-4 p-4 md:p-6">
+      <div className="text-xs">
+        <Link href="/app/coalition/fag" className="text-muted-foreground hover:underline">
+          ← Back to FAG
+        </Link>
+      </div>
+
+      <header>
+        <h1 className="font-serif text-3xl font-bold text-primary">{member.fullName}</h1>
+        <p className="text-sm text-muted-foreground">
+          {member.role} · status{' '}
+          <span
+            className={
+              member.status === 'active'
+                ? 'text-emerald-700 dark:text-emerald-400'
+                : 'text-muted-foreground'
+            }
+          >
+            {member.status}
+          </span>{' '}
+          · {fmtMoney(member.hourlyRateCents)}/hr
+        </p>
+      </header>
+
+      <div className="grid gap-3 md:grid-cols-2">
+        <Card>
+          <CardContent>
+            <p className="text-xs uppercase tracking-wide text-muted-foreground">Paid to date</p>
+            <p className="text-3xl font-semibold">{fmtMoney(totalPaid)}</p>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardContent>
+            <p className="text-xs uppercase tracking-wide text-muted-foreground">Outstanding</p>
+            <p className={`text-3xl font-semibold ${totalUnpaid > 0 ? 'text-destructive' : ''}`}>
+              {fmtMoney(totalUnpaid)}
+            </p>
+          </CardContent>
+        </Card>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">Add compensation entry</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <FagEntryForm memberId={member.id} defaultRateCents={member.hourlyRateCents} />
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">Compensation history ({entries.length})</CardTitle>
+        </CardHeader>
+        <CardContent>
+          {entries.length === 0 ? (
+            <p className="text-sm text-muted-foreground">No entries yet.</p>
+          ) : (
+            <ul className="divide-y divide-border text-sm">
+              {entries.map((e) => (
+                <li key={e.id} className="space-y-1 py-2">
+                  <div className="flex flex-wrap items-baseline justify-between gap-2">
+                    <span className="font-medium">{e.description}</span>
+                    <span
+                      className={`text-xs ${
+                        e.status === 'paid'
+                          ? 'text-emerald-700 dark:text-emerald-400'
+                          : e.status === 'voided'
+                            ? 'text-muted-foreground'
+                            : 'text-destructive'
+                      }`}
+                    >
+                      {e.status}
+                    </span>
+                  </div>
+                  <p className="text-xs text-muted-foreground">
+                    {fmtDate(e.occurredOn)} · {(e.hoursTenths / 10).toFixed(1)}h ×{' '}
+                    {fmtMoney(e.hourlyRateCents)}/hr = <strong>{fmtMoney(e.totalCents)}</strong>
+                    {e.paidAt ? <> · paid {fmtTime(e.paidAt)}</> : null}
+                  </p>
+                  {e.notes ? <p className="text-xs italic">"{e.notes}"</p> : null}
+                  {e.status === 'unpaid' ? (
+                    <div className="pt-1">
+                      <FagMarkPaidButton entryId={e.id} />
+                    </div>
+                  ) : null}
+                </li>
+              ))}
+            </ul>
+          )}
+        </CardContent>
+      </Card>
+
+      <details className="rounded-md border border-border bg-card p-3 text-sm">
+        <summary className="cursor-pointer font-medium">Edit advisor details</summary>
+        <div className="pt-3">
+          <FagMemberForm
+            initial={{
+              id: member.id,
+              fullName: member.fullName,
+              role: member.role,
+              contactPhone: member.contactPhone,
+              contactEmail: member.contactEmail,
+              hourlyRateCents: member.hourlyRateCents,
+              status: member.status,
+              notes: member.notes,
+              onboardedOn: member.onboardedOn,
+            }}
+          />
+        </div>
+      </details>
+
+      {member.contactPhone || member.contactEmail || member.notes ? (
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-base">Contact + notes</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-1 text-sm">
+            {member.contactPhone ? (
+              <p>
+                <span className="text-muted-foreground">Phone:</span> {member.contactPhone}
+              </p>
+            ) : null}
+            {member.contactEmail ? (
+              <p>
+                <span className="text-muted-foreground">Email:</span> {member.contactEmail}
+              </p>
+            ) : null}
+            {member.onboardedOn ? (
+              <p>
+                <span className="text-muted-foreground">Onboarded:</span>{' '}
+                {fmtDate(member.onboardedOn)}
+              </p>
+            ) : null}
+            {member.notes ? (
+              <p className="text-xs italic text-muted-foreground">{member.notes}</p>
+            ) : null}
+          </CardContent>
+        </Card>
+      ) : null}
+    </div>
+  );
+}

--- a/src/app/app/coalition/fag/new/page.tsx
+++ b/src/app/app/coalition/fag/new/page.tsx
@@ -1,0 +1,37 @@
+import Link from 'next/link';
+import { FagMemberForm } from '@/components/coalition/fag-member-form';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { requireRole } from '@/lib/auth';
+
+export const dynamic = 'force-dynamic';
+
+export default async function NewFagMemberPage() {
+  await requireRole(['admin']);
+
+  return (
+    <div className="mx-auto max-w-2xl space-y-4 p-4 md:p-6">
+      <div className="text-xs">
+        <Link href="/app/coalition/fag" className="text-muted-foreground hover:underline">
+          ← Back to FAG
+        </Link>
+      </div>
+
+      <header>
+        <h1 className="font-serif text-3xl font-bold text-primary">Add advisor</h1>
+        <p className="text-sm text-muted-foreground">
+          Real contact info goes here; it doesn't leave this admin surface. Default $100/hr per
+          coalition policy — edit if a specific arrangement applies.
+        </p>
+      </header>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">Advisor details</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <FagMemberForm />
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/app/app/coalition/fag/page.tsx
+++ b/src/app/app/coalition/fag/page.tsx
@@ -1,0 +1,114 @@
+import Link from 'next/link';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { getFagAggregates, listFagMemberSummaries } from '@/db/queries/fag';
+import { requireRole } from '@/lib/auth';
+
+export const dynamic = 'force-dynamic';
+
+const fmtMoney = (cents: number) =>
+  new Intl.NumberFormat('en-US', {
+    style: 'currency',
+    currency: 'USD',
+    maximumFractionDigits: 0,
+  }).format(cents / 100);
+
+export default async function FagPage() {
+  await requireRole(['admin']);
+  const [summaries, totals] = await Promise.all([listFagMemberSummaries(), getFagAggregates()]);
+
+  return (
+    <div className="mx-auto max-w-4xl space-y-4 p-4 md:p-6">
+      <header className="flex flex-wrap items-baseline justify-between gap-2">
+        <div>
+          <h1 className="font-serif text-3xl font-bold text-primary">Frontline Advisory Group</h1>
+          <p className="text-sm text-muted-foreground">
+            Lived-experience advisors who get paid for their time. Roster, hours, and payout status.
+          </p>
+        </div>
+        <Link href="/app/coalition/fag/new">
+          <Button>Add advisor</Button>
+        </Link>
+      </header>
+
+      <div className="grid gap-3 md:grid-cols-3">
+        <Card>
+          <CardContent>
+            <p className="text-xs uppercase tracking-wide text-muted-foreground">Active advisors</p>
+            <p className="text-3xl font-semibold">{totals.activeMemberCount}</p>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardContent>
+            <p className="text-xs uppercase tracking-wide text-muted-foreground">Paid to date</p>
+            <p className="text-3xl font-semibold">{fmtMoney(totals.totalPaidCents)}</p>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardContent>
+            <p className="text-xs uppercase tracking-wide text-muted-foreground">Outstanding</p>
+            <p
+              className={`text-3xl font-semibold ${totals.totalUnpaidCents > 0 ? 'text-destructive' : ''}`}
+            >
+              {fmtMoney(totals.totalUnpaidCents)}
+            </p>
+          </CardContent>
+        </Card>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">Roster</CardTitle>
+        </CardHeader>
+        <CardContent>
+          {summaries.length === 0 ? (
+            <p className="text-sm text-muted-foreground">
+              No advisors yet. Click <strong>Add advisor</strong> to start.
+            </p>
+          ) : (
+            <ul className="divide-y divide-border text-sm">
+              {summaries.map((s) => (
+                <li
+                  key={s.member.id}
+                  className="flex flex-wrap items-baseline justify-between gap-2 py-2"
+                >
+                  <Link
+                    href={`/app/coalition/fag/${s.member.id}`}
+                    className="font-medium hover:underline"
+                  >
+                    {s.member.fullName}
+                  </Link>
+                  <span className="text-xs text-muted-foreground">
+                    {s.member.role} ·{' '}
+                    <span
+                      className={
+                        s.member.status === 'active'
+                          ? 'text-emerald-700 dark:text-emerald-400'
+                          : 'text-muted-foreground'
+                      }
+                    >
+                      {s.member.status}
+                    </span>{' '}
+                    · {s.entryCount} entr{s.entryCount === 1 ? 'y' : 'ies'} ·{' '}
+                    {s.unpaidCents > 0 ? (
+                      <span className="text-destructive">{fmtMoney(s.unpaidCents)} owed</span>
+                    ) : (
+                      <span>all paid</span>
+                    )}
+                  </span>
+                </li>
+              ))}
+            </ul>
+          )}
+        </CardContent>
+      </Card>
+
+      <Card className="border-amber-500/40 bg-amber-500/5">
+        <CardContent className="text-xs text-muted-foreground">
+          <strong>Pay at the time of the session, not after.</strong> Coalition policy. Backed-up
+          payouts are how advisors lose trust in the FAG.
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/components/app-shell/nav-config.ts
+++ b/src/components/app-shell/nav-config.ts
@@ -82,6 +82,11 @@ export const NAV_ITEMS: NavItem[] = [
     roles: ['attorney', 'caseworker', 'ed_coordinator', 'shelter_staff', 'admin'],
   },
   {
+    label: 'Frontline Advisory Group',
+    href: '/app/coalition/fag',
+    roles: ['admin'],
+  },
+  {
     label: 'Bed availability',
     href: '/app/coalition/beds',
     roles: ['attorney', 'caseworker', 'ed_coordinator', 'shelter_staff', 'admin'],

--- a/src/components/coalition/fag-entry-form.tsx
+++ b/src/components/coalition/fag-entry-form.tsx
@@ -1,0 +1,142 @@
+'use client';
+
+import { useId, useState, useTransition } from 'react';
+import { addFagCompensationEntryAction } from '@/app/actions/fag';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+
+export function FagEntryForm({
+  memberId,
+  defaultRateCents,
+}: {
+  memberId: string;
+  defaultRateCents: number;
+}) {
+  const dateId = useId();
+  const descId = useId();
+  const hoursId = useId();
+  const rateId = useId();
+  const notesId = useId();
+  const [occurredOn, setOccurredOn] = useState(new Date().toISOString().slice(0, 10));
+  const [description, setDescription] = useState('');
+  const [hours, setHours] = useState('1.0');
+  const [rateDollars, setRateDollars] = useState(Math.round(defaultRateCents / 100));
+  const [notes, setNotes] = useState('');
+  const [pending, startTransition] = useTransition();
+  const [error, setError] = useState<string | null>(null);
+  const [savedAt, setSavedAt] = useState<Date | null>(null);
+
+  const onSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    setError(null);
+    const hoursTenths = Math.round(Number.parseFloat(hours) * 10);
+    if (!Number.isFinite(hoursTenths) || hoursTenths <= 0) {
+      setError('Enter hours as a positive decimal (e.g. 1.5).');
+      return;
+    }
+    startTransition(async () => {
+      const r = await addFagCompensationEntryAction({
+        memberId,
+        occurredOn,
+        description,
+        hoursTenths,
+        hourlyRateCents: Math.max(0, Math.round(rateDollars * 100)),
+        notes: notes || null,
+      });
+      if (!r.ok) {
+        setError(r.error);
+        return;
+      }
+      setDescription('');
+      setHours('1.0');
+      setNotes('');
+      setSavedAt(new Date());
+    });
+  };
+
+  return (
+    <form onSubmit={onSubmit} className="space-y-3">
+      <div className="grid gap-3 md:grid-cols-2">
+        <div className="space-y-1">
+          <Label htmlFor={dateId}>Date</Label>
+          <Input
+            id={dateId}
+            type="date"
+            value={occurredOn}
+            onChange={(e) => setOccurredOn(e.target.value)}
+            disabled={pending}
+            required
+          />
+        </div>
+        <div className="space-y-1">
+          <Label htmlFor={hoursId}>Hours</Label>
+          <Input
+            id={hoursId}
+            type="number"
+            step="0.1"
+            min="0.1"
+            max="24"
+            value={hours}
+            onChange={(e) => setHours(e.target.value)}
+            disabled={pending}
+            required
+          />
+        </div>
+      </div>
+
+      <div className="space-y-1">
+        <Label htmlFor={descId}>What did the advisor do?</Label>
+        <Input
+          id={descId}
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+          placeholder='e.g. "DTRS-005 consent UX review"'
+          disabled={pending}
+          required
+          maxLength={200}
+        />
+      </div>
+
+      <div className="space-y-1">
+        <Label htmlFor={rateId}>Hourly rate this entry (USD)</Label>
+        <Input
+          id={rateId}
+          type="number"
+          min={0}
+          max={1000}
+          value={rateDollars}
+          onChange={(e) => setRateDollars(Number.parseInt(e.target.value, 10) || 0)}
+          disabled={pending}
+          required
+        />
+        <p className="text-xs text-muted-foreground">
+          Defaults to the member's current rate. Edit if this entry pays a different rate.
+        </p>
+      </div>
+
+      <div className="space-y-1">
+        <Label htmlFor={notesId}>Notes (optional)</Label>
+        <Input
+          id={notesId}
+          value={notes}
+          onChange={(e) => setNotes(e.target.value)}
+          placeholder="payout method, transit reimbursement, etc."
+          disabled={pending}
+          maxLength={500}
+        />
+      </div>
+
+      {error ? <p className="text-sm text-destructive">{error}</p> : null}
+      {savedAt ? (
+        <p className="text-sm text-emerald-700 dark:text-emerald-400">
+          Saved at {new Intl.DateTimeFormat('en-US', { timeStyle: 'short' }).format(savedAt)}.
+        </p>
+      ) : null}
+
+      <Button type="submit" disabled={pending}>
+        {pending ? 'Saving…' : 'Add entry'}
+      </Button>
+    </form>
+  );
+}

--- a/src/components/coalition/fag-mark-paid-button.tsx
+++ b/src/components/coalition/fag-mark-paid-button.tsx
@@ -1,0 +1,27 @@
+'use client';
+
+import { useState, useTransition } from 'react';
+import { markFagEntryPaidAction } from '@/app/actions/fag';
+import { Button } from '@/components/ui/button';
+
+export function FagMarkPaidButton({ entryId }: { entryId: string }) {
+  const [pending, startTransition] = useTransition();
+  const [error, setError] = useState<string | null>(null);
+
+  const onClick = () => {
+    setError(null);
+    startTransition(async () => {
+      const r = await markFagEntryPaidAction(entryId);
+      if (!r.ok) setError(r.error);
+    });
+  };
+
+  return (
+    <div>
+      <Button type="button" size="sm" variant="outline" disabled={pending} onClick={onClick}>
+        {pending ? 'Marking…' : 'Mark paid'}
+      </Button>
+      {error ? <p className="text-xs text-destructive">{error}</p> : null}
+    </div>
+  );
+}

--- a/src/components/coalition/fag-member-form.tsx
+++ b/src/components/coalition/fag-member-form.tsx
@@ -1,0 +1,187 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { useId, useState, useTransition } from 'react';
+import { saveFagMemberAction } from '@/app/actions/fag';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import type { FagMemberStatus } from '@/db/schema/enums';
+
+const STATUS_OPTIONS: FagMemberStatus[] = ['active', 'paused', 'ended'];
+
+export function FagMemberForm({
+  initial,
+}: {
+  initial?: {
+    id: string;
+    fullName: string;
+    role: string;
+    contactPhone: string | null;
+    contactEmail: string | null;
+    hourlyRateCents: number;
+    status: FagMemberStatus;
+    notes: string | null;
+    onboardedOn: string | null;
+  };
+}) {
+  const router = useRouter();
+  const nameId = useId();
+  const roleId = useId();
+  const phoneId = useId();
+  const emailId = useId();
+  const rateId = useId();
+  const statusId = useId();
+  const onboardedId = useId();
+  const notesId = useId();
+  const [fullName, setFullName] = useState(initial?.fullName ?? '');
+  const [role, setRole] = useState(initial?.role ?? 'lived-experience advisor');
+  const [phone, setPhone] = useState(initial?.contactPhone ?? '');
+  const [email, setEmail] = useState(initial?.contactEmail ?? '');
+  const [rateDollars, setRateDollars] = useState(
+    Math.round((initial?.hourlyRateCents ?? 10_000) / 100),
+  );
+  const [status, setStatus] = useState<FagMemberStatus>(initial?.status ?? 'active');
+  const [onboardedOn, setOnboardedOn] = useState(initial?.onboardedOn ?? '');
+  const [notes, setNotes] = useState(initial?.notes ?? '');
+  const [pending, startTransition] = useTransition();
+  const [error, setError] = useState<string | null>(null);
+
+  const onSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    setError(null);
+    startTransition(async () => {
+      const r = await saveFagMemberAction({
+        id: initial?.id,
+        fullName,
+        role,
+        contactPhone: phone || null,
+        contactEmail: email || null,
+        hourlyRateCents: Math.max(0, Math.round(rateDollars * 100)),
+        status,
+        notes: notes || null,
+        onboardedOn: onboardedOn || null,
+      });
+      if (!r.ok) {
+        setError(r.error);
+        return;
+      }
+      router.push(`/app/coalition/fag/${r.id}`);
+    });
+  };
+
+  return (
+    <form onSubmit={onSubmit} className="space-y-4">
+      <div className="grid gap-3 md:grid-cols-2">
+        <div className="space-y-1">
+          <Label htmlFor={nameId}>Full name</Label>
+          <Input
+            id={nameId}
+            value={fullName}
+            onChange={(e) => setFullName(e.target.value)}
+            disabled={pending}
+            required
+            maxLength={80}
+          />
+        </div>
+        <div className="space-y-1">
+          <Label htmlFor={roleId}>Role label</Label>
+          <Input
+            id={roleId}
+            value={role}
+            onChange={(e) => setRole(e.target.value)}
+            disabled={pending}
+            required
+            maxLength={60}
+          />
+        </div>
+      </div>
+
+      <div className="grid gap-3 md:grid-cols-2">
+        <div className="space-y-1">
+          <Label htmlFor={phoneId}>Phone (optional)</Label>
+          <Input
+            id={phoneId}
+            value={phone}
+            onChange={(e) => setPhone(e.target.value)}
+            disabled={pending}
+          />
+        </div>
+        <div className="space-y-1">
+          <Label htmlFor={emailId}>Email (optional)</Label>
+          <Input
+            id={emailId}
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            disabled={pending}
+          />
+        </div>
+      </div>
+
+      <div className="grid gap-3 md:grid-cols-3">
+        <div className="space-y-1">
+          <Label htmlFor={rateId}>Hourly rate (USD)</Label>
+          <Input
+            id={rateId}
+            type="number"
+            min={0}
+            max={1000}
+            step={5}
+            value={rateDollars}
+            onChange={(e) => setRateDollars(Number.parseInt(e.target.value, 10) || 0)}
+            disabled={pending}
+            required
+          />
+          <p className="text-xs text-muted-foreground">
+            Default $100/hr per Strategy Funding policy.
+          </p>
+        </div>
+        <div className="space-y-1">
+          <Label htmlFor={statusId}>Status</Label>
+          <select
+            id={statusId}
+            value={status}
+            onChange={(e) => setStatus(e.target.value as FagMemberStatus)}
+            disabled={pending}
+            className="h-9 w-full rounded-md border border-input bg-background px-3 text-sm"
+          >
+            {STATUS_OPTIONS.map((s) => (
+              <option key={s} value={s}>
+                {s}
+              </option>
+            ))}
+          </select>
+        </div>
+        <div className="space-y-1">
+          <Label htmlFor={onboardedId}>Onboarded on</Label>
+          <Input
+            id={onboardedId}
+            type="date"
+            value={onboardedOn}
+            onChange={(e) => setOnboardedOn(e.target.value)}
+            disabled={pending}
+          />
+        </div>
+      </div>
+
+      <div className="space-y-1">
+        <Label htmlFor={notesId}>Notes (accommodations, scheduling, etc.)</Label>
+        <textarea
+          id={notesId}
+          value={notes}
+          onChange={(e) => setNotes(e.target.value)}
+          rows={4}
+          maxLength={500}
+          disabled={pending}
+          className="w-full rounded-md border border-input bg-background p-2 text-sm"
+        />
+      </div>
+
+      {error ? <p className="text-sm text-destructive">{error}</p> : null}
+
+      <Button type="submit" disabled={pending}>
+        {pending ? 'Saving…' : initial ? 'Save changes' : 'Add advisor'}
+      </Button>
+    </form>
+  );
+}

--- a/src/db/queries/fag.ts
+++ b/src/db/queries/fag.ts
@@ -1,0 +1,88 @@
+import { asc, desc, eq, sql } from 'drizzle-orm';
+import { db } from '@/db/client';
+import {
+  type FagCompensationEntry,
+  type FagMember,
+  fagCompensationEntries,
+  fagMembers,
+} from '@/db/schema/fag-members';
+
+export async function listFagMembers(): Promise<FagMember[]> {
+  return await db
+    .select()
+    .from(fagMembers)
+    .orderBy(asc(fagMembers.status), asc(fagMembers.fullName));
+}
+
+export async function getFagMemberById(id: string): Promise<FagMember | null> {
+  const [row] = await db.select().from(fagMembers).where(eq(fagMembers.id, id)).limit(1);
+  return row ?? null;
+}
+
+export async function listEntriesForMember(memberId: string): Promise<FagCompensationEntry[]> {
+  return await db
+    .select()
+    .from(fagCompensationEntries)
+    .where(eq(fagCompensationEntries.memberId, memberId))
+    .orderBy(desc(fagCompensationEntries.occurredOn));
+}
+
+export type FagMemberSummary = {
+  member: FagMember;
+  totalCents: number;
+  unpaidCents: number;
+  entryCount: number;
+};
+
+/**
+ * One-shot per-member roll-up for the FAG dashboard. Aggregates total
+ * earned and total still-unpaid in cents.
+ */
+export async function listFagMemberSummaries(): Promise<FagMemberSummary[]> {
+  const rows = await db
+    .select({
+      member: fagMembers,
+      totalCents: sql<number>`COALESCE(SUM(${fagCompensationEntries.totalCents}), 0)::int`.as(
+        'total_cents',
+      ),
+      unpaidCents:
+        sql<number>`COALESCE(SUM(${fagCompensationEntries.totalCents}) FILTER (WHERE ${fagCompensationEntries.status} = 'unpaid'), 0)::int`.as(
+          'unpaid_cents',
+        ),
+      entryCount: sql<number>`COUNT(${fagCompensationEntries.id})::int`.as('entry_count'),
+    })
+    .from(fagMembers)
+    .leftJoin(fagCompensationEntries, eq(fagCompensationEntries.memberId, fagMembers.id))
+    .groupBy(fagMembers.id)
+    .orderBy(asc(fagMembers.status), asc(fagMembers.fullName));
+  return rows.map((r) => ({
+    member: r.member,
+    totalCents: Number(r.totalCents),
+    unpaidCents: Number(r.unpaidCents),
+    entryCount: Number(r.entryCount),
+  }));
+}
+
+export type FagAggregates = {
+  activeMemberCount: number;
+  totalPaidCents: number;
+  totalUnpaidCents: number;
+};
+
+/** Coalition-wide FAG aggregates for the dashboard headline. */
+export async function getFagAggregates(): Promise<FagAggregates> {
+  const [memberRow] = await db.execute<{ active: number }>(sql`
+    SELECT COUNT(*)::int AS active FROM ${fagMembers} WHERE status = 'active'
+  `);
+  const [moneyRow] = await db.execute<{ paid: number; unpaid: number }>(sql`
+    SELECT
+      COALESCE(SUM(total_cents) FILTER (WHERE status = 'paid'), 0)::int AS paid,
+      COALESCE(SUM(total_cents) FILTER (WHERE status = 'unpaid'), 0)::int AS unpaid
+    FROM ${fagCompensationEntries}
+  `);
+  return {
+    activeMemberCount: Number(memberRow.active),
+    totalPaidCents: Number(moneyRow.paid),
+    totalUnpaidCents: Number(moneyRow.unpaid),
+  };
+}

--- a/src/db/schema/enums.ts
+++ b/src/db/schema/enums.ts
@@ -167,6 +167,14 @@ export const clientDocumentStatusEnum = pgEnum('client_document_status', [
 
 export type ClientDocumentStatus = (typeof clientDocumentStatusEnum.enumValues)[number];
 
+export const fagMemberStatusEnum = pgEnum('fag_member_status', ['active', 'paused', 'ended']);
+
+export type FagMemberStatus = (typeof fagMemberStatusEnum.enumValues)[number];
+
+export const fagPayoutStatusEnum = pgEnum('fag_payout_status', ['unpaid', 'paid', 'voided']);
+
+export type FagPayoutStatus = (typeof fagPayoutStatusEnum.enumValues)[number];
+
 export const partnerServiceEventTypeEnum = pgEnum('partner_service_event_type', [
   'food_pantry',
   'shelter_intake',

--- a/src/db/schema/fag-members.ts
+++ b/src/db/schema/fag-members.ts
@@ -1,0 +1,80 @@
+import { date, index, integer, pgTable, text, timestamp, uuid } from 'drizzle-orm/pg-core';
+import { fagMemberStatusEnum, fagPayoutStatusEnum } from './enums';
+import { users } from './users';
+
+/**
+ * OPRT-004: Frontline Advisory Group member registry. Lived-experience
+ * advisors who get paid for their time. Per the Strategy Funding page,
+ * the coalition's standing policy is $100 per advisor per session +
+ * food + transit.
+ *
+ * Privacy: members are real people with real contact info. The table
+ * is admin/coalition-staff visible only; individual advisor records
+ * never leave this DB. Compensation entries roll up to public counts
+ * (number of advisors paid, total dollars paid out) via an admin-side
+ * aggregation, not by exposing rows.
+ */
+export const fagMembers = pgTable(
+  'fag_members',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    fullName: text('full_name').notNull(),
+    /** Free-form short label — "lived-experience advisor", "youth advisor", etc. */
+    role: text('role').notNull(),
+    contactPhone: text('contact_phone'),
+    contactEmail: text('contact_email'),
+    /** Hourly rate in CENTS. Matches the platform-wide money convention. */
+    hourlyRateCents: integer('hourly_rate_cents').notNull().default(10_000),
+    status: fagMemberStatusEnum('status').notNull().default('active'),
+    /** Free-form notes — accommodations, scheduling preferences, etc. */
+    notes: text('notes'),
+    /** When the advisor joined the FAG. Date only; payout history starts here. */
+    onboardedOn: date('onboarded_on'),
+    createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),
+  },
+  (t) => [index('fag_members_status_idx').on(t.status)],
+);
+
+export type FagMember = typeof fagMembers.$inferSelect;
+export type NewFagMember = typeof fagMembers.$inferInsert;
+
+/**
+ * One row per session / batch the coalition pays an advisor for. Captures
+ * the agreed rate + hours + total at the time the entry was logged so a
+ * later rate change doesn't retro-edit older payouts.
+ */
+export const fagCompensationEntries = pgTable(
+  'fag_compensation_entries',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    memberId: uuid('member_id')
+      .notNull()
+      .references(() => fagMembers.id, { onDelete: 'restrict' }),
+    /** Calendar date the work happened. */
+    occurredOn: date('occurred_on').notNull(),
+    /** What the advisor did — "DTRS-005 consent UX review", etc. */
+    description: text('description').notNull(),
+    /** Hours billed. Stored as numeric tenths via integer * 10 to avoid floats. */
+    hoursTenths: integer('hours_tenths').notNull(),
+    /** Rate in cents at time of entry — snapshot, not a FK. */
+    hourlyRateCents: integer('hourly_rate_cents').notNull(),
+    /** Total owed in cents. Computed at insert; null-safe denormalization. */
+    totalCents: integer('total_cents').notNull(),
+    status: fagPayoutStatusEnum('status').notNull().default('unpaid'),
+    paidAt: timestamp('paid_at', { withTimezone: true }),
+    paidByUserId: uuid('paid_by_user_id').references(() => users.id, { onDelete: 'set null' }),
+    /** Notes — payout method, transit reimbursement, etc. */
+    notes: text('notes'),
+    createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),
+  },
+  (t) => [
+    index('fag_compensation_member_idx').on(t.memberId),
+    index('fag_compensation_status_idx').on(t.status),
+    index('fag_compensation_occurred_idx').on(t.occurredOn),
+  ],
+);
+
+export type FagCompensationEntry = typeof fagCompensationEntries.$inferSelect;
+export type NewFagCompensationEntry = typeof fagCompensationEntries.$inferInsert;

--- a/src/db/schema/index.ts
+++ b/src/db/schema/index.ts
@@ -11,6 +11,7 @@ export * from './eviction-case-outcomes';
 export * from './eviction-filing-risk-scores';
 export * from './eviction-filings';
 export * from './eviction-response-packets';
+export * from './fag-members';
 export * from './health-check';
 export * from './org-memberships';
 export * from './partner-orgs';


### PR DESCRIPTION
Closes #145.

Lived-experience advisors get paid for their time; this is the operational backbone. Per the Strategy Funding policy, default rate is **$100/hr** — editable per-member and per-entry.

## Schema
- **`fag_members`** — name, role, contact, `hourly_rate_cents`, status (active / paused / ended), notes, onboarded_on date.
- **`fag_compensation_entries`** — one row per session/batch with `occurred_on`, description, `hours_tenths` (1.5h = 15), `hourly_rate_cents` (snapshot, not a FK — so a future rate change doesn't retro-edit older payouts), `total_cents`, status (unpaid / paid / voided), `paid_at`, `paid_by_user_id`.

## UI
- `/app/coalition/fag` — admin-only roster + headline aggregates (active count, paid-to-date, outstanding-owed in dollars). Banner reminder: **pay at the time of the session**.
- `/app/coalition/fag/new` — onboarding form.
- `/app/coalition/fag/[id]` — per-member detail with paid/outstanding cards, add-entry form, history list with **Mark paid** action, inline edit collapsible.

Audit-log events: `fag_member.{created,updated}`, `fag_compensation.{created,paid}`.

Admin-only surface — real contact info goes here, never leaves.

## Verification
- 202/202 tests passing, typecheck + build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)