### PR TITLE
feat(EVDT): "Ask Claude about this case" Q&A

### DIFF
--- a/src/ai/prompts/case-qa.ts
+++ b/src/ai/prompts/case-qa.ts
@@ -1,0 +1,105 @@
+/**
+ * Case-detail Q&A prompt.
+ *
+ * Attorney is staring at a single eviction filing and asks Claude
+ * questions about it: "what's the strongest defense angle?", "should
+ * I prioritize this one?", "what's the catch with the amount
+ * claimed?". Claude answers based ONLY on what's in the filing and
+ * the existing risk-score rationale + packet state. It does not
+ * invent facts, does not give legal advice, and is upfront about the
+ * limits of what it can see.
+ */
+
+export const CASE_QA_PROMPT_VERSION = 'case-qa-v1@2026-04-26';
+
+export const CASE_QA_SYSTEM_PROMPT = `You are a case-research assistant for a Kentucky Legal Aid (KLA)
+attorney. The attorney is looking at one specific eviction filing
+and asking you questions about it. You answer based on the
+structured facts of the filing plus the existing AI-generated risk
+score rationale (if any) and the current packet draft state.
+
+Voice and constraints:
+- Plain, direct, attorney-to-attorney tone. No filler. No "great
+  question". No emoji.
+- Answers should be 1-3 short paragraphs. The attorney is reading
+  fast, between client meetings.
+- When the answer depends on something you don't have (e.g. the
+  lease, the actual rent ledger, who the plaintiff's lawyer is),
+  say so explicitly. "I don't see X in the filing — you'd need to
+  pull it from Y."
+- Never invent facts about the case. If the user asks "did the
+  tenant pay rent in March", the right answer is "the filing
+  doesn't say."
+- This is NOT legal advice. If the user asks "should I take this
+  case" or "what's the right defense to plead", reframe: "Based on
+  the filing facts, here's what stands out — your judgment on
+  strategy."
+- Don't lecture about Kentucky landlord-tenant law generally.
+  Answer the specific question.
+- If the user asks a non-case question (general legal questions,
+  questions about the platform, off-topic), redirect briefly: "I'm
+  scoped to this case — for general questions try the docs."
+
+Scope of what you have access to:
+- Case number, court division, plaintiff
+- Cause type (non-payment / lease violation / holdover / other)
+- Amount claimed, filed date, current status
+- The AI risk-score rationale (if scored), and the score number
+- Whether a response packet has been drafted (and its status)
+- Whether an outcome has been recorded
+- The defendant's first and last name (PUBLIC court record)
+
+You do NOT have access to:
+- The lease itself or rent ledger
+- Anything the tenant said to KLA
+- Anything from the caseworker side of the platform
+- Court calendar / hearing dates beyond the filed_at date
+- Any other case in the docket (the attorney has a separate triage
+  view for that)
+
+Output: plain text. No markdown headers. Inline lists are fine.`;
+
+export type CaseFacts = {
+  case_number: string;
+  court_division: string | null;
+  plaintiff: string;
+  defendant_name: string;
+  cause_type: string;
+  amount_claimed_cents: number | null;
+  filed_at: string;
+  status: string;
+  risk_score: number | null;
+  risk_rationale: string | null;
+  risk_model_version: string | null;
+  packet_status: string | null;
+  outcome_recorded: boolean;
+};
+
+export function buildCaseFactsBlock(facts: CaseFacts): string {
+  const amount =
+    facts.amount_claimed_cents != null
+      ? `$${(facts.amount_claimed_cents / 100).toFixed(2)}`
+      : 'unknown';
+  const lines = [
+    'Case facts available to you:',
+    `- Case number: ${facts.case_number}`,
+    `- Court: ${facts.court_division ?? 'unknown'}`,
+    `- Plaintiff: ${facts.plaintiff}`,
+    `- Defendant: ${facts.defendant_name}`,
+    `- Cause type: ${facts.cause_type}`,
+    `- Amount claimed: ${amount}`,
+    `- Filed: ${facts.filed_at}`,
+    `- Current status: ${facts.status}`,
+    facts.risk_score != null
+      ? `- Risk score: ${facts.risk_score} (model ${facts.risk_model_version ?? 'unknown'})`
+      : '- Risk score: not yet scored',
+    facts.risk_rationale
+      ? `- Risk rationale: ${facts.risk_rationale}`
+      : '- Risk rationale: (none recorded)',
+    facts.packet_status
+      ? `- Response packet: drafted, status=${facts.packet_status}`
+      : '- Response packet: not yet drafted',
+    `- Outcome recorded: ${facts.outcome_recorded ? 'yes' : 'no'}`,
+  ];
+  return lines.join('\n');
+}

--- a/src/app/actions/eviction.ts
+++ b/src/app/actions/eviction.ts
@@ -1,8 +1,9 @@
 'use server';
 
 import * as Sentry from '@sentry/nextjs';
-import { eq } from 'drizzle-orm';
+import { desc, eq } from 'drizzle-orm';
 import { revalidatePath } from 'next/cache';
+import type { CaseFacts } from '@/ai/prompts/case-qa';
 import { CaseFilingsRoles } from '@/components/eviction/case-filings-roles';
 import { db } from '@/db/client';
 import { listTriageCandidates } from '@/db/queries/attorney-triage';
@@ -19,9 +20,10 @@ import { logAuditEvent } from '@/lib/audit';
 import { requireKlaAttorney, requireRole } from '@/lib/auth';
 import { recordAiGeneration } from '@/lib/dtrs/data-access';
 import { type AttorneyTriageResult, generateAttorneyTriage } from '@/lib/eviction/attorney-triage';
+import { answerCaseQuestion, type CaseQATurn } from '@/lib/eviction/case-qa';
 import { renderPacketPdf } from '@/lib/eviction/packet-pdf';
 import { generateResponsePacket, validateDisclaimer } from '@/lib/eviction/response-packet';
-import { scoreFiling } from '@/lib/eviction/risk-score';
+import { getLatestScore, scoreFiling } from '@/lib/eviction/risk-score';
 import { generateOutreachLetter } from '@/lib/eviction/tenant-outreach';
 
 export type ScoreFilingResult = { ok: true } | { ok: false; error: string };
@@ -217,6 +219,98 @@ export async function generateOutreachLetterAction(
   } catch (err) {
     Sentry.captureException(err, { tags: { action: 'generateOutreachLetterAction', filingId } });
     return { ok: false, error: 'Letter generation failed. Please try again.' };
+  }
+}
+
+export type AskCaseQuestionResult =
+  | { ok: true; answer: string; promptVersion: string }
+  | { ok: false; error: string };
+
+const QA_USER_QUESTION_MAX = 1500;
+const QA_HISTORY_MAX_TURNS = 30;
+
+export async function askCaseQuestionAction(
+  filingId: string,
+  history: CaseQATurn[],
+): Promise<AskCaseQuestionResult> {
+  const user = await requireKlaAttorney();
+
+  if (!Array.isArray(history) || history.length === 0) {
+    return { ok: false, error: 'Question is required.' };
+  }
+  if (history.length > QA_HISTORY_MAX_TURNS) {
+    return { ok: false, error: 'Conversation too long — start a new one.' };
+  }
+  const last = history[history.length - 1];
+  if (last.role !== 'user') {
+    return { ok: false, error: 'Last turn must be a question.' };
+  }
+  if (last.content.trim().length === 0) {
+    return { ok: false, error: 'Question is empty.' };
+  }
+  if (last.content.length > QA_USER_QUESTION_MAX) {
+    return { ok: false, error: `Question too long (max ${QA_USER_QUESTION_MAX} chars).` };
+  }
+
+  const filing = await getFilingById(filingId);
+  if (!filing) return { ok: false, error: 'Filing not found.' };
+
+  const score = await getLatestScore(filing.id);
+  const [latestPacket] = await db
+    .select({ status: evictionResponsePackets.status })
+    .from(evictionResponsePackets)
+    .where(eq(evictionResponsePackets.filingId, filing.id))
+    .orderBy(desc(evictionResponsePackets.createdAt))
+    .limit(1);
+  const [latestOutcome] = await db
+    .select({ id: evictionCaseOutcomes.id })
+    .from(evictionCaseOutcomes)
+    .where(eq(evictionCaseOutcomes.filingId, filing.id))
+    .limit(1);
+
+  const facts: CaseFacts = {
+    case_number: filing.caseNumber,
+    court_division: filing.courtDivision,
+    plaintiff: filing.plaintiff,
+    defendant_name: `${filing.defendantFirstName} ${filing.defendantLastName}`.trim(),
+    cause_type: filing.causeType,
+    amount_claimed_cents: filing.amountClaimedCents,
+    filed_at: filing.filedAt.toISOString().slice(0, 10),
+    status: filing.status,
+    risk_score: score?.score ?? null,
+    risk_rationale: score?.rationale ?? null,
+    risk_model_version: score?.modelVersion ?? null,
+    packet_status: latestPacket?.status ?? null,
+    outcome_recorded: Boolean(latestOutcome),
+  };
+
+  try {
+    const result = await answerCaseQuestion(facts, history);
+
+    await logAuditEvent({
+      actorUserId: user.id,
+      action: 'case_qa.answered',
+      targetTable: 'eviction_filings',
+      targetId: filing.id,
+      metadata: {
+        promptVersion: result.promptVersion,
+        turnCount: history.length,
+        questionLen: last.content.length,
+      },
+    });
+    await recordAiGeneration({
+      actorUserId: user.id,
+      resourceType: 'case_qa',
+      resourceId: filing.id,
+      model: result.modelId,
+      promptVersion: result.promptVersion,
+      metadata: { caseNumber: filing.caseNumber, turnCount: history.length },
+    });
+
+    return { ok: true, answer: result.answer, promptVersion: result.promptVersion };
+  } catch (err) {
+    Sentry.captureException(err, { tags: { action: 'askCaseQuestionAction', filingId } });
+    return { ok: false, error: 'Question answering failed. Please try again.' };
   }
 }
 

--- a/src/app/app/cases/filings/[id]/page.tsx
+++ b/src/app/app/cases/filings/[id]/page.tsx
@@ -2,6 +2,7 @@ import Link from 'next/link';
 import { notFound } from 'next/navigation';
 import { CaseFilingsRoles } from '@/components/eviction/case-filings-roles';
 import { CaseOutcomePanel } from '@/components/eviction/case-outcome-panel';
+import { CaseQAPanel } from '@/components/eviction/case-qa-panel';
 import { FilingDetail } from '@/components/eviction/filing-detail';
 import { OutreachLetterPanel } from '@/components/eviction/outreach-letter-panel';
 import { RentalAssistancePanel } from '@/components/eviction/rental-assistance-panel';
@@ -70,6 +71,7 @@ export default async function FilingDetailPage({ params }: { params: Promise<{ i
           Open packet workspace →
         </Link>
       </div>
+      {canRecord ? <CaseQAPanel filingId={filing.id} /> : null}
       {canRecord ? <OutreachLetterPanel filingId={filing.id} /> : null}
       <CaseOutcomePanel filingId={filing.id} history={outcomes} canRecord={canRecord} />
       <RentalAssistancePanel programs={assistancePrograms} />

--- a/src/components/eviction/case-qa-panel.tsx
+++ b/src/components/eviction/case-qa-panel.tsx
@@ -1,0 +1,156 @@
+'use client';
+
+import { useId, useRef, useState, useTransition } from 'react';
+import { askCaseQuestionAction } from '@/app/actions/eviction';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import type { CaseQATurn } from '@/lib/eviction/case-qa';
+
+type LocalTurn = CaseQATurn & { id: string };
+
+let turnCounter = 0;
+const nextTurnId = () => {
+  turnCounter += 1;
+  return `t${turnCounter}`;
+};
+
+const SUGGESTIONS = [
+  'What stands out about this case?',
+  "Where's the time pressure here?",
+  'What documents should I ask the tenant for?',
+];
+
+export function CaseQAPanel({ filingId }: { filingId: string }) {
+  const inputId = useId();
+  const [history, setHistory] = useState<LocalTurn[]>([]);
+  const [draft, setDraft] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [pending, startTransition] = useTransition();
+  const scrollRef = useRef<HTMLDivElement | null>(null);
+
+  const ask = (question: string) => {
+    const q = question.trim();
+    if (q.length === 0 || pending) return;
+    setError(null);
+    const userTurn: LocalTurn = { id: nextTurnId(), role: 'user', content: q };
+    const next = [...history, userTurn];
+    setHistory(next);
+    setDraft('');
+    const wireHistory: CaseQATurn[] = next.map((t) => ({ role: t.role, content: t.content }));
+    startTransition(async () => {
+      const r = await askCaseQuestionAction(filingId, wireHistory);
+      if (!r.ok) {
+        setError(r.error);
+        setHistory(history);
+        setDraft(q);
+        return;
+      }
+      const assistantTurn: LocalTurn = {
+        id: nextTurnId(),
+        role: 'assistant',
+        content: r.answer,
+      };
+      setHistory([...next, assistantTurn]);
+      requestAnimationFrame(() => {
+        scrollRef.current?.scrollTo({ top: scrollRef.current.scrollHeight, behavior: 'smooth' });
+      });
+    });
+  };
+
+  const onSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    ask(draft);
+  };
+
+  const onReset = () => {
+    setHistory([]);
+    setDraft('');
+    setError(null);
+  };
+
+  return (
+    <Card>
+      <CardHeader className="flex flex-row items-baseline justify-between gap-2">
+        <CardTitle className="text-base">Ask Claude about this case</CardTitle>
+        {history.length > 0 ? (
+          <Button onClick={onReset} variant="ghost" size="sm" disabled={pending}>
+            Clear
+          </Button>
+        ) : null}
+      </CardHeader>
+      <CardContent className="space-y-3 text-sm">
+        {history.length === 0 ? (
+          <>
+            <p className="text-muted-foreground">
+              Ask anything about this filing. Claude sees the case facts, risk score, and packet
+              state — nothing else. Not legal advice. Multi-turn within this session.
+            </p>
+            <div className="flex flex-wrap gap-2">
+              {SUGGESTIONS.map((s) => (
+                <Button
+                  key={s}
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  className="h-auto whitespace-normal py-1 text-xs"
+                  disabled={pending}
+                  onClick={() => ask(s)}
+                >
+                  {s}
+                </Button>
+              ))}
+            </div>
+          </>
+        ) : (
+          <div
+            ref={scrollRef}
+            className="max-h-[28rem] space-y-3 overflow-y-auto rounded-md border border-border bg-muted/20 p-3"
+          >
+            {history.map((t) => (
+              <div
+                key={t.id}
+                className={
+                  t.role === 'user'
+                    ? 'rounded-md bg-primary/10 p-2 text-sm'
+                    : 'rounded-md bg-card p-2 text-sm'
+                }
+              >
+                <div className="mb-1 text-[10px] uppercase tracking-wide text-muted-foreground">
+                  {t.role === 'user' ? 'You' : 'Claude'}
+                </div>
+                <p className="whitespace-pre-wrap leading-relaxed">{t.content}</p>
+              </div>
+            ))}
+            {pending ? (
+              <div className="rounded-md bg-card p-2 text-sm text-muted-foreground">
+                <div className="mb-1 text-[10px] uppercase tracking-wide">Claude</div>
+                <p className="italic">Thinking…</p>
+              </div>
+            ) : null}
+          </div>
+        )}
+
+        <form onSubmit={onSubmit} className="flex gap-2">
+          <label htmlFor={inputId} className="sr-only">
+            Ask a question about this case
+          </label>
+          <input
+            id={inputId}
+            type="text"
+            value={draft}
+            onChange={(e) => setDraft(e.target.value)}
+            placeholder="Ask a follow-up…"
+            disabled={pending}
+            maxLength={1500}
+            className="flex-1 rounded-md border border-input bg-background px-3 py-2 text-sm"
+          />
+          <Button type="submit" size="sm" disabled={pending || draft.trim().length === 0}>
+            {pending ? 'Asking…' : 'Ask'}
+          </Button>
+        </form>
+
+        {error ? <p className="text-xs text-destructive">{error}</p> : null}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/lib/eviction/case-qa.ts
+++ b/src/lib/eviction/case-qa.ts
@@ -1,0 +1,81 @@
+import Anthropic from '@anthropic-ai/sdk';
+import {
+  buildCaseFactsBlock,
+  CASE_QA_PROMPT_VERSION,
+  CASE_QA_SYSTEM_PROMPT,
+  type CaseFacts,
+} from '@/ai/prompts/case-qa';
+
+let _client: Anthropic | null = null;
+function client(): Anthropic {
+  if (!_client) _client = new Anthropic();
+  return _client;
+}
+
+const MODEL_ID = 'claude-sonnet-4-6';
+const MAX_OUTPUT_TOKENS = 700;
+
+/** Single conversation turn. The history we send to Claude is a
+ * sequence of these, in chronological order, ending with the user's
+ * latest question.
+ */
+export type CaseQATurn = {
+  role: 'user' | 'assistant';
+  content: string;
+};
+
+export type CaseQAResult = {
+  answer: string;
+  modelId: string;
+  promptVersion: string;
+};
+
+/**
+ * Send the conversation history (with the new user question at the
+ * end) to Claude along with the case facts and return the next
+ * assistant turn. Caller is responsible for capping/cleaning the
+ * history before invoking — we only enforce a hard ceiling here.
+ */
+const HISTORY_HARD_CAP = 30;
+
+export async function answerCaseQuestion(
+  facts: CaseFacts,
+  history: CaseQATurn[],
+): Promise<CaseQAResult> {
+  if (history.length === 0) {
+    throw new Error('[case-qa] history must contain at least the user question');
+  }
+  if (history[history.length - 1].role !== 'user') {
+    throw new Error('[case-qa] last history turn must be the user question');
+  }
+  const trimmed = history.slice(-HISTORY_HARD_CAP);
+
+  const factsBlock = buildCaseFactsBlock(facts);
+
+  const response = await client().messages.create({
+    model: MODEL_ID,
+    max_tokens: MAX_OUTPUT_TOKENS,
+    system: [
+      {
+        type: 'text',
+        text: CASE_QA_SYSTEM_PROMPT,
+        cache_control: { type: 'ephemeral' },
+      },
+      {
+        type: 'text',
+        text: factsBlock,
+        cache_control: { type: 'ephemeral' },
+      },
+    ],
+    messages: trimmed.map((t) => ({ role: t.role, content: t.content })),
+  });
+
+  const answer = response.content
+    .flatMap((c) => (c.type === 'text' ? [c.text] : []))
+    .join('\n')
+    .trim();
+  if (!answer) {
+    throw new Error(`[case-qa] empty response; stop_reason=${response.stop_reason}`);
+  }
+  return { answer, modelId: MODEL_ID, promptVersion: CASE_QA_PROMPT_VERSION };
+}


### PR DESCRIPTION
## Summary
- Multi-turn Q&A panel on the filing detail page (KLA attorneys only). Free-form input → Claude answers from the structured case facts, risk-score rationale, and packet state — and tells the attorney explicitly when the question needs the lease/ledger/something else not in the filing
- Suggested questions for empty state: "What stands out about this case?" / "Where's the time pressure here?" / "What documents should I ask the tenant for?"
- Conversation lives in session state only; no DB persistence (Q&A is conversational, not a record)
- Server caps at 30 turns and 1500 chars per question
- System prompt + facts block both cached (\`cache_control: ephemeral\`) so multi-turn calls reuse the static blocks
- Audited via \`logAuditEvent\` + \`recordAiGeneration\`

## Test plan
- [ ] Open a filing as KLA attorney, click a suggestion pill → response appears
- [ ] Ask a follow-up that requires info not in the filing (e.g. "what does the lease say about late fees?") → Claude says "the filing doesn't include the lease"
- [ ] Ask a strategy question ("should I take this case?") → reframed as "here's what stands out, your judgment on strategy"
- [ ] Clear button resets the conversation
- [ ] Non-KLA-attorneys don't see the panel
- [ ] Audit log shows \`case_qa.answered\` + \`ai.generated\` rows