### PR TITLE
feat(CWT-011/012): unified per-person view + AI pre-meeting briefing

### DIFF
--- a/src/ai/prompts/pre-meeting-summary.ts
+++ b/src/ai/prompts/pre-meeting-summary.ts
@@ -1,0 +1,110 @@
+import type { PersonProfileDelta } from '@/db/queries/person-profile';
+
+/**
+ * CWT-012 pre-meeting summary prompt.
+ *
+ * Caseworker is about to meet a client. The system has a record of
+ * everything the coalition has touched for this person since the
+ * last meeting. The AI's job is to surface what matters — what
+ * changed, what's urgent, what the caseworker should ask about.
+ *
+ * The summary is read in 30 seconds, not skimmed. Two paragraphs
+ * max. Lead with what's most likely to surprise the caseworker.
+ */
+
+export const PRE_MEETING_SUMMARY_MODEL_VERSION = 'pre-meeting-v1@2026-04-26';
+
+export const PRE_MEETING_SUMMARY_SYSTEM_PROMPT = `You write a 30-second pre-meeting briefing for a caseworker about to
+sit down with a client. You see what changed in the coalition's
+records about this client since the last meeting (or in the lookback
+window). You don't have everything — only what coalition partners
+recorded.
+
+Write 2 short paragraphs (~80 words total):
+
+PARAGRAPH 1 — what changed.
+Lead with the highest-signal change since the cutoff. Examples:
+- "Marisol picked up an eviction filing last Friday and didn't text it
+  in. The court date is the 12th."
+- "Frank's been to St. Benedict's three nights this week and the
+  food pantry once. Hasn't been to his usual shelter."
+- "No new activity since the last meeting on the 18th."
+
+PARAGRAPH 2 — what to ask about.
+1-2 specific questions or things to verify. Examples:
+- "Ask whether anyone has helped them respond to the court papers."
+- "Verify the new phone number — old one is bouncing."
+- "Confirm the SNAP recertification date the AI extracted from last
+  week's intake (the AI flagged uncertainty)."
+
+Hard rules:
+1. NEVER invent facts. Only reference activity in the data provided.
+2. If the lookback window is empty, say so explicitly. Don't pad.
+3. Use the synthetic ref as a name placeholder — the caseworker
+   knows who they're meeting; you don't need to repeat the ref.
+4. Skip anything the caseworker likely already knows (today's date,
+   what coalition the client is in).
+
+Output ONLY plain text — two paragraphs, no headers, no bullet points
+in the output. The caseworker reads it fast.`;
+
+export function buildPreMeetingUserPrompt(delta: PersonProfileDelta): string {
+  const sinceIso = delta.since.toISOString().slice(0, 10);
+  const lines: string[] = [
+    `Synthetic person ref: ${delta.syntheticPersonRef}`,
+    `Lookback window: since ${sinceIso}`,
+    '',
+  ];
+
+  if (delta.serviceEvents.length > 0) {
+    lines.push('## Service events in window');
+    for (const e of delta.serviceEvents) {
+      const at = new Date(e.eventAt).toISOString().slice(0, 10);
+      const noteFrag = e.notes ? ` — ${e.notes}` : '';
+      lines.push(`- ${at} · ${e.partnerOrgName} · ${e.eventType}${noteFrag}`);
+    }
+    lines.push('');
+  } else {
+    lines.push('## Service events in window');
+    lines.push('(none recorded)');
+    lines.push('');
+  }
+
+  if (delta.newConsentGrants.length > 0 || delta.newConsentRevocations.length > 0) {
+    lines.push('## Consent changes in window');
+    for (const c of delta.newConsentGrants) {
+      lines.push(`- granted to ${c.partnerOrgName}`);
+    }
+    for (const c of delta.newConsentRevocations) {
+      lines.push(`- revoked from ${c.partnerOrgName}`);
+    }
+    lines.push('');
+  }
+
+  if (delta.newIntakes.length > 0) {
+    lines.push('## New intakes in window');
+    for (const i of delta.newIntakes) {
+      const at = new Date(i.createdAt).toISOString().slice(0, 10);
+      const profile = i.extractedProfile as Record<string, unknown> | null;
+      const presenting =
+        profile && typeof profile.presenting_issue === 'string' ? profile.presenting_issue : null;
+      const urgency = profile && typeof profile.urgency === 'string' ? profile.urgency : null;
+      lines.push(
+        `- ${at} · "${i.label}"${presenting ? ` · ${presenting}` : ''}${urgency ? ` · urgency=${urgency}` : ''}`,
+      );
+    }
+    lines.push('');
+  }
+
+  if (delta.newDocuments.length > 0) {
+    lines.push('## New documents in window');
+    for (const d of delta.newDocuments) {
+      const at = new Date(d.createdAt).toISOString().slice(0, 10);
+      lines.push(`- ${at} · ${d.kind} · "${d.label}" · status=${d.status}`);
+    }
+    lines.push('');
+  }
+
+  lines.push('Write the briefing.');
+  return lines.join('\n');
+}

--- a/src/app/actions/pre-meeting-summary.ts
+++ b/src/app/actions/pre-meeting-summary.ts
@@ -1,0 +1,71 @@
+'use server';
+
+import * as Sentry from '@sentry/nextjs';
+import { getPersonProfileDelta } from '@/db/queries/person-profile';
+import { logAuditEvent } from '@/lib/audit';
+import { requireRole } from '@/lib/auth';
+import { generatePreMeetingSummary } from '@/lib/cwt/pre-meeting-summary';
+import { recordAiGeneration } from '@/lib/dtrs/data-access';
+import { isValidSyntheticPersonRef } from '@/lib/synthetic-person';
+
+export type PreMeetingSummaryResult =
+  | { ok: true; text: string; sinceIso: string; model: string }
+  | { ok: false; error: string };
+
+const ROLES = ['caseworker', 'shelter_staff', 'ed_coordinator', 'admin'] as const;
+
+const DAYS_MAX = 365;
+
+/**
+ * Generate a fresh pre-meeting summary for the given synthetic
+ * person ref. `daysBack` defaults to 30; capped at DAYS_MAX.
+ */
+export async function generatePreMeetingSummaryAction(
+  syntheticPersonRef: string,
+  daysBack = 30,
+): Promise<PreMeetingSummaryResult> {
+  const actor = await requireRole(ROLES);
+
+  if (!isValidSyntheticPersonRef(syntheticPersonRef)) {
+    return { ok: false, error: 'Invalid synthetic-person reference.' };
+  }
+  const days = Math.max(1, Math.min(DAYS_MAX, Math.round(daysBack)));
+  const since = new Date();
+  since.setDate(since.getDate() - days);
+
+  try {
+    const delta = await getPersonProfileDelta(syntheticPersonRef, since);
+    const result = await generatePreMeetingSummary(delta);
+
+    await logAuditEvent({
+      actorUserId: actor.id,
+      action: 'pre_meeting_summary.generated',
+      targetTable: 'partner_service_events',
+      targetId: syntheticPersonRef,
+      metadata: { daysBack: days, eventCount: delta.serviceEvents.length },
+    });
+    await recordAiGeneration({
+      actorUserId: actor.id,
+      resourceType: 'pre_meeting_summary',
+      resourceId: syntheticPersonRef,
+      model: result.modelId,
+      promptVersion: result.modelId,
+      metadata: { daysBack: days },
+    });
+
+    return {
+      ok: true,
+      text: result.text,
+      sinceIso: since.toISOString().slice(0, 10),
+      model: result.modelId,
+    };
+  } catch (err) {
+    Sentry.captureException(err, {
+      tags: { action: 'generatePreMeetingSummaryAction', ref: syntheticPersonRef },
+    });
+    return {
+      ok: false,
+      error: 'Summary generation failed. Try again in a moment.',
+    };
+  }
+}

--- a/src/app/app/clients/page.tsx
+++ b/src/app/app/clients/page.tsx
@@ -94,7 +94,7 @@ export default async function ClientsPage() {
                   className="flex items-baseline justify-between gap-2 py-2"
                 >
                   <Link
-                    href={`/p/${p.syntheticPersonRef}/consent`}
+                    href={`/app/clients/person/${p.syntheticPersonRef}`}
                     className="font-mono text-xs hover:underline"
                   >
                     {p.syntheticPersonRef}

--- a/src/app/app/clients/person/[ref]/page.tsx
+++ b/src/app/app/clients/person/[ref]/page.tsx
@@ -1,0 +1,236 @@
+import Link from 'next/link';
+import { notFound } from 'next/navigation';
+import { PreMeetingSummary } from '@/components/cwt/pre-meeting-summary';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { getPersonProfile } from '@/db/queries/person-profile';
+import { requireRole } from '@/lib/auth';
+import { recordDataAccess } from '@/lib/dtrs/data-access';
+import { isValidSyntheticPersonRef } from '@/lib/synthetic-person';
+
+export const dynamic = 'force-dynamic';
+
+const ROLES = ['caseworker', 'shelter_staff', 'ed_coordinator', 'admin'] as const;
+
+const fmtDate = (d: Date | string | null) => {
+  if (d == null) return '—';
+  return new Intl.DateTimeFormat('en-US', { dateStyle: 'medium' }).format(new Date(d));
+};
+
+const fmtDateTime = (d: Date) =>
+  new Intl.DateTimeFormat('en-US', { dateStyle: 'medium', timeStyle: 'short' }).format(new Date(d));
+
+export default async function PersonProfilePage({ params }: { params: Promise<{ ref: string }> }) {
+  const me = await requireRole(ROLES);
+  const { ref } = await params;
+  if (!isValidSyntheticPersonRef(ref)) notFound();
+
+  const profile = await getPersonProfile(ref);
+
+  await recordDataAccess({
+    actorUserId: me.id,
+    resourceType: 'person_profile',
+    resourceId: ref,
+    purpose: 'caseworker_unified_view',
+    metadata: {
+      eventCount: profile.serviceEvents.length,
+      consentCount: profile.consents.length,
+      intakeCount: profile.intakes.length,
+      documentCount: profile.documents.length,
+    },
+  });
+
+  const empty =
+    profile.serviceEvents.length === 0 &&
+    profile.consents.length === 0 &&
+    profile.intakes.length === 0 &&
+    profile.documents.length === 0;
+
+  return (
+    <div className="mx-auto max-w-4xl space-y-4 p-4 md:p-6">
+      <div className="text-xs">
+        <Link href="/app/clients" className="text-muted-foreground hover:underline">
+          ← Back to clients
+        </Link>
+      </div>
+
+      <header>
+        <p className="text-xs uppercase tracking-wide text-muted-foreground">Person profile</p>
+        <h1 className="font-serif text-3xl font-bold text-primary">
+          <span className="font-mono">{ref}</span>
+        </h1>
+        <p className="text-sm text-muted-foreground">
+          Unified per-person view across coalition partners. Identifier is opaque; the platform
+          never holds the mapping to a real name. {profile.serviceEvents.length} service event
+          {profile.serviceEvents.length === 1 ? '' : 's'} · {profile.consents.length} partner
+          consent
+          {profile.consents.length === 1 ? '' : 's'} · {profile.intakes.length} intake
+          {profile.intakes.length === 1 ? '' : 's'} · {profile.documents.length} document
+          {profile.documents.length === 1 ? '' : 's'}.
+        </p>
+      </header>
+
+      {empty ? (
+        <Card>
+          <CardContent className="text-sm text-muted-foreground">
+            No coalition records for this identifier. Either it's brand-new (no partners have
+            recorded an event yet) or the ref is wrong. Cross-check with the caseworker who shared
+            the link.
+          </CardContent>
+        </Card>
+      ) : null}
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">Pre-meeting briefing</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <PreMeetingSummary syntheticPersonRef={ref} />
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">
+            Cross-org service events ({profile.serviceEvents.length})
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          {profile.serviceEvents.length === 0 ? (
+            <p className="text-sm text-muted-foreground">No partner service events recorded.</p>
+          ) : (
+            <ul className="divide-y divide-border text-sm">
+              {profile.serviceEvents.map((e) => (
+                <li key={e.id} className="flex flex-wrap items-baseline justify-between gap-2 py-2">
+                  <span>
+                    <span className="font-medium">{e.partnerOrgName}</span>
+                    <span className="text-muted-foreground"> · {e.eventType}</span>
+                  </span>
+                  <span className="whitespace-nowrap text-xs text-muted-foreground">
+                    {fmtDate(e.eventAt)}
+                  </span>
+                </li>
+              ))}
+            </ul>
+          )}
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">Partner consents ({profile.consents.length})</CardTitle>
+        </CardHeader>
+        <CardContent>
+          {profile.consents.length === 0 ? (
+            <p className="text-sm text-muted-foreground">
+              No partner consents on record. Ask the client to grant via{' '}
+              <code className="font-mono">/p/{ref}/consent/grant</code> (caseworker mints the
+              token).
+            </p>
+          ) : (
+            <ul className="divide-y divide-border text-sm">
+              {profile.consents.map((c) => {
+                const isRevoked = c.revokedAt != null;
+                return (
+                  <li
+                    key={c.id}
+                    className="flex flex-wrap items-baseline justify-between gap-2 py-2"
+                  >
+                    <span>
+                      <span className="font-medium">{c.partnerOrgName}</span>
+                      {isRevoked ? (
+                        <span className="ml-2 rounded bg-destructive/15 px-2 py-0.5 text-xs text-destructive">
+                          revoked {fmtDate(c.revokedAt)}
+                        </span>
+                      ) : (
+                        <span className="ml-2 rounded bg-emerald-600/15 px-2 py-0.5 text-xs text-emerald-700 dark:text-emerald-400">
+                          sharing
+                        </span>
+                      )}
+                    </span>
+                    <span className="whitespace-nowrap text-xs text-muted-foreground">
+                      granted {fmtDate(c.grantedAt)}
+                    </span>
+                  </li>
+                );
+              })}
+            </ul>
+          )}
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">Voice intakes ({profile.intakes.length})</CardTitle>
+        </CardHeader>
+        <CardContent>
+          {profile.intakes.length === 0 ? (
+            <p className="text-sm text-muted-foreground">
+              No intakes for this identifier yet. Record one at{' '}
+              <Link href="/app/clients/intakes/new" className="text-primary hover:underline">
+                /app/clients/intakes/new
+              </Link>
+              .
+            </p>
+          ) : (
+            <ul className="divide-y divide-border text-sm">
+              {profile.intakes.map((i) => (
+                <li key={i.id} className="flex flex-wrap items-baseline justify-between gap-2 py-2">
+                  <Link
+                    href={`/app/clients/intakes/${i.id}`}
+                    className="font-medium hover:underline"
+                  >
+                    {i.label}
+                  </Link>
+                  <span className="text-xs text-muted-foreground">
+                    {fmtDateTime(i.createdAt)} · status <strong>{i.status}</strong>
+                  </span>
+                </li>
+              ))}
+            </ul>
+          )}
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">Documents ({profile.documents.length})</CardTitle>
+        </CardHeader>
+        <CardContent>
+          {profile.documents.length === 0 ? (
+            <p className="text-sm text-muted-foreground">
+              No documents linked to this identifier yet.
+            </p>
+          ) : (
+            <ul className="divide-y divide-border text-sm">
+              {profile.documents.map((d) => (
+                <li key={d.id} className="flex flex-wrap items-baseline justify-between gap-2 py-2">
+                  <Link
+                    href={`/app/clients/documents/${d.id}`}
+                    className="font-medium hover:underline"
+                  >
+                    {d.label}
+                  </Link>
+                  <span className="text-xs text-muted-foreground">
+                    {d.kind} · {fmtDateTime(d.createdAt)} · status <strong>{d.status}</strong>
+                  </span>
+                </li>
+              ))}
+            </ul>
+          )}
+        </CardContent>
+      </Card>
+
+      <Card className="border-amber-500/40 bg-amber-500/5">
+        <CardContent className="text-xs">
+          <p className="font-medium">Phase-1 scope.</p>
+          <p className="mt-1 text-muted-foreground">
+            Eviction filings, ED encounters, and care plans aren't joined here yet — they're keyed
+            on different identifiers (defendant name + DOB; opaque patient hash). Cross-table joins
+            land with the data-trust steward (DTRS-014). For now, look those up by their own
+            surfaces.
+          </p>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/app/app/coalition/coordination/page.tsx
+++ b/src/app/app/coalition/coordination/page.tsx
@@ -1,3 +1,4 @@
+import Link from 'next/link';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { listCrossOrgTouchpointsForViewer } from '@/db/queries/partner-service-events';
 import { requireRole } from '@/lib/auth';
@@ -70,7 +71,12 @@ export default async function CrossOrgCoordinationPage() {
                   className="rounded-md border border-border bg-card p-3 text-sm"
                 >
                   <div className="mb-1 flex flex-wrap items-baseline justify-between gap-2">
-                    <p className="font-mono text-xs font-medium">{p.syntheticPersonRef}</p>
+                    <Link
+                      href={`/app/clients/person/${p.syntheticPersonRef}`}
+                      className="font-mono text-xs font-medium hover:underline"
+                    >
+                      {p.syntheticPersonRef}
+                    </Link>
                     <span className="text-xs text-muted-foreground">
                       latest {fmtDateTime(p.latestEventAt)}
                     </span>

--- a/src/components/cwt/pre-meeting-summary.tsx
+++ b/src/components/cwt/pre-meeting-summary.tsx
@@ -1,0 +1,82 @@
+'use client';
+
+import { useState, useTransition } from 'react';
+import { generatePreMeetingSummaryAction } from '@/app/actions/pre-meeting-summary';
+import { Button } from '@/components/ui/button';
+
+export function PreMeetingSummary({
+  syntheticPersonRef,
+  defaultDaysBack = 30,
+}: {
+  syntheticPersonRef: string;
+  defaultDaysBack?: number;
+}) {
+  const [pending, startTransition] = useTransition();
+  const [result, setResult] = useState<{ text: string; sinceIso: string; model: string } | null>(
+    null,
+  );
+  const [error, setError] = useState<string | null>(null);
+  const [daysBack, setDaysBack] = useState(defaultDaysBack);
+
+  const onGenerate = () => {
+    setError(null);
+    startTransition(async () => {
+      const r = await generatePreMeetingSummaryAction(syntheticPersonRef, daysBack);
+      if (!r.ok) {
+        setError(r.error);
+        return;
+      }
+      setResult({ text: r.text, sinceIso: r.sinceIso, model: r.model });
+    });
+  };
+
+  return (
+    <div className="space-y-3">
+      <div className="flex flex-wrap items-baseline justify-between gap-2">
+        <p className="text-xs text-muted-foreground">
+          What changed in the last{' '}
+          <input
+            type="number"
+            min={1}
+            max={365}
+            value={daysBack}
+            onChange={(e) => {
+              const n = Number.parseInt(e.target.value, 10);
+              if (Number.isInteger(n) && n >= 1 && n <= 365) setDaysBack(n);
+            }}
+            className="mx-1 inline-block w-14 rounded border border-input bg-background px-1 text-xs"
+            disabled={pending}
+          />{' '}
+          days?
+        </p>
+        <Button type="button" size="sm" disabled={pending} onClick={onGenerate}>
+          {pending ? 'Generating…' : result ? 'Regenerate' : 'Generate briefing'}
+        </Button>
+      </div>
+
+      {error ? <p className="text-sm text-destructive">{error}</p> : null}
+
+      {result ? (
+        <div className="rounded-md border border-emerald-500/40 bg-emerald-500/5 p-4">
+          <p className="text-xs uppercase tracking-wide text-emerald-700 dark:text-emerald-400">
+            30-second briefing · since {result.sinceIso}
+          </p>
+          <article className="mt-2 space-y-2 text-sm leading-relaxed">
+            {result.text.split(/\n\n+/).map((para) => (
+              <p key={para.slice(0, 32)}>{para}</p>
+            ))}
+          </article>
+          <p className="mt-3 text-[10px] uppercase tracking-wide text-muted-foreground">
+            model: {result.model}
+          </p>
+        </div>
+      ) : (
+        <div className="rounded-md border border-border bg-muted/40 p-4 text-sm text-muted-foreground">
+          Click <strong>Generate briefing</strong> to ask Claude to summarize what's changed for
+          this person across the coalition. The briefing is two short paragraphs you can read in
+          under 30 seconds.
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/db/queries/person-profile.ts
+++ b/src/db/queries/person-profile.ts
@@ -1,0 +1,162 @@
+import { and, desc, eq, gte } from 'drizzle-orm';
+import { db } from '@/db/client';
+import { type ClientDocument, clientDocuments } from '@/db/schema/client-documents';
+import { type ClientIntake, clientIntakes } from '@/db/schema/client-intakes';
+import { partnerOrgs } from '@/db/schema/partner-orgs';
+import { type PartnerServiceEvent, partnerServiceEvents } from '@/db/schema/partner-service-events';
+import {
+  type PersonPartnerConsent,
+  personPartnerConsents,
+} from '@/db/schema/person-partner-consents';
+
+export type PersonServiceEvent = PartnerServiceEvent & { partnerOrgName: string };
+export type PersonConsentRow = PersonPartnerConsent & { partnerOrgName: string };
+
+export type PersonProfile = {
+  syntheticPersonRef: string;
+  serviceEvents: PersonServiceEvent[];
+  consents: PersonConsentRow[];
+  intakes: ClientIntake[];
+  documents: ClientDocument[];
+};
+
+/**
+ * Pull every coalition-side artifact tied to a synthetic_person_ref.
+ * Phase-1 scope: service events, person/partner consents, voice
+ * intakes, and uploaded documents. Eviction filings, ED encounters,
+ * and care plans aren't keyed on synthetic_person_ref yet (they use
+ * defendant name + DOB / patient hash) — they join in post-data-trust
+ * (DTRS-014).
+ */
+export async function getPersonProfile(syntheticPersonRef: string): Promise<PersonProfile> {
+  const eventsRows = await db
+    .select({
+      event: partnerServiceEvents,
+      partnerOrgName: partnerOrgs.name,
+    })
+    .from(partnerServiceEvents)
+    .innerJoin(partnerOrgs, eq(partnerOrgs.id, partnerServiceEvents.partnerOrgId))
+    .where(eq(partnerServiceEvents.syntheticPersonRef, syntheticPersonRef))
+    .orderBy(desc(partnerServiceEvents.eventAt));
+
+  const consentRows = await db
+    .select({
+      consent: personPartnerConsents,
+      partnerOrgName: partnerOrgs.name,
+    })
+    .from(personPartnerConsents)
+    .innerJoin(partnerOrgs, eq(partnerOrgs.id, personPartnerConsents.partnerOrgId))
+    .where(eq(personPartnerConsents.syntheticPersonRef, syntheticPersonRef))
+    .orderBy(desc(personPartnerConsents.grantedAt));
+
+  const intakes = await db
+    .select()
+    .from(clientIntakes)
+    .where(eq(clientIntakes.syntheticPersonRef, syntheticPersonRef))
+    .orderBy(desc(clientIntakes.createdAt));
+
+  const documents = await db
+    .select()
+    .from(clientDocuments)
+    .where(eq(clientDocuments.syntheticPersonRef, syntheticPersonRef))
+    .orderBy(desc(clientDocuments.createdAt));
+
+  return {
+    syntheticPersonRef,
+    serviceEvents: eventsRows.map((r) => ({ ...r.event, partnerOrgName: r.partnerOrgName })),
+    consents: consentRows.map((r) => ({ ...r.consent, partnerOrgName: r.partnerOrgName })),
+    intakes,
+    documents,
+  };
+}
+
+/**
+ * Subset of the profile filtered to a since-cutoff. Used by the
+ * pre-meeting summary so the AI sees only what changed since the
+ * last meeting.
+ */
+export type PersonProfileDelta = {
+  syntheticPersonRef: string;
+  since: Date;
+  serviceEvents: PersonServiceEvent[];
+  newConsentGrants: PersonConsentRow[];
+  newConsentRevocations: PersonConsentRow[];
+  newIntakes: ClientIntake[];
+  newDocuments: ClientDocument[];
+};
+
+export async function getPersonProfileDelta(
+  syntheticPersonRef: string,
+  since: Date,
+): Promise<PersonProfileDelta> {
+  const eventsRows = await db
+    .select({ event: partnerServiceEvents, partnerOrgName: partnerOrgs.name })
+    .from(partnerServiceEvents)
+    .innerJoin(partnerOrgs, eq(partnerOrgs.id, partnerServiceEvents.partnerOrgId))
+    .where(
+      and(
+        eq(partnerServiceEvents.syntheticPersonRef, syntheticPersonRef),
+        gte(partnerServiceEvents.eventAt, since),
+      ),
+    )
+    .orderBy(desc(partnerServiceEvents.eventAt));
+
+  const grants = await db
+    .select({ consent: personPartnerConsents, partnerOrgName: partnerOrgs.name })
+    .from(personPartnerConsents)
+    .innerJoin(partnerOrgs, eq(partnerOrgs.id, personPartnerConsents.partnerOrgId))
+    .where(
+      and(
+        eq(personPartnerConsents.syntheticPersonRef, syntheticPersonRef),
+        gte(personPartnerConsents.grantedAt, since),
+      ),
+    )
+    .orderBy(desc(personPartnerConsents.grantedAt));
+
+  const revocations = await db
+    .select({ consent: personPartnerConsents, partnerOrgName: partnerOrgs.name })
+    .from(personPartnerConsents)
+    .innerJoin(partnerOrgs, eq(partnerOrgs.id, personPartnerConsents.partnerOrgId))
+    .where(
+      and(
+        eq(personPartnerConsents.syntheticPersonRef, syntheticPersonRef),
+        gte(personPartnerConsents.revokedAt, since),
+      ),
+    )
+    .orderBy(desc(personPartnerConsents.revokedAt));
+
+  const intakes = await db
+    .select()
+    .from(clientIntakes)
+    .where(
+      and(
+        eq(clientIntakes.syntheticPersonRef, syntheticPersonRef),
+        gte(clientIntakes.createdAt, since),
+      ),
+    )
+    .orderBy(desc(clientIntakes.createdAt));
+
+  const documents = await db
+    .select()
+    .from(clientDocuments)
+    .where(
+      and(
+        eq(clientDocuments.syntheticPersonRef, syntheticPersonRef),
+        gte(clientDocuments.createdAt, since),
+      ),
+    )
+    .orderBy(desc(clientDocuments.createdAt));
+
+  return {
+    syntheticPersonRef,
+    since,
+    serviceEvents: eventsRows.map((r) => ({ ...r.event, partnerOrgName: r.partnerOrgName })),
+    newConsentGrants: grants.map((r) => ({ ...r.consent, partnerOrgName: r.partnerOrgName })),
+    newConsentRevocations: revocations.map((r) => ({
+      ...r.consent,
+      partnerOrgName: r.partnerOrgName,
+    })),
+    newIntakes: intakes,
+    newDocuments: documents,
+  };
+}

--- a/src/lib/cwt/pre-meeting-summary.ts
+++ b/src/lib/cwt/pre-meeting-summary.ts
@@ -1,0 +1,51 @@
+import Anthropic from '@anthropic-ai/sdk';
+import {
+  buildPreMeetingUserPrompt,
+  PRE_MEETING_SUMMARY_MODEL_VERSION,
+  PRE_MEETING_SUMMARY_SYSTEM_PROMPT,
+} from '@/ai/prompts/pre-meeting-summary';
+import type { PersonProfileDelta } from '@/db/queries/person-profile';
+
+let _client: Anthropic | null = null;
+function client(): Anthropic {
+  if (!_client) _client = new Anthropic();
+  return _client;
+}
+
+const MODEL_ID = 'claude-sonnet-4-6';
+const MAX_OUTPUT_TOKENS = 400;
+
+export type PreMeetingSummaryResult = {
+  text: string;
+  modelId: string;
+};
+
+/**
+ * Generate the 30-second briefing for a pre-meeting view. Returns a
+ * plain-text body the UI renders verbatim.
+ */
+export async function generatePreMeetingSummary(
+  delta: PersonProfileDelta,
+): Promise<PreMeetingSummaryResult> {
+  const response = await client().messages.create({
+    model: MODEL_ID,
+    max_tokens: MAX_OUTPUT_TOKENS,
+    system: [
+      {
+        type: 'text',
+        text: PRE_MEETING_SUMMARY_SYSTEM_PROMPT,
+        cache_control: { type: 'ephemeral' },
+      },
+    ],
+    messages: [{ role: 'user', content: buildPreMeetingUserPrompt(delta) }],
+  });
+
+  const text = response.content
+    .flatMap((c) => (c.type === 'text' ? [c.text] : []))
+    .join('\n')
+    .trim();
+  if (!text) {
+    throw new Error(`[pre-meeting-summary] empty response; stop_reason=${response.stop_reason}`);
+  }
+  return { text, modelId: PRE_MEETING_SUMMARY_MODEL_VERSION };
+}


### PR DESCRIPTION
Closes #91 (CWT-011), #93 (CWT-012).

Caseworker opens `/app/clients/person/[ref]` → sees one page pulling everything the coalition has on a person — service events, consents, voice intakes, documents — plus an **on-demand 30-second briefing** Claude generates from what changed since the chosen lookback.

## Person view (CWT-011)
- `/app/clients/person/[ref]` gated to caseworker / shelter_staff / ed_coordinator / admin. Records a DTRS-003 data-access event on each visit.
- Sections: pre-meeting briefing, cross-org service events, partner consents (grant / revoke state), voice intakes, documents.
- Empty-state copy for fresh refs and an honest scope-note that eviction filings + ED encounters aren't joined here yet (different identifiers; lands with DTRS-014).
- `getPersonProfile` / `getPersonProfileDelta` queries assemble everything keyed on `synthetic_person_ref`. No mystery cross-table joins — each section is its own clean query.
- Cross-org coordination view + clients hub now link person refs through to this page.

## Pre-meeting briefing (CWT-012)
- `generatePreMeetingSummaryAction` pulls the window delta, sends it to Claude Sonnet, returns ~80 words across two paragraphs:
  - **¶1 what changed** (lead with highest-signal new event)
  - **¶2 what to ask about** (1-2 specific questions / things to verify)
- System prompt bans invented facts and forces null-safe handling of empty windows.
- Lookback is caseworker-controlled (1-365 days, default 30).
- Audited via `recordAiGeneration` + audit-log `pre_meeting_summary.generated` event.

## Demo path
1. Sign in as caseworker
2. Open `/app/clients` → click any synthetic person ref in the cross-org coordination card
3. Land on `/app/clients/person/SYN-PERSON-001` — see all coalition data
4. Click **Generate briefing** at the top → Claude produces a 30-second pre-meeting summary

## Verification
- 202/202 tests passing, typecheck + build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)