### PR TITLE
feat(EVDT): AI-drafted tenant outreach letter

### DIFF
--- a/src/ai/prompts/eviction-tenant-outreach.ts
+++ b/src/ai/prompts/eviction-tenant-outreach.ts
@@ -1,0 +1,101 @@
+/**
+ * Tenant outreach letter prompt.
+ *
+ * When a high-risk eviction filing surfaces, KLA attorneys want to
+ * mail the tenant a short, plain-language letter telling them: (1)
+ * we offer free legal help, (2) here's how to reach us, (3) here are
+ * 2-3 things you should do right now while you wait. The AI drafts
+ * the letter from the filing facts; the attorney reviews, edits, and
+ * mails it. The cost of getting this wrong is low (it's an outreach
+ * invitation, not a court filing) — but the language must be plain
+ * and the legal claims hedged. This is NOT legal advice.
+ */
+
+import type { EvictionFiling } from '@/db/schema/eviction-filings';
+
+export const TENANT_OUTREACH_PROMPT_VERSION = 'tenant-outreach-v1@2026-04-26';
+
+export const TENANT_OUTREACH_SYSTEM_PROMPT = `You write a short outreach letter from Kentucky Legal Aid (KLA) to a
+tenant who has just been served with an eviction filing in Daviess
+County, Kentucky. The letter's job is to invite the tenant to call
+KLA for free legal help and to give them 2-3 plain-language things
+to do right now.
+
+Voice and constraints:
+- Plain English. 6th-grade reading level. Short sentences.
+- Warm but factual. Do not catastrophize ("you will lose your home")
+  and do not falsely reassure ("everything will be fine").
+- Never claim a specific legal outcome. Never give legal advice. The
+  letter says "we may be able to help" not "we will win this case".
+- Never quote dollar amounts back to the tenant beyond what's already
+  in the filing. Do not name the plaintiff's lawyer.
+- Do not invent facts. Only reference what the filing actually says.
+- KLA serves all of western Kentucky free of charge to people who
+  qualify income-wise. The Owensboro office is the local one.
+
+Structure (write in this order, no headers, just paragraphs):
+
+1. Greeting using "Dear {first name}," — first name only.
+
+2. One sentence acknowledging that the tenant has been served. Cite
+   the case number once. Do NOT recite the full case caption.
+
+3. One short paragraph: KLA offers free legal help to people facing
+   eviction in this court. We may be able to help with this case. The
+   call is free; nothing they say to us gets back to the landlord.
+
+4. A "What you can do right now" list — exactly 2 or 3 numbered items.
+   Each item is one sentence. Pick the most relevant for this filing
+   from this set:
+   - DO NOT MOVE OUT just because you got served. The court has not
+     ordered you to leave yet.
+   - Save copies of every piece of paper from the landlord and the
+     court — keep them somewhere safe.
+   - If you can pay any of the rent claimed, write down the date and
+     keep the receipt. Do not pay in cash with no receipt.
+   - Write down what happened — when the landlord first told you
+     there was a problem, what you said, what they said.
+   - If your home has black mold, no heat, no working plumbing, or
+     other serious problems, take photos with your phone today.
+   - Apply for KY rental assistance through the state housing site
+     before your court date if you owe back rent.
+   Pick items that match the cause type (non-payment vs. lease
+   violation vs. holdover) and the amount claimed. Do not pad to 3
+   if 2 fit better.
+
+5. One short paragraph: how to reach KLA. Phone is the fastest. Use
+   the literal placeholder \`[KLA Owensboro phone]\` for the number;
+   the attorney will fill it in. Include the line "Tell whoever
+   answers that you got an eviction paper — they'll move you to the
+   front of the line."
+
+6. Closing: "Sincerely," on its own line, then "Kentucky Legal Aid —
+   Owensboro Office" on the next line. No attorney signature line.
+
+Length target: 200-280 words total. Hard cap: 320.
+
+Output ONLY the letter body. No headers like "OUTREACH LETTER", no
+metadata. The attorney pastes this into letterhead.`;
+
+export type TenantOutreachInputs = {
+  case_number: string;
+  defendant_first_name: string;
+  cause_type: EvictionFiling['causeType'];
+  amount_claimed_cents: number | null;
+  filed_at: string;
+  court_division: string | null;
+};
+
+export function buildTenantOutreachUserPrompt(inputs: TenantOutreachInputs): string {
+  const lines = [
+    'Draft the outreach letter for this filing.',
+    '',
+    `Case number: ${inputs.case_number}`,
+    `Tenant first name: ${inputs.defendant_first_name}`,
+    `Cause type: ${inputs.cause_type}`,
+    `Amount claimed (cents): ${inputs.amount_claimed_cents ?? 'unknown'}`,
+    `Filed: ${inputs.filed_at}`,
+    `Court division: ${inputs.court_division ?? 'unknown'}`,
+  ];
+  return lines.join('\n');
+}

--- a/src/app/actions/eviction.ts
+++ b/src/app/actions/eviction.ts
@@ -16,9 +16,11 @@ import { evictionCaseOutcomes } from '@/db/schema/eviction-case-outcomes';
 import { evictionResponsePackets } from '@/db/schema/eviction-response-packets';
 import { logAuditEvent } from '@/lib/audit';
 import { requireKlaAttorney, requireRole } from '@/lib/auth';
+import { recordAiGeneration } from '@/lib/dtrs/data-access';
 import { renderPacketPdf } from '@/lib/eviction/packet-pdf';
 import { generateResponsePacket, validateDisclaimer } from '@/lib/eviction/response-packet';
 import { scoreFiling } from '@/lib/eviction/risk-score';
+import { generateOutreachLetter } from '@/lib/eviction/tenant-outreach';
 
 export type ScoreFilingResult = { ok: true } | { ok: false; error: string };
 
@@ -179,6 +181,41 @@ export async function exportPacketPdfAction(packetId: string): Promise<ExportPac
     filename: `packet-${safeCase}-${packet.id.slice(0, 8)}.pdf`,
     base64: bytes.toString('base64'),
   };
+}
+
+export type GenerateOutreachLetterResult =
+  | { ok: true; text: string; promptVersion: string }
+  | { ok: false; error: string };
+
+export async function generateOutreachLetterAction(
+  filingId: string,
+): Promise<GenerateOutreachLetterResult> {
+  const user = await requireKlaAttorney();
+  const filing = await getFilingById(filingId);
+  if (!filing) return { ok: false, error: 'Filing not found.' };
+
+  try {
+    const result = await generateOutreachLetter(filing);
+    await logAuditEvent({
+      actorUserId: user.id,
+      action: 'outreach_letter.generated',
+      targetTable: 'eviction_filings',
+      targetId: filing.id,
+      metadata: { promptVersion: result.promptVersion, caseNumber: filing.caseNumber },
+    });
+    await recordAiGeneration({
+      actorUserId: user.id,
+      resourceType: 'tenant_outreach_letter',
+      resourceId: filing.id,
+      model: result.modelId,
+      promptVersion: result.promptVersion,
+      metadata: { caseNumber: filing.caseNumber },
+    });
+    return { ok: true, text: result.text, promptVersion: result.promptVersion };
+  } catch (err) {
+    Sentry.captureException(err, { tags: { action: 'generateOutreachLetterAction', filingId } });
+    return { ok: false, error: 'Letter generation failed. Please try again.' };
+  }
 }
 
 export type RecordCaseOutcomeResult = { ok: true } | { ok: false; error: string };

--- a/src/app/app/cases/filings/[id]/page.tsx
+++ b/src/app/app/cases/filings/[id]/page.tsx
@@ -3,6 +3,7 @@ import { notFound } from 'next/navigation';
 import { CaseFilingsRoles } from '@/components/eviction/case-filings-roles';
 import { CaseOutcomePanel } from '@/components/eviction/case-outcome-panel';
 import { FilingDetail } from '@/components/eviction/filing-detail';
+import { OutreachLetterPanel } from '@/components/eviction/outreach-letter-panel';
 import { RentalAssistancePanel } from '@/components/eviction/rental-assistance-panel';
 import { listCaseOutcomes } from '@/db/queries/eviction-case-outcomes';
 import { getFilingByIdForViewer } from '@/db/queries/eviction-filings';
@@ -69,6 +70,7 @@ export default async function FilingDetailPage({ params }: { params: Promise<{ i
           Open packet workspace →
         </Link>
       </div>
+      {canRecord ? <OutreachLetterPanel filingId={filing.id} /> : null}
       <CaseOutcomePanel filingId={filing.id} history={outcomes} canRecord={canRecord} />
       <RentalAssistancePanel programs={assistancePrograms} />
     </div>

--- a/src/components/eviction/outreach-letter-panel.tsx
+++ b/src/components/eviction/outreach-letter-panel.tsx
@@ -1,0 +1,91 @@
+'use client';
+
+import { useId, useState, useTransition } from 'react';
+import { generateOutreachLetterAction } from '@/app/actions/eviction';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+
+export function OutreachLetterPanel({ filingId }: { filingId: string }) {
+  const textareaId = useId();
+  const [pending, startTransition] = useTransition();
+  const [text, setText] = useState<string>('');
+  const [error, setError] = useState<string | null>(null);
+  const [copied, setCopied] = useState(false);
+
+  const onGenerate = () => {
+    setError(null);
+    setCopied(false);
+    startTransition(async () => {
+      const result = await generateOutreachLetterAction(filingId);
+      if (!result.ok) {
+        setError(result.error);
+        return;
+      }
+      setText(result.text);
+    });
+  };
+
+  const onCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(text);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      setError('Copy failed — select the text manually.');
+    }
+  };
+
+  return (
+    <Card>
+      <CardHeader className="flex flex-row items-baseline justify-between gap-2">
+        <CardTitle className="text-base">Tenant outreach letter</CardTitle>
+        {text ? (
+          <Button onClick={onGenerate} disabled={pending} size="sm" variant="outline">
+            {pending ? 'Drafting…' : 'Re-draft'}
+          </Button>
+        ) : null}
+      </CardHeader>
+      <CardContent className="space-y-3 text-sm">
+        {!text ? (
+          <>
+            <p className="text-muted-foreground">
+              Draft a plain-language letter inviting the tenant to call KLA for free legal help. AI
+              writes it from the filing facts only — no PHI. You review, edit, and mail it.
+            </p>
+            <div className="flex items-center gap-3">
+              <Button onClick={onGenerate} disabled={pending} size="sm">
+                {pending ? 'Drafting…' : 'Draft outreach letter'}
+              </Button>
+              {error ? <span className="text-destructive text-xs">{error}</span> : null}
+            </div>
+          </>
+        ) : (
+          <>
+            <p className="text-xs text-muted-foreground">
+              Edit freely below before sending. Replace{' '}
+              <code className="font-mono">[KLA Owensboro phone]</code> with the real number, paste
+              into letterhead, mail it. The AI is not your attorney — read every word.
+            </p>
+            <label htmlFor={textareaId} className="sr-only">
+              Outreach letter draft
+            </label>
+            <textarea
+              id={textareaId}
+              value={text}
+              onChange={(e) => setText(e.target.value)}
+              rows={18}
+              className="w-full rounded-md border border-input bg-background p-3 font-mono text-xs leading-relaxed"
+            />
+            <div className="flex flex-wrap items-center gap-3">
+              <Button type="button" size="sm" variant="outline" onClick={onCopy}>
+                {copied ? 'Copied ✓' : 'Copy to clipboard'}
+              </Button>
+              <span className="text-xs text-muted-foreground">{text.length} chars</span>
+              {error ? <span className="text-destructive text-xs">{error}</span> : null}
+            </div>
+          </>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/lib/eviction/tenant-outreach.ts
+++ b/src/lib/eviction/tenant-outreach.ts
@@ -1,0 +1,66 @@
+import Anthropic from '@anthropic-ai/sdk';
+import {
+  buildTenantOutreachUserPrompt,
+  TENANT_OUTREACH_PROMPT_VERSION,
+  TENANT_OUTREACH_SYSTEM_PROMPT,
+} from '@/ai/prompts/eviction-tenant-outreach';
+import type { EvictionFiling } from '@/db/schema/eviction-filings';
+
+let _client: Anthropic | null = null;
+function client(): Anthropic {
+  if (!_client) _client = new Anthropic();
+  return _client;
+}
+
+const MODEL_ID = 'claude-sonnet-4-6';
+const MAX_OUTPUT_TOKENS = 800;
+
+export type OutreachLetterResult = {
+  text: string;
+  modelId: string;
+  promptVersion: string;
+};
+
+function scrubForPrompt(filing: EvictionFiling) {
+  return {
+    case_number: filing.caseNumber,
+    defendant_first_name: filing.defendantFirstName,
+    cause_type: filing.causeType,
+    amount_claimed_cents: filing.amountClaimedCents,
+    filed_at: filing.filedAt.toISOString(),
+    court_division: filing.courtDivision,
+  };
+}
+
+/**
+ * Generate a tenant outreach letter for a filing. Plain text out;
+ * the attorney edits in a textarea before sending. Not persisted —
+ * this is an invitation letter, not a court filing, and re-running
+ * is cheap.
+ */
+export async function generateOutreachLetter(
+  filing: EvictionFiling,
+): Promise<OutreachLetterResult> {
+  const inputs = scrubForPrompt(filing);
+  const response = await client().messages.create({
+    model: MODEL_ID,
+    max_tokens: MAX_OUTPUT_TOKENS,
+    system: [
+      {
+        type: 'text',
+        text: TENANT_OUTREACH_SYSTEM_PROMPT,
+        cache_control: { type: 'ephemeral' },
+      },
+    ],
+    messages: [{ role: 'user', content: buildTenantOutreachUserPrompt(inputs) }],
+  });
+
+  const text = response.content
+    .flatMap((c) => (c.type === 'text' ? [c.text] : []))
+    .join('\n')
+    .trim();
+  if (!text) {
+    throw new Error(`[tenant-outreach] empty response; stop_reason=${response.stop_reason}`);
+  }
+  return { text, modelId: MODEL_ID, promptVersion: TENANT_OUTREACH_PROMPT_VERSION };
+}


### PR DESCRIPTION
## Summary
- KLA attorneys click **Draft outreach letter** on the filing detail page → Claude writes a 200-280 word plain-language letter inviting the tenant to call KLA for free help, with 2-3 case-specific "do this right now" items
- Sonnet 4.6, plain text, no DB persistence (invitation letter, not a court filing — re-running is cheap)
- Hedged language baked into the system prompt: "we may be able to help" / never quotes a specific outcome / 6th-grade reading level
- Editable in-place textarea; copy-to-clipboard button; `[KLA Owensboro phone]` left as a literal placeholder for the attorney to fill in
- Audited via `logAuditEvent` + `recordAiGeneration` so DTRS-013 transparency report counts it

## Test plan
- [ ] Open a filing as a KLA attorney → click "Draft outreach letter" → verify a letter appears with the case number, tenant first name, and 2-3 numbered action items matching the cause type
- [ ] Verify a non-KLA-attorney user (caseworker / admin / shelter_staff) does NOT see the panel
- [ ] Click "Re-draft" → second letter generates; "Copy to clipboard" works
- [ ] Audit log shows `outreach_letter.generated` + `ai.generated` rows