### PR TITLE
feat(EVDT/CWT): linked-intake panel on filing detail

### DIFF
--- a/src/app/app/cases/filings/[id]/page.tsx
+++ b/src/app/app/cases/filings/[id]/page.tsx
@@ -4,9 +4,11 @@ import { CaseFilingsRoles } from '@/components/eviction/case-filings-roles';
 import { CaseOutcomePanel } from '@/components/eviction/case-outcome-panel';
 import { CaseQAPanel } from '@/components/eviction/case-qa-panel';
 import { FilingDetail } from '@/components/eviction/filing-detail';
+import { LinkedIntakePanel } from '@/components/eviction/linked-intake-panel';
 import { OutreachLetterPanel } from '@/components/eviction/outreach-letter-panel';
 import { ReferToCaseworkerPanel } from '@/components/eviction/refer-to-caseworker-panel';
 import { RentalAssistancePanel } from '@/components/eviction/rental-assistance-panel';
+import { getReferralIntakeForFiling } from '@/db/queries/client-intakes';
 import { listCaseOutcomes } from '@/db/queries/eviction-case-outcomes';
 import { getFilingByIdForViewer } from '@/db/queries/eviction-filings';
 import { matchAssistancePrograms } from '@/db/queries/rental-assistance';
@@ -31,11 +33,12 @@ export default async function FilingDetailPage({ params }: { params: Promise<{ i
   const filing = await getFilingByIdForViewer(id, me.role);
   if (!filing) notFound();
 
-  const [score, outcomes, canRecord, assistancePrograms] = await Promise.all([
+  const [score, outcomes, canRecord, assistancePrograms, linkedIntake] = await Promise.all([
     getLatestScore(filing.id),
     listCaseOutcomes(filing.id),
     userIsKlaAttorney(me),
     matchAssistancePrograms(filing),
+    getReferralIntakeForFiling(filing.id),
   ]);
 
   // DTRS-003: log this read. We log AFTER the row is fetched so the
@@ -74,7 +77,8 @@ export default async function FilingDetailPage({ params }: { params: Promise<{ i
       </div>
       {canRecord ? <CaseQAPanel filingId={filing.id} /> : null}
       {canRecord ? <OutreachLetterPanel filingId={filing.id} /> : null}
-      {canRecord ? <ReferToCaseworkerPanel filingId={filing.id} /> : null}
+      {linkedIntake ? <LinkedIntakePanel intake={linkedIntake} /> : null}
+      {canRecord && !linkedIntake ? <ReferToCaseworkerPanel filingId={filing.id} /> : null}
       <CaseOutcomePanel filingId={filing.id} history={outcomes} canRecord={canRecord} />
       <RentalAssistancePanel programs={assistancePrograms} />
     </div>

--- a/src/components/eviction/linked-intake-panel.tsx
+++ b/src/components/eviction/linked-intake-panel.tsx
@@ -1,0 +1,61 @@
+import Link from 'next/link';
+import type { IntakeProfile } from '@/ai/prompts/intake-extraction';
+import { Card, CardContent } from '@/components/ui/card';
+import type { ClientIntake } from '@/db/schema/client-intakes';
+
+const statusLabel: Record<ClientIntake['status'], string> = {
+  recording: 'recording in progress',
+  transcribed: 'transcribed (waiting on extraction)',
+  extracting: 'extraction in progress',
+  extracted: 'extracted',
+  failed: 'extraction failed',
+};
+
+const fmtDateTime = (d: Date | string) =>
+  new Intl.DateTimeFormat('en-US', { dateStyle: 'medium', timeStyle: 'short' }).format(new Date(d));
+
+export function LinkedIntakePanel({ intake }: { intake: ClientIntake }) {
+  const profile = intake.extractedProfile as IntakeProfile | null;
+  const presenting = profile?.presenting_issue ?? null;
+  const urgency = profile?.urgency ?? null;
+
+  return (
+    <Card className="border-emerald-500/40 bg-emerald-500/5">
+      <CardContent className="space-y-2 text-sm">
+        <div className="flex flex-wrap items-baseline justify-between gap-2">
+          <p className="font-medium">Referred to caseworker queue ✓</p>
+          <span className="text-xs text-muted-foreground">{fmtDateTime(intake.createdAt)}</span>
+        </div>
+        <p className="text-xs text-muted-foreground">
+          Intake status: <strong>{statusLabel[intake.status]}</strong>
+          {intake.syntheticPersonRef ? (
+            <>
+              {' '}
+              · Person ref:{' '}
+              <Link
+                href={`/app/clients/person/${intake.syntheticPersonRef}`}
+                className="font-mono text-primary hover:underline"
+              >
+                {intake.syntheticPersonRef}
+              </Link>
+            </>
+          ) : null}
+        </p>
+        {presenting ? (
+          <p className="text-sm">
+            <strong>Presenting:</strong> {presenting}
+            {urgency ? (
+              <span className="ml-2 text-xs text-muted-foreground">({urgency})</span>
+            ) : null}
+          </p>
+        ) : null}
+        <Link
+          href={`/app/clients/intakes/${intake.id}`}
+          className="inline-block text-xs text-primary hover:underline"
+        >
+          Open intake →
+        </Link>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/db/queries/client-intakes.ts
+++ b/src/db/queries/client-intakes.ts
@@ -10,3 +10,20 @@ export async function getClientIntakeById(id: string): Promise<ClientIntake | nu
   const [row] = await db.select().from(clientIntakes).where(eq(clientIntakes.id, id)).limit(1);
   return row ?? null;
 }
+
+/**
+ * Look up the intake spawned by EVDT-CWT bridge referral for a given
+ * filing, if any. Matches on the literal label token used by
+ * referFilingToCaseworkerAction (`EVDT-REF:{filingId}`) so the join
+ * is exact and free of collisions.
+ */
+export async function getReferralIntakeForFiling(
+  filingId: string,
+): Promise<ClientIntake | null> {
+  const [row] = await db
+    .select()
+    .from(clientIntakes)
+    .where(eq(clientIntakes.label, `EVDT-REF:${filingId}`))
+    .limit(1);
+  return row ?? null;
+}


### PR DESCRIPTION
## Summary
- After a filing has been referred to the caseworker queue (#288), the filing detail surfaces the spawned intake's status: \`recording\` / \`transcribed\` / \`extracted\` / etc, plus presenting issue + urgency once extraction runs, plus link to the unified person view if a syntheticPersonRef is attached
- The "Refer to caseworker →" CTA is hidden when a referral already exists — that real estate is now the linked-intake panel
- Match is exact via the literal label token \`EVDT-REF:{filingId}\` the referral action writes

## Test plan
- [ ] Open a filing without a referral → "Refer to caseworker" CTA visible
- [ ] Click refer → navigate back to filing detail → CTA gone, linked-intake panel shows status=transcribed, "Open intake →" link works
- [ ] Run extraction on the spawned intake → reload filing detail → presenting issue + urgency appear
- [ ] Attach a synthetic_person_ref to the intake (manual edit) → reload → person-ref link appears