### PR TITLE
feat(CWT): post-meeting note structurer

### DIFF
--- a/src/ai/prompts/post-meeting-notes.ts
+++ b/src/ai/prompts/post-meeting-notes.ts
@@ -1,0 +1,87 @@
+import { z } from 'zod';
+
+/**
+ * Post-meeting note structurer.
+ *
+ * Caseworker just finished a meeting with a client. They paste (or
+ * dictate) raw notes — usually a wall of text written in a hurry.
+ * The AI structures them into:
+ *  - one-sentence summary
+ *  - explicit next steps the caseworker committed to
+ *  - watch-fors (concerns, things to verify next time)
+ *  - one open question to bring to the next meeting (optional)
+ *
+ * The structured form is what the caseworker reads back later and
+ * what feeds the next pre-meeting briefing. Companion to
+ * pre-meeting-summary.ts (CWT-012).
+ */
+
+export const POST_MEETING_NOTES_PROMPT_VERSION = 'post-meeting-notes-v1@2026-04-26';
+
+export const POST_MEETING_NOTES_SYSTEM_PROMPT = `You read a caseworker's raw notes from a just-finished meeting
+with a client and turn them into a structured record. The notes are
+usually written fast — fragments, abbreviations, sometimes typos.
+Your job is to find the substance and put it in the right buckets.
+
+Output buckets:
+
+1. **summary** — 1-2 sentences. What was the meeting about, and
+   what's the headline takeaway? In the caseworker's voice (not
+   the client's), past tense.
+
+2. **next_steps** — list of 1-5 concrete actions the caseworker
+   COMMITTED to in the meeting. Phrase each as an imperative the
+   caseworker can read tomorrow morning ("Call Sarah back Tuesday
+   AM with KCHIP eligibility result"). If the notes don't mention
+   commitments, return an empty array — don't invent.
+
+3. **watch_fors** — list of 0-3 things to keep an eye on. Concerns
+   the client raised that don't need immediate action but should
+   come up next time. Inconsistencies the caseworker noticed.
+   Things to verify.
+
+4. **followup_question** — optional. ONE question worth asking
+   next meeting. null if nothing in the notes suggests one.
+
+Hard rules:
+1. NEVER invent. If the notes don't mention a follow-up date, don't
+   make one up. If the notes don't mention next steps, return [].
+2. Use the caseworker's words where you can. Don't paraphrase to
+   sound clinical.
+3. Don't include the client's name in summary or next_steps — the
+   record is per-person already; repeating the name is noise.
+4. If the notes are too short (< ~30 words) or unstructured to
+   extract anything meaningful, return summary = "(notes too short
+   to structure)" and empty arrays. Don't pad.
+5. Output ONLY the structured JSON your schema demands.`;
+
+export const PostMeetingNotesSchema = z.object({
+  summary: z.string().min(1).max(400),
+  next_steps: z
+    .array(z.string().min(3).max(220))
+    .max(5)
+    .describe('Imperative form, caseworker-readable tomorrow morning. [] if none.'),
+  watch_fors: z
+    .array(z.string().min(3).max(220))
+    .max(3)
+    .describe('Concerns, inconsistencies, things to verify next time. [] if none.'),
+  followup_question: z
+    .string()
+    .max(220)
+    .nullable()
+    .describe('One question for the next meeting. null if nothing suggests one.'),
+});
+
+export type PostMeetingNotesOutput = z.infer<typeof PostMeetingNotesSchema>;
+
+export function buildPostMeetingNotesUserPrompt(rawNotes: string): string {
+  return [
+    "Here are the caseworker's raw notes from a just-finished meeting:",
+    '',
+    '---',
+    rawNotes.trim(),
+    '---',
+    '',
+    'Structure them now.',
+  ].join('\n');
+}

--- a/src/app/actions/post-meeting-notes.ts
+++ b/src/app/actions/post-meeting-notes.ts
@@ -1,0 +1,80 @@
+'use server';
+
+import * as Sentry from '@sentry/nextjs';
+import { logAuditEvent } from '@/lib/audit';
+import { requireRole } from '@/lib/auth';
+import {
+  type PostMeetingNotesResult,
+  structurePostMeetingNotes,
+} from '@/lib/cwt/post-meeting-notes';
+import { recordAiGeneration } from '@/lib/dtrs/data-access';
+import { isValidSyntheticPersonRef } from '@/lib/synthetic-person';
+
+export type StructurePostMeetingNotesResult =
+  | {
+      ok: true;
+      output: PostMeetingNotesResult['output'];
+      modelId: string;
+      promptVersion: string;
+    }
+  | { ok: false; error: string };
+
+const ROLES = ['caseworker', 'shelter_staff', 'ed_coordinator', 'admin'] as const;
+
+const NOTES_MIN = 20;
+const NOTES_MAX = 10_000;
+
+export async function structurePostMeetingNotesAction(
+  syntheticPersonRef: string,
+  rawNotes: string,
+): Promise<StructurePostMeetingNotesResult> {
+  const actor = await requireRole(ROLES);
+
+  if (!isValidSyntheticPersonRef(syntheticPersonRef)) {
+    return { ok: false, error: 'Invalid synthetic-person reference.' };
+  }
+  const trimmed = rawNotes.trim();
+  if (trimmed.length < NOTES_MIN) {
+    return { ok: false, error: `Notes too short (min ${NOTES_MIN} chars).` };
+  }
+  if (trimmed.length > NOTES_MAX) {
+    return { ok: false, error: `Notes too long (max ${NOTES_MAX} chars).` };
+  }
+
+  try {
+    const result = await structurePostMeetingNotes(trimmed);
+
+    await logAuditEvent({
+      actorUserId: actor.id,
+      action: 'post_meeting_notes.structured',
+      targetTable: 'partner_service_events',
+      targetId: syntheticPersonRef,
+      metadata: {
+        promptVersion: result.promptVersion,
+        rawChars: trimmed.length,
+        nextStepsCount: result.output.next_steps.length,
+        watchForsCount: result.output.watch_fors.length,
+      },
+    });
+    await recordAiGeneration({
+      actorUserId: actor.id,
+      resourceType: 'post_meeting_notes',
+      resourceId: syntheticPersonRef,
+      model: result.modelId,
+      promptVersion: result.promptVersion,
+      metadata: { rawChars: trimmed.length },
+    });
+
+    return {
+      ok: true,
+      output: result.output,
+      modelId: result.modelId,
+      promptVersion: result.promptVersion,
+    };
+  } catch (err) {
+    Sentry.captureException(err, {
+      tags: { action: 'structurePostMeetingNotesAction', ref: syntheticPersonRef },
+    });
+    return { ok: false, error: 'Note structuring failed. Try again in a moment.' };
+  }
+}

--- a/src/app/app/clients/person/[ref]/page.tsx
+++ b/src/app/app/clients/person/[ref]/page.tsx
@@ -2,6 +2,7 @@ import Link from 'next/link';
 import { notFound } from 'next/navigation';
 import { FollowupSmsPanel } from '@/components/cwt/followup-sms-panel';
 import { PersonQAPanel } from '@/components/cwt/person-qa-panel';
+import { PostMeetingNotesPanel } from '@/components/cwt/post-meeting-notes-panel';
 import { PreMeetingSummary } from '@/components/cwt/pre-meeting-summary';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { getPersonProfile } from '@/db/queries/person-profile';
@@ -105,6 +106,15 @@ export default async function PersonProfilePage({ params }: { params: Promise<{ 
         </CardHeader>
         <CardContent>
           <FollowupSmsPanel syntheticPersonRef={ref} />
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">Structure post-meeting notes</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <PostMeetingNotesPanel syntheticPersonRef={ref} />
         </CardContent>
       </Card>
 

--- a/src/components/cwt/post-meeting-notes-panel.tsx
+++ b/src/components/cwt/post-meeting-notes-panel.tsx
@@ -1,0 +1,148 @@
+'use client';
+
+import { useId, useState, useTransition } from 'react';
+import {
+  type StructurePostMeetingNotesResult,
+  structurePostMeetingNotesAction,
+} from '@/app/actions/post-meeting-notes';
+import { Button } from '@/components/ui/button';
+
+type SuccessOutput = Extract<StructurePostMeetingNotesResult, { ok: true }>['output'];
+
+export function PostMeetingNotesPanel({ syntheticPersonRef }: { syntheticPersonRef: string }) {
+  const notesId = useId();
+  const [raw, setRaw] = useState('');
+  const [output, setOutput] = useState<SuccessOutput | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [pending, startTransition] = useTransition();
+  const [copied, setCopied] = useState(false);
+
+  const onStructure = () => {
+    setError(null);
+    setCopied(false);
+    if (raw.trim().length < 20) {
+      setError('Type at least a few sentences before structuring.');
+      return;
+    }
+    startTransition(async () => {
+      const r = await structurePostMeetingNotesAction(syntheticPersonRef, raw);
+      if (!r.ok) {
+        setError(r.error);
+        return;
+      }
+      setOutput(r.output);
+    });
+  };
+
+  const onCopy = async () => {
+    if (!output) return;
+    const lines = [
+      `Summary: ${output.summary}`,
+      '',
+      output.next_steps.length > 0 ? 'Next steps:' : '',
+      ...output.next_steps.map((s) => `- ${s}`),
+      output.watch_fors.length > 0 ? '\nWatch for:' : '',
+      ...output.watch_fors.map((s) => `- ${s}`),
+      output.followup_question ? `\nNext meeting: ${output.followup_question}` : '',
+    ].filter(Boolean);
+    try {
+      await navigator.clipboard.writeText(lines.join('\n'));
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      setError('Copy failed — select the text manually.');
+    }
+  };
+
+  return (
+    <div className="space-y-3 text-sm">
+      <p className="text-muted-foreground">
+        Just finished a meeting? Type or dictate raw notes below — Claude restructures them into a
+        summary, next steps, watch-fors, and one open question for next time. You copy into your
+        real case-management tool.
+      </p>
+
+      <div className="space-y-1">
+        <label htmlFor={notesId} className="text-xs font-medium">
+          Raw notes
+        </label>
+        <textarea
+          id={notesId}
+          value={raw}
+          onChange={(e) => setRaw(e.target.value)}
+          rows={6}
+          placeholder="Met w/ client at 2pm. Said landlord shut off heat last week, has 3 kids u/12. Hasn't paid Apr rent. Going to call KCAA Tuesday. Want to follow up re KCHIP for kids — she thought they were already on it but Sarah from St Ben said no. Verify."
+          maxLength={10_000}
+          disabled={pending}
+          className="w-full rounded-md border border-input bg-background p-2 font-mono text-xs leading-relaxed"
+        />
+      </div>
+
+      <div className="flex items-center gap-3">
+        <Button onClick={onStructure} disabled={pending} size="sm">
+          {pending ? 'Structuring…' : output ? 'Re-structure' : 'Structure notes'}
+        </Button>
+        {error ? <span className="text-xs text-destructive">{error}</span> : null}
+      </div>
+
+      {output ? (
+        <div className="space-y-3 rounded-md border border-primary/40 bg-primary/5 p-3">
+          <Section label="Summary">
+            <p className="text-sm leading-relaxed">{output.summary}</p>
+          </Section>
+
+          <Section label={`Next steps (${output.next_steps.length})`}>
+            {output.next_steps.length === 0 ? (
+              <p className="text-xs text-muted-foreground italic">
+                Nothing in the notes mentions a commitment.
+              </p>
+            ) : (
+              <ul className="list-disc space-y-1 pl-5 text-sm">
+                {output.next_steps.map((s) => (
+                  <li key={s} className="leading-relaxed">
+                    {s}
+                  </li>
+                ))}
+              </ul>
+            )}
+          </Section>
+
+          {output.watch_fors.length > 0 ? (
+            <Section label={`Watch for (${output.watch_fors.length})`}>
+              <ul className="list-disc space-y-1 pl-5 text-sm">
+                {output.watch_fors.map((s) => (
+                  <li key={s} className="leading-relaxed">
+                    {s}
+                  </li>
+                ))}
+              </ul>
+            </Section>
+          ) : null}
+
+          {output.followup_question ? (
+            <Section label="For next meeting">
+              <p className="text-sm leading-relaxed">{output.followup_question}</p>
+            </Section>
+          ) : null}
+
+          <div className="flex flex-wrap items-center gap-3 pt-1 text-xs">
+            <Button type="button" size="sm" variant="outline" onClick={onCopy}>
+              {copied ? 'Copied ✓' : 'Copy structured notes'}
+            </Button>
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function Section({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div className="space-y-1">
+      <p className="text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
+        {label}
+      </p>
+      {children}
+    </div>
+  );
+}

--- a/src/lib/cwt/post-meeting-notes.ts
+++ b/src/lib/cwt/post-meeting-notes.ts
@@ -1,0 +1,49 @@
+import Anthropic from '@anthropic-ai/sdk';
+import { zodOutputFormat } from '@anthropic-ai/sdk/helpers/zod';
+import {
+  buildPostMeetingNotesUserPrompt,
+  POST_MEETING_NOTES_PROMPT_VERSION,
+  POST_MEETING_NOTES_SYSTEM_PROMPT,
+  type PostMeetingNotesOutput,
+  PostMeetingNotesSchema,
+} from '@/ai/prompts/post-meeting-notes';
+
+let _client: Anthropic | null = null;
+function client(): Anthropic {
+  if (!_client) _client = new Anthropic();
+  return _client;
+}
+
+const MODEL_ID = 'claude-sonnet-4-6';
+
+export type PostMeetingNotesResult = {
+  output: PostMeetingNotesOutput;
+  modelId: string;
+  promptVersion: string;
+};
+
+export async function structurePostMeetingNotes(rawNotes: string): Promise<PostMeetingNotesResult> {
+  const response = await client().messages.parse({
+    model: MODEL_ID,
+    max_tokens: 1200,
+    system: [
+      {
+        type: 'text',
+        text: POST_MEETING_NOTES_SYSTEM_PROMPT,
+        cache_control: { type: 'ephemeral' },
+      },
+    ],
+    messages: [{ role: 'user', content: buildPostMeetingNotesUserPrompt(rawNotes) }],
+    output_config: { format: zodOutputFormat(PostMeetingNotesSchema) },
+  });
+
+  if (!response.parsed_output) {
+    throw new Error(`[post-meeting-notes] parse failed; stop_reason=${response.stop_reason}`);
+  }
+
+  return {
+    output: response.parsed_output,
+    modelId: MODEL_ID,
+    promptVersion: POST_MEETING_NOTES_PROMPT_VERSION,
+  };
+}


### PR DESCRIPTION
## Summary
- New panel on the person view: caseworker types/pastes raw post-meeting notes, AI restructures into summary / next_steps / watch_fors / followup_question
- Companion to the pre-meeting briefing (CWT-012) — closes the meeting loop
- Structured output (zod schema), so the UI renders distinct sections; caseworker copies into their real case-management tool
- System prompt baked in: never invent (next_steps = [] if no commitment), use the caseworker's words, don't include the client's name, return "(notes too short to structure)" rather than padding short input

## Test plan
- [ ] Open a person view as caseworker → paste raw notes (3-5 sentences, mention a few next steps) → "Structure notes" → verify sections populate
- [ ] Try short notes (< 30 words) → verify the AI says "notes too short" rather than padding
- [ ] "Re-structure" works
- [ ] "Copy structured notes" produces a readable markdown-style block
- [ ] Audit log shows \`post_meeting_notes.structured\` + \`ai.generated\`