### PR TITLE
feat(COAL): coalition coordinator weekly insights

### DIFF
--- a/src/ai/prompts/coalition-insights.ts
+++ b/src/ai/prompts/coalition-insights.ts
@@ -1,0 +1,119 @@
+/**
+ * Coalition weekly insights prompt.
+ *
+ * Coordinator (admin / steering committee) opens this view at the
+ * start of the week and gets a 3-paragraph summary of what's
+ * happening across the coalition: volume, patterns, who's at risk,
+ * where action is stuck. Plain prose, no headers — they read it
+ * in 60 seconds.
+ *
+ * The AI sees aggregate counts, top patterns (cross-org, high-risk
+ * filings without packets), and a sample of recent activity. It
+ * does NOT see individual identities — synthetic person refs are
+ * opaque, and the recipient (coordinator) is the right audience for
+ * coalition-level patterns, not per-person detail.
+ */
+
+import type { CoalitionWeeklyDigest } from '@/db/queries/coalition-weekly-digest';
+
+export const COALITION_INSIGHTS_PROMPT_VERSION = 'coalition-insights-v1@2026-04-26';
+
+export const COALITION_INSIGHTS_SYSTEM_PROMPT = `You write a short weekly insights brief for a Daviess County
+homelessness coalition coordinator. The coordinator opens this on
+Monday morning and reads it in under 60 seconds. The point is to
+surface what changed, what's stuck, and what they should ask about
+in the next steering meeting.
+
+Write 3 short paragraphs (~120 words total):
+
+PARAGRAPH 1 — pulse.
+Lead with the volume signal: how does activity this window compare
+to a typical week? If counts are low, say so plainly ("quiet week
+— 3 new filings"). If high, name what's driving it ("12 new filings,
+mostly Plaintiff X — third week in a row").
+
+PARAGRAPH 2 — patterns / at-risk.
+What's the most coalition-relevant pattern? Examples:
+- Cross-org touchpoints — people hitting 3+ partners are the cases
+  that prove the platform's value; lead with those if any.
+- High-score filings without packets — the action-blocked queue
+  the coordinator can clear by talking to KLA.
+- Urgent extracted intakes — caseworker-side time pressure.
+Don't list everything — pick the one or two that most need a human
+decision this week.
+
+PARAGRAPH 3 — what to ask.
+1-2 specific questions for the steering meeting. Examples:
+- "Is KLA capacity the constraint? 8 high-score filings without
+  packets is twice last week."
+- "Why did consent revocations double? Worth a quick word with
+  the partner who's losing them."
+- "Quiet week, but the cross-org count is up 30% — proof the
+  platform is doing what we built it for."
+
+Hard rules:
+1. NEVER invent numbers. The counts you have are the counts you
+   have. If a count is 0, don't suggest a trend.
+2. Don't reference individual synthetic_person_refs. The coordinator
+   doesn't read per-person specifics in this view; that's caseworker
+   territory.
+3. If the window is empty (everything = 0), say so in one line and
+   stop. Don't pad.
+4. No emoji. No headers. Just three paragraphs.
+
+Output: plain text. The UI renders it verbatim.`;
+
+const fmtDate = (d: Date) => d.toISOString().slice(0, 10);
+
+export function buildCoalitionInsightsUserPrompt(digest: CoalitionWeeklyDigest): string {
+  const lines: string[] = [
+    `Today: ${fmtDate(new Date())}`,
+    `Window: last ${digest.windowDays} day${digest.windowDays === 1 ? '' : 's'} (since ${fmtDate(digest.since)})`,
+    '',
+    '## Volume counts',
+    `- New eviction filings: ${digest.newFilings}`,
+    `- New intakes: ${digest.newIntakes}`,
+    `- New service events: ${digest.newServiceEvents}`,
+    `- New consent grants: ${digest.newConsentGrants}`,
+    `- New consent revocations: ${digest.newConsentRevocations}`,
+    '',
+    '## Action-blocked queues',
+    `- Urgent extracted intakes (today / within_7_days): ${digest.urgentExtractedIntakes}`,
+    `- High-risk open filings without a response packet drafted: ${digest.highScoreFilingsNoPacket}`,
+    '',
+  ];
+
+  if (digest.crossOrgTouchpoints.length > 0) {
+    lines.push(`## Cross-org touchpoints (${digest.crossOrgTouchpoints.length})`);
+    for (const p of digest.crossOrgTouchpoints) {
+      lines.push(
+        `- ${p.uniqueOrgs} partners · ${p.totalEvents} events · ${p.orgNames.join(', ')}`,
+      );
+    }
+    lines.push('');
+  } else {
+    lines.push('## Cross-org touchpoints: (none)');
+    lines.push('');
+  }
+
+  if (digest.recentHighRiskFilings.length > 0) {
+    lines.push(`## Recent high-risk filings (top ${digest.recentHighRiskFilings.length})`);
+    for (const f of digest.recentHighRiskFilings) {
+      lines.push(
+        `- ${f.caseNumber} · ${f.plaintiff} · score ${f.score} · packet=${f.packetStatus ?? 'none'}`,
+      );
+    }
+    lines.push('');
+  }
+
+  if (digest.topPartnerEventTypes.length > 0) {
+    lines.push('## Top partner activity by event type');
+    for (const t of digest.topPartnerEventTypes) {
+      lines.push(`- ${t.partnerOrgName} · ${t.eventType} · ${t.count}`);
+    }
+    lines.push('');
+  }
+
+  lines.push('Write the brief now.');
+  return lines.join('\n');
+}

--- a/src/ai/prompts/person-qa.ts
+++ b/src/ai/prompts/person-qa.ts
@@ -89,7 +89,7 @@ export function buildPersonProfileBlock(profile: PersonProfile): string {
       const presenting = p && typeof p.presenting_issue === 'string' ? p.presenting_issue : null;
       const urgency = p && typeof p.urgency === 'string' ? p.urgency : null;
       const flags =
-        p && p.flags && typeof p.flags === 'object'
+        p?.flags && typeof p.flags === 'object'
           ? Object.entries(p.flags as Record<string, boolean>)
               .filter(([, v]) => v === true)
               .map(([k]) => k)

--- a/src/app/actions/coalition-insights.ts
+++ b/src/app/actions/coalition-insights.ts
@@ -1,0 +1,71 @@
+'use server';
+
+import * as Sentry from '@sentry/nextjs';
+import {
+  type CoalitionWeeklyDigest,
+  getCoalitionWeeklyDigest,
+} from '@/db/queries/coalition-weekly-digest';
+import { logAuditEvent } from '@/lib/audit';
+import { requireRole } from '@/lib/auth';
+import { generateCoalitionInsights } from '@/lib/coalition/weekly-insights';
+import { recordAiGeneration } from '@/lib/dtrs/data-access';
+
+export type CoalitionInsightsResult =
+  | {
+      ok: true;
+      text: string;
+      modelId: string;
+      promptVersion: string;
+      digest: CoalitionWeeklyDigest;
+    }
+  | { ok: false; error: string };
+
+const ROLES = ['admin', 'attorney'] as const;
+
+const DAYS_MIN = 1;
+const DAYS_MAX = 90;
+
+export async function generateCoalitionInsightsAction(
+  windowDays = 7,
+): Promise<CoalitionInsightsResult> {
+  const actor = await requireRole(ROLES);
+
+  const days = Math.max(DAYS_MIN, Math.min(DAYS_MAX, Math.round(windowDays)));
+
+  try {
+    const digest = await getCoalitionWeeklyDigest({ windowDays: days });
+    const result = await generateCoalitionInsights(digest);
+
+    await logAuditEvent({
+      actorUserId: actor.id,
+      action: 'coalition_insights.generated',
+      targetTable: 'partner_service_events',
+      metadata: {
+        promptVersion: result.promptVersion,
+        windowDays: days,
+        newFilings: digest.newFilings,
+        newIntakes: digest.newIntakes,
+        crossOrg: digest.crossOrgTouchpoints.length,
+      },
+    });
+    await recordAiGeneration({
+      actorUserId: actor.id,
+      resourceType: 'coalition_insights',
+      resourceId: 'weekly',
+      model: result.modelId,
+      promptVersion: result.promptVersion,
+      metadata: { windowDays: days },
+    });
+
+    return {
+      ok: true,
+      text: result.text,
+      modelId: result.modelId,
+      promptVersion: result.promptVersion,
+      digest,
+    };
+  } catch (err) {
+    Sentry.captureException(err, { tags: { action: 'generateCoalitionInsightsAction' } });
+    return { ok: false, error: 'Insights generation failed. Please try again.' };
+  }
+}

--- a/src/app/app/coalition/insights/page.tsx
+++ b/src/app/app/coalition/insights/page.tsx
@@ -1,0 +1,40 @@
+import Link from 'next/link';
+import { CoalitionInsightsPanel } from '@/components/coalition/coalition-insights-panel';
+import { Card, CardContent } from '@/components/ui/card';
+import { requireRole } from '@/lib/auth';
+
+export const dynamic = 'force-dynamic';
+
+export default async function CoalitionInsightsPage() {
+  await requireRole(['admin', 'attorney']);
+
+  return (
+    <div className="mx-auto max-w-4xl space-y-4 p-4 md:p-6">
+      <div className="text-xs">
+        <Link href="/app/coalition" className="text-muted-foreground hover:underline">
+          ← Back to coalition
+        </Link>
+      </div>
+      <header>
+        <h1 className="font-serif text-3xl font-bold text-primary">Coalition insights</h1>
+        <p className="text-sm text-muted-foreground">
+          A weekly read for the coordinator and steering committee. Volume signal, the most
+          coalition-relevant pattern, and 1-2 questions worth raising at the next meeting.
+        </p>
+      </header>
+
+      <CoalitionInsightsPanel />
+
+      <Card className="border-amber-500/40 bg-amber-500/5">
+        <CardContent className="text-xs">
+          <p className="font-medium">This is a coordinator's view, not a per-person view.</p>
+          <p className="mt-1 text-muted-foreground">
+            Synthetic person refs are intentionally left out of the brief — for per-person detail,
+            jump to the unified person view from the cross-org coordination page. The numbers here
+            are fence-clean: counts, top patterns, no identities.
+          </p>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/app/app/coalition/page.tsx
+++ b/src/app/app/coalition/page.tsx
@@ -1,21 +1,33 @@
+import Link from 'next/link';
 import { PartnerDirectory } from '@/components/coalition/partner-directory';
 import { listPartnerOrgs } from '@/db/queries/coalition';
 import { requireUser } from '@/lib/auth';
 
 export default async function CoalitionPage() {
-  await requireUser();
+  const me = await requireUser();
   const orgs = await listPartnerOrgs();
   const aggregateCount = orgs.filter((o) => o.dataSharingTier !== 'none').length;
+  const canSeeInsights = me.role === 'admin' || me.role === 'attorney';
 
   return (
     <div className="mx-auto max-w-6xl space-y-4 p-6">
-      <header>
-        <h1 className="font-serif text-3xl font-bold text-primary">Coalition</h1>
-        <p className="text-sm text-muted-foreground">
-          Daviess County homelessness-response stakeholders catalogued in the pilot report.
-          {orgs.length} organizations · {aggregateCount} actively contributing data ·{' '}
-          {orgs.length - aggregateCount} not yet on the data trust.
-        </p>
+      <header className="flex flex-wrap items-baseline justify-between gap-3">
+        <div>
+          <h1 className="font-serif text-3xl font-bold text-primary">Coalition</h1>
+          <p className="text-sm text-muted-foreground">
+            Daviess County homelessness-response stakeholders catalogued in the pilot report.
+            {orgs.length} organizations · {aggregateCount} actively contributing data ·{' '}
+            {orgs.length - aggregateCount} not yet on the data trust.
+          </p>
+        </div>
+        {canSeeInsights ? (
+          <Link
+            href="/app/coalition/insights"
+            className="shrink-0 rounded-md bg-primary px-3 py-2 text-xs font-medium text-primary-foreground hover:bg-primary/90"
+          >
+            Weekly insights →
+          </Link>
+        ) : null}
       </header>
       <PartnerDirectory orgs={orgs} />
     </div>

--- a/src/components/coalition/coalition-insights-panel.tsx
+++ b/src/components/coalition/coalition-insights-panel.tsx
@@ -1,0 +1,117 @@
+'use client';
+
+import { useState, useTransition } from 'react';
+import {
+  type CoalitionInsightsResult,
+  generateCoalitionInsightsAction,
+} from '@/app/actions/coalition-insights';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+
+const fmtDate = (d: Date) =>
+  new Intl.DateTimeFormat('en-US', { dateStyle: 'medium' }).format(new Date(d));
+
+type SuccessResult = Extract<CoalitionInsightsResult, { ok: true }>;
+
+const WINDOW_OPTIONS = [
+  { label: 'Last 7 days', days: 7 },
+  { label: 'Last 14 days', days: 14 },
+  { label: 'Last 30 days', days: 30 },
+];
+
+export function CoalitionInsightsPanel() {
+  const [windowDays, setWindowDays] = useState(7);
+  const [data, setData] = useState<SuccessResult | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [pending, startTransition] = useTransition();
+
+  const onClick = () => {
+    setError(null);
+    startTransition(async () => {
+      const r = await generateCoalitionInsightsAction(windowDays);
+      if (!r.ok) {
+        setError(r.error);
+        return;
+      }
+      setData(r);
+    });
+  };
+
+  return (
+    <Card>
+      <CardHeader className="flex flex-row items-baseline justify-between gap-2">
+        <CardTitle className="text-base">Weekly insights</CardTitle>
+        <div className="flex items-center gap-2">
+          {WINDOW_OPTIONS.map((w) => (
+            <Button
+              key={w.days}
+              type="button"
+              variant={windowDays === w.days ? 'default' : 'outline'}
+              size="sm"
+              disabled={pending}
+              onClick={() => setWindowDays(w.days)}
+              className="text-xs"
+            >
+              {w.label}
+            </Button>
+          ))}
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-4 text-sm">
+        {!data ? (
+          <>
+            <p className="text-muted-foreground">
+              Claude reads the aggregate counts (filings, intakes, service events, consents) plus
+              the action-blocked queues (urgent intakes, high-risk filings without packets) and
+              writes a 3-paragraph brief: pulse, patterns, what to ask in the next steering meeting.
+            </p>
+            <div className="flex items-center gap-3">
+              <Button onClick={onClick} disabled={pending} size="sm">
+                {pending ? 'Reading the coalition…' : 'Run weekly insights'}
+              </Button>
+              {error ? <span className="text-xs text-destructive">{error}</span> : null}
+            </div>
+          </>
+        ) : (
+          <>
+            <p className="whitespace-pre-wrap leading-relaxed">{data.text}</p>
+
+            <div className="rounded-md border border-border bg-muted/30 p-3 text-xs">
+              <p className="mb-2 font-medium">By the numbers</p>
+              <div className="grid grid-cols-2 gap-x-4 gap-y-1 md:grid-cols-3">
+                <Stat label="New filings" value={data.digest.newFilings} />
+                <Stat label="New intakes" value={data.digest.newIntakes} />
+                <Stat label="Service events" value={data.digest.newServiceEvents} />
+                <Stat label="Consent grants" value={data.digest.newConsentGrants} />
+                <Stat label="Consent revocations" value={data.digest.newConsentRevocations} />
+                <Stat label="Urgent intakes" value={data.digest.urgentExtractedIntakes} />
+                <Stat label="High-risk no-packet" value={data.digest.highScoreFilingsNoPacket} />
+                <Stat label="Cross-org touches" value={data.digest.crossOrgTouchpoints.length} />
+              </div>
+            </div>
+
+            <div className="flex flex-wrap items-center justify-between gap-3 text-[11px] text-muted-foreground">
+              <span>
+                Window: since {fmtDate(new Date(data.digest.since))} · Model:{' '}
+                <span className="font-mono">{data.modelId}</span> · Prompt:{' '}
+                <span className="font-mono">{data.promptVersion}</span>
+              </span>
+              <Button onClick={onClick} disabled={pending} size="sm" variant="outline">
+                {pending ? 'Re-running…' : 'Re-run'}
+              </Button>
+            </div>
+          </>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+function Stat({ label, value }: { label: string; value: number }) {
+  return (
+    <div className="flex items-baseline gap-2">
+      <span className="font-mono text-sm font-medium tabular-nums">{value}</span>
+      <span className="text-xs text-muted-foreground">{label}</span>
+    </div>
+  );
+}

--- a/src/db/queries/coalition-weekly-digest.ts
+++ b/src/db/queries/coalition-weekly-digest.ts
@@ -1,0 +1,182 @@
+import { and, count, desc, eq, gte, inArray, isNotNull, isNull, sql } from 'drizzle-orm';
+import { RISK_SCORE_MODEL_VERSION } from '@/ai/prompts/eviction-risk-score';
+import { db } from '@/db/client';
+import { clientIntakes } from '@/db/schema/client-intakes';
+import { evictionFilingRiskScores } from '@/db/schema/eviction-filing-risk-scores';
+import { evictionFilings } from '@/db/schema/eviction-filings';
+import { evictionResponsePackets } from '@/db/schema/eviction-response-packets';
+import { partnerOrgs } from '@/db/schema/partner-orgs';
+import { partnerServiceEvents } from '@/db/schema/partner-service-events';
+import { personPartnerConsents } from '@/db/schema/person-partner-consents';
+import { listCrossOrgTouchpoints, type PersonAggregate } from './partner-service-events';
+
+export type RecentHighRiskFiling = {
+  id: string;
+  caseNumber: string;
+  plaintiff: string;
+  score: number;
+  packetStatus: string | null;
+  filedAt: Date;
+};
+
+export type TopPartnerEventType = {
+  partnerOrgName: string;
+  eventType: string;
+  count: number;
+};
+
+export type CoalitionWeeklyDigest = {
+  since: Date;
+  windowDays: number;
+  // Aggregate counts
+  newFilings: number;
+  newIntakes: number;
+  newServiceEvents: number;
+  newConsentGrants: number;
+  newConsentRevocations: number;
+  urgentExtractedIntakes: number;
+  highScoreFilingsNoPacket: number;
+  // Top patterns (small samples for the AI to reason over)
+  crossOrgTouchpoints: PersonAggregate[];
+  recentHighRiskFilings: RecentHighRiskFiling[];
+  topPartnerEventTypes: TopPartnerEventType[];
+};
+
+const HIGH_SCORE_THRESHOLD = 60;
+
+export async function getCoalitionWeeklyDigest(
+  opts: { windowDays?: number } = {},
+): Promise<CoalitionWeeklyDigest> {
+  const windowDays = opts.windowDays ?? 7;
+  const since = new Date();
+  since.setDate(since.getDate() - windowDays);
+
+  const [
+    [filingsAgg],
+    [intakesAgg],
+    [eventsAgg],
+    [grantsAgg],
+    [revocationsAgg],
+    [urgentAgg],
+    [hiNoPacketAgg],
+    crossOrgTouchpoints,
+    recentHighRiskRows,
+    topEventTypeRows,
+  ] = await Promise.all([
+    db.select({ n: count() }).from(evictionFilings).where(gte(evictionFilings.filedAt, since)),
+    db.select({ n: count() }).from(clientIntakes).where(gte(clientIntakes.createdAt, since)),
+    db
+      .select({ n: count() })
+      .from(partnerServiceEvents)
+      .where(gte(partnerServiceEvents.eventAt, since)),
+    db
+      .select({ n: count() })
+      .from(personPartnerConsents)
+      .where(gte(personPartnerConsents.grantedAt, since)),
+    db
+      .select({ n: count() })
+      .from(personPartnerConsents)
+      .where(
+        and(
+          isNotNull(personPartnerConsents.revokedAt),
+          gte(personPartnerConsents.revokedAt, since),
+        ),
+      ),
+    db
+      .select({ n: count() })
+      .from(clientIntakes)
+      .where(
+        and(
+          eq(clientIntakes.status, 'extracted'),
+          gte(clientIntakes.createdAt, since),
+          sql`${clientIntakes.extractedProfile}->>'urgency' IN ('today', 'within_7_days')`,
+        ),
+      ),
+    // High-score filings with no packet drafted yet (any time, not just window —
+    // these are the action-blocked cases the coordinator should know about).
+    db
+      .select({ n: count() })
+      .from(evictionFilings)
+      .innerJoin(
+        evictionFilingRiskScores,
+        and(
+          eq(evictionFilingRiskScores.filingId, evictionFilings.id),
+          eq(evictionFilingRiskScores.modelVersion, RISK_SCORE_MODEL_VERSION),
+        ),
+      )
+      .leftJoin(evictionResponsePackets, eq(evictionResponsePackets.filingId, evictionFilings.id))
+      .where(
+        and(
+          gte(evictionFilingRiskScores.score, HIGH_SCORE_THRESHOLD),
+          inArray(evictionFilings.status, ['filed', 'served']),
+          isNull(evictionResponsePackets.id),
+        ),
+      ),
+    listCrossOrgTouchpoints({ windowDays, limit: 5 }),
+    db
+      .select({
+        filing: evictionFilings,
+        score: evictionFilingRiskScores.score,
+        packetStatus: evictionResponsePackets.status,
+      })
+      .from(evictionFilings)
+      .innerJoin(
+        evictionFilingRiskScores,
+        and(
+          eq(evictionFilingRiskScores.filingId, evictionFilings.id),
+          eq(evictionFilingRiskScores.modelVersion, RISK_SCORE_MODEL_VERSION),
+        ),
+      )
+      .leftJoin(evictionResponsePackets, eq(evictionResponsePackets.filingId, evictionFilings.id))
+      .where(
+        and(
+          gte(evictionFilings.filedAt, since),
+          gte(evictionFilingRiskScores.score, HIGH_SCORE_THRESHOLD),
+        ),
+      )
+      .orderBy(desc(evictionFilingRiskScores.score), desc(evictionFilings.filedAt))
+      .limit(5),
+    db
+      .select({
+        partnerOrgName: partnerOrgs.name,
+        eventType: partnerServiceEvents.eventType,
+        n: count(),
+      })
+      .from(partnerServiceEvents)
+      .innerJoin(partnerOrgs, eq(partnerOrgs.id, partnerServiceEvents.partnerOrgId))
+      .where(gte(partnerServiceEvents.eventAt, since))
+      .groupBy(partnerOrgs.name, partnerServiceEvents.eventType)
+      .orderBy(desc(count()))
+      .limit(10),
+  ]);
+
+  const recentHighRiskFilings: RecentHighRiskFiling[] = recentHighRiskRows.map((r) => ({
+    id: r.filing.id,
+    caseNumber: r.filing.caseNumber,
+    plaintiff: r.filing.plaintiff,
+    score: r.score,
+    packetStatus: r.packetStatus,
+    filedAt: r.filing.filedAt,
+  }));
+
+  const topPartnerEventTypes: TopPartnerEventType[] = topEventTypeRows.map((r) => ({
+    partnerOrgName: r.partnerOrgName,
+    eventType: r.eventType,
+    count: Number(r.n),
+  }));
+
+  return {
+    since,
+    windowDays,
+    newFilings: Number(filingsAgg?.n ?? 0),
+    newIntakes: Number(intakesAgg?.n ?? 0),
+    newServiceEvents: Number(eventsAgg?.n ?? 0),
+    newConsentGrants: Number(grantsAgg?.n ?? 0),
+    newConsentRevocations: Number(revocationsAgg?.n ?? 0),
+    urgentExtractedIntakes: Number(urgentAgg?.n ?? 0),
+    highScoreFilingsNoPacket: Number(hiNoPacketAgg?.n ?? 0),
+    crossOrgTouchpoints,
+    recentHighRiskFilings,
+    topPartnerEventTypes,
+  };
+}

--- a/src/lib/coalition/weekly-insights.ts
+++ b/src/lib/coalition/weekly-insights.ts
@@ -1,0 +1,48 @@
+import Anthropic from '@anthropic-ai/sdk';
+import {
+  buildCoalitionInsightsUserPrompt,
+  COALITION_INSIGHTS_PROMPT_VERSION,
+  COALITION_INSIGHTS_SYSTEM_PROMPT,
+} from '@/ai/prompts/coalition-insights';
+import type { CoalitionWeeklyDigest } from '@/db/queries/coalition-weekly-digest';
+
+let _client: Anthropic | null = null;
+function client(): Anthropic {
+  if (!_client) _client = new Anthropic();
+  return _client;
+}
+
+const MODEL_ID = 'claude-sonnet-4-6';
+const MAX_OUTPUT_TOKENS = 500;
+
+export type CoalitionInsightsResult = {
+  text: string;
+  modelId: string;
+  promptVersion: string;
+};
+
+export async function generateCoalitionInsights(
+  digest: CoalitionWeeklyDigest,
+): Promise<CoalitionInsightsResult> {
+  const response = await client().messages.create({
+    model: MODEL_ID,
+    max_tokens: MAX_OUTPUT_TOKENS,
+    system: [
+      {
+        type: 'text',
+        text: COALITION_INSIGHTS_SYSTEM_PROMPT,
+        cache_control: { type: 'ephemeral' },
+      },
+    ],
+    messages: [{ role: 'user', content: buildCoalitionInsightsUserPrompt(digest) }],
+  });
+
+  const text = response.content
+    .flatMap((c) => (c.type === 'text' ? [c.text] : []))
+    .join('\n')
+    .trim();
+  if (!text) {
+    throw new Error(`[coalition-insights] empty response; stop_reason=${response.stop_reason}`);
+  }
+  return { text, modelId: MODEL_ID, promptVersion: COALITION_INSIGHTS_PROMPT_VERSION };
+}


### PR DESCRIPTION
## Summary
- New \`/app/coalition/insights\` view for the coordinator / steering committee. Claude reads aggregates + action-blocked queues + top patterns and writes a 3-paragraph brief (pulse / patterns / what-to-ask)
- Coordinator persona — system prompt is explicit about NOT referencing individual synthetic_person_refs; per-person detail lives on the person view
- 10 parallel aggregates in one query function (filings, intakes, service events, consent grants/revocations, urgent intakes, high-risk filings without packets, cross-org touches, top high-risk filings, top partner event types)
- Window picker (7 / 14 / 30 days), by-the-numbers grid alongside the AI brief, model + prompt fingerprint at the bottom
- Gated to \`admin\` + \`attorney\`. CTA on coalition hub for those roles only

## Test plan
- [ ] Visit /app/coalition/insights as admin → click "Run weekly insights" → 3-paragraph brief renders alongside the by-the-numbers grid
- [ ] Switch the window to 14 days → re-run → counts and brief update
- [ ] Verify the brief never names a synthetic_person_ref
- [ ] On a fresh DB with everything = 0, the brief is one line ("nothing to report") not padded
- [ ] Caseworker / shelter_staff users get 404 on the insights page; CTA does not render on coalition hub
- [ ] Audit log shows \`coalition_insights.generated\` + \`ai.generated\` rows