### PR TITLE
feat(CWT): AI-drafted follow-up SMS on person view

### DIFF
--- a/src/ai/prompts/followup-sms.ts
+++ b/src/ai/prompts/followup-sms.ts
@@ -1,0 +1,115 @@
+/**
+ * Follow-up SMS draft prompt.
+ *
+ * Caseworker is on the unified person view, just read the
+ * pre-meeting briefing, and wants to send the client a short SMS
+ * (reminder, check-in, doc nudge). The AI sees the same coalition
+ * activity the briefing sees plus a free-text "purpose" the
+ * caseworker types ("remind about Friday 2pm, bring SNAP recert").
+ * Output: 1-2 sentences, signed with the caseworker's first name
+ * and partner-org abbreviation as a placeholder.
+ *
+ * The caseworker edits before sending. The platform doesn't send
+ * the SMS itself today — the caseworker pastes into Twilio/Front/
+ * Google Voice/whatever they actually use.
+ */
+
+import type { PersonProfileDelta } from '@/db/queries/person-profile';
+
+export const FOLLOWUP_SMS_PROMPT_VERSION = 'followup-sms-v1@2026-04-26';
+
+export const FOLLOWUP_SMS_SYSTEM_PROMPT = `You draft short SMS messages for a caseworker to send to a client
+they're working with on housing-related services in Daviess County,
+Kentucky. The caseworker tells you the purpose of the message in
+their own words; you draft from that plus the recent coalition
+activity they've shown you.
+
+Voice and constraints:
+- Friendly but not overfamiliar. The caseworker and client likely
+  know each other but aren't friends. No "Hey friend!", no emoji
+  unless the purpose explicitly asks for one.
+- Plain English, 6th-grade reading level. Short sentences.
+- 1-2 sentences total. Hard cap: 320 characters (so it fits in a
+  2-segment SMS for safety; many carriers split at 153 chars but a
+  2-segment message reads fine).
+- Sign with the placeholder \`— [name]\`. The caseworker fills in
+  their first name before sending.
+- If the purpose mentions a specific time/day, include it verbatim.
+  Don't paraphrase "Friday" to "the end of the week".
+
+Hard rules:
+1. NEVER invent facts the caseworker didn't tell you. If they said
+   "remind about Friday", don't decide a time. If they said
+   "remind about the meeting", don't decide a day.
+2. Don't reference the synthetic_person_ref or any platform jargon
+   (no "your case", "your file", "the system"). The client is a
+   person, not a row.
+3. Don't promise outcomes ("we'll get you SNAP", "you'll be fine").
+   Soft language: "we'll work through it", "let's talk about it".
+4. If the purpose is a check-in with no specific ask, the message
+   should be open: "Just checking in — let me know how things are
+   going."
+5. If the purpose mentions DV, safety, or a sensitive topic, default
+   to vague language. Don't put specifics in an SMS — those can be
+   read by anyone in the household.
+
+Output: ONLY the SMS body. No preamble like "Here's a draft:". No
+quotes around the text. Just the message the caseworker will edit
+and send.`;
+
+export type FollowupSmsInputs = {
+  syntheticPersonRef: string;
+  purpose: string;
+  delta: PersonProfileDelta;
+};
+
+export function buildFollowupSmsUserPrompt(inputs: FollowupSmsInputs): string {
+  const lines: string[] = [
+    `Caseworker's purpose: ${inputs.purpose}`,
+    '',
+    `Synthetic person ref: ${inputs.syntheticPersonRef}`,
+    `Lookback window: since ${inputs.delta.since.toISOString().slice(0, 10)}`,
+    '',
+  ];
+
+  if (inputs.delta.serviceEvents.length > 0) {
+    lines.push('## Recent service events');
+    for (const e of inputs.delta.serviceEvents) {
+      const at = new Date(e.eventAt).toISOString().slice(0, 10);
+      const noteFrag = e.notes ? ` — ${e.notes}` : '';
+      lines.push(`- ${at} · ${e.partnerOrgName} · ${e.eventType}${noteFrag}`);
+    }
+    lines.push('');
+  }
+
+  if (inputs.delta.newIntakes.length > 0) {
+    lines.push('## Recent intakes');
+    for (const i of inputs.delta.newIntakes) {
+      const at = new Date(i.createdAt).toISOString().slice(0, 10);
+      const profile = i.extractedProfile as Record<string, unknown> | null;
+      const presenting =
+        profile && typeof profile.presenting_issue === 'string' ? profile.presenting_issue : null;
+      const topNeeds =
+        profile && Array.isArray(profile.top_needs) ? profile.top_needs.join(', ') : null;
+      lines.push(
+        `- ${at} · ${i.label}${presenting ? ` · ${presenting}` : ''}${
+          topNeeds ? ` · top needs: ${topNeeds}` : ''
+        }`,
+      );
+    }
+    lines.push('');
+  }
+
+  if (
+    inputs.delta.serviceEvents.length === 0 &&
+    inputs.delta.newIntakes.length === 0 &&
+    inputs.delta.newConsentGrants.length === 0 &&
+    inputs.delta.newConsentRevocations.length === 0
+  ) {
+    lines.push('## No recent activity in the lookback window.');
+    lines.push('');
+  }
+
+  lines.push('Draft the SMS now.');
+  return lines.join('\n');
+}

--- a/src/app/actions/followup-sms.ts
+++ b/src/app/actions/followup-sms.ts
@@ -1,0 +1,80 @@
+'use server';
+
+import * as Sentry from '@sentry/nextjs';
+import { getPersonProfileDelta } from '@/db/queries/person-profile';
+import { logAuditEvent } from '@/lib/audit';
+import { requireRole } from '@/lib/auth';
+import { generateFollowupSms } from '@/lib/cwt/followup-sms';
+import { recordAiGeneration } from '@/lib/dtrs/data-access';
+import { isValidSyntheticPersonRef } from '@/lib/synthetic-person';
+
+export type FollowupSmsResult =
+  | { ok: true; text: string; promptVersion: string }
+  | { ok: false; error: string };
+
+const ROLES = ['caseworker', 'shelter_staff', 'ed_coordinator', 'admin'] as const;
+
+const PURPOSE_MIN = 4;
+const PURPOSE_MAX = 500;
+const DAYS_BACK = 30;
+
+export async function generateFollowupSmsAction(
+  syntheticPersonRef: string,
+  purpose: string,
+): Promise<FollowupSmsResult> {
+  const actor = await requireRole(ROLES);
+
+  if (!isValidSyntheticPersonRef(syntheticPersonRef)) {
+    return { ok: false, error: 'Invalid synthetic-person reference.' };
+  }
+  const trimmed = purpose.trim();
+  if (trimmed.length < PURPOSE_MIN) {
+    return {
+      ok: false,
+      error: `Tell Claude what the message is about (min ${PURPOSE_MIN} chars).`,
+    };
+  }
+  if (trimmed.length > PURPOSE_MAX) {
+    return { ok: false, error: `Purpose too long (max ${PURPOSE_MAX} chars).` };
+  }
+
+  const since = new Date();
+  since.setDate(since.getDate() - DAYS_BACK);
+
+  try {
+    const delta = await getPersonProfileDelta(syntheticPersonRef, since);
+    const result = await generateFollowupSms({
+      syntheticPersonRef,
+      purpose: trimmed,
+      delta,
+    });
+
+    await logAuditEvent({
+      actorUserId: actor.id,
+      action: 'followup_sms.drafted',
+      targetTable: 'partner_service_events',
+      targetId: syntheticPersonRef,
+      metadata: {
+        promptVersion: result.promptVersion,
+        purposeChars: trimmed.length,
+        outputChars: result.text.length,
+        eventCount: delta.serviceEvents.length,
+      },
+    });
+    await recordAiGeneration({
+      actorUserId: actor.id,
+      resourceType: 'followup_sms',
+      resourceId: syntheticPersonRef,
+      model: result.modelId,
+      promptVersion: result.promptVersion,
+      metadata: { purposeChars: trimmed.length },
+    });
+
+    return { ok: true, text: result.text, promptVersion: result.promptVersion };
+  } catch (err) {
+    Sentry.captureException(err, {
+      tags: { action: 'generateFollowupSmsAction', ref: syntheticPersonRef },
+    });
+    return { ok: false, error: 'SMS draft generation failed. Try again in a moment.' };
+  }
+}

--- a/src/app/app/clients/person/[ref]/page.tsx
+++ b/src/app/app/clients/person/[ref]/page.tsx
@@ -1,5 +1,6 @@
 import Link from 'next/link';
 import { notFound } from 'next/navigation';
+import { FollowupSmsPanel } from '@/components/cwt/followup-sms-panel';
 import { PreMeetingSummary } from '@/components/cwt/pre-meeting-summary';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { getPersonProfile } from '@/db/queries/person-profile';
@@ -85,6 +86,15 @@ export default async function PersonProfilePage({ params }: { params: Promise<{ 
         </CardHeader>
         <CardContent>
           <PreMeetingSummary syntheticPersonRef={ref} />
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">Draft a follow-up SMS</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <FollowupSmsPanel syntheticPersonRef={ref} />
         </CardContent>
       </Card>
 

--- a/src/components/cwt/followup-sms-panel.tsx
+++ b/src/components/cwt/followup-sms-panel.tsx
@@ -1,0 +1,130 @@
+'use client';
+
+import { useId, useState, useTransition } from 'react';
+import { generateFollowupSmsAction } from '@/app/actions/followup-sms';
+import { Button } from '@/components/ui/button';
+
+const PRESET_PURPOSES = [
+  { label: 'Appointment reminder', value: 'Remind them about their upcoming appointment.' },
+  { label: 'Check-in', value: "Just checking in — no specific ask, see how they're doing." },
+  {
+    label: 'Doc reminder',
+    value: 'Remind them to bring the documents we discussed at the last meeting.',
+  },
+];
+
+const SMS_SOFT_LIMIT = 320;
+
+export function FollowupSmsPanel({ syntheticPersonRef }: { syntheticPersonRef: string }) {
+  const purposeId = useId();
+  const draftId = useId();
+  const [purpose, setPurpose] = useState('');
+  const [draft, setDraft] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [copied, setCopied] = useState(false);
+  const [pending, startTransition] = useTransition();
+
+  const onGenerate = (purposeOverride?: string) => {
+    const effective = (purposeOverride ?? purpose).trim();
+    if (effective.length === 0) {
+      setError('Tell Claude what the message is about.');
+      return;
+    }
+    if (purposeOverride !== undefined) setPurpose(effective);
+    setError(null);
+    setCopied(false);
+    startTransition(async () => {
+      const r = await generateFollowupSmsAction(syntheticPersonRef, effective);
+      if (!r.ok) {
+        setError(r.error);
+        return;
+      }
+      setDraft(r.text);
+    });
+  };
+
+  const onCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(draft);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      setError('Copy failed — select the text manually.');
+    }
+  };
+
+  return (
+    <div className="space-y-3 text-sm">
+      <p className="text-muted-foreground">
+        Type what the message should be about. Claude drafts a 1-2 sentence SMS using the same
+        coalition activity the briefing sees. You edit it, paste into your real SMS tool, send.
+      </p>
+
+      <div className="flex flex-wrap gap-2">
+        {PRESET_PURPOSES.map((p) => (
+          <Button
+            key={p.label}
+            type="button"
+            variant="outline"
+            size="sm"
+            disabled={pending}
+            onClick={() => onGenerate(p.value)}
+          >
+            {p.label}
+          </Button>
+        ))}
+      </div>
+
+      <div className="space-y-1">
+        <label htmlFor={purposeId} className="text-xs font-medium">
+          Or describe the purpose in your own words
+        </label>
+        <input
+          id={purposeId}
+          type="text"
+          value={purpose}
+          onChange={(e) => setPurpose(e.target.value)}
+          placeholder='e.g. "Remind about Friday 2pm, bring SNAP recert papers"'
+          maxLength={500}
+          disabled={pending}
+          className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
+        />
+      </div>
+
+      <div className="flex items-center gap-3">
+        <Button onClick={() => onGenerate()} disabled={pending} size="sm">
+          {pending ? 'Drafting…' : draft ? 'Re-draft' : 'Draft SMS'}
+        </Button>
+        {error ? <span className="text-xs text-destructive">{error}</span> : null}
+      </div>
+
+      {draft ? (
+        <div className="space-y-2 rounded-md border border-border bg-muted/20 p-3">
+          <label htmlFor={draftId} className="text-xs font-medium">
+            Draft (edit before sending)
+          </label>
+          <textarea
+            id={draftId}
+            value={draft}
+            onChange={(e) => setDraft(e.target.value)}
+            rows={4}
+            className="w-full rounded-md border border-input bg-background p-2 text-sm leading-relaxed"
+          />
+          <div className="flex flex-wrap items-center gap-3 text-xs text-muted-foreground">
+            <Button type="button" size="sm" variant="outline" onClick={onCopy}>
+              {copied ? 'Copied ✓' : 'Copy to clipboard'}
+            </Button>
+            <span>
+              {draft.length} chars{' '}
+              {draft.length > SMS_SOFT_LIMIT ? (
+                <span className="text-amber-600 dark:text-amber-400">
+                  · over {SMS_SOFT_LIMIT}-char soft limit
+                </span>
+              ) : null}
+            </span>
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/src/lib/cwt/followup-sms.ts
+++ b/src/lib/cwt/followup-sms.ts
@@ -1,0 +1,46 @@
+import Anthropic from '@anthropic-ai/sdk';
+import {
+  buildFollowupSmsUserPrompt,
+  FOLLOWUP_SMS_PROMPT_VERSION,
+  FOLLOWUP_SMS_SYSTEM_PROMPT,
+  type FollowupSmsInputs,
+} from '@/ai/prompts/followup-sms';
+
+let _client: Anthropic | null = null;
+function client(): Anthropic {
+  if (!_client) _client = new Anthropic();
+  return _client;
+}
+
+const MODEL_ID = 'claude-sonnet-4-6';
+const MAX_OUTPUT_TOKENS = 200;
+
+export type FollowupSmsResult = {
+  text: string;
+  modelId: string;
+  promptVersion: string;
+};
+
+export async function generateFollowupSms(inputs: FollowupSmsInputs): Promise<FollowupSmsResult> {
+  const response = await client().messages.create({
+    model: MODEL_ID,
+    max_tokens: MAX_OUTPUT_TOKENS,
+    system: [
+      {
+        type: 'text',
+        text: FOLLOWUP_SMS_SYSTEM_PROMPT,
+        cache_control: { type: 'ephemeral' },
+      },
+    ],
+    messages: [{ role: 'user', content: buildFollowupSmsUserPrompt(inputs) }],
+  });
+
+  const text = response.content
+    .flatMap((c) => (c.type === 'text' ? [c.text] : []))
+    .join('\n')
+    .trim();
+  if (!text) {
+    throw new Error(`[followup-sms] empty response; stop_reason=${response.stop_reason}`);
+  }
+  return { text, modelId: MODEL_ID, promptVersion: FOLLOWUP_SMS_PROMPT_VERSION };
+}


### PR DESCRIPTION
## Summary
- Companion to the pre-meeting briefing on the person view: caseworker types a purpose ("remind about Friday 2pm, bring SNAP recert") or clicks a preset (Appointment reminder / Check-in / Doc reminder), Claude drafts a 1-2 sentence SMS
- Same role gate and lookback (30 days) as the briefing; uses \`PersonProfileDelta\` so recent service events + intakes inform the draft
- System prompt baked in: friendly-not-overfamiliar voice, no emoji, soft language ("we'll work through it" not "we'll get you SNAP"), DV/safety stays vague, sign-off uses \`— [name]\` placeholder
- Editable textarea + char counter (320-char soft limit warning) + copy-to-clipboard. Platform doesn't send the SMS — caseworker pastes into their real tool

## Test plan
- [ ] Open a person view with recent activity → click "Appointment reminder" → verify a 1-2 sentence SMS draft appears
- [ ] Type a custom purpose, click "Draft SMS" → verify content reflects the purpose
- [ ] Edit the draft → char counter updates, soft-limit warning appears past 320
- [ ] "Copy to clipboard" works
- [ ] Audit log shows \`followup_sms.drafted\` + \`ai.generated\`