### PR TITLE
feat(EVDT): attorney morning triage view

### DIFF
--- a/src/ai/prompts/attorney-triage.ts
+++ b/src/ai/prompts/attorney-triage.ts
@@ -1,0 +1,120 @@
+import { z } from 'zod';
+import type { TriageCandidate } from '@/db/queries/attorney-triage';
+
+/**
+ * Attorney morning-triage prompt.
+ *
+ * Input: ~20 open eviction cases with risk scores and current state
+ * (packet drafted? filed? outcome recorded?). Output: a ranked list
+ * of 3-5 cases the attorney should focus on today, with one short
+ * sentence per case explaining why.
+ *
+ * The job is NOT to repeat the risk score. The job is to think like
+ * a triage nurse: what's most time-sensitive, where is action
+ * blocked, where is the highest-impact-per-minute work?
+ */
+
+export const ATTORNEY_TRIAGE_PROMPT_VERSION = 'attorney-triage-v1@2026-04-26';
+
+export const ATTORNEY_TRIAGE_SYSTEM_PROMPT = `You are the morning triage assistant for a Kentucky Legal Aid (KLA)
+attorney handling eviction defense in Daviess County. The attorney
+opens this view at 9am and gets ~30 seconds to plan their day.
+
+Input: a list of open eviction cases (status filed or served, last
+~30 days), each with risk score, packet draft state, and outcome
+state.
+
+Output: 3 to 5 cases ranked by what the attorney should work on
+FIRST today. For each pick, write one sentence (under 25 words)
+explaining the rationale. Plain English. No legal jargon.
+
+How to think about ranking:
+
+1. **Time pressure beats risk score.** A served filing with no
+   packet drafted and a high amount claimed is more urgent than a
+   high-risk filing that's already been answered.
+2. **Action-blocking gaps go first.** "No packet drafted yet" or
+   "no risk score yet" is high triage value — the attorney can
+   unblock it in one click.
+3. **High score + no movement** is your bread and butter. These are
+   the cases with the most upside if KLA gets involved.
+4. **Don't pick already-handled cases.** If a case has an approved
+   or filed packet AND an outcome recorded, it's done — don't
+   surface it.
+5. **Don't pad to 5.** If only 3 cases deserve attention, return 3.
+   If only 1 does, return 1.
+
+Reasoning style for each pick:
+- Lead with WHY this one. Examples:
+  - "Served 4 days ago, $3,400 claimed, no packet drafted — answer
+    deadline is the tightest in the docket."
+  - "Risk score 87 with no movement; this is the highest-leverage
+    case where KLA hasn't started yet."
+  - "Score is mid but it's a holdover with no rent owed — likely
+    fast win once the answer is filed."
+- Don't restate the case number or dollar amount in the rationale —
+  the UI shows those next to the rationale.
+
+Hard rules:
+- Reference cases ONLY by their filing_id from the input. Do not
+  invent ids.
+- Do not invent facts about the case (defendant name, court date,
+  etc.) that aren't in the input.
+- Output ONLY the structured JSON your schema demands.`;
+
+export const AttorneyTriageItemSchema = z.object({
+  filing_id: z.string().uuid(),
+  priority_rank: z.number().int().min(1).max(5),
+  rationale: z
+    .string()
+    .min(10)
+    .max(220)
+    .describe('One sentence under 25 words explaining why this case ranks here.'),
+});
+
+export const AttorneyTriageOutputSchema = z.object({
+  picks: z
+    .array(AttorneyTriageItemSchema)
+    .min(1)
+    .max(5)
+    .describe('Up to 5 cases ranked by today-priority. Order matters; do not pad.'),
+  overall_note: z
+    .string()
+    .max(200)
+    .nullable()
+    .describe(
+      'Optional one-sentence overview of the docket today (e.g. "Quiet morning — only 2 cases need attention"). Null if nothing to say.',
+    ),
+});
+
+export type AttorneyTriageOutput = z.infer<typeof AttorneyTriageOutputSchema>;
+
+export function buildAttorneyTriageUserPrompt(candidates: TriageCandidate[]): string {
+  const lines: string[] = [
+    'Here is the list of open eviction cases. Pick the top 3-5 to focus on first today.',
+    '',
+    `Today's date: ${new Date().toISOString().slice(0, 10)}`,
+    `Candidate count: ${candidates.length}`,
+    '',
+  ];
+
+  for (const c of candidates) {
+    const filed = c.filing.filedAt.toISOString().slice(0, 10);
+    const amount =
+      c.filing.amountClaimedCents != null
+        ? `$${(c.filing.amountClaimedCents / 100).toFixed(2)}`
+        : 'unknown';
+    const score = c.score != null ? String(c.score) : 'unscored';
+    const packet = c.packetStatus ?? 'no packet drafted';
+    const outcome = c.hasOutcome ? 'outcome recorded' : 'no outcome yet';
+    lines.push(
+      `- filing_id=${c.filing.id} · case=${c.filing.caseNumber} · status=${c.filing.status} ` +
+        `· cause=${c.filing.causeType} · filed=${filed} · amount=${amount} ` +
+        `· risk_score=${score} · packet=${packet} · ${outcome}`,
+    );
+  }
+
+  lines.push('');
+  lines.push('Return the structured triage list now.');
+  return lines.join('\n');
+}

--- a/src/app/actions/eviction.ts
+++ b/src/app/actions/eviction.ts
@@ -5,6 +5,7 @@ import { eq } from 'drizzle-orm';
 import { revalidatePath } from 'next/cache';
 import { CaseFilingsRoles } from '@/components/eviction/case-filings-roles';
 import { db } from '@/db/client';
+import { listTriageCandidates } from '@/db/queries/attorney-triage';
 import { getFilingById } from '@/db/queries/eviction-filings';
 import {
   type EvictionCaseOutcome,
@@ -17,6 +18,7 @@ import { evictionResponsePackets } from '@/db/schema/eviction-response-packets';
 import { logAuditEvent } from '@/lib/audit';
 import { requireKlaAttorney, requireRole } from '@/lib/auth';
 import { recordAiGeneration } from '@/lib/dtrs/data-access';
+import { type AttorneyTriageResult, generateAttorneyTriage } from '@/lib/eviction/attorney-triage';
 import { renderPacketPdf } from '@/lib/eviction/packet-pdf';
 import { generateResponsePacket, validateDisclaimer } from '@/lib/eviction/response-packet';
 import { scoreFiling } from '@/lib/eviction/risk-score';
@@ -215,6 +217,65 @@ export async function generateOutreachLetterAction(
   } catch (err) {
     Sentry.captureException(err, { tags: { action: 'generateOutreachLetterAction', filingId } });
     return { ok: false, error: 'Letter generation failed. Please try again.' };
+  }
+}
+
+export type GenerateAttorneyTriageResult =
+  | {
+      ok: true;
+      result: AttorneyTriageResult;
+      candidates: Array<{
+        filingId: string;
+        caseNumber: string;
+        amountClaimedCents: number | null;
+        score: number | null;
+        packetStatus: string | null;
+        causeType: string;
+        status: string;
+        filedAt: string;
+      }>;
+    }
+  | { ok: false; error: string };
+
+export async function generateAttorneyTriageAction(): Promise<GenerateAttorneyTriageResult> {
+  const user = await requireKlaAttorney();
+  try {
+    const candidates = await listTriageCandidates({ windowDays: 30, limit: 20 });
+    const result = await generateAttorneyTriage(candidates);
+
+    await logAuditEvent({
+      actorUserId: user.id,
+      action: 'attorney_triage.generated',
+      targetTable: 'eviction_filings',
+      metadata: {
+        candidateCount: result.candidateCount,
+        picksReturned: result.output.picks.length,
+      },
+    });
+    await recordAiGeneration({
+      actorUserId: user.id,
+      resourceType: 'attorney_triage',
+      resourceId: 'morning_triage',
+      model: result.modelId,
+      promptVersion: result.promptVersion,
+      metadata: { candidateCount: result.candidateCount },
+    });
+
+    const candidateMeta = candidates.map((c) => ({
+      filingId: c.filing.id,
+      caseNumber: c.filing.caseNumber,
+      amountClaimedCents: c.filing.amountClaimedCents,
+      score: c.score,
+      packetStatus: c.packetStatus,
+      causeType: c.filing.causeType,
+      status: c.filing.status,
+      filedAt: c.filing.filedAt.toISOString(),
+    }));
+
+    return { ok: true, result, candidates: candidateMeta };
+  } catch (err) {
+    Sentry.captureException(err, { tags: { action: 'generateAttorneyTriageAction' } });
+    return { ok: false, error: 'Triage generation failed. Please try again.' };
   }
 }
 

--- a/src/app/app/cases/filings/page.tsx
+++ b/src/app/app/cases/filings/page.tsx
@@ -1,10 +1,11 @@
+import Link from 'next/link';
 import { CaseFilingsRoles } from '@/components/eviction/case-filings-roles';
 import { FilingsTable } from '@/components/eviction/filings-table';
 import { SourceFilter } from '@/components/eviction/source-filter';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { listRecentFilingsForViewer } from '@/db/queries/eviction-filings';
 import type { EvictionFilingSource } from '@/db/schema/enums';
-import { requireRole } from '@/lib/auth';
+import { requireRole, userIsKlaAttorney } from '@/lib/auth';
 
 const ALLOWED_SOURCES: EvictionFilingSource[] = ['synthetic', 'manual', 'courtnet'];
 
@@ -17,15 +18,28 @@ export default async function FilingsPage({
 
   const params = await searchParams;
   const source = ALLOWED_SOURCES.find((s) => s === params.source);
-  const filings = await listRecentFilingsForViewer({ limit: 50, source }, me.role);
+  const [filings, canTriage] = await Promise.all([
+    listRecentFilingsForViewer({ limit: 50, source }, me.role),
+    userIsKlaAttorney(me),
+  ]);
 
   return (
     <div className="mx-auto max-w-6xl p-6 space-y-4">
-      <header>
-        <h1 className="font-serif text-3xl font-bold text-primary">Filings</h1>
-        <p className="text-sm text-muted-foreground">
-          Most recent {filings.length} eviction filings (Daviess District Court).
-        </p>
+      <header className="flex flex-wrap items-baseline justify-between gap-3">
+        <div>
+          <h1 className="font-serif text-3xl font-bold text-primary">Filings</h1>
+          <p className="text-sm text-muted-foreground">
+            Most recent {filings.length} eviction filings (Daviess District Court).
+          </p>
+        </div>
+        {canTriage ? (
+          <Link
+            href="/app/cases/triage"
+            className="shrink-0 rounded-md bg-primary px-3 py-2 text-xs font-medium text-primary-foreground hover:bg-primary/90"
+          >
+            Morning triage →
+          </Link>
+        ) : null}
       </header>
 
       <SourceFilter selected={source} />

--- a/src/app/app/cases/triage/page.tsx
+++ b/src/app/app/cases/triage/page.tsx
@@ -1,0 +1,41 @@
+import Link from 'next/link';
+import { AttorneyTriagePanel } from '@/components/eviction/attorney-triage-panel';
+import { Card, CardContent } from '@/components/ui/card';
+import { requireKlaAttorney } from '@/lib/auth';
+
+export const dynamic = 'force-dynamic';
+
+export default async function AttorneyTriagePage() {
+  await requireKlaAttorney();
+
+  return (
+    <div className="mx-auto max-w-4xl space-y-4 p-4 md:p-6">
+      <div className="text-xs">
+        <Link href="/app/cases/filings" className="text-muted-foreground hover:underline">
+          ← Back to docket
+        </Link>
+      </div>
+      <header>
+        <h1 className="font-serif text-3xl font-bold text-primary">Morning triage</h1>
+        <p className="text-sm text-muted-foreground">
+          Claude reads every open case from the last 30 days and tells you the 3-5 to focus on
+          first. Time pressure beats risk score; action-blocking gaps go first; already-handled
+          cases drop out. Re-run any time the docket changes.
+        </p>
+      </header>
+
+      <AttorneyTriagePanel />
+
+      <Card className="border-amber-500/40 bg-amber-500/5">
+        <CardContent className="text-xs">
+          <p className="font-medium">This is a planning aid, not a decision.</p>
+          <p className="mt-1 text-muted-foreground">
+            The AI ranks based on the structured facts the platform has — risk score, packet state,
+            outcome state. It doesn't see attorney notes, client phone calls, or anything you
+            haven't recorded. Trust your read of the docket over the AI's.
+          </p>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/components/eviction/attorney-triage-panel.tsx
+++ b/src/components/eviction/attorney-triage-panel.tsx
@@ -1,0 +1,147 @@
+'use client';
+
+import Link from 'next/link';
+import { useState, useTransition } from 'react';
+import {
+  type GenerateAttorneyTriageResult,
+  generateAttorneyTriageAction,
+} from '@/app/actions/eviction';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { riskBandClass } from '@/lib/eviction/risk-band';
+
+const fmtMoney = (cents: number | null) => {
+  if (cents == null) return '—';
+  return new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' }).format(cents / 100);
+};
+
+const fmtDate = (iso: string) =>
+  new Intl.DateTimeFormat('en-US', { dateStyle: 'medium' }).format(new Date(iso));
+
+type SuccessResult = Extract<GenerateAttorneyTriageResult, { ok: true }>;
+
+export function AttorneyTriagePanel() {
+  const [pending, startTransition] = useTransition();
+  const [data, setData] = useState<SuccessResult | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const onClick = () => {
+    setError(null);
+    startTransition(async () => {
+      const r = await generateAttorneyTriageAction();
+      if (!r.ok) {
+        setError(r.error);
+        return;
+      }
+      setData(r);
+    });
+  };
+
+  if (!data) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">Today's priority cases</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-3 text-sm">
+          <p className="text-muted-foreground">
+            Claude reviews every open case in the last 30 days and picks the 3-5 you should focus on
+            first today. The reasoning isn't your risk score restated — it's "where's the time
+            pressure, where's the highest leverage."
+          </p>
+          <div className="flex items-center gap-3">
+            <Button onClick={onClick} disabled={pending} size="sm">
+              {pending ? 'Reviewing the docket…' : "Run today's triage"}
+            </Button>
+            {error ? <span className="text-destructive text-xs">{error}</span> : null}
+          </div>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  const { result, candidates } = data;
+  const candById = new Map(candidates.map((c) => [c.filingId, c]));
+  const sortedPicks = [...result.output.picks].sort((a, b) => a.priority_rank - b.priority_rank);
+
+  return (
+    <Card>
+      <CardHeader className="flex flex-row items-baseline justify-between gap-2">
+        <CardTitle className="text-base">Today's priority cases</CardTitle>
+        <Button onClick={onClick} disabled={pending} size="sm" variant="outline">
+          {pending ? 'Re-running…' : 'Re-run triage'}
+        </Button>
+      </CardHeader>
+      <CardContent className="space-y-4 text-sm">
+        {result.output.overall_note ? (
+          <p className="rounded-md border border-primary/40 bg-primary/5 p-3 text-sm">
+            {result.output.overall_note}
+          </p>
+        ) : null}
+
+        {sortedPicks.length === 0 ? (
+          <p className="text-muted-foreground">
+            No cases need attention today out of {result.candidateCount} open in the window.
+          </p>
+        ) : (
+          <ol className="space-y-3">
+            {sortedPicks.map((p) => {
+              const c = candById.get(p.filing_id);
+              if (!c) return null;
+              return (
+                <li
+                  key={p.filing_id}
+                  className="rounded-md border border-border bg-card p-3 text-sm"
+                >
+                  <div className="mb-1 flex flex-wrap items-baseline justify-between gap-2">
+                    <div className="flex items-baseline gap-2">
+                      <span className="rounded bg-muted px-1.5 py-0.5 font-mono text-[10px]">
+                        #{p.priority_rank}
+                      </span>
+                      <Link
+                        href={`/app/cases/filings/${p.filing_id}`}
+                        className="font-mono text-xs font-medium hover:underline"
+                      >
+                        {c.caseNumber}
+                      </Link>
+                      <span className="text-xs text-muted-foreground">{c.causeType}</span>
+                    </div>
+                    <div className="flex items-baseline gap-3 text-xs">
+                      {c.score != null ? (
+                        <span className={`font-medium ${riskBandClass(c.score)}`}>
+                          score {c.score}
+                        </span>
+                      ) : (
+                        <span className="text-muted-foreground italic">unscored</span>
+                      )}
+                      <span className="text-muted-foreground">
+                        {fmtMoney(c.amountClaimedCents)}
+                      </span>
+                    </div>
+                  </div>
+                  <p className="text-sm leading-relaxed">{p.rationale}</p>
+                  <div className="mt-1 text-[11px] text-muted-foreground">
+                    filed {fmtDate(c.filedAt)} · status {c.status} ·{' '}
+                    {c.packetStatus ? `packet ${c.packetStatus}` : 'no packet drafted'}
+                  </div>
+                </li>
+              );
+            })}
+          </ol>
+        )}
+
+        <div className="flex flex-wrap gap-x-4 gap-y-1 text-[11px] text-muted-foreground">
+          <span>
+            Reviewed {result.candidateCount} open case{result.candidateCount === 1 ? '' : 's'}
+          </span>
+          <span>
+            Model: <span className="font-mono">{result.modelId}</span>
+          </span>
+          <span>
+            Prompt: <span className="font-mono">{result.promptVersion}</span>
+          </span>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/db/queries/attorney-triage.ts
+++ b/src/db/queries/attorney-triage.ts
@@ -1,0 +1,86 @@
+import { and, desc, eq, gte, inArray, sql } from 'drizzle-orm';
+import { RISK_SCORE_MODEL_VERSION } from '@/ai/prompts/eviction-risk-score';
+import { db } from '@/db/client';
+import type { EvictionFilingStatus, EvictionResponsePacketStatus } from '@/db/schema/enums';
+import { evictionCaseOutcomes } from '@/db/schema/eviction-case-outcomes';
+import { evictionFilingRiskScores } from '@/db/schema/eviction-filing-risk-scores';
+import { type EvictionFiling, evictionFilings } from '@/db/schema/eviction-filings';
+import { evictionResponsePackets } from '@/db/schema/eviction-response-packets';
+
+export type TriageCandidate = {
+  filing: EvictionFiling;
+  score: number | null;
+  rationale: string | null;
+  packetStatus: EvictionResponsePacketStatus | null;
+  hasOutcome: boolean;
+};
+
+const OPEN_STATUSES: EvictionFilingStatus[] = ['filed', 'served'];
+
+/**
+ * Open cases the attorney could plausibly act on today: filed within
+ * the window, status filed/served (i.e. court hasn't entered judgment
+ * or the case dismissed yet), joined to current-version risk score,
+ * latest packet status, and whether an outcome's been recorded.
+ *
+ * Filings without a score are included — those are exactly the cases
+ * the attorney needs to triage even if the score didn't run yet.
+ */
+export async function listTriageCandidates(
+  opts: { windowDays?: number; limit?: number } = {},
+): Promise<TriageCandidate[]> {
+  const { windowDays = 30, limit = 20 } = opts;
+  const since = new Date();
+  since.setDate(since.getDate() - windowDays);
+
+  const rows = await db
+    .select({
+      filing: evictionFilings,
+      score: evictionFilingRiskScores.score,
+      rationale: evictionFilingRiskScores.rationale,
+    })
+    .from(evictionFilings)
+    .leftJoin(
+      evictionFilingRiskScores,
+      and(
+        eq(evictionFilingRiskScores.filingId, evictionFilings.id),
+        eq(evictionFilingRiskScores.modelVersion, RISK_SCORE_MODEL_VERSION),
+      ),
+    )
+    .where(and(inArray(evictionFilings.status, OPEN_STATUSES), gte(evictionFilings.filedAt, since)))
+    .orderBy(
+      desc(sql`COALESCE(${evictionFilingRiskScores.score}, 0)`),
+      desc(evictionFilings.filedAt),
+    )
+    .limit(limit);
+
+  if (rows.length === 0) return [];
+
+  const filingIds = rows.map((r) => r.filing.id);
+
+  const [packets, outcomes] = await Promise.all([
+    db
+      .select({
+        filingId: evictionResponsePackets.filingId,
+        status: evictionResponsePackets.status,
+      })
+      .from(evictionResponsePackets)
+      .where(inArray(evictionResponsePackets.filingId, filingIds)),
+    db
+      .select({ filingId: evictionCaseOutcomes.filingId })
+      .from(evictionCaseOutcomes)
+      .where(inArray(evictionCaseOutcomes.filingId, filingIds)),
+  ]);
+
+  const packetByFiling = new Map<string, EvictionResponsePacketStatus>();
+  for (const p of packets) packetByFiling.set(p.filingId, p.status);
+  const outcomeIds = new Set(outcomes.map((o) => o.filingId));
+
+  return rows.map((r) => ({
+    filing: r.filing,
+    score: r.score,
+    rationale: r.rationale,
+    packetStatus: packetByFiling.get(r.filing.id) ?? null,
+    hasOutcome: outcomeIds.has(r.filing.id),
+  }));
+}

--- a/src/lib/eviction/attorney-triage.ts
+++ b/src/lib/eviction/attorney-triage.ts
@@ -1,0 +1,72 @@
+import Anthropic from '@anthropic-ai/sdk';
+import { zodOutputFormat } from '@anthropic-ai/sdk/helpers/zod';
+import {
+  ATTORNEY_TRIAGE_PROMPT_VERSION,
+  ATTORNEY_TRIAGE_SYSTEM_PROMPT,
+  type AttorneyTriageOutput,
+  AttorneyTriageOutputSchema,
+  buildAttorneyTriageUserPrompt,
+} from '@/ai/prompts/attorney-triage';
+import type { TriageCandidate } from '@/db/queries/attorney-triage';
+
+let _client: Anthropic | null = null;
+function client(): Anthropic {
+  if (!_client) _client = new Anthropic();
+  return _client;
+}
+
+const MODEL_ID = 'claude-sonnet-4-6';
+
+export type AttorneyTriageResult = {
+  output: AttorneyTriageOutput;
+  modelId: string;
+  promptVersion: string;
+  candidateCount: number;
+};
+
+export async function generateAttorneyTriage(
+  candidates: TriageCandidate[],
+): Promise<AttorneyTriageResult> {
+  if (candidates.length === 0) {
+    return {
+      output: { picks: [], overall_note: null },
+      modelId: MODEL_ID,
+      promptVersion: ATTORNEY_TRIAGE_PROMPT_VERSION,
+      candidateCount: 0,
+    };
+  }
+
+  const response = await client().messages.parse({
+    model: MODEL_ID,
+    max_tokens: 1500,
+    system: [
+      {
+        type: 'text',
+        text: ATTORNEY_TRIAGE_SYSTEM_PROMPT,
+        cache_control: { type: 'ephemeral' },
+      },
+    ],
+    messages: [{ role: 'user', content: buildAttorneyTriageUserPrompt(candidates) }],
+    output_config: { format: zodOutputFormat(AttorneyTriageOutputSchema) },
+  });
+
+  if (!response.parsed_output) {
+    throw new Error(`[attorney-triage] parse failed; stop_reason=${response.stop_reason}`);
+  }
+
+  // Belt-and-braces: drop any picks the model invented (filing_id not
+  // in candidates). Don't trust unconstrained model output to
+  // reference real DB rows.
+  const validIds = new Set(candidates.map((c) => c.filing.id));
+  const cleaned: AttorneyTriageOutput = {
+    picks: response.parsed_output.picks.filter((p) => validIds.has(p.filing_id)),
+    overall_note: response.parsed_output.overall_note,
+  };
+
+  return {
+    output: cleaned,
+    modelId: MODEL_ID,
+    promptVersion: ATTORNEY_TRIAGE_PROMPT_VERSION,
+    candidateCount: candidates.length,
+  };
+}


### PR DESCRIPTION
## Summary
- New `/app/cases/triage` page for KLA attorneys: one button → Claude reads the open docket (filed/served, last 30 days) and returns 3-5 ranked picks for "what to work on first today" with one-sentence rationale each
- Reasoning is *triage*, not risk score restated: time pressure beats score, action-blocking gaps (no packet drafted, unscored) go first, already-handled cases drop out — and the AI is told not to pad to 5
- Structured output via zod schema; any pick referencing a filing_id outside the candidate set is dropped server-side (belt-and-braces against hallucination)
- "Morning triage →" CTA added to the docket header, gated on `userIsKlaAttorney`
- Audited via `logAuditEvent` + `recordAiGeneration` (DTRS-013 transparency report counts it)

## Test plan
- [ ] Open `/app/cases/triage` as a KLA attorney → click "Run today's triage" → verify 3-5 picks with rationale, ranked, with score/amount/packet status next to each
- [ ] Click a case from the picks → lands on filing detail
- [ ] "Re-run triage" works
- [ ] Non-KLA-attorney users get 404 on the page; "Morning triage →" CTA does not render on the docket for them
- [ ] Audit log shows `attorney_triage.generated` + `ai.generated` rows