### PR TITLE
feat(EVDT/CWT): refer filing to caseworker queue

### DIFF
--- a/src/app/actions/eviction.ts
+++ b/src/app/actions/eviction.ts
@@ -8,6 +8,7 @@ import { CaseFilingsRoles } from '@/components/eviction/case-filings-roles';
 import { db } from '@/db/client';
 import { listTriageCandidates } from '@/db/queries/attorney-triage';
 import { getFilingById } from '@/db/queries/eviction-filings';
+import { clientIntakes } from '@/db/schema/client-intakes';
 import {
   type EvictionCaseOutcome,
   type EvictionResponsePacketStatus,
@@ -219,6 +220,98 @@ export async function generateOutreachLetterAction(
   } catch (err) {
     Sentry.captureException(err, { tags: { action: 'generateOutreachLetterAction', filingId } });
     return { ok: false, error: 'Letter generation failed. Please try again.' };
+  }
+}
+
+export type ReferToCaseworkerResult =
+  | { ok: true; intakeId: string; alreadyExisted: boolean }
+  | { ok: false; error: string };
+
+const fmtMoneyForReferral = (cents: number | null): string => {
+  if (cents == null) return 'an unspecified amount';
+  return new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' }).format(cents / 100);
+};
+
+const causeNarrative: Record<string, string> = {
+  non_payment: 'non-payment of rent',
+  lease_violation: 'a lease violation',
+  holdover: 'holdover (lease ended, tenant remained)',
+  other: 'an unspecified cause',
+};
+
+/**
+ * KLA attorney sees a filing they can't fully serve alone (benefits
+ * gap, care plan, shelter risk) and refers the defendant to the
+ * caseworker queue. We spawn a `client_intakes` row with a templated
+ * narrative the caseworker reads before meeting the client. The
+ * caseworker can edit the transcript and run the existing extraction
+ * pipeline; the intake then flows through the regular chain
+ * (extraction → screener → person view).
+ *
+ * Idempotent: if a referral intake already exists for this filing
+ * (label suffix `· EVDT-REF · {filing.id}`), we return its id rather
+ * than creating a duplicate.
+ */
+export async function referFilingToCaseworkerAction(
+  filingId: string,
+): Promise<ReferToCaseworkerResult> {
+  const user = await requireKlaAttorney();
+  const filing = await getFilingById(filingId);
+  if (!filing) return { ok: false, error: 'Filing not found.' };
+
+  const refTag = `EVDT-REF:${filing.id}`;
+
+  const [existing] = await db
+    .select({ id: clientIntakes.id })
+    .from(clientIntakes)
+    .where(eq(clientIntakes.label, refTag))
+    .limit(1);
+  if (existing) {
+    return { ok: true, intakeId: existing.id, alreadyExisted: true };
+  }
+
+  const filedDate = filing.filedAt.toISOString().slice(0, 10);
+  const cause = causeNarrative[filing.causeType] ?? 'an unspecified cause';
+  const amount = fmtMoneyForReferral(filing.amountClaimedCents);
+
+  const narrative = [
+    'Referral from Kentucky Legal Aid (KLA — Owensboro Office).',
+    '',
+    `${filing.defendantFirstName} was named in eviction case ${filing.caseNumber}, filed ${filedDate} by ${filing.plaintiff}. The cause is ${cause} and the amount claimed is ${amount}. The case is currently in "${filing.status}" status.`,
+    '',
+    "We're referring this person here for benefits screening, possible care planning, and any other support the coalition can offer. KLA may take the legal side of this case independently.",
+    '',
+    "We have not yet contacted the tenant directly. When you meet them, please bring up the eviction proactively — many tenants don't realize free legal help is available. Run the benefits screener; SNAP and KCHIP are likely worth checking given the financial stress of an active filing. If they're paying any rent at all today, encourage them to keep receipts.",
+    '',
+    `(Edit this transcript with what the client tells you, then run extraction. Or replace it entirely with a fresh intake recording — your call.)`,
+  ].join('\n');
+
+  try {
+    const [created] = await db
+      .insert(clientIntakes)
+      .values({
+        label: refTag,
+        transcriptMd: narrative,
+        recordedByUserId: user.id,
+        status: 'transcribed',
+      })
+      .returning({ id: clientIntakes.id });
+
+    await logAuditEvent({
+      actorUserId: user.id,
+      action: 'eviction.referred_to_caseworker',
+      targetTable: 'eviction_filings',
+      targetId: filing.id,
+      metadata: {
+        intakeId: created.id,
+        caseNumber: filing.caseNumber,
+      },
+    });
+
+    return { ok: true, intakeId: created.id, alreadyExisted: false };
+  } catch (err) {
+    Sentry.captureException(err, { tags: { action: 'referFilingToCaseworkerAction', filingId } });
+    return { ok: false, error: 'Referral failed. Please try again.' };
   }
 }
 

--- a/src/app/app/cases/filings/[id]/page.tsx
+++ b/src/app/app/cases/filings/[id]/page.tsx
@@ -5,6 +5,7 @@ import { CaseOutcomePanel } from '@/components/eviction/case-outcome-panel';
 import { CaseQAPanel } from '@/components/eviction/case-qa-panel';
 import { FilingDetail } from '@/components/eviction/filing-detail';
 import { OutreachLetterPanel } from '@/components/eviction/outreach-letter-panel';
+import { ReferToCaseworkerPanel } from '@/components/eviction/refer-to-caseworker-panel';
 import { RentalAssistancePanel } from '@/components/eviction/rental-assistance-panel';
 import { listCaseOutcomes } from '@/db/queries/eviction-case-outcomes';
 import { getFilingByIdForViewer } from '@/db/queries/eviction-filings';
@@ -73,6 +74,7 @@ export default async function FilingDetailPage({ params }: { params: Promise<{ i
       </div>
       {canRecord ? <CaseQAPanel filingId={filing.id} /> : null}
       {canRecord ? <OutreachLetterPanel filingId={filing.id} /> : null}
+      {canRecord ? <ReferToCaseworkerPanel filingId={filing.id} /> : null}
       <CaseOutcomePanel filingId={filing.id} history={outcomes} canRecord={canRecord} />
       <RentalAssistancePanel programs={assistancePrograms} />
     </div>

--- a/src/components/eviction/refer-to-caseworker-panel.tsx
+++ b/src/components/eviction/refer-to-caseworker-panel.tsx
@@ -1,0 +1,44 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { useState, useTransition } from 'react';
+import { referFilingToCaseworkerAction } from '@/app/actions/eviction';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent } from '@/components/ui/card';
+
+export function ReferToCaseworkerPanel({ filingId }: { filingId: string }) {
+  const router = useRouter();
+  const [pending, startTransition] = useTransition();
+  const [error, setError] = useState<string | null>(null);
+
+  const onClick = () => {
+    setError(null);
+    startTransition(async () => {
+      const r = await referFilingToCaseworkerAction(filingId);
+      if (!r.ok) {
+        setError(r.error);
+        return;
+      }
+      router.push(`/app/clients/intakes/${r.intakeId}`);
+    });
+  };
+
+  return (
+    <Card className="border-primary/40 bg-primary/5">
+      <CardContent className="flex flex-wrap items-center justify-between gap-3 text-sm">
+        <div>
+          <p className="font-medium">Refer this tenant to the caseworker queue</p>
+          <p className="mt-1 text-xs text-muted-foreground">
+            Drops a pre-filled intake into the queue with a templated referral note. KLA still
+            handles the legal side; the caseworker picks up benefits, care plan, shelter risk, and
+            anything else the coalition can offer.
+          </p>
+          {error ? <p className="mt-1 text-xs text-destructive">{error}</p> : null}
+        </div>
+        <Button onClick={onClick} disabled={pending} size="sm" className="shrink-0">
+          {pending ? 'Referring…' : 'Refer to caseworker →'}
+        </Button>
+      </CardContent>
+    </Card>
+  );
+}


### PR DESCRIPTION
## Summary
- "Refer to caseworker →" button on the filing detail page (KLA-only). One click spawns a pre-filled \`client_intakes\` row with a templated referral narrative; redirects the attorney to the new intake's detail page so the caseworker can pick it up
- Idempotent: re-clicks return the existing intake (label = \`EVDT-REF:{filing.id}\`) instead of creating duplicates
- The narrative gives the caseworker context (case #, plaintiff, cause type, amount) plus operating instructions ("bring up proactively", "run the benefits screener; SNAP and KCHIP likely worth checking"). Caseworker edits the transcript with what they learn from the client and runs extraction normally
- Audited as \`eviction.referred_to_caseworker\`

This bridges the two halves of the platform — EVDT cases now have a one-click path into the caseworker chain (extraction → benefits screener → person view).

## Test plan
- [ ] Open a filing as a KLA attorney → click "Refer to caseworker" → verify redirect to a new intake with the templated narrative pre-populated
- [ ] Click the button again → verify it surfaces the same intake (no duplicate)
- [ ] As a caseworker, open the spawned intake → run extraction → confirm the resulting profile reflects what's in the narrative
- [ ] Non-KLA-attorney users don't see the panel