### PR TITLE
feat(EVDT): batch outreach drafting on attorney triage

### DIFF
--- a/src/app/actions/eviction.ts
+++ b/src/app/actions/eviction.ts
@@ -407,6 +407,86 @@ export async function askCaseQuestionAction(
   }
 }
 
+export type BatchOutreachItem =
+  | { ok: true; filingId: string; text: string; promptVersion: string }
+  | { ok: false; filingId: string; error: string };
+
+export type GenerateBatchOutreachResult =
+  | { ok: true; items: BatchOutreachItem[] }
+  | { ok: false; error: string };
+
+const BATCH_OUTREACH_MAX = 8;
+
+/**
+ * Run `generateOutreachLetter` for a list of filing ids in parallel.
+ * Used by the attorney morning-triage page to draft outreach for
+ * every pick at once. Failures are per-item so a single bad filing
+ * id (or an Anthropic glitch) doesn't fail the batch.
+ */
+export async function generateOutreachLettersBatchAction(
+  filingIds: string[],
+): Promise<GenerateBatchOutreachResult> {
+  const user = await requireKlaAttorney();
+
+  if (!Array.isArray(filingIds) || filingIds.length === 0) {
+    return { ok: false, error: 'No filings provided.' };
+  }
+  if (filingIds.length > BATCH_OUTREACH_MAX) {
+    return {
+      ok: false,
+      error: `Batch too large (max ${BATCH_OUTREACH_MAX}). Run triage and try again.`,
+    };
+  }
+  const seen = new Set<string>();
+  const unique = filingIds.filter((id) => {
+    if (seen.has(id)) return false;
+    seen.add(id);
+    return true;
+  });
+
+  const settled = await Promise.allSettled(
+    unique.map(async (filingId): Promise<BatchOutreachItem> => {
+      const filing = await getFilingById(filingId);
+      if (!filing) return { ok: false, filingId, error: 'Filing not found.' };
+      try {
+        const result = await generateOutreachLetter(filing);
+        await logAuditEvent({
+          actorUserId: user.id,
+          action: 'outreach_letter.generated',
+          targetTable: 'eviction_filings',
+          targetId: filing.id,
+          metadata: {
+            promptVersion: result.promptVersion,
+            caseNumber: filing.caseNumber,
+            via: 'triage_batch',
+          },
+        });
+        await recordAiGeneration({
+          actorUserId: user.id,
+          resourceType: 'tenant_outreach_letter',
+          resourceId: filing.id,
+          model: result.modelId,
+          promptVersion: result.promptVersion,
+          metadata: { caseNumber: filing.caseNumber, via: 'triage_batch' },
+        });
+        return { ok: true, filingId, text: result.text, promptVersion: result.promptVersion };
+      } catch (err) {
+        Sentry.captureException(err, {
+          tags: { action: 'generateOutreachLettersBatchAction', filingId },
+        });
+        return { ok: false, filingId, error: 'Letter generation failed.' };
+      }
+    }),
+  );
+
+  const items: BatchOutreachItem[] = settled.map((s, i) => {
+    if (s.status === 'fulfilled') return s.value;
+    return { ok: false, filingId: unique[i], error: 'Unexpected failure.' };
+  });
+
+  return { ok: true, items };
+}
+
 export type GenerateAttorneyTriageResult =
   | {
       ok: true;

--- a/src/components/eviction/attorney-triage-panel.tsx
+++ b/src/components/eviction/attorney-triage-panel.tsx
@@ -3,8 +3,10 @@
 import Link from 'next/link';
 import { useState, useTransition } from 'react';
 import {
+  type BatchOutreachItem,
   type GenerateAttorneyTriageResult,
   generateAttorneyTriageAction,
+  generateOutreachLettersBatchAction,
 } from '@/app/actions/eviction';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
@@ -20,10 +22,59 @@ const fmtDate = (iso: string) =>
 
 type SuccessResult = Extract<GenerateAttorneyTriageResult, { ok: true }>;
 
+function BatchLetterBlock({ filingId, letter }: { filingId: string; letter: BatchOutreachItem }) {
+  const [text, setText] = useState(letter.ok ? letter.text : '');
+  const [copied, setCopied] = useState(false);
+  const [copyError, setCopyError] = useState<string | null>(null);
+
+  if (!letter.ok) {
+    return (
+      <p className="mt-3 rounded-md border border-destructive/40 bg-destructive/5 p-2 text-xs text-destructive">
+        Couldn't draft outreach for this filing: {letter.error}
+      </p>
+    );
+  }
+
+  const onCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(text);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      setCopyError('Copy failed — select the text manually.');
+    }
+  };
+
+  return (
+    <div className="mt-3 space-y-2 rounded-md border border-primary/40 bg-primary/5 p-2">
+      <p className="text-[11px] uppercase tracking-wide text-muted-foreground">
+        Outreach letter draft
+      </p>
+      <textarea
+        value={text}
+        onChange={(e) => setText(e.target.value)}
+        rows={10}
+        className="w-full rounded-md border border-input bg-background p-2 font-mono text-[11px] leading-relaxed"
+        aria-label={`Outreach letter draft for ${filingId}`}
+      />
+      <div className="flex flex-wrap items-center gap-3 text-xs text-muted-foreground">
+        <Button type="button" size="sm" variant="outline" onClick={onCopy}>
+          {copied ? 'Copied ✓' : 'Copy'}
+        </Button>
+        <span>{text.length} chars</span>
+        {copyError ? <span className="text-destructive">{copyError}</span> : null}
+      </div>
+    </div>
+  );
+}
+
 export function AttorneyTriagePanel() {
   const [pending, startTransition] = useTransition();
+  const [batchPending, startBatchTransition] = useTransition();
   const [data, setData] = useState<SuccessResult | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [batchError, setBatchError] = useState<string | null>(null);
+  const [outreachByFiling, setOutreachByFiling] = useState<Record<string, BatchOutreachItem>>({});
 
   const onClick = () => {
     setError(null);
@@ -34,6 +85,22 @@ export function AttorneyTriagePanel() {
         return;
       }
       setData(r);
+      setOutreachByFiling({});
+      setBatchError(null);
+    });
+  };
+
+  const onBatchOutreach = (filingIds: string[]) => {
+    setBatchError(null);
+    startBatchTransition(async () => {
+      const r = await generateOutreachLettersBatchAction(filingIds);
+      if (!r.ok) {
+        setBatchError(r.error);
+        return;
+      }
+      const next: Record<string, BatchOutreachItem> = {};
+      for (const item of r.items) next[item.filingId] = item;
+      setOutreachByFiling(next);
     });
   };
 
@@ -84,50 +151,78 @@ export function AttorneyTriagePanel() {
             No cases need attention today out of {result.candidateCount} open in the window.
           </p>
         ) : (
-          <ol className="space-y-3">
-            {sortedPicks.map((p) => {
-              const c = candById.get(p.filing_id);
-              if (!c) return null;
-              return (
-                <li
-                  key={p.filing_id}
-                  className="rounded-md border border-border bg-card p-3 text-sm"
-                >
-                  <div className="mb-1 flex flex-wrap items-baseline justify-between gap-2">
-                    <div className="flex items-baseline gap-2">
-                      <span className="rounded bg-muted px-1.5 py-0.5 font-mono text-[10px]">
-                        #{p.priority_rank}
-                      </span>
-                      <Link
-                        href={`/app/cases/filings/${p.filing_id}`}
-                        className="font-mono text-xs font-medium hover:underline"
-                      >
-                        {c.caseNumber}
-                      </Link>
-                      <span className="text-xs text-muted-foreground">{c.causeType}</span>
-                    </div>
-                    <div className="flex items-baseline gap-3 text-xs">
-                      {c.score != null ? (
-                        <span className={`font-medium ${riskBandClass(c.score)}`}>
-                          score {c.score}
+          <>
+            <div className="flex flex-wrap items-center gap-3 rounded-md border border-primary/40 bg-primary/5 p-3">
+              <div className="flex-1 text-xs text-muted-foreground">
+                Draft a tenant outreach letter for every pick at once. Each one is fully editable
+                inline; you copy the text into your real mail tool.
+              </div>
+              <Button
+                onClick={() => onBatchOutreach(sortedPicks.map((p) => p.filing_id))}
+                disabled={batchPending}
+                size="sm"
+              >
+                {batchPending
+                  ? `Drafting ${sortedPicks.length}…`
+                  : `Draft outreach for all ${sortedPicks.length}`}
+              </Button>
+              {batchError ? (
+                <span className="w-full text-xs text-destructive">{batchError}</span>
+              ) : null}
+            </div>
+            <ol className="space-y-3">
+              {sortedPicks.map((p) => {
+                const c = candById.get(p.filing_id);
+                if (!c) return null;
+                const letter = outreachByFiling[p.filing_id];
+                return (
+                  <li
+                    key={p.filing_id}
+                    className="rounded-md border border-border bg-card p-3 text-sm"
+                  >
+                    <div className="mb-1 flex flex-wrap items-baseline justify-between gap-2">
+                      <div className="flex items-baseline gap-2">
+                        <span className="rounded bg-muted px-1.5 py-0.5 font-mono text-[10px]">
+                          #{p.priority_rank}
                         </span>
-                      ) : (
-                        <span className="text-muted-foreground italic">unscored</span>
-                      )}
-                      <span className="text-muted-foreground">
-                        {fmtMoney(c.amountClaimedCents)}
-                      </span>
+                        <Link
+                          href={`/app/cases/filings/${p.filing_id}`}
+                          className="font-mono text-xs font-medium hover:underline"
+                        >
+                          {c.caseNumber}
+                        </Link>
+                        <span className="text-xs text-muted-foreground">{c.causeType}</span>
+                      </div>
+                      <div className="flex items-baseline gap-3 text-xs">
+                        {c.score != null ? (
+                          <span className={`font-medium ${riskBandClass(c.score)}`}>
+                            score {c.score}
+                          </span>
+                        ) : (
+                          <span className="text-muted-foreground italic">unscored</span>
+                        )}
+                        <span className="text-muted-foreground">
+                          {fmtMoney(c.amountClaimedCents)}
+                        </span>
+                      </div>
                     </div>
-                  </div>
-                  <p className="text-sm leading-relaxed">{p.rationale}</p>
-                  <div className="mt-1 text-[11px] text-muted-foreground">
-                    filed {fmtDate(c.filedAt)} · status {c.status} ·{' '}
-                    {c.packetStatus ? `packet ${c.packetStatus}` : 'no packet drafted'}
-                  </div>
-                </li>
-              );
-            })}
-          </ol>
+                    <p className="text-sm leading-relaxed">{p.rationale}</p>
+                    <div className="mt-1 text-[11px] text-muted-foreground">
+                      filed {fmtDate(c.filedAt)} · status {c.status} ·{' '}
+                      {c.packetStatus ? `packet ${c.packetStatus}` : 'no packet drafted'}
+                    </div>
+                    {letter ? (
+                      <BatchLetterBlock filingId={p.filing_id} letter={letter} />
+                    ) : batchPending ? (
+                      <p className="mt-3 rounded-md border border-dashed border-border bg-muted/30 p-2 text-xs text-muted-foreground italic">
+                        Drafting outreach letter…
+                      </p>
+                    ) : null}
+                  </li>
+                );
+              })}
+            </ol>
+          </>
         )}
 
         <div className="flex flex-wrap gap-x-4 gap-y-1 text-[11px] text-muted-foreground">


### PR DESCRIPTION
## Summary
- After morning triage returns 3-5 picks, KLA attorney clicks "Draft outreach for all N" → batch action drafts a tenant outreach letter for every pick in parallel
- Each letter renders inline under its pick: editable textarea, char counter, copy-to-clipboard
- \`Promise.allSettled\` per filing — one bad filing id or one Anthropic glitch doesn't fail the batch; per-item errors render as a small red note in place of the textarea
- Each letter audited individually with \`via=triage_batch\` metadata tag so the DTRS transparency report can split single-letter from batch generations
- Server-side cap of 8 letters per batch + dedup of input ids

## Test plan
- [ ] Run today's triage → click "Draft outreach for all" → verify all picks show a letter draft inline
- [ ] Edit a draft → char counter updates; "Copy" copies the edited text
- [ ] If one filing is invalid, the others still render; the bad one shows the per-item error
- [ ] Audit log shows N rows of \`outreach_letter.generated\` with \`via=triage_batch\`