### PR TITLE
feat(CWT): chain intake → benefits screener

### DIFF
--- a/src/app/app/clients/intakes/[id]/page.tsx
+++ b/src/app/app/clients/intakes/[id]/page.tsx
@@ -83,6 +83,26 @@ export default async function IntakeDetailPage({ params }: { params: Promise<{ i
         </CardContent>
       </Card>
 
+      {intake.status === 'extracted' && profile ? (
+        <Card className="border-primary/40 bg-primary/5">
+          <CardContent className="flex flex-wrap items-center justify-between gap-3 text-sm">
+            <div>
+              <p className="font-medium">Next step: benefits eligibility</p>
+              <p className="mt-1 text-xs text-muted-foreground">
+                Open the screener with household size, kids, and presenting issue prefilled from
+                this intake. You'll still see — and can edit — every field before quoting numbers.
+              </p>
+            </div>
+            <Link
+              href={`/app/clients/screener?fromIntake=${intake.id}`}
+              className="shrink-0 rounded-md bg-primary px-3 py-2 text-xs font-medium text-primary-foreground hover:bg-primary/90"
+            >
+              Run benefits screener →
+            </Link>
+          </CardContent>
+        </Card>
+      ) : null}
+
       <Card>
         <CardHeader>
           <CardTitle className="text-base">Transcript</CardTitle>

--- a/src/app/app/clients/screener/page.tsx
+++ b/src/app/app/clients/screener/page.tsx
@@ -1,11 +1,27 @@
+import Link from 'next/link';
+import type { IntakeProfile } from '@/ai/prompts/intake-extraction';
 import { BenefitsScreener } from '@/components/cwt/benefits-screener';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { getClientIntakeById } from '@/db/queries/client-intakes';
 import { requireRole } from '@/lib/auth';
+import { intakeProfileToScreenerPrefill } from '@/lib/cwt/intake-to-screener';
 
 export const dynamic = 'force-dynamic';
 
-export default async function BenefitsScreenerPage() {
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export default async function BenefitsScreenerPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ fromIntake?: string }>;
+}) {
   await requireRole(['caseworker', 'shelter_staff', 'admin']);
+  const sp = await searchParams;
+
+  let prefill: Awaited<ReturnType<typeof loadPrefill>> = null;
+  if (sp.fromIntake && UUID_RE.test(sp.fromIntake)) {
+    prefill = await loadPrefill(sp.fromIntake);
+  }
 
   return (
     <div className="mx-auto max-w-5xl space-y-4 p-4 md:p-6">
@@ -17,14 +33,54 @@ export default async function BenefitsScreenerPage() {
         </p>
       </header>
 
+      {prefill ? (
+        <Card className="border-primary/40 bg-primary/5">
+          <CardContent className="text-sm">
+            <p className="font-medium">Prefilled from intake.</p>
+            <p className="mt-1 text-muted-foreground">
+              Pulled from{' '}
+              <Link
+                href={`/app/clients/intakes/${prefill.intakeId}`}
+                className="text-primary hover:underline"
+              >
+                "{prefill.intakeLabel}"
+              </Link>
+              . Adjust any field below before quoting numbers — the AI gets things wrong.
+            </p>
+          </CardContent>
+        </Card>
+      ) : null}
+
       <Card>
         <CardHeader>
           <CardTitle className="text-base">Household details</CardTitle>
         </CardHeader>
         <CardContent>
-          <BenefitsScreener />
+          <BenefitsScreener
+            initialHousehold={prefill?.initialHousehold}
+            prefillSource={
+              prefill && prefill.prefillFields.length > 0
+                ? { fields: prefill.prefillFields, label: 'from intake' }
+                : undefined
+            }
+            contextNote={prefill?.contextNote ?? null}
+          />
         </CardContent>
       </Card>
     </div>
   );
+}
+
+async function loadPrefill(intakeId: string) {
+  const intake = await getClientIntakeById(intakeId);
+  if (!intake?.extractedProfile) return null;
+  const profile = intake.extractedProfile as IntakeProfile;
+  const { initialHousehold, prefillFields, contextNote } = intakeProfileToScreenerPrefill(profile);
+  return {
+    intakeId: intake.id,
+    intakeLabel: intake.label,
+    initialHousehold,
+    prefillFields,
+    contextNote,
+  };
 }

--- a/src/components/cwt/benefits-screener.tsx
+++ b/src/components/cwt/benefits-screener.tsx
@@ -25,20 +25,43 @@ const STATUS_BADGE: Record<EligibilityMatch['status'], string> = {
   ineligible: 'bg-muted text-muted-foreground',
 };
 
-export function BenefitsScreener() {
+export type PrefillSource = {
+  /** Field keys that came from an upstream source (intake, etc.) — surface a small badge. */
+  fields: ReadonlyArray<keyof Household>;
+  /** Short label shown next to each prefilled field, e.g. "from intake". */
+  label: string;
+};
+
+const DEFAULT_HOUSEHOLD: Household = {
+  monthlyIncomeCents: 100_000,
+  householdSize: 1,
+  hasChildrenUnder18: false,
+  hasPregnantMember: false,
+  isVeteran: false,
+  isDisabled: false,
+  ageOldest: 35,
+  kyResident: true,
+  citizenOrQualified: true,
+};
+
+export function BenefitsScreener({
+  initialHousehold,
+  prefillSource,
+  contextNote,
+}: {
+  initialHousehold?: Partial<Household>;
+  prefillSource?: PrefillSource;
+  /** Free-form note shown above the form (e.g. the intake's income_summary). */
+  contextNote?: string | null;
+} = {}) {
   const incomeId = useId();
   const sizeId = useId();
   const [household, setHousehold] = useState<Household>({
-    monthlyIncomeCents: 100_000,
-    householdSize: 1,
-    hasChildrenUnder18: false,
-    hasPregnantMember: false,
-    isVeteran: false,
-    isDisabled: false,
-    ageOldest: 35,
-    kyResident: true,
-    citizenOrQualified: true,
+    ...DEFAULT_HOUSEHOLD,
+    ...initialHousehold,
   });
+  const prefillKeys = new Set(prefillSource?.fields ?? []);
+  const prefillLabel = prefillSource?.label ?? 'prefilled';
 
   const results = useMemo(() => screenHousehold(household), [household]);
   const totalLikely = useMemo(() => totalLikelyMonthlyCents(results), [results]);
@@ -53,13 +76,32 @@ export function BenefitsScreener() {
       setHousehold((prev) => ({ ...prev, [key]: value }));
     };
 
+  const PrefillBadge = ({ k }: { k: keyof Household }) =>
+    prefillKeys.has(k) ? (
+      <span className="ml-2 rounded bg-primary/10 px-1.5 py-0.5 text-[10px] uppercase tracking-wide text-primary">
+        {prefillLabel}
+      </span>
+    ) : null;
+
   return (
     <div className="grid gap-6 md:grid-cols-2">
       <section className="space-y-4">
         <h2 className="font-serif text-lg font-semibold">Household</h2>
 
+        {contextNote ? (
+          <div className="rounded-md border border-primary/40 bg-primary/5 p-3 text-xs">
+            <p className="font-medium uppercase tracking-wide text-primary">
+              From the intake transcript
+            </p>
+            <p className="mt-1 text-muted-foreground">{contextNote}</p>
+          </div>
+        ) : null}
+
         <div className="space-y-1">
-          <Label htmlFor={incomeId}>Monthly income (gross, before deductions)</Label>
+          <Label htmlFor={incomeId}>
+            Monthly income (gross, before deductions)
+            <PrefillBadge k="monthlyIncomeCents" />
+          </Label>
           <Input
             id={incomeId}
             type="number"
@@ -76,7 +118,10 @@ export function BenefitsScreener() {
         </div>
 
         <div className="space-y-1">
-          <Label htmlFor={sizeId}>Household size</Label>
+          <Label htmlFor={sizeId}>
+            Household size
+            <PrefillBadge k="householdSize" />
+          </Label>
           <Input
             id={sizeId}
             type="number"
@@ -132,6 +177,7 @@ export function BenefitsScreener() {
                 className="h-4 w-4"
               />
               {label}
+              <PrefillBadge k={k as keyof Household} />
             </label>
           ))}
         </fieldset>
@@ -140,19 +186,7 @@ export function BenefitsScreener() {
           type="button"
           variant="outline"
           size="sm"
-          onClick={() =>
-            setHousehold({
-              monthlyIncomeCents: 100_000,
-              householdSize: 1,
-              hasChildrenUnder18: false,
-              hasPregnantMember: false,
-              isVeteran: false,
-              isDisabled: false,
-              ageOldest: 35,
-              kyResident: true,
-              citizenOrQualified: true,
-            })
-          }
+          onClick={() => setHousehold({ ...DEFAULT_HOUSEHOLD })}
         >
           Reset
         </Button>

--- a/src/lib/cwt/intake-to-screener.ts
+++ b/src/lib/cwt/intake-to-screener.ts
@@ -1,0 +1,49 @@
+import type { IntakeProfile } from '@/ai/prompts/intake-extraction';
+import type { Household } from '@/lib/cwt/benefits';
+
+export type ScreenerPrefill = {
+  initialHousehold: Partial<Household>;
+  prefillFields: Array<keyof Household>;
+  contextNote: string | null;
+};
+
+/**
+ * Map an extracted intake profile to a benefits-screener prefill.
+ *
+ * Only fields we can map cleanly get carried over. Income is left
+ * as a free-text context note (income_summary) rather than guessed
+ * into cents — the caseworker types the dollar amount themselves
+ * after the conversation, with the AI's transcript-derived
+ * summary visible for reference.
+ */
+export function intakeProfileToScreenerPrefill(profile: IntakeProfile): ScreenerPrefill {
+  const initialHousehold: Partial<Household> = {};
+  const prefillFields: Array<keyof Household> = [];
+
+  if (typeof profile.household_size === 'number' && profile.household_size > 0) {
+    initialHousehold.householdSize = profile.household_size;
+    prefillFields.push('householdSize');
+  }
+  if (typeof profile.has_children_under_18 === 'boolean') {
+    initialHousehold.hasChildrenUnder18 = profile.has_children_under_18;
+    prefillFields.push('hasChildrenUnder18');
+  }
+
+  // Income is free-text in the profile; surface it as a context note
+  // rather than guessing a number.
+  const contextParts: string[] = [];
+  if (profile.income_summary) contextParts.push(`Income: ${profile.income_summary}`);
+  if (profile.presenting_issue) contextParts.push(`Presenting issue: ${profile.presenting_issue}`);
+  if (profile.flags.dv_concern) {
+    contextParts.push('DV concern flagged in intake — check OASIS routing.');
+  }
+  if (profile.flags.has_caseworker_relationship) {
+    contextParts.push('Already working with another caseworker.');
+  }
+
+  return {
+    initialHousehold,
+    prefillFields,
+    contextNote: contextParts.length > 0 ? contextParts.join(' · ') : null,
+  };
+}


### PR DESCRIPTION
## Summary
- Caseworker workflow: record voice intake → extract profile → **Run benefits screener →** button → screener prefilled from the intake
- `benefits-screener` accepts `initialHousehold` / `prefillSource` / `contextNote`; renders a "from intake" badge next to prefilled fields and a primary-tinted callout for unparseable context (income, DV concern, existing caseworker relationship)
- `intake-to-screener` mapper deliberately only carries fields we can map cleanly (household size, kids); income stays as text context — free-text in the profile isn't safely parseable to cents
- Screener page reads `?fromIntake=<uuid>`, loads the intake, links back to the source

## Test plan
- [ ] Record an intake with household details, run extraction, click "Run benefits screener →" — verify household size, kids checkbox, and presenting-issue context all flow through
- [ ] Confirm prefill banner links back to the source intake
- [ ] Edit fields after prefill; reset returns to defaults (not prefill values)