### PR TITLE
feat(ESUC): ED morning triage view

### DIFF
--- a/src/ai/prompts/ed-triage.ts
+++ b/src/ai/prompts/ed-triage.ts
@@ -1,0 +1,114 @@
+import { z } from 'zod';
+import type { EdTriageCandidate } from '@/db/queries/ed-triage';
+
+/**
+ * ED super-utilizer morning-triage prompt.
+ *
+ * Care coordinator opens this view at 8am, reads it in 30 seconds,
+ * and decides who to chart-review or call first. Input: the current
+ * super-utilizer queue (≥3 ED visits in 180d + housing instability)
+ * with each patient's care-plan status. Output: 3-5 patients ranked,
+ * one sentence each.
+ *
+ * The patient_id is opaque (SYN-PAT-... synthetic, hashed post-BAA).
+ * The model sees no PHI — chief complaints stay summarized as the
+ * field is, but no name, MRN, or contact info is ever in the prompt.
+ */
+
+export const ED_TRIAGE_PROMPT_VERSION = 'ed-triage-v1@2026-04-26';
+
+export const ED_TRIAGE_SYSTEM_PROMPT = `You are the morning triage assistant for a Daviess County ED
+super-utilizer care coordinator. The coordinator opens this view at
+8am with ~30 seconds to plan the day.
+
+Input: the current super-utilizer queue. Each row is one patient
+identified ONLY by an opaque ref (SYN-PAT-...) plus visit count,
+housing status, last chief complaint, latest visit timestamp, and
+the status of any AI-drafted care plan on file.
+
+Output: 3 to 5 patients ranked by who needs the coordinator's
+attention FIRST today. For each pick, write one sentence (under 25
+words) explaining the rationale. Plain English. No clinical jargon.
+
+How to think about ranking:
+
+1. **Action-blocked goes first.** A patient with no care plan
+   drafted is more triage-urgent than a patient whose plan is
+   approved and active.
+2. **Recent visit + unsheltered** is higher priority than
+   recent visit + doubled-up. The housing exposure matters.
+3. **Visit volume matters but doesn't trump action gaps.** A 9-visit
+   patient with an active plan can wait if a 4-visit unsheltered
+   patient has no plan.
+4. **Don't pick patients with archived or active plans** unless the
+   visit volume just spiked — those are coordinator-stable.
+5. **Don't pad to 5.** If only 3 patients deserve attention today,
+   return 3.
+
+Reasoning style:
+- Lead with WHY this one. Examples:
+  - "Unsheltered, 5 visits in 30 days, no plan drafted — the
+    coordinator can unblock this in 10 minutes."
+  - "Plan was drafted last month but never approved — worth a quick
+    review before re-engaging the patient."
+  - "Top of queue by volume (12 visits) but plan is active — not
+    urgent today, just a check-in."
+- Don't restate the visit count or housing status — the UI shows
+  those next to the rationale.
+
+Hard rules:
+- Reference patients ONLY by their patient_id from the input. Do
+  not invent ids.
+- Do not invent clinical facts — only what's in the input.
+- Do not give clinical advice. The coordinator decides care.
+- Output ONLY the structured JSON your schema demands.`;
+
+export const EdTriageItemSchema = z.object({
+  patient_id: z.string().min(1),
+  priority_rank: z.number().int().min(1).max(5),
+  rationale: z
+    .string()
+    .min(10)
+    .max(220)
+    .describe('One sentence under 25 words explaining why this patient ranks here.'),
+});
+
+export const EdTriageOutputSchema = z.object({
+  picks: z
+    .array(EdTriageItemSchema)
+    .min(1)
+    .max(5)
+    .describe('Up to 5 patients ranked by today-priority. Order matters; do not pad.'),
+  overall_note: z
+    .string()
+    .max(200)
+    .nullable()
+    .describe(
+      'Optional one-sentence overview ("Quiet morning — only 2 patients need attention"). Null if nothing to say.',
+    ),
+});
+
+export type EdTriageOutput = z.infer<typeof EdTriageOutputSchema>;
+
+export function buildEdTriageUserPrompt(candidates: EdTriageCandidate[]): string {
+  const lines: string[] = [
+    "Here is today's ED super-utilizer queue. Pick the top 3-5 to focus on first.",
+    '',
+    `Today's date: ${new Date().toISOString().slice(0, 10)}`,
+    `Candidate count: ${candidates.length}`,
+    '',
+  ];
+
+  for (const c of candidates) {
+    const latest = c.latestVisitAt.toISOString().slice(0, 10);
+    const plan = c.carePlanStatus ?? 'no plan';
+    lines.push(
+      `- patient_id=${c.patientId} · visits=${c.visitCount} · housing=${c.housingStatus} ` +
+        `· last_visit=${latest} · last_complaint="${c.lastChiefComplaint}" · plan=${plan}`,
+    );
+  }
+
+  lines.push('');
+  lines.push('Return the structured triage list now.');
+  return lines.join('\n');
+}

--- a/src/app/actions/care.ts
+++ b/src/app/actions/care.ts
@@ -4,11 +4,14 @@ import * as Sentry from '@sentry/nextjs';
 import { eq } from 'drizzle-orm';
 import { revalidatePath } from 'next/cache';
 import { db } from '@/db/client';
+import { listEdTriageCandidates } from '@/db/queries/ed-triage';
 import { type EsucCarePlanStatus, esucCarePlanStatusEnum } from '@/db/schema/enums';
 import { esucCarePlans } from '@/db/schema/esuc-care-plans';
 import { logAuditEvent } from '@/lib/audit';
 import { requireRole } from '@/lib/auth';
+import { recordAiGeneration } from '@/lib/dtrs/data-access';
 import { generateCarePlan, validateCarePlanDisclaimer } from '@/lib/esuc/care-plan';
+import { type EdTriageResult, generateEdTriage } from '@/lib/esuc/ed-triage';
 
 export type GenerateCarePlanResult = { ok: true } | { ok: false; error: string };
 
@@ -26,6 +29,62 @@ export async function generateCarePlanAction(patientId: string): Promise<Generat
 
   revalidatePath(`/app/care/patients/${patientId}`);
   return { ok: true };
+}
+
+export type GenerateEdTriageResult =
+  | {
+      ok: true;
+      result: EdTriageResult;
+      candidates: Array<{
+        patientId: string;
+        visitCount: number;
+        housingStatus: string;
+        latestVisitAt: string;
+        lastChiefComplaint: string;
+        carePlanStatus: string | null;
+      }>;
+    }
+  | { ok: false; error: string };
+
+export async function generateEdTriageAction(): Promise<GenerateEdTriageResult> {
+  const user = await requireRole(CARE_ROLES);
+
+  try {
+    const candidates = await listEdTriageCandidates({ windowDays: 180, limit: 20 });
+    const result = await generateEdTriage(candidates);
+
+    await logAuditEvent({
+      actorUserId: user.id,
+      action: 'ed_triage.generated',
+      targetTable: 'ed_encounters',
+      metadata: {
+        candidateCount: result.candidateCount,
+        picksReturned: result.output.picks.length,
+      },
+    });
+    await recordAiGeneration({
+      actorUserId: user.id,
+      resourceType: 'ed_triage',
+      resourceId: 'morning_triage',
+      model: result.modelId,
+      promptVersion: result.promptVersion,
+      metadata: { candidateCount: result.candidateCount },
+    });
+
+    const candidateMeta = candidates.map((c) => ({
+      patientId: c.patientId,
+      visitCount: c.visitCount,
+      housingStatus: c.housingStatus,
+      latestVisitAt: c.latestVisitAt.toISOString(),
+      lastChiefComplaint: c.lastChiefComplaint,
+      carePlanStatus: c.carePlanStatus,
+    }));
+
+    return { ok: true, result, candidates: candidateMeta };
+  } catch (err) {
+    Sentry.captureException(err, { tags: { action: 'generateEdTriageAction' } });
+    return { ok: false, error: 'Triage generation failed. Please try again.' };
+  }
 }
 
 export type SaveCarePlanResult = { ok: true } | { ok: false; error: string };

--- a/src/app/app/care/queue/page.tsx
+++ b/src/app/app/care/queue/page.tsx
@@ -1,3 +1,4 @@
+import Link from 'next/link';
 import { CareQueueFilters, type CareQueueFilterValues } from '@/components/esuc/care-queue-filters';
 import { CareQueueTable } from '@/components/esuc/care-queue-table';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
@@ -54,12 +55,20 @@ export default async function CareQueuePage({
 
   return (
     <div className="mx-auto max-w-6xl space-y-4 p-6">
-      <header>
-        <h1 className="font-serif text-3xl font-bold text-primary">Care queue</h1>
-        <p className="text-sm text-muted-foreground">
-          ED super-utilizers (3+ visits in 180 days, housing-unstable) for care-coordinator
-          outreach. Patient identifiers are opaque — names live in Epic, not here.
-        </p>
+      <header className="flex flex-wrap items-baseline justify-between gap-3">
+        <div>
+          <h1 className="font-serif text-3xl font-bold text-primary">Care queue</h1>
+          <p className="text-sm text-muted-foreground">
+            ED super-utilizers (3+ visits in 180 days, housing-unstable) for care-coordinator
+            outreach. Patient identifiers are opaque — names live in Epic, not here.
+          </p>
+        </div>
+        <Link
+          href="/app/care/triage"
+          className="shrink-0 rounded-md bg-primary px-3 py-2 text-xs font-medium text-primary-foreground hover:bg-primary/90"
+        >
+          Morning triage →
+        </Link>
       </header>
 
       <CareQueueFilters values={values} />

--- a/src/app/app/care/triage/page.tsx
+++ b/src/app/app/care/triage/page.tsx
@@ -1,0 +1,41 @@
+import Link from 'next/link';
+import { EdTriagePanel } from '@/components/esuc/ed-triage-panel';
+import { Card, CardContent } from '@/components/ui/card';
+import { requireRole } from '@/lib/auth';
+
+export const dynamic = 'force-dynamic';
+
+export default async function EdTriagePage() {
+  await requireRole(['ed_coordinator', 'admin']);
+
+  return (
+    <div className="mx-auto max-w-4xl space-y-4 p-4 md:p-6">
+      <div className="text-xs">
+        <Link href="/app/care/queue" className="text-muted-foreground hover:underline">
+          ← Back to care queue
+        </Link>
+      </div>
+      <header>
+        <h1 className="font-serif text-3xl font-bold text-primary">ED morning triage</h1>
+        <p className="text-sm text-muted-foreground">
+          Claude reads the super-utilizer queue and picks the 3-5 patients you should focus on
+          first. Action-blocked goes first; stable patients with active plans drop out. Re-run any
+          time the queue changes.
+        </p>
+      </header>
+
+      <EdTriagePanel />
+
+      <Card className="border-amber-500/40 bg-amber-500/5">
+        <CardContent className="text-xs">
+          <p className="font-medium">Triage aid, not a clinical decision.</p>
+          <p className="mt-1 text-muted-foreground">
+            Patient identifiers are opaque (SYN-PAT-... synthetic, hashed Epic ids post-BAA). Claude
+            sees no PHI — just visit count, housing status, last chief complaint, plan status. Your
+            judgment on next steps; the AI just orders the queue.
+          </p>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/components/esuc/ed-triage-panel.tsx
+++ b/src/components/esuc/ed-triage-panel.tsx
@@ -1,0 +1,139 @@
+'use client';
+
+import Link from 'next/link';
+import { useState, useTransition } from 'react';
+import { type GenerateEdTriageResult, generateEdTriageAction } from '@/app/actions/care';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+
+const fmtDate = (iso: string) =>
+  new Intl.DateTimeFormat('en-US', { dateStyle: 'medium' }).format(new Date(iso));
+
+const housingClass: Record<string, string> = {
+  unsheltered: 'text-destructive',
+  shelter: 'text-amber-700 dark:text-amber-400',
+  doubled_up: 'text-amber-700 dark:text-amber-400',
+  housed: 'text-emerald-700 dark:text-emerald-400',
+  unknown: 'text-muted-foreground',
+};
+
+type SuccessResult = Extract<GenerateEdTriageResult, { ok: true }>;
+
+export function EdTriagePanel() {
+  const [pending, startTransition] = useTransition();
+  const [data, setData] = useState<SuccessResult | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const onClick = () => {
+    setError(null);
+    startTransition(async () => {
+      const r = await generateEdTriageAction();
+      if (!r.ok) {
+        setError(r.error);
+        return;
+      }
+      setData(r);
+    });
+  };
+
+  if (!data) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">Today's priority patients</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-3 text-sm">
+          <p className="text-muted-foreground">
+            Claude reviews the super-utilizer queue (3+ ED visits in 180 days, housing instability)
+            and picks the 3-5 patients you should focus on first today. Action-blocked goes first;
+            stable patients with active plans drop out.
+          </p>
+          <div className="flex items-center gap-3">
+            <Button onClick={onClick} disabled={pending} size="sm">
+              {pending ? 'Reading the queue…' : "Run today's triage"}
+            </Button>
+            {error ? <span className="text-xs text-destructive">{error}</span> : null}
+          </div>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  const { result, candidates } = data;
+  const candById = new Map(candidates.map((c) => [c.patientId, c]));
+  const sortedPicks = [...result.output.picks].sort((a, b) => a.priority_rank - b.priority_rank);
+
+  return (
+    <Card>
+      <CardHeader className="flex flex-row items-baseline justify-between gap-2">
+        <CardTitle className="text-base">Today's priority patients</CardTitle>
+        <Button onClick={onClick} disabled={pending} size="sm" variant="outline">
+          {pending ? 'Re-running…' : 'Re-run triage'}
+        </Button>
+      </CardHeader>
+      <CardContent className="space-y-4 text-sm">
+        {result.output.overall_note ? (
+          <p className="rounded-md border border-primary/40 bg-primary/5 p-3 text-sm">
+            {result.output.overall_note}
+          </p>
+        ) : null}
+
+        {sortedPicks.length === 0 ? (
+          <p className="text-muted-foreground">
+            No patients need attention today out of {result.candidateCount} on the queue.
+          </p>
+        ) : (
+          <ol className="space-y-3">
+            {sortedPicks.map((p) => {
+              const c = candById.get(p.patient_id);
+              if (!c) return null;
+              return (
+                <li
+                  key={p.patient_id}
+                  className="rounded-md border border-border bg-card p-3 text-sm"
+                >
+                  <div className="mb-1 flex flex-wrap items-baseline justify-between gap-2">
+                    <div className="flex items-baseline gap-2">
+                      <span className="rounded bg-muted px-1.5 py-0.5 font-mono text-[10px]">
+                        #{p.priority_rank}
+                      </span>
+                      <Link
+                        href={`/app/care/patients/${p.patient_id}`}
+                        className="font-mono text-xs font-medium hover:underline"
+                      >
+                        {p.patient_id}
+                      </Link>
+                    </div>
+                    <div className="flex items-baseline gap-3 text-xs">
+                      <span className="font-medium">{c.visitCount} visits</span>
+                      <span className={`font-medium ${housingClass[c.housingStatus] ?? ''}`}>
+                        {c.housingStatus}
+                      </span>
+                    </div>
+                  </div>
+                  <p className="text-sm leading-relaxed">{p.rationale}</p>
+                  <div className="mt-1 text-[11px] text-muted-foreground">
+                    last visit {fmtDate(c.latestVisitAt)} · "{c.lastChiefComplaint}" ·{' '}
+                    {c.carePlanStatus ? `plan ${c.carePlanStatus}` : 'no plan drafted'}
+                  </div>
+                </li>
+              );
+            })}
+          </ol>
+        )}
+
+        <div className="flex flex-wrap gap-x-4 gap-y-1 text-[11px] text-muted-foreground">
+          <span>
+            Reviewed {result.candidateCount} patient{result.candidateCount === 1 ? '' : 's'}
+          </span>
+          <span>
+            Model: <span className="font-mono">{result.modelId}</span>
+          </span>
+          <span>
+            Prompt: <span className="font-mono">{result.promptVersion}</span>
+          </span>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/db/queries/ed-triage.ts
+++ b/src/db/queries/ed-triage.ts
@@ -1,0 +1,46 @@
+import { desc, eq, inArray } from 'drizzle-orm';
+import { db } from '@/db/client';
+import type { EsucCarePlanStatus } from '@/db/schema/enums';
+import { esucCarePlans } from '@/db/schema/esuc-care-plans';
+import type { SuperUtilizerRow } from '@/lib/esuc/super-utilizer-ranking';
+import { listSuperUtilizers } from './ed-encounters';
+
+export type EdTriageCandidate = SuperUtilizerRow & {
+  carePlanStatus: EsucCarePlanStatus | null;
+};
+
+/**
+ * Pull the current super-utilizer queue and join each patient's most
+ * recent care-plan status. The AI uses both signals: visit volume +
+ * housing flag tells the queue who's burning the system; care-plan
+ * presence/status tells it where coordinator action is blocked or
+ * already done.
+ */
+export async function listEdTriageCandidates(
+  opts: { windowDays?: number; limit?: number } = {},
+): Promise<EdTriageCandidate[]> {
+  const candidates = await listSuperUtilizers({
+    windowDays: opts.windowDays ?? 180,
+    limit: opts.limit ?? 20,
+  });
+  if (candidates.length === 0) return [];
+
+  const patientIds = candidates.map((c) => c.patientId);
+  const planRows = await db
+    .select({ patientId: esucCarePlans.patientId, status: esucCarePlans.status })
+    .from(esucCarePlans)
+    .where(inArray(esucCarePlans.patientId, patientIds))
+    .orderBy(desc(esucCarePlans.createdAt));
+
+  const latestPlanByPatient = new Map<string, EsucCarePlanStatus>();
+  for (const row of planRows) {
+    if (!latestPlanByPatient.has(row.patientId)) {
+      latestPlanByPatient.set(row.patientId, row.status);
+    }
+  }
+
+  return candidates.map((c) => ({
+    ...c,
+    carePlanStatus: latestPlanByPatient.get(c.patientId) ?? null,
+  }));
+}

--- a/src/lib/esuc/ed-triage.ts
+++ b/src/lib/esuc/ed-triage.ts
@@ -1,0 +1,67 @@
+import Anthropic from '@anthropic-ai/sdk';
+import { zodOutputFormat } from '@anthropic-ai/sdk/helpers/zod';
+import {
+  buildEdTriageUserPrompt,
+  ED_TRIAGE_PROMPT_VERSION,
+  ED_TRIAGE_SYSTEM_PROMPT,
+  type EdTriageOutput,
+  EdTriageOutputSchema,
+} from '@/ai/prompts/ed-triage';
+import type { EdTriageCandidate } from '@/db/queries/ed-triage';
+
+let _client: Anthropic | null = null;
+function client(): Anthropic {
+  if (!_client) _client = new Anthropic();
+  return _client;
+}
+
+const MODEL_ID = 'claude-sonnet-4-6';
+
+export type EdTriageResult = {
+  output: EdTriageOutput;
+  modelId: string;
+  promptVersion: string;
+  candidateCount: number;
+};
+
+export async function generateEdTriage(candidates: EdTriageCandidate[]): Promise<EdTriageResult> {
+  if (candidates.length === 0) {
+    return {
+      output: { picks: [], overall_note: null },
+      modelId: MODEL_ID,
+      promptVersion: ED_TRIAGE_PROMPT_VERSION,
+      candidateCount: 0,
+    };
+  }
+
+  const response = await client().messages.parse({
+    model: MODEL_ID,
+    max_tokens: 1500,
+    system: [
+      {
+        type: 'text',
+        text: ED_TRIAGE_SYSTEM_PROMPT,
+        cache_control: { type: 'ephemeral' },
+      },
+    ],
+    messages: [{ role: 'user', content: buildEdTriageUserPrompt(candidates) }],
+    output_config: { format: zodOutputFormat(EdTriageOutputSchema) },
+  });
+
+  if (!response.parsed_output) {
+    throw new Error(`[ed-triage] parse failed; stop_reason=${response.stop_reason}`);
+  }
+
+  const validIds = new Set(candidates.map((c) => c.patientId));
+  const cleaned: EdTriageOutput = {
+    picks: response.parsed_output.picks.filter((p) => validIds.has(p.patient_id)),
+    overall_note: response.parsed_output.overall_note,
+  };
+
+  return {
+    output: cleaned,
+    modelId: MODEL_ID,
+    promptVersion: ED_TRIAGE_PROMPT_VERSION,
+    candidateCount: candidates.length,
+  };
+}


### PR DESCRIPTION
## Summary
- New \`/app/care/triage\` view for care coordinators. Claude reads the super-utilizer queue (3+ ED visits in 180d + housing instability) plus each patient's care-plan status and returns 3-5 ranked picks for who to chart-review or call first today
- Triage logic mirrors attorney triage: action-blocked goes first (no plan drafted), stable patients with active plans drop out, don't pad to 5
- PHI fence stays clean — patient ids in the prompt are opaque (\`SYN-PAT-...\`), no name/MRN/contact info ever crosses
- Belt-and-braces filter drops any pick whose patient_id isn't in the candidate set
- "Morning triage →" CTA on the care queue header

## Test plan
- [ ] Open /app/care/triage as ed_coordinator → click "Run today's triage" → verify 3-5 picks with rationale, ranked, with visits/housing/plan-status next to each
- [ ] Click a patient from the picks → lands on patient detail
- [ ] Re-run works
- [ ] Non-coordinator users get 404 on the page; CTA does not render on the care queue for them
- [ ] Audit log shows \`ed_triage.generated\` + \`ai.generated\` rows