### PR TITLE
feat(CWT): caseworker morning triage view

### DIFF
--- a/src/ai/prompts/cwt-triage.ts
+++ b/src/ai/prompts/cwt-triage.ts
@@ -1,0 +1,125 @@
+import { z } from 'zod';
+import { type CwtTriageCandidate, summarizeIntakeForTriage } from '@/db/queries/cwt-triage';
+
+/**
+ * Caseworker morning-triage prompt.
+ *
+ * Caseworker opens this view at 9am with ~30 seconds to plan their
+ * day. Two kinds of candidates feed in:
+ *  - intake (extracted, last 30 days) — urgency + presenting issue
+ *    are the action signals
+ *  - person (cross-partner touchpoints, last 14 days) — the pattern
+ *    is the action signal
+ *
+ * AI picks 3-5, ordered by who needs the caseworker FIRST.
+ */
+
+export const CWT_TRIAGE_PROMPT_VERSION = 'cwt-triage-v1@2026-04-26';
+
+export const CWT_TRIAGE_SYSTEM_PROMPT = `You are the morning triage assistant for a caseworker in a Daviess
+County, Kentucky homelessness coalition. The caseworker opens this
+view at 9am with ~30 seconds to plan their day. They handle a mix
+of fresh intakes (people who just walked in) and ongoing cases
+(people whose activity across coalition partners says they need
+follow-up).
+
+Input: a list of candidates. Each candidate is either:
+- kind=intake: a recently extracted intake. You see the label,
+  presenting issue (in the client's words), urgency, top needs,
+  and any flags (DV concern, SUD engaged, mental-health engaged,
+  has-caseworker-relationship).
+- kind=person: a synthetic person ref with cross-partner touchpoints
+  in the last 14 days. You see the partner count, total events, and
+  partner names.
+
+Output: 3 to 5 candidates ranked by who needs the caseworker FIRST
+today. For each, write one sentence (under 25 words) of rationale.
+
+Ranking heuristics:
+
+1. **DV-flagged intakes go first.** Safety risk trumps everything.
+2. **Urgent intakes (today / within_7_days) over 30-day-urgent.**
+3. **Cross-partner pattern (3+ partners) over 2-partner pattern.**
+   The high-touch pattern is exactly the signal the platform was
+   built to surface.
+4. **Fresh intakes with no caseworker-relationship flag** over
+   intakes flagged "has_caseworker_relationship" — those are
+   already being worked.
+5. **Don't pad to 5.** If only 2 candidates deserve attention,
+   return 2.
+
+Reasoning style for each pick:
+- Lead with WHY this one. Examples:
+  - "DV concern flagged in this intake, urgency=today — call before
+    anything else this morning."
+  - "Touched 4 partners in 10 days but no recent intake — worth a
+    check-in to see if anything's slipping through."
+  - "Fresh extract with urgency=within_7_days, top need is 'rent
+    by Friday' — the kind of case that fits the screener."
+
+Hard rules:
+- Reference candidates ONLY by candidate_id from the input.
+- Don't invent facts — only what's in the candidate row.
+- Don't give clinical or legal advice. The caseworker decides.
+- Output ONLY the structured JSON your schema demands.`;
+
+export const CwtTriageItemSchema = z.object({
+  candidate_id: z.string().min(1),
+  kind: z.enum(['intake', 'person']),
+  priority_rank: z.number().int().min(1).max(5),
+  rationale: z
+    .string()
+    .min(10)
+    .max(220)
+    .describe('One sentence under 25 words explaining why this candidate ranks here.'),
+});
+
+export const CwtTriageOutputSchema = z.object({
+  picks: z
+    .array(CwtTriageItemSchema)
+    .min(1)
+    .max(5)
+    .describe('Up to 5 candidates ranked by today-priority. Order matters; do not pad.'),
+  overall_note: z
+    .string()
+    .max(200)
+    .nullable()
+    .describe('Optional one-sentence overview of the queue today. Null if nothing to say.'),
+});
+
+export type CwtTriageOutput = z.infer<typeof CwtTriageOutputSchema>;
+
+export function buildCwtTriageUserPrompt(candidates: CwtTriageCandidate[]): string {
+  const lines: string[] = [
+    "Here is today's caseworker queue. Pick the top 3-5 to focus on first.",
+    '',
+    `Today's date: ${new Date().toISOString().slice(0, 10)}`,
+    `Candidate count: ${candidates.length}`,
+    '',
+  ];
+
+  for (const c of candidates) {
+    if (c.kind === 'intake') {
+      const s = summarizeIntakeForTriage(c.intake);
+      const created = c.intake.createdAt.toISOString().slice(0, 10);
+      lines.push(
+        `- candidate_id=${c.candidateId} · kind=intake · created=${created} · label="${c.intake.label}"` +
+          (s.presenting ? ` · presenting="${s.presenting}"` : '') +
+          (s.urgency ? ` · urgency=${s.urgency}` : '') +
+          (s.flags.length > 0 ? ` · flags=${s.flags.join(',')}` : '') +
+          (s.topNeeds.length > 0 ? ` · top_needs="${s.topNeeds.join(', ')}"` : ''),
+      );
+    } else {
+      const a = c.aggregate;
+      const latest = a.latestEventAt.toISOString().slice(0, 10);
+      lines.push(
+        `- candidate_id=${c.candidateId} · kind=person · latest=${latest} · ` +
+          `partners=${a.uniqueOrgs} · events=${a.totalEvents} · org_names="${a.orgNames.join(', ')}"`,
+      );
+    }
+  }
+
+  lines.push('');
+  lines.push('Return the structured triage list now.');
+  return lines.join('\n');
+}

--- a/src/app/actions/cwt-triage.ts
+++ b/src/app/actions/cwt-triage.ts
@@ -1,0 +1,97 @@
+'use server';
+
+import * as Sentry from '@sentry/nextjs';
+import {
+  type CwtTriageCandidate,
+  listCwtTriageCandidates,
+  summarizeIntakeForTriage,
+} from '@/db/queries/cwt-triage';
+import { logAuditEvent } from '@/lib/audit';
+import { requireRole } from '@/lib/auth';
+import { type CwtTriageResult, generateCwtTriage } from '@/lib/cwt/cwt-triage';
+import { recordAiGeneration } from '@/lib/dtrs/data-access';
+
+const ROLES = ['caseworker', 'shelter_staff', 'admin'] as const;
+
+export type CwtTriageCandidateMeta = {
+  candidateId: string;
+  kind: 'intake' | 'person';
+  // Intake-specific
+  label?: string;
+  createdAt?: string;
+  presenting?: string | null;
+  urgency?: string | null;
+  topNeeds?: string[];
+  flags?: string[];
+  // Person-specific
+  partners?: number;
+  events?: number;
+  orgNames?: string[];
+  latestEventAt?: string;
+};
+
+export type GenerateCwtTriageResult =
+  | { ok: true; result: CwtTriageResult; candidates: CwtTriageCandidateMeta[] }
+  | { ok: false; error: string };
+
+export async function generateCwtTriageAction(): Promise<GenerateCwtTriageResult> {
+  const actor = await requireRole(ROLES);
+
+  try {
+    const candidates = await listCwtTriageCandidates({
+      intakeWindowDays: 30,
+      touchWindowDays: 14,
+      limit: 25,
+    });
+    const result = await generateCwtTriage(candidates);
+
+    await logAuditEvent({
+      actorUserId: actor.id,
+      action: 'cwt_triage.generated',
+      targetTable: 'client_intakes',
+      metadata: {
+        candidateCount: result.candidateCount,
+        picksReturned: result.output.picks.length,
+      },
+    });
+    await recordAiGeneration({
+      actorUserId: actor.id,
+      resourceType: 'cwt_triage',
+      resourceId: 'morning_triage',
+      model: result.modelId,
+      promptVersion: result.promptVersion,
+      metadata: { candidateCount: result.candidateCount },
+    });
+
+    const meta: CwtTriageCandidateMeta[] = candidates.map((c) => candidateMeta(c));
+
+    return { ok: true, result, candidates: meta };
+  } catch (err) {
+    Sentry.captureException(err, { tags: { action: 'generateCwtTriageAction' } });
+    return { ok: false, error: 'Triage generation failed. Please try again.' };
+  }
+}
+
+function candidateMeta(c: CwtTriageCandidate): CwtTriageCandidateMeta {
+  if (c.kind === 'intake') {
+    const s = summarizeIntakeForTriage(c.intake);
+    return {
+      candidateId: c.candidateId,
+      kind: 'intake',
+      label: c.intake.label,
+      createdAt: c.intake.createdAt.toISOString(),
+      presenting: s.presenting,
+      urgency: s.urgency,
+      topNeeds: s.topNeeds,
+      flags: s.flags,
+    };
+  }
+  return {
+    candidateId: c.candidateId,
+    kind: 'person',
+    partners: c.aggregate.uniqueOrgs,
+    events: c.aggregate.totalEvents,
+    orgNames: c.aggregate.orgNames,
+    latestEventAt: c.aggregate.latestEventAt.toISOString(),
+  };
+}

--- a/src/app/app/clients/morning/page.tsx
+++ b/src/app/app/clients/morning/page.tsx
@@ -1,0 +1,41 @@
+import Link from 'next/link';
+import { MorningTriagePanel } from '@/components/cwt/morning-triage-panel';
+import { Card, CardContent } from '@/components/ui/card';
+import { requireRole } from '@/lib/auth';
+
+export const dynamic = 'force-dynamic';
+
+export default async function CaseworkerMorningTriagePage() {
+  await requireRole(['caseworker', 'shelter_staff', 'admin']);
+
+  return (
+    <div className="mx-auto max-w-4xl space-y-4 p-4 md:p-6">
+      <div className="text-xs">
+        <Link href="/app/clients" className="text-muted-foreground hover:underline">
+          ← Back to clients
+        </Link>
+      </div>
+      <header>
+        <h1 className="font-serif text-3xl font-bold text-primary">Morning triage</h1>
+        <p className="text-sm text-muted-foreground">
+          Claude reads recent extracted intakes and people who touched ≥2 partners in the last two
+          weeks, picks the 3-5 you should focus on first. DV-flagged goes first; urgent intakes
+          before 30-day-urgent; cross-partner patterns where the platform earns its keep.
+        </p>
+      </header>
+
+      <MorningTriagePanel />
+
+      <Card className="border-amber-500/40 bg-amber-500/5">
+        <CardContent className="text-xs">
+          <p className="font-medium">Triage aid, not a decision.</p>
+          <p className="mt-1 text-muted-foreground">
+            The AI ranks based on what's recorded — extracted intake fields, partner event counts.
+            It doesn't see your conversations, your gut feel, or anything you haven't recorded.
+            Trust your read of the queue over the AI's.
+          </p>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/app/app/clients/page.tsx
+++ b/src/app/app/clients/page.tsx
@@ -14,12 +14,20 @@ export default async function ClientsPage() {
 
   return (
     <div className="mx-auto max-w-5xl space-y-4 p-6">
-      <header>
-        <h1 className="font-serif text-3xl font-bold text-primary">Clients</h1>
-        <p className="text-sm text-muted-foreground">
-          Caseworker tools and the cross-agency view. Real per-person records gated behind PHI
-          consent + BAA — Phase 1 surfaces work against synthetic person refs.
-        </p>
+      <header className="flex flex-wrap items-baseline justify-between gap-3">
+        <div>
+          <h1 className="font-serif text-3xl font-bold text-primary">Clients</h1>
+          <p className="text-sm text-muted-foreground">
+            Caseworker tools and the cross-agency view. Real per-person records gated behind PHI
+            consent + BAA — Phase 1 surfaces work against synthetic person refs.
+          </p>
+        </div>
+        <Link
+          href="/app/clients/morning"
+          className="shrink-0 rounded-md bg-primary px-3 py-2 text-xs font-medium text-primary-foreground hover:bg-primary/90"
+        >
+          Morning triage →
+        </Link>
       </header>
 
       <div className="grid gap-3 md:grid-cols-3">

--- a/src/components/cwt/morning-triage-panel.tsx
+++ b/src/components/cwt/morning-triage-panel.tsx
@@ -1,0 +1,187 @@
+'use client';
+
+import Link from 'next/link';
+import { useState, useTransition } from 'react';
+import {
+  type CwtTriageCandidateMeta,
+  type GenerateCwtTriageResult,
+  generateCwtTriageAction,
+} from '@/app/actions/cwt-triage';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+
+const fmtDate = (iso: string) =>
+  new Intl.DateTimeFormat('en-US', { dateStyle: 'medium' }).format(new Date(iso));
+
+const urgencyClass: Record<string, string> = {
+  today: 'text-destructive',
+  within_7_days: 'text-amber-700 dark:text-amber-400',
+  within_30_days: 'text-muted-foreground',
+  not_urgent: 'text-muted-foreground',
+};
+
+type SuccessResult = Extract<GenerateCwtTriageResult, { ok: true }>;
+
+export function MorningTriagePanel() {
+  const [pending, startTransition] = useTransition();
+  const [data, setData] = useState<SuccessResult | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const onClick = () => {
+    setError(null);
+    startTransition(async () => {
+      const r = await generateCwtTriageAction();
+      if (!r.ok) {
+        setError(r.error);
+        return;
+      }
+      setData(r);
+    });
+  };
+
+  if (!data) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">Today's caseworker priorities</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-3 text-sm">
+          <p className="text-muted-foreground">
+            Claude reads recent extracted intakes plus people who touched ≥2 partners in the last
+            two weeks, and picks the 3-5 you should focus on first today. DV-flagged goes first;
+            "today/within-7-days" urgency before "within-30-days"; cross-partner patterns where the
+            platform earns its keep.
+          </p>
+          <div className="flex items-center gap-3">
+            <Button onClick={onClick} disabled={pending} size="sm">
+              {pending ? 'Reading the queue…' : "Run today's triage"}
+            </Button>
+            {error ? <span className="text-xs text-destructive">{error}</span> : null}
+          </div>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  const { result, candidates } = data;
+  const candById = new Map(candidates.map((c) => [c.candidateId, c]));
+  const sortedPicks = [...result.output.picks].sort((a, b) => a.priority_rank - b.priority_rank);
+
+  return (
+    <Card>
+      <CardHeader className="flex flex-row items-baseline justify-between gap-2">
+        <CardTitle className="text-base">Today's caseworker priorities</CardTitle>
+        <Button onClick={onClick} disabled={pending} size="sm" variant="outline">
+          {pending ? 'Re-running…' : 'Re-run triage'}
+        </Button>
+      </CardHeader>
+      <CardContent className="space-y-4 text-sm">
+        {result.output.overall_note ? (
+          <p className="rounded-md border border-primary/40 bg-primary/5 p-3 text-sm">
+            {result.output.overall_note}
+          </p>
+        ) : null}
+
+        {sortedPicks.length === 0 ? (
+          <p className="text-muted-foreground">
+            No candidates need attention today out of {result.candidateCount} on the queue.
+          </p>
+        ) : (
+          <ol className="space-y-3">
+            {sortedPicks.map((p) => {
+              const c = candById.get(p.candidate_id);
+              if (!c) return null;
+              return (
+                <li
+                  key={p.candidate_id}
+                  className="rounded-md border border-border bg-card p-3 text-sm"
+                >
+                  <PickHeader pick={p} candidate={c} />
+                  <p className="text-sm leading-relaxed">{p.rationale}</p>
+                  <PickFooter candidate={c} />
+                </li>
+              );
+            })}
+          </ol>
+        )}
+
+        <div className="flex flex-wrap gap-x-4 gap-y-1 text-[11px] text-muted-foreground">
+          <span>
+            Reviewed {result.candidateCount} candidate{result.candidateCount === 1 ? '' : 's'}
+          </span>
+          <span>
+            Model: <span className="font-mono">{result.modelId}</span>
+          </span>
+          <span>
+            Prompt: <span className="font-mono">{result.promptVersion}</span>
+          </span>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+function PickHeader({
+  pick,
+  candidate,
+}: {
+  pick: { candidate_id: string; priority_rank: number; kind: 'intake' | 'person' };
+  candidate: CwtTriageCandidateMeta;
+}) {
+  const href =
+    candidate.kind === 'intake'
+      ? `/app/clients/intakes/${candidate.candidateId}`
+      : `/app/clients/person/${candidate.candidateId}`;
+  const label =
+    candidate.kind === 'intake'
+      ? (candidate.label ?? candidate.candidateId)
+      : candidate.candidateId;
+
+  return (
+    <div className="mb-1 flex flex-wrap items-baseline justify-between gap-2">
+      <div className="flex items-baseline gap-2">
+        <span className="rounded bg-muted px-1.5 py-0.5 font-mono text-[10px]">
+          #{pick.priority_rank}
+        </span>
+        <span className="rounded border border-border px-1.5 py-0.5 text-[10px] uppercase tracking-wide">
+          {pick.kind}
+        </span>
+        <Link href={href} className="font-mono text-xs font-medium hover:underline">
+          {label}
+        </Link>
+      </div>
+      <div className="flex items-baseline gap-3 text-xs">
+        {candidate.kind === 'intake' && candidate.urgency ? (
+          <span className={`font-medium ${urgencyClass[candidate.urgency] ?? ''}`}>
+            {candidate.urgency}
+          </span>
+        ) : null}
+        {candidate.kind === 'person' && candidate.partners ? (
+          <span className="font-medium">{candidate.partners} partners</span>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+function PickFooter({ candidate }: { candidate: CwtTriageCandidateMeta }) {
+  if (candidate.kind === 'intake') {
+    const flags = candidate.flags ?? [];
+    return (
+      <div className="mt-1 text-[11px] text-muted-foreground">
+        {candidate.createdAt ? `extracted ${fmtDate(candidate.createdAt)}` : ''}
+        {candidate.presenting ? ` · "${candidate.presenting}"` : ''}
+        {flags.length > 0 ? ` · flags: ${flags.join(', ')}` : ''}
+      </div>
+    );
+  }
+  return (
+    <div className="mt-1 text-[11px] text-muted-foreground">
+      {candidate.events ?? 0} events ·{' '}
+      {candidate.latestEventAt ? `latest ${fmtDate(candidate.latestEventAt)}` : ''}
+      {candidate.orgNames && candidate.orgNames.length > 0
+        ? ` · ${candidate.orgNames.join(' · ')}`
+        : ''}
+    </div>
+  );
+}

--- a/src/db/queries/cwt-triage.ts
+++ b/src/db/queries/cwt-triage.ts
@@ -1,0 +1,88 @@
+import { and, desc, eq, gte } from 'drizzle-orm';
+import type { IntakeProfile } from '@/ai/prompts/intake-extraction';
+import { db } from '@/db/client';
+import { type ClientIntake, clientIntakes } from '@/db/schema/client-intakes';
+import { listCrossOrgTouchpoints, type PersonAggregate } from './partner-service-events';
+
+export type CwtIntakeCandidate = {
+  kind: 'intake';
+  candidateId: string;
+  intake: ClientIntake;
+};
+
+export type CwtPersonCandidate = {
+  kind: 'person';
+  candidateId: string;
+  aggregate: PersonAggregate;
+};
+
+export type CwtTriageCandidate = CwtIntakeCandidate | CwtPersonCandidate;
+
+/**
+ * Build the candidate set for the caseworker morning triage. Two
+ * sources, normalized into a discriminated union:
+ *
+ *  - `intake` — recently extracted intakes (last 30 days). The
+ *    presenting issue + urgency are the action signals.
+ *  - `person` — synthetic person refs with cross-partner touchpoints
+ *    in the last 14 days. The pattern itself is the action signal.
+ *
+ * candidateId is unique across the union (intake UUID or
+ * synthetic_person_ref). The AI references a candidateId in its
+ * picks; the UI dispatches by `kind` to render and link.
+ */
+export async function listCwtTriageCandidates(
+  opts: { intakeWindowDays?: number; touchWindowDays?: number; limit?: number } = {},
+): Promise<CwtTriageCandidate[]> {
+  const intakeWindowDays = opts.intakeWindowDays ?? 30;
+  const touchWindowDays = opts.touchWindowDays ?? 14;
+  const limit = opts.limit ?? 25;
+
+  const intakeSince = new Date();
+  intakeSince.setDate(intakeSince.getDate() - intakeWindowDays);
+
+  const [intakes, touchpoints] = await Promise.all([
+    db
+      .select()
+      .from(clientIntakes)
+      .where(and(eq(clientIntakes.status, 'extracted'), gte(clientIntakes.createdAt, intakeSince)))
+      .orderBy(desc(clientIntakes.createdAt))
+      .limit(limit),
+    listCrossOrgTouchpoints({ windowDays: touchWindowDays, limit }),
+  ]);
+
+  const intakeCandidates: CwtIntakeCandidate[] = intakes.map((i) => ({
+    kind: 'intake',
+    candidateId: i.id,
+    intake: i,
+  }));
+
+  const personCandidates: CwtPersonCandidate[] = touchpoints
+    .filter((p) => p.uniqueOrgs >= 2)
+    .map((p) => ({
+      kind: 'person',
+      candidateId: p.syntheticPersonRef,
+      aggregate: p,
+    }));
+
+  return [...intakeCandidates, ...personCandidates];
+}
+
+export function summarizeIntakeForTriage(intake: ClientIntake): {
+  presenting: string | null;
+  urgency: string | null;
+  topNeeds: string[];
+  flags: string[];
+} {
+  const profile = intake.extractedProfile as IntakeProfile | null;
+  if (!profile) return { presenting: null, urgency: null, topNeeds: [], flags: [] };
+  const flagsObj = (profile.flags ?? {}) as Record<string, boolean>;
+  return {
+    presenting: profile.presenting_issue ?? null,
+    urgency: profile.urgency ?? null,
+    topNeeds: Array.isArray(profile.top_needs) ? profile.top_needs.slice(0, 3) : [],
+    flags: Object.entries(flagsObj)
+      .filter(([, v]) => v === true)
+      .map(([k]) => k),
+  };
+}

--- a/src/lib/cwt/cwt-triage.ts
+++ b/src/lib/cwt/cwt-triage.ts
@@ -1,0 +1,69 @@
+import Anthropic from '@anthropic-ai/sdk';
+import { zodOutputFormat } from '@anthropic-ai/sdk/helpers/zod';
+import {
+  buildCwtTriageUserPrompt,
+  CWT_TRIAGE_PROMPT_VERSION,
+  CWT_TRIAGE_SYSTEM_PROMPT,
+  type CwtTriageOutput,
+  CwtTriageOutputSchema,
+} from '@/ai/prompts/cwt-triage';
+import type { CwtTriageCandidate } from '@/db/queries/cwt-triage';
+
+let _client: Anthropic | null = null;
+function client(): Anthropic {
+  if (!_client) _client = new Anthropic();
+  return _client;
+}
+
+const MODEL_ID = 'claude-sonnet-4-6';
+
+export type CwtTriageResult = {
+  output: CwtTriageOutput;
+  modelId: string;
+  promptVersion: string;
+  candidateCount: number;
+};
+
+export async function generateCwtTriage(
+  candidates: CwtTriageCandidate[],
+): Promise<CwtTriageResult> {
+  if (candidates.length === 0) {
+    return {
+      output: { picks: [], overall_note: null },
+      modelId: MODEL_ID,
+      promptVersion: CWT_TRIAGE_PROMPT_VERSION,
+      candidateCount: 0,
+    };
+  }
+
+  const response = await client().messages.parse({
+    model: MODEL_ID,
+    max_tokens: 1500,
+    system: [
+      {
+        type: 'text',
+        text: CWT_TRIAGE_SYSTEM_PROMPT,
+        cache_control: { type: 'ephemeral' },
+      },
+    ],
+    messages: [{ role: 'user', content: buildCwtTriageUserPrompt(candidates) }],
+    output_config: { format: zodOutputFormat(CwtTriageOutputSchema) },
+  });
+
+  if (!response.parsed_output) {
+    throw new Error(`[cwt-triage] parse failed; stop_reason=${response.stop_reason}`);
+  }
+
+  const validIds = new Set(candidates.map((c) => c.candidateId));
+  const cleaned: CwtTriageOutput = {
+    picks: response.parsed_output.picks.filter((p) => validIds.has(p.candidate_id)),
+    overall_note: response.parsed_output.overall_note,
+  };
+
+  return {
+    output: cleaned,
+    modelId: MODEL_ID,
+    promptVersion: CWT_TRIAGE_PROMPT_VERSION,
+    candidateCount: candidates.length,
+  };
+}


### PR DESCRIPTION
## Summary
- New \`/app/clients/morning\` view for caseworkers. Two candidate sources fused into a discriminated union: recent extracted intakes (last 30 days) + synthetic-person refs touching ≥2 partners (last 14 days)
- AI picks 3-5 ranked, each linking to either the intake or the person view
- Heuristics: DV-flagged first, urgent intakes before 30-day-urgent, 3+ partners before 2-partner pattern, fresh intakes before ones already worked, don't pad to 5
- Belt-and-braces filter on output (drops picks whose candidate_id isn't in the input set)
- "Morning triage →" CTA on the clients hub

This rounds out the trio of triage AI surfaces: attorney (#286), ED coordinator (#294), and now caseworker.

## Test plan
- [ ] /app/clients/morning as caseworker → "Run today's triage" → 3-5 picks with kind-tagged links
- [ ] Click an intake-kind pick → lands on intake detail; click a person-kind pick → lands on person view
- [ ] Re-run works
- [ ] Non-caseworker users get 404; CTA hidden
- [ ] Audit log shows \`cwt_triage.generated\` + \`ai.generated\`