### PR TITLE
feat(CWT): "Ask Claude about this person" Q&A

### DIFF
--- a/src/ai/prompts/person-qa.ts
+++ b/src/ai/prompts/person-qa.ts
@@ -1,0 +1,120 @@
+/**
+ * Person-view Q&A prompt.
+ *
+ * Caseworker is on the unified person view — they can see the
+ * pre-meeting briefing, recent service events, consents, intakes,
+ * documents — and asks Claude follow-up questions: "what's the
+ * pattern with St. Benedict's?", "is this person engaged with
+ * mental health care?", "should I be worried about anything?".
+ * Claude answers from the structured profile only and is upfront
+ * when the answer isn't in the data.
+ */
+
+import type { PersonProfile } from '@/db/queries/person-profile';
+
+export const PERSON_QA_PROMPT_VERSION = 'person-qa-v1@2026-04-26';
+
+export const PERSON_QA_SYSTEM_PROMPT = `You are a case-coordination assistant for a caseworker working
+inside a Daviess County, Kentucky homelessness coalition. The
+caseworker is looking at one specific person's unified profile
+across coalition partners and asking you questions about it.
+
+Voice and constraints:
+- Caseworker-to-caseworker tone. Direct, no filler, no "great
+  question". No emoji.
+- 1-3 short paragraphs. The caseworker is reading between meetings.
+- Be honest about what you don't know. The data here is partial —
+  many partners aren't in the data trust yet, and some events
+  predate the platform. If the question would need real
+  conversation history, eviction data, or ED encounters, say so.
+- Never invent facts. If the user asks "have they been to the
+  shelter this week?" and the answer isn't in the events, say "I
+  don't see a shelter event in the lookback."
+- This is NOT clinical advice. If asked things like "do they need
+  inpatient psychiatric care", reframe: "Based on what's in the
+  record, here's what I'd flag — your judgment on next steps."
+- Don't repeat the synthetic_person_ref. The caseworker knows who
+  they're asking about.
+
+Scope of what you have access to:
+- Cross-partner service events (date, partner, event type, notes)
+- Partner consents (granted / revoked, by partner)
+- Voice intake history (label, date, presenting issue, urgency,
+  flags from extraction, top needs)
+- Documents on file (label, kind, status)
+
+You do NOT have access to:
+- Eviction filings (different identifier; not joined yet)
+- ED encounters or care plans (different identifier)
+- The actual content of intake transcripts (only the extracted
+  fields above)
+- Anything outside the coalition data trust (private partner
+  systems, the client's own phone, etc.)
+
+Output: plain text. No markdown headers. Inline lists are fine.`;
+
+export function buildPersonProfileBlock(profile: PersonProfile): string {
+  const lines: string[] = [`Synthetic person ref: ${profile.syntheticPersonRef}`, ''];
+
+  if (profile.serviceEvents.length > 0) {
+    lines.push(`## Service events (${profile.serviceEvents.length})`);
+    for (const e of profile.serviceEvents) {
+      const at = new Date(e.eventAt).toISOString().slice(0, 10);
+      const noteFrag = e.notes ? ` — ${e.notes}` : '';
+      lines.push(`- ${at} · ${e.partnerOrgName} · ${e.eventType}${noteFrag}`);
+    }
+    lines.push('');
+  } else {
+    lines.push('## Service events: (none recorded)');
+    lines.push('');
+  }
+
+  if (profile.consents.length > 0) {
+    lines.push(`## Consents (${profile.consents.length})`);
+    for (const c of profile.consents) {
+      const granted = new Date(c.grantedAt).toISOString().slice(0, 10);
+      const revoked = c.revokedAt ? new Date(c.revokedAt).toISOString().slice(0, 10) : null;
+      lines.push(
+        `- ${c.partnerOrgName} · granted ${granted}${revoked ? ` · revoked ${revoked}` : ' · active'}`,
+      );
+    }
+    lines.push('');
+  }
+
+  if (profile.intakes.length > 0) {
+    lines.push(`## Voice intakes (${profile.intakes.length})`);
+    for (const i of profile.intakes) {
+      const at = new Date(i.createdAt).toISOString().slice(0, 10);
+      const p = i.extractedProfile as Record<string, unknown> | null;
+      const presenting = p && typeof p.presenting_issue === 'string' ? p.presenting_issue : null;
+      const urgency = p && typeof p.urgency === 'string' ? p.urgency : null;
+      const flags =
+        p && p.flags && typeof p.flags === 'object'
+          ? Object.entries(p.flags as Record<string, boolean>)
+              .filter(([, v]) => v === true)
+              .map(([k]) => k)
+              .join(', ')
+          : '';
+      const topNeeds = p && Array.isArray(p.top_needs) ? (p.top_needs as string[]).join(', ') : '';
+      lines.push(
+        `- ${at} · "${i.label}" · status=${i.status}` +
+          (presenting ? ` · presenting: ${presenting}` : '') +
+          (urgency ? ` · urgency=${urgency}` : '') +
+          (flags ? ` · flags: ${flags}` : '') +
+          (topNeeds ? ` · needs: ${topNeeds}` : ''),
+      );
+    }
+    lines.push('');
+  }
+
+  if (profile.documents.length > 0) {
+    lines.push(`## Documents (${profile.documents.length})`);
+    for (const d of profile.documents) {
+      const at = new Date(d.createdAt).toISOString().slice(0, 10);
+      lines.push(`- ${at} · ${d.kind} · "${d.label}" · status=${d.status}`);
+    }
+    lines.push('');
+  }
+
+  return lines.join('\n');
+}

--- a/src/app/actions/person-qa.ts
+++ b/src/app/actions/person-qa.ts
@@ -1,0 +1,78 @@
+'use server';
+
+import * as Sentry from '@sentry/nextjs';
+import { getPersonProfile } from '@/db/queries/person-profile';
+import { logAuditEvent } from '@/lib/audit';
+import { requireRole } from '@/lib/auth';
+import { answerPersonQuestion, type PersonQATurn } from '@/lib/cwt/person-qa';
+import { recordAiGeneration } from '@/lib/dtrs/data-access';
+import { isValidSyntheticPersonRef } from '@/lib/synthetic-person';
+
+export type AskPersonQuestionResult =
+  | { ok: true; answer: string; promptVersion: string }
+  | { ok: false; error: string };
+
+const ROLES = ['caseworker', 'shelter_staff', 'ed_coordinator', 'admin'] as const;
+
+const QUESTION_MAX = 1500;
+const HISTORY_MAX_TURNS = 30;
+
+export async function askPersonQuestionAction(
+  syntheticPersonRef: string,
+  history: PersonQATurn[],
+): Promise<AskPersonQuestionResult> {
+  const actor = await requireRole(ROLES);
+
+  if (!isValidSyntheticPersonRef(syntheticPersonRef)) {
+    return { ok: false, error: 'Invalid synthetic-person reference.' };
+  }
+  if (!Array.isArray(history) || history.length === 0) {
+    return { ok: false, error: 'Question is required.' };
+  }
+  if (history.length > HISTORY_MAX_TURNS) {
+    return { ok: false, error: 'Conversation too long — start a new one.' };
+  }
+  const last = history[history.length - 1];
+  if (last.role !== 'user') {
+    return { ok: false, error: 'Last turn must be a question.' };
+  }
+  const q = last.content.trim();
+  if (q.length === 0) return { ok: false, error: 'Question is empty.' };
+  if (q.length > QUESTION_MAX) {
+    return { ok: false, error: `Question too long (max ${QUESTION_MAX} chars).` };
+  }
+
+  try {
+    const profile = await getPersonProfile(syntheticPersonRef);
+    const result = await answerPersonQuestion(profile, history);
+
+    await logAuditEvent({
+      actorUserId: actor.id,
+      action: 'person_qa.answered',
+      targetTable: 'partner_service_events',
+      targetId: syntheticPersonRef,
+      metadata: {
+        promptVersion: result.promptVersion,
+        turnCount: history.length,
+        questionLen: q.length,
+        eventCount: profile.serviceEvents.length,
+        intakeCount: profile.intakes.length,
+      },
+    });
+    await recordAiGeneration({
+      actorUserId: actor.id,
+      resourceType: 'person_qa',
+      resourceId: syntheticPersonRef,
+      model: result.modelId,
+      promptVersion: result.promptVersion,
+      metadata: { turnCount: history.length },
+    });
+
+    return { ok: true, answer: result.answer, promptVersion: result.promptVersion };
+  } catch (err) {
+    Sentry.captureException(err, {
+      tags: { action: 'askPersonQuestionAction', ref: syntheticPersonRef },
+    });
+    return { ok: false, error: 'Question answering failed. Try again in a moment.' };
+  }
+}

--- a/src/app/app/clients/person/[ref]/page.tsx
+++ b/src/app/app/clients/person/[ref]/page.tsx
@@ -1,6 +1,7 @@
 import Link from 'next/link';
 import { notFound } from 'next/navigation';
 import { FollowupSmsPanel } from '@/components/cwt/followup-sms-panel';
+import { PersonQAPanel } from '@/components/cwt/person-qa-panel';
 import { PreMeetingSummary } from '@/components/cwt/pre-meeting-summary';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { getPersonProfile } from '@/db/queries/person-profile';
@@ -86,6 +87,15 @@ export default async function PersonProfilePage({ params }: { params: Promise<{ 
         </CardHeader>
         <CardContent>
           <PreMeetingSummary syntheticPersonRef={ref} />
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">Ask Claude about this person</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <PersonQAPanel syntheticPersonRef={ref} />
         </CardContent>
       </Card>
 

--- a/src/components/cwt/person-qa-panel.tsx
+++ b/src/components/cwt/person-qa-panel.tsx
@@ -1,0 +1,151 @@
+'use client';
+
+import { useId, useRef, useState, useTransition } from 'react';
+import { askPersonQuestionAction } from '@/app/actions/person-qa';
+import { Button } from '@/components/ui/button';
+import type { PersonQATurn } from '@/lib/cwt/person-qa';
+
+type LocalTurn = PersonQATurn & { id: string };
+
+let turnCounter = 0;
+const nextTurnId = () => {
+  turnCounter += 1;
+  return `t${turnCounter}`;
+};
+
+const SUGGESTIONS = [
+  "What's the pattern across the partners they've touched?",
+  'Anything I should worry about?',
+  'What questions should I ask at our next meeting?',
+];
+
+export function PersonQAPanel({ syntheticPersonRef }: { syntheticPersonRef: string }) {
+  const inputId = useId();
+  const [history, setHistory] = useState<LocalTurn[]>([]);
+  const [draft, setDraft] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [pending, startTransition] = useTransition();
+  const scrollRef = useRef<HTMLDivElement | null>(null);
+
+  const ask = (question: string) => {
+    const q = question.trim();
+    if (q.length === 0 || pending) return;
+    setError(null);
+    const userTurn: LocalTurn = { id: nextTurnId(), role: 'user', content: q };
+    const next = [...history, userTurn];
+    setHistory(next);
+    setDraft('');
+    const wireHistory: PersonQATurn[] = next.map((t) => ({ role: t.role, content: t.content }));
+    startTransition(async () => {
+      const r = await askPersonQuestionAction(syntheticPersonRef, wireHistory);
+      if (!r.ok) {
+        setError(r.error);
+        setHistory(history);
+        setDraft(q);
+        return;
+      }
+      const assistantTurn: LocalTurn = {
+        id: nextTurnId(),
+        role: 'assistant',
+        content: r.answer,
+      };
+      setHistory([...next, assistantTurn]);
+      requestAnimationFrame(() => {
+        scrollRef.current?.scrollTo({ top: scrollRef.current.scrollHeight, behavior: 'smooth' });
+      });
+    });
+  };
+
+  const onSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    ask(draft);
+  };
+
+  const onReset = () => {
+    setHistory([]);
+    setDraft('');
+    setError(null);
+  };
+
+  return (
+    <div className="space-y-3 text-sm">
+      <div className="flex items-baseline justify-between gap-2">
+        <p className="text-muted-foreground text-xs">
+          Multi-turn within this session. Claude sees only the structured profile — service events,
+          consents, intake extractions, documents. Not clinical advice.
+        </p>
+        {history.length > 0 ? (
+          <Button onClick={onReset} variant="ghost" size="sm" disabled={pending}>
+            Clear
+          </Button>
+        ) : null}
+      </div>
+
+      {history.length === 0 ? (
+        <div className="flex flex-wrap gap-2">
+          {SUGGESTIONS.map((s) => (
+            <Button
+              key={s}
+              type="button"
+              variant="outline"
+              size="sm"
+              className="h-auto whitespace-normal py-1 text-xs"
+              disabled={pending}
+              onClick={() => ask(s)}
+            >
+              {s}
+            </Button>
+          ))}
+        </div>
+      ) : (
+        <div
+          ref={scrollRef}
+          className="max-h-[28rem] space-y-3 overflow-y-auto rounded-md border border-border bg-muted/20 p-3"
+        >
+          {history.map((t) => (
+            <div
+              key={t.id}
+              className={
+                t.role === 'user'
+                  ? 'rounded-md bg-primary/10 p-2 text-sm'
+                  : 'rounded-md bg-card p-2 text-sm'
+              }
+            >
+              <div className="mb-1 text-[10px] uppercase tracking-wide text-muted-foreground">
+                {t.role === 'user' ? 'You' : 'Claude'}
+              </div>
+              <p className="whitespace-pre-wrap leading-relaxed">{t.content}</p>
+            </div>
+          ))}
+          {pending ? (
+            <div className="rounded-md bg-card p-2 text-sm text-muted-foreground">
+              <div className="mb-1 text-[10px] uppercase tracking-wide">Claude</div>
+              <p className="italic">Thinking…</p>
+            </div>
+          ) : null}
+        </div>
+      )}
+
+      <form onSubmit={onSubmit} className="flex gap-2">
+        <label htmlFor={inputId} className="sr-only">
+          Ask a question about this person
+        </label>
+        <input
+          id={inputId}
+          type="text"
+          value={draft}
+          onChange={(e) => setDraft(e.target.value)}
+          placeholder="Ask a follow-up…"
+          disabled={pending}
+          maxLength={1500}
+          className="flex-1 rounded-md border border-input bg-background px-3 py-2 text-sm"
+        />
+        <Button type="submit" size="sm" disabled={pending || draft.trim().length === 0}>
+          {pending ? 'Asking…' : 'Ask'}
+        </Button>
+      </form>
+
+      {error ? <p className="text-xs text-destructive">{error}</p> : null}
+    </div>
+  );
+}

--- a/src/lib/cwt/person-qa.ts
+++ b/src/lib/cwt/person-qa.ts
@@ -1,0 +1,70 @@
+import Anthropic from '@anthropic-ai/sdk';
+import {
+  buildPersonProfileBlock,
+  PERSON_QA_PROMPT_VERSION,
+  PERSON_QA_SYSTEM_PROMPT,
+} from '@/ai/prompts/person-qa';
+import type { PersonProfile } from '@/db/queries/person-profile';
+
+let _client: Anthropic | null = null;
+function client(): Anthropic {
+  if (!_client) _client = new Anthropic();
+  return _client;
+}
+
+const MODEL_ID = 'claude-sonnet-4-6';
+const MAX_OUTPUT_TOKENS = 700;
+
+export type PersonQATurn = {
+  role: 'user' | 'assistant';
+  content: string;
+};
+
+export type PersonQAResult = {
+  answer: string;
+  modelId: string;
+  promptVersion: string;
+};
+
+const HISTORY_HARD_CAP = 30;
+
+export async function answerPersonQuestion(
+  profile: PersonProfile,
+  history: PersonQATurn[],
+): Promise<PersonQAResult> {
+  if (history.length === 0) {
+    throw new Error('[person-qa] history must contain at least the user question');
+  }
+  if (history[history.length - 1].role !== 'user') {
+    throw new Error('[person-qa] last history turn must be the user question');
+  }
+  const trimmed = history.slice(-HISTORY_HARD_CAP);
+  const factsBlock = buildPersonProfileBlock(profile);
+
+  const response = await client().messages.create({
+    model: MODEL_ID,
+    max_tokens: MAX_OUTPUT_TOKENS,
+    system: [
+      {
+        type: 'text',
+        text: PERSON_QA_SYSTEM_PROMPT,
+        cache_control: { type: 'ephemeral' },
+      },
+      {
+        type: 'text',
+        text: factsBlock,
+        cache_control: { type: 'ephemeral' },
+      },
+    ],
+    messages: trimmed.map((t) => ({ role: t.role, content: t.content })),
+  });
+
+  const answer = response.content
+    .flatMap((c) => (c.type === 'text' ? [c.text] : []))
+    .join('\n')
+    .trim();
+  if (!answer) {
+    throw new Error(`[person-qa] empty response; stop_reason=${response.stop_reason}`);
+  }
+  return { answer, modelId: MODEL_ID, promptVersion: PERSON_QA_PROMPT_VERSION };
+}


### PR DESCRIPTION
## Summary
- Symmetric to the case Q&A on filings (#287). Multi-turn Q&A on the unified person view: caseworker types a question, Claude answers from the structured profile (service events, consents, intakes-with-extracted-fields, documents)
- System prompt scopes Claude tightly: says "I don't see X in the data" when not in the profile; explicitly told it doesn't have access to eviction filings, ED encounters, or intake transcript content (only extracted fields)
- Suggestion pills for cold start: "What's the pattern across the partners they've touched?" / "Anything I should worry about?" / "What questions should I ask at our next meeting?"
- Multi-turn within session, no DB persistence. Caps at 30 turns and 1500 chars per question. Same role gate as the briefing.

## Test plan
- [ ] Open a person view with activity → click a suggestion pill → response appears
- [ ] Ask a question that requires content not in the data ("what does their lease say?") → Claude says it's not in the profile
- [ ] Ask multi-turn follow-ups → context preserved
- [ ] Clear button resets
- [ ] Audit log shows \`person_qa.answered\` + \`ai.generated\` rows