### PR TITLE
feat(ESUC): batch care-plan drafting on ED triage

### DIFF
--- a/src/app/actions/care.ts
+++ b/src/app/actions/care.ts
@@ -87,6 +87,82 @@ export async function generateEdTriageAction(): Promise<GenerateEdTriageResult> 
   }
 }
 
+export type BatchCarePlanItem =
+  | { ok: true; patientId: string; planId: string; alreadyExisted: boolean }
+  | { ok: false; patientId: string; error: string };
+
+export type GenerateBatchCarePlansResult =
+  | { ok: true; items: BatchCarePlanItem[] }
+  | { ok: false; error: string };
+
+const BATCH_CAREPLANS_MAX = 5;
+
+/**
+ * Run `generateCarePlan` for a list of patient ids in parallel.
+ * Used by the ED morning-triage page to draft a care plan for
+ * every pick at once. Per-item failures don't fail the batch.
+ *
+ * `generateCarePlan` is idempotent on (patient_id, prompt_version)
+ * — re-running for an already-drafted patient returns the existing
+ * plan; we surface that as alreadyExisted=true so the UI can
+ * differentiate "fresh draft" from "already on file".
+ */
+export async function generateCarePlansBatchAction(
+  patientIds: string[],
+): Promise<GenerateBatchCarePlansResult> {
+  const user = await requireRole(CARE_ROLES);
+
+  if (!Array.isArray(patientIds) || patientIds.length === 0) {
+    return { ok: false, error: 'No patients provided.' };
+  }
+  if (patientIds.length > BATCH_CAREPLANS_MAX) {
+    return {
+      ok: false,
+      error: `Batch too large (max ${BATCH_CAREPLANS_MAX}). Trim the picks and try again.`,
+    };
+  }
+  const seen = new Set<string>();
+  const unique = patientIds.filter((id) => {
+    if (seen.has(id)) return false;
+    seen.add(id);
+    return true;
+  });
+
+  const settled = await Promise.allSettled(
+    unique.map(async (patientId): Promise<BatchCarePlanItem> => {
+      try {
+        const before = await db
+          .select({ id: esucCarePlans.id })
+          .from(esucCarePlans)
+          .where(eq(esucCarePlans.patientId, patientId))
+          .limit(1);
+        const plan = await generateCarePlan(patientId, user.id);
+        const alreadyExisted = before.length > 0 && before[0].id === plan.id;
+        await logAuditEvent({
+          actorUserId: user.id,
+          action: 'care_plan.generated',
+          targetTable: 'esuc_care_plans',
+          targetId: plan.id,
+          metadata: { patientId, alreadyExisted, via: 'triage_batch' },
+        });
+        return { ok: true, patientId, planId: plan.id, alreadyExisted };
+      } catch (err) {
+        Sentry.captureException(err, {
+          tags: { action: 'generateCarePlansBatchAction', patientId },
+        });
+        return { ok: false, patientId, error: 'Care plan generation failed.' };
+      }
+    }),
+  );
+
+  const items: BatchCarePlanItem[] = settled.map((s, i) => {
+    if (s.status === 'fulfilled') return s.value;
+    return { ok: false, patientId: unique[i], error: 'Unexpected failure.' };
+  });
+
+  return { ok: true, items };
+}
+
 export type SaveCarePlanResult = { ok: true } | { ok: false; error: string };
 
 export async function saveCarePlanAction(

--- a/src/components/esuc/ed-triage-panel.tsx
+++ b/src/components/esuc/ed-triage-panel.tsx
@@ -2,7 +2,12 @@
 
 import Link from 'next/link';
 import { useState, useTransition } from 'react';
-import { type GenerateEdTriageResult, generateEdTriageAction } from '@/app/actions/care';
+import {
+  type BatchCarePlanItem,
+  type GenerateEdTriageResult,
+  generateCarePlansBatchAction,
+  generateEdTriageAction,
+} from '@/app/actions/care';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 
@@ -19,10 +24,47 @@ const housingClass: Record<string, string> = {
 
 type SuccessResult = Extract<GenerateEdTriageResult, { ok: true }>;
 
+function BatchPlanChip({
+  filingId,
+  item,
+  pending,
+}: {
+  filingId: string;
+  item: BatchCarePlanItem | undefined;
+  pending: boolean;
+}) {
+  if (!item) {
+    if (pending) {
+      return <p className="mt-2 text-[11px] text-muted-foreground italic">Drafting care plan…</p>;
+    }
+    return null;
+  }
+  if (!item.ok) {
+    return (
+      <p className="mt-2 rounded border border-destructive/40 bg-destructive/5 px-2 py-1 text-[11px] text-destructive">
+        Care plan draft failed: {item.error}
+      </p>
+    );
+  }
+  return (
+    <p className="mt-2 rounded border border-emerald-500/40 bg-emerald-500/5 px-2 py-1 text-[11px]">
+      <span className="font-medium text-emerald-700 dark:text-emerald-400">
+        {item.alreadyExisted ? 'Care plan already on file' : 'Care plan drafted ✓'}
+      </span>{' '}
+      <Link href={`/app/care/patients/${filingId}`} className="ml-1 text-primary hover:underline">
+        Open patient →
+      </Link>
+    </p>
+  );
+}
+
 export function EdTriagePanel() {
   const [pending, startTransition] = useTransition();
+  const [batchPending, startBatchTransition] = useTransition();
   const [data, setData] = useState<SuccessResult | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [batchError, setBatchError] = useState<string | null>(null);
+  const [planByPatient, setPlanByPatient] = useState<Record<string, BatchCarePlanItem>>({});
 
   const onClick = () => {
     setError(null);
@@ -33,6 +75,22 @@ export function EdTriagePanel() {
         return;
       }
       setData(r);
+      setPlanByPatient({});
+      setBatchError(null);
+    });
+  };
+
+  const onBatchPlans = (patientIds: string[]) => {
+    setBatchError(null);
+    startBatchTransition(async () => {
+      const r = await generateCarePlansBatchAction(patientIds);
+      if (!r.ok) {
+        setBatchError(r.error);
+        return;
+      }
+      const next: Record<string, BatchCarePlanItem> = {};
+      for (const item of r.items) next[item.patientId] = item;
+      setPlanByPatient(next);
     });
   };
 
@@ -83,43 +141,66 @@ export function EdTriagePanel() {
             No patients need attention today out of {result.candidateCount} on the queue.
           </p>
         ) : (
-          <ol className="space-y-3">
-            {sortedPicks.map((p) => {
-              const c = candById.get(p.patient_id);
-              if (!c) return null;
-              return (
-                <li
-                  key={p.patient_id}
-                  className="rounded-md border border-border bg-card p-3 text-sm"
-                >
-                  <div className="mb-1 flex flex-wrap items-baseline justify-between gap-2">
-                    <div className="flex items-baseline gap-2">
-                      <span className="rounded bg-muted px-1.5 py-0.5 font-mono text-[10px]">
-                        #{p.priority_rank}
-                      </span>
-                      <Link
-                        href={`/app/care/patients/${p.patient_id}`}
-                        className="font-mono text-xs font-medium hover:underline"
-                      >
-                        {p.patient_id}
-                      </Link>
+          <>
+            <div className="flex flex-wrap items-center gap-3 rounded-md border border-primary/40 bg-primary/5 p-3">
+              <div className="flex-1 text-xs text-muted-foreground">
+                Draft a care plan for every pick at once. Idempotent — patients with an existing
+                draft for the current prompt version surface as "already on file" rather than
+                regenerating.
+              </div>
+              <Button
+                onClick={() => onBatchPlans(sortedPicks.map((p) => p.patient_id))}
+                disabled={batchPending}
+                size="sm"
+              >
+                {batchPending
+                  ? `Drafting ${sortedPicks.length}…`
+                  : `Draft care plans for all ${sortedPicks.length}`}
+              </Button>
+              {batchError ? (
+                <span className="w-full text-xs text-destructive">{batchError}</span>
+              ) : null}
+            </div>
+            <ol className="space-y-3">
+              {sortedPicks.map((p) => {
+                const c = candById.get(p.patient_id);
+                if (!c) return null;
+                const planItem = planByPatient[p.patient_id];
+                return (
+                  <li
+                    key={p.patient_id}
+                    className="rounded-md border border-border bg-card p-3 text-sm"
+                  >
+                    <div className="mb-1 flex flex-wrap items-baseline justify-between gap-2">
+                      <div className="flex items-baseline gap-2">
+                        <span className="rounded bg-muted px-1.5 py-0.5 font-mono text-[10px]">
+                          #{p.priority_rank}
+                        </span>
+                        <Link
+                          href={`/app/care/patients/${p.patient_id}`}
+                          className="font-mono text-xs font-medium hover:underline"
+                        >
+                          {p.patient_id}
+                        </Link>
+                      </div>
+                      <div className="flex items-baseline gap-3 text-xs">
+                        <span className="font-medium">{c.visitCount} visits</span>
+                        <span className={`font-medium ${housingClass[c.housingStatus] ?? ''}`}>
+                          {c.housingStatus}
+                        </span>
+                      </div>
                     </div>
-                    <div className="flex items-baseline gap-3 text-xs">
-                      <span className="font-medium">{c.visitCount} visits</span>
-                      <span className={`font-medium ${housingClass[c.housingStatus] ?? ''}`}>
-                        {c.housingStatus}
-                      </span>
+                    <p className="text-sm leading-relaxed">{p.rationale}</p>
+                    <div className="mt-1 text-[11px] text-muted-foreground">
+                      last visit {fmtDate(c.latestVisitAt)} · "{c.lastChiefComplaint}" ·{' '}
+                      {c.carePlanStatus ? `plan ${c.carePlanStatus}` : 'no plan drafted'}
                     </div>
-                  </div>
-                  <p className="text-sm leading-relaxed">{p.rationale}</p>
-                  <div className="mt-1 text-[11px] text-muted-foreground">
-                    last visit {fmtDate(c.latestVisitAt)} · "{c.lastChiefComplaint}" ·{' '}
-                    {c.carePlanStatus ? `plan ${c.carePlanStatus}` : 'no plan drafted'}
-                  </div>
-                </li>
-              );
-            })}
-          </ol>
+                    <BatchPlanChip filingId={p.patient_id} item={planItem} pending={batchPending} />
+                  </li>
+                );
+              })}
+            </ol>
+          </>
         )}
 
         <div className="flex flex-wrap gap-x-4 gap-y-1 text-[11px] text-muted-foreground">


### PR DESCRIPTION
## Summary
- After ED morning triage returns picks, care coordinator clicks "Draft care plans for all N" → batch action runs \`generateCarePlan\` for every pick in parallel
- Per-pick status chip: "Care plan drafted ✓" / "already on file" / "failed" with link to patient detail
- Idempotent: \`generateCarePlan\` returns existing row for (patient_id, prompt_version) hits — the action peeks beforehand to distinguish fresh draft from no-op (\`alreadyExisted=true\`)
- \`Promise.allSettled\` per patient — one bad patient or one Anthropic glitch doesn't fail the batch
- Cap of 5 (care plans use Opus 4.7 with thinking + 16k token output — more expensive than outreach letters)
- Each generation audited individually with \`via=triage_batch\` metadata

Symmetric to the attorney triage → batch outreach orchestration (#293).

## Test plan
- [ ] Run ED triage → click "Draft care plans for all" → verify per-pick status chips appear
- [ ] Patients without an existing plan show "Care plan drafted ✓"
- [ ] Patients with an existing plan show "already on file"
- [ ] Click "Open patient →" on a pick → lands on patient detail with the new plan
- [ ] Audit log shows N rows of \`care_plan.generated\` with \`via=triage_batch\` and an \`alreadyExisted\` field