### PR TITLE
feat(ESUC): "Ask Claude about this patient" Q&A

### DIFF
--- a/src/ai/prompts/patient-qa.ts
+++ b/src/ai/prompts/patient-qa.ts
@@ -1,0 +1,99 @@
+/**
+ * ED patient Q&A prompt.
+ *
+ * Care coordinator is on a single ED super-utilizer's detail page,
+ * sees the encounter history + care plan state, and asks Claude
+ * follow-up questions: "is the pattern getting worse?", "do all
+ * the visits cluster around the weekend?", "any signal this is
+ * SUD-driven?". Multi-turn within session, like case-qa and
+ * person-qa.
+ */
+
+import type { EdEncounter } from '@/db/schema/ed-encounters';
+import type { EsucCarePlan } from '@/db/schema/esuc-care-plans';
+
+export const PATIENT_QA_PROMPT_VERSION = 'patient-qa-v1@2026-04-26';
+
+export const PATIENT_QA_SYSTEM_PROMPT = `You are a care-coordination assistant for a Daviess County ED
+super-utilizer care coordinator. The coordinator is looking at one
+specific patient's encounter history and asking you questions
+about it.
+
+Voice and constraints:
+- Coordinator-to-coordinator tone. Direct, no filler. No emoji.
+- 1-3 short paragraphs. The coordinator is reading fast between
+  charts.
+- Be honest about what you don't know. The data here is just ED
+  encounter rows + care-plan status — no labs, no medications, no
+  primary-care notes. If a question would need clinical record
+  detail, say so.
+- Never invent facts. If asked "have they been admitted in the
+  last month" and the disposition history doesn't show admission,
+  answer "no admissions in the encounters I see."
+- This is NOT clinical advice. If asked things like "should they
+  be on an SUD treatment pathway", reframe: "Based on the encounter
+  pattern, here's what I'd flag — your clinical judgment on next
+  steps."
+- The patient_id is opaque (SYN-PAT-... synthetic, hashed Epic id
+  post-BAA). Do not refer to the patient by name — you don't have
+  one and the coordinator already knows who they're working on.
+
+Scope of what you have access to:
+- Every ED encounter for this patient: arrival/discharge time,
+  chief complaint, disposition, housing status at the time, charge
+  in cents, free-text notes
+- The most recent care plan (if any), its status, and when it was
+  last updated
+
+You do NOT have access to:
+- Inpatient records, primary-care notes, medication lists
+- Anything from outside ED encounters
+- The patient's own communications
+- Other patients' data
+
+Output: plain text. No markdown headers. Inline lists are fine.`;
+
+export function buildPatientFactsBlock({
+  patientId,
+  encounters,
+  plan,
+}: {
+  patientId: string;
+  encounters: EdEncounter[];
+  plan: EsucCarePlan | null;
+}): string {
+  const lines: string[] = [
+    `Patient id (opaque): ${patientId}`,
+    `Total encounters on file: ${encounters.length}`,
+    '',
+  ];
+
+  if (encounters.length > 0) {
+    lines.push('## Encounters (most recent first)');
+    for (const e of encounters) {
+      const at = e.arrivedAt.toISOString().slice(0, 10);
+      const dischargeFrag = e.dischargedAt
+        ? ` · discharged ${e.dischargedAt.toISOString().slice(0, 10)}`
+        : '';
+      const chargeFrag =
+        e.chargeCents != null ? ` · charge=$${(e.chargeCents / 100).toFixed(0)}` : '';
+      const notesFrag = e.notes ? ` · notes="${e.notes.replace(/\n/g, ' ')}"` : '';
+      lines.push(
+        `- ${at} · "${e.chiefComplaint}" · disposition=${e.disposition} · housing=${e.housingStatus}${dischargeFrag}${chargeFrag}${notesFrag}`,
+      );
+    }
+    lines.push('');
+  }
+
+  if (plan) {
+    lines.push('## Care plan');
+    lines.push(`- status=${plan.status}`);
+    lines.push(`- last updated ${plan.updatedAt.toISOString().slice(0, 10)}`);
+    lines.push('');
+  } else {
+    lines.push('## Care plan: none on file');
+    lines.push('');
+  }
+
+  return lines.join('\n');
+}

--- a/src/app/actions/patient-qa.ts
+++ b/src/app/actions/patient-qa.ts
@@ -1,0 +1,82 @@
+'use server';
+
+import * as Sentry from '@sentry/nextjs';
+import { listEncountersForPatient } from '@/db/queries/ed-encounters';
+import { logAuditEvent } from '@/lib/audit';
+import { requireRole } from '@/lib/auth';
+import { recordAiGeneration } from '@/lib/dtrs/data-access';
+import { getCarePlanByPatient } from '@/lib/esuc/care-plan';
+import { answerPatientQuestion, type PatientQATurn } from '@/lib/esuc/patient-qa';
+
+export type AskPatientQuestionResult =
+  | { ok: true; answer: string; promptVersion: string }
+  | { ok: false; error: string };
+
+const ROLES = ['ed_coordinator', 'admin'] as const;
+
+const QUESTION_MAX = 1500;
+const HISTORY_MAX_TURNS = 30;
+
+export async function askPatientQuestionAction(
+  patientId: string,
+  history: PatientQATurn[],
+): Promise<AskPatientQuestionResult> {
+  const actor = await requireRole(ROLES);
+
+  if (!/^[A-Za-z0-9_-]{6,}$/.test(patientId)) {
+    return { ok: false, error: 'Invalid patient identifier.' };
+  }
+  if (!Array.isArray(history) || history.length === 0) {
+    return { ok: false, error: 'Question is required.' };
+  }
+  if (history.length > HISTORY_MAX_TURNS) {
+    return { ok: false, error: 'Conversation too long — start a new one.' };
+  }
+  const last = history[history.length - 1];
+  if (last.role !== 'user') {
+    return { ok: false, error: 'Last turn must be a question.' };
+  }
+  const q = last.content.trim();
+  if (q.length === 0) return { ok: false, error: 'Question is empty.' };
+  if (q.length > QUESTION_MAX) {
+    return { ok: false, error: `Question too long (max ${QUESTION_MAX} chars).` };
+  }
+
+  try {
+    const [encounters, plan] = await Promise.all([
+      listEncountersForPatient(patientId),
+      getCarePlanByPatient(patientId),
+    ]);
+    if (encounters.length === 0) {
+      return { ok: false, error: 'No encounters on file for this patient.' };
+    }
+
+    const result = await answerPatientQuestion({ patientId, encounters, plan }, history);
+
+    await logAuditEvent({
+      actorUserId: actor.id,
+      action: 'patient_qa.answered',
+      targetTable: 'ed_encounters',
+      targetId: patientId,
+      metadata: {
+        promptVersion: result.promptVersion,
+        turnCount: history.length,
+        questionLen: q.length,
+        encounterCount: encounters.length,
+      },
+    });
+    await recordAiGeneration({
+      actorUserId: actor.id,
+      resourceType: 'patient_qa',
+      resourceId: patientId,
+      model: result.modelId,
+      promptVersion: result.promptVersion,
+      metadata: { turnCount: history.length },
+    });
+
+    return { ok: true, answer: result.answer, promptVersion: result.promptVersion };
+  } catch (err) {
+    Sentry.captureException(err, { tags: { action: 'askPatientQuestionAction', patientId } });
+    return { ok: false, error: 'Question answering failed. Try again in a moment.' };
+  }
+}

--- a/src/app/app/care/patients/[id]/page.tsx
+++ b/src/app/app/care/patients/[id]/page.tsx
@@ -1,6 +1,7 @@
 import Link from 'next/link';
 import { notFound } from 'next/navigation';
 import { CarePlanPanel } from '@/components/esuc/care-plan-panel';
+import { PatientQAPanel } from '@/components/esuc/patient-qa-panel';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { listEncountersForPatient } from '@/db/queries/ed-encounters';
 import { requireRole } from '@/lib/auth';
@@ -62,6 +63,7 @@ export default async function PatientDetailPage({ params }: { params: Promise<{ 
         </CardContent>
       </Card>
 
+      <PatientQAPanel patientId={patientId} />
       <CarePlanPanel patientId={patientId} plan={carePlan} />
     </div>
   );

--- a/src/components/esuc/patient-qa-panel.tsx
+++ b/src/components/esuc/patient-qa-panel.tsx
@@ -1,0 +1,157 @@
+'use client';
+
+import { useId, useRef, useState, useTransition } from 'react';
+import { askPatientQuestionAction } from '@/app/actions/patient-qa';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import type { PatientQATurn } from '@/lib/esuc/patient-qa';
+
+type LocalTurn = PatientQATurn & { id: string };
+
+let turnCounter = 0;
+const nextTurnId = () => {
+  turnCounter += 1;
+  return `t${turnCounter}`;
+};
+
+const SUGGESTIONS = [
+  'Is the visit pattern getting worse?',
+  'Anything that suggests SUD or mental-health drivers?',
+  "What should I look at first when I open this patient's chart?",
+];
+
+export function PatientQAPanel({ patientId }: { patientId: string }) {
+  const inputId = useId();
+  const [history, setHistory] = useState<LocalTurn[]>([]);
+  const [draft, setDraft] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [pending, startTransition] = useTransition();
+  const scrollRef = useRef<HTMLDivElement | null>(null);
+
+  const ask = (question: string) => {
+    const q = question.trim();
+    if (q.length === 0 || pending) return;
+    setError(null);
+    const userTurn: LocalTurn = { id: nextTurnId(), role: 'user', content: q };
+    const next = [...history, userTurn];
+    setHistory(next);
+    setDraft('');
+    const wireHistory: PatientQATurn[] = next.map((t) => ({ role: t.role, content: t.content }));
+    startTransition(async () => {
+      const r = await askPatientQuestionAction(patientId, wireHistory);
+      if (!r.ok) {
+        setError(r.error);
+        setHistory(history);
+        setDraft(q);
+        return;
+      }
+      const assistantTurn: LocalTurn = {
+        id: nextTurnId(),
+        role: 'assistant',
+        content: r.answer,
+      };
+      setHistory([...next, assistantTurn]);
+      requestAnimationFrame(() => {
+        scrollRef.current?.scrollTo({ top: scrollRef.current.scrollHeight, behavior: 'smooth' });
+      });
+    });
+  };
+
+  const onSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    ask(draft);
+  };
+
+  const onReset = () => {
+    setHistory([]);
+    setDraft('');
+    setError(null);
+  };
+
+  return (
+    <Card>
+      <CardHeader className="flex flex-row items-baseline justify-between gap-2">
+        <CardTitle className="text-base">Ask Claude about this patient</CardTitle>
+        {history.length > 0 ? (
+          <Button onClick={onReset} variant="ghost" size="sm" disabled={pending}>
+            Clear
+          </Button>
+        ) : null}
+      </CardHeader>
+      <CardContent className="space-y-3 text-sm">
+        {history.length === 0 ? (
+          <>
+            <p className="text-muted-foreground">
+              Multi-turn within this session. Claude sees only the encounter history (chief
+              complaint, disposition, housing, charge, notes) plus care-plan status — no labs, no
+              meds, no inpatient records. Not clinical advice.
+            </p>
+            <div className="flex flex-wrap gap-2">
+              {SUGGESTIONS.map((s) => (
+                <Button
+                  key={s}
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  className="h-auto whitespace-normal py-1 text-xs"
+                  disabled={pending}
+                  onClick={() => ask(s)}
+                >
+                  {s}
+                </Button>
+              ))}
+            </div>
+          </>
+        ) : (
+          <div
+            ref={scrollRef}
+            className="max-h-[28rem] space-y-3 overflow-y-auto rounded-md border border-border bg-muted/20 p-3"
+          >
+            {history.map((t) => (
+              <div
+                key={t.id}
+                className={
+                  t.role === 'user'
+                    ? 'rounded-md bg-primary/10 p-2 text-sm'
+                    : 'rounded-md bg-card p-2 text-sm'
+                }
+              >
+                <div className="mb-1 text-[10px] uppercase tracking-wide text-muted-foreground">
+                  {t.role === 'user' ? 'You' : 'Claude'}
+                </div>
+                <p className="whitespace-pre-wrap leading-relaxed">{t.content}</p>
+              </div>
+            ))}
+            {pending ? (
+              <div className="rounded-md bg-card p-2 text-sm text-muted-foreground">
+                <div className="mb-1 text-[10px] uppercase tracking-wide">Claude</div>
+                <p className="italic">Thinking…</p>
+              </div>
+            ) : null}
+          </div>
+        )}
+
+        <form onSubmit={onSubmit} className="flex gap-2">
+          <label htmlFor={inputId} className="sr-only">
+            Ask a question about this patient
+          </label>
+          <input
+            id={inputId}
+            type="text"
+            value={draft}
+            onChange={(e) => setDraft(e.target.value)}
+            placeholder="Ask a follow-up…"
+            disabled={pending}
+            maxLength={1500}
+            className="flex-1 rounded-md border border-input bg-background px-3 py-2 text-sm"
+          />
+          <Button type="submit" size="sm" disabled={pending || draft.trim().length === 0}>
+            {pending ? 'Asking…' : 'Ask'}
+          </Button>
+        </form>
+
+        {error ? <p className="text-xs text-destructive">{error}</p> : null}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/lib/esuc/patient-qa.ts
+++ b/src/lib/esuc/patient-qa.ts
@@ -1,0 +1,71 @@
+import Anthropic from '@anthropic-ai/sdk';
+import {
+  buildPatientFactsBlock,
+  PATIENT_QA_PROMPT_VERSION,
+  PATIENT_QA_SYSTEM_PROMPT,
+} from '@/ai/prompts/patient-qa';
+import type { EdEncounter } from '@/db/schema/ed-encounters';
+import type { EsucCarePlan } from '@/db/schema/esuc-care-plans';
+
+let _client: Anthropic | null = null;
+function client(): Anthropic {
+  if (!_client) _client = new Anthropic();
+  return _client;
+}
+
+const MODEL_ID = 'claude-sonnet-4-6';
+const MAX_OUTPUT_TOKENS = 700;
+
+export type PatientQATurn = {
+  role: 'user' | 'assistant';
+  content: string;
+};
+
+export type PatientQAResult = {
+  answer: string;
+  modelId: string;
+  promptVersion: string;
+};
+
+const HISTORY_HARD_CAP = 30;
+
+export async function answerPatientQuestion(
+  facts: { patientId: string; encounters: EdEncounter[]; plan: EsucCarePlan | null },
+  history: PatientQATurn[],
+): Promise<PatientQAResult> {
+  if (history.length === 0) {
+    throw new Error('[patient-qa] history must contain at least the user question');
+  }
+  if (history[history.length - 1].role !== 'user') {
+    throw new Error('[patient-qa] last history turn must be the user question');
+  }
+  const trimmed = history.slice(-HISTORY_HARD_CAP);
+  const factsBlock = buildPatientFactsBlock(facts);
+
+  const response = await client().messages.create({
+    model: MODEL_ID,
+    max_tokens: MAX_OUTPUT_TOKENS,
+    system: [
+      {
+        type: 'text',
+        text: PATIENT_QA_SYSTEM_PROMPT,
+        cache_control: { type: 'ephemeral' },
+      },
+      {
+        type: 'text',
+        text: factsBlock,
+        cache_control: { type: 'ephemeral' },
+      },
+    ],
+    messages: trimmed.map((t) => ({ role: t.role, content: t.content })),
+  });
+
+  const answer = response.content
+    .flatMap((c) => (c.type === 'text' ? [c.text] : []))
+    .join('\n')
+    .trim();
+  if (!answer) {
+    throw new Error(`[patient-qa] empty response; stop_reason=${response.stop_reason}`);
+  }
+  return { answer, modelId: MODEL_ID, promptVersion: PATIENT_QA_PROMPT_VERSION };
+}


### PR DESCRIPTION
## Summary
- Multi-turn Q&A panel on the patient detail page (ed_coordinator + admin only). Free-form input → Claude answers from the structured ED encounter history + care-plan status, says "not in the data" when asked about labs/meds/inpatient records
- Suggestion pills: "Is the visit pattern getting worse?" / "Anything that suggests SUD or MH drivers?" / "What should I look at first when I open this chart?"
- Conversation lives in session state only; no DB persistence; cap of 30 turns and 1500 chars per question
- Patient ids stay opaque (SYN-PAT-...) — no PHI in the prompt; PHI fence stays clean
- System prompt + facts block both cached (\`cache_control: ephemeral\`) so multi-turn calls reuse the static blocks
- Audited via \`logAuditEvent\` + \`recordAiGeneration\`

This rounds out the Q&A trio: filing (#287), person view (#290), patient.

## Test plan
- [ ] Open a patient as ed_coordinator → click a suggestion pill → response appears
- [ ] Ask a question that requires data not in encounters ("what meds is this patient on?") → Claude says it's not in what it sees
- [ ] Ask multi-turn follow-ups → context preserved
- [ ] Clear button resets
- [ ] Audit log shows \`patient_qa.answered\` + \`ai.generated\`