### PR TITLE
feat(COAL): multi-turn Q&A on cross-org coordination view

### DIFF
--- a/src/ai/prompts/coordination-qa.ts
+++ b/src/ai/prompts/coordination-qa.ts
@@ -1,0 +1,116 @@
+/**
+ * Coalition coordination Q&A prompt.
+ *
+ * Caseworker / coordinator is on the cross-org coordination page,
+ * sees the list of people touching ≥2 partners and the broader
+ * coalition activity, and wants to ask AI questions about patterns:
+ *  - "Which person stands out the most this week?"
+ *  - "Why might this person be bouncing between partners?"
+ *  - "Is any partner getting overloaded?"
+ *  - "What changed since last week?"
+ *
+ * Different scope from per-person Q&A (one person's profile) and
+ * from the weekly insights brief (one-shot summary). This is
+ * multi-turn pattern probing across the coalition.
+ */
+
+import type { CoalitionWeeklyDigest } from '@/db/queries/coalition-weekly-digest';
+
+export const COORDINATION_QA_PROMPT_VERSION = 'coordination-qa-v1@2026-04-26';
+
+export const COORDINATION_QA_SYSTEM_PROMPT = `You are a coalition-pattern assistant for a Daviess County
+homelessness coalition. The user is looking at the cross-org
+coordination view — people who touched 2+ partners recently, plus
+aggregate volume across filings, intakes, service events, consents
+— and asking you questions about patterns.
+
+Voice and constraints:
+- Coordinator-to-coordinator tone. Direct, no filler. No emoji.
+- 1-3 short paragraphs. The user is reading fast.
+- Reference cross-org touchpoints and patterns. You can cite a
+  synthetic_person_ref when the question is about a specific
+  person ("the SYN-PERSON-014 case"), but don't invent names —
+  the platform deliberately doesn't have them.
+- Be honest about what you don't know. The data here is
+  aggregate counts + cross-partner touchpoints + per-partner event
+  type breakdowns. You don't see clinical detail, court filings'
+  contents, or any individual's intake transcript.
+- If asked something requiring data outside the coalition trust
+  (e.g. "what's happening at this partner internally"), say so.
+- Never invent numbers or identifiers. If a count is 0, the count
+  is 0.
+
+Scope of what you have access to:
+- Aggregate volume counts in the window: new filings, new intakes,
+  new service events, new consent grants/revocations
+- Action-blocked queue counts: urgent extracted intakes, high-risk
+  filings without packets
+- Top cross-org touchpoints (synthetic_person_ref + partner count
+  + event count + partner names)
+- Top partner event types (which partner generated which event
+  type, how many)
+- Recent high-risk filings (case number, plaintiff, score, packet
+  status)
+
+You do NOT have access to:
+- Individual intake transcripts or extracted profile detail
+- ED encounter detail (ED super-utilizers live in a different view)
+- Individual eviction filings beyond the high-risk-recent sample
+- Anything outside the data trust window
+- Non-coalition data (private partner systems, the client's own
+  records, etc.)
+
+Output: plain text. No markdown headers. Inline lists are fine.`;
+
+export function buildCoordinationFactsBlock(digest: CoalitionWeeklyDigest): string {
+  const lines: string[] = [
+    `Today: ${new Date().toISOString().slice(0, 10)}`,
+    `Window: last ${digest.windowDays} day${digest.windowDays === 1 ? '' : 's'} (since ${digest.since.toISOString().slice(0, 10)})`,
+    '',
+    '## Volume counts',
+    `- New eviction filings: ${digest.newFilings}`,
+    `- New intakes: ${digest.newIntakes}`,
+    `- New service events: ${digest.newServiceEvents}`,
+    `- New consent grants: ${digest.newConsentGrants}`,
+    `- New consent revocations: ${digest.newConsentRevocations}`,
+    '',
+    '## Action-blocked queues',
+    `- Urgent extracted intakes (today / within_7_days): ${digest.urgentExtractedIntakes}`,
+    `- High-risk open filings without packet: ${digest.highScoreFilingsNoPacket}`,
+    '',
+  ];
+
+  if (digest.crossOrgTouchpoints.length > 0) {
+    lines.push(`## Cross-org touchpoints (${digest.crossOrgTouchpoints.length})`);
+    for (const p of digest.crossOrgTouchpoints) {
+      const at = p.latestEventAt.toISOString().slice(0, 10);
+      lines.push(
+        `- ${p.syntheticPersonRef} · ${p.uniqueOrgs} partners · ${p.totalEvents} events · latest ${at} · ${p.orgNames.join(', ')}`,
+      );
+    }
+    lines.push('');
+  } else {
+    lines.push('## Cross-org touchpoints: (none)');
+    lines.push('');
+  }
+
+  if (digest.recentHighRiskFilings.length > 0) {
+    lines.push('## Recent high-risk filings');
+    for (const f of digest.recentHighRiskFilings) {
+      lines.push(
+        `- ${f.caseNumber} · ${f.plaintiff} · score ${f.score} · packet=${f.packetStatus ?? 'none'}`,
+      );
+    }
+    lines.push('');
+  }
+
+  if (digest.topPartnerEventTypes.length > 0) {
+    lines.push('## Top partner activity by event type');
+    for (const t of digest.topPartnerEventTypes) {
+      lines.push(`- ${t.partnerOrgName} · ${t.eventType} · ${t.count}`);
+    }
+    lines.push('');
+  }
+
+  return lines.join('\n');
+}

--- a/src/app/actions/coordination-qa.ts
+++ b/src/app/actions/coordination-qa.ts
@@ -1,0 +1,74 @@
+'use server';
+
+import * as Sentry from '@sentry/nextjs';
+import { getCoalitionWeeklyDigest } from '@/db/queries/coalition-weekly-digest';
+import { logAuditEvent } from '@/lib/audit';
+import { requireRole } from '@/lib/auth';
+import {
+  answerCoordinationQuestion,
+  type CoordinationQATurn,
+} from '@/lib/coalition/coordination-qa';
+import { recordAiGeneration } from '@/lib/dtrs/data-access';
+
+export type AskCoordinationQuestionResult =
+  | { ok: true; answer: string; promptVersion: string }
+  | { ok: false; error: string };
+
+const ROLES = ['attorney', 'caseworker', 'ed_coordinator', 'shelter_staff', 'admin'] as const;
+
+const QUESTION_MAX = 1500;
+const HISTORY_MAX_TURNS = 30;
+const WINDOW_DAYS = 14;
+
+export async function askCoordinationQuestionAction(
+  history: CoordinationQATurn[],
+): Promise<AskCoordinationQuestionResult> {
+  const actor = await requireRole(ROLES);
+
+  if (!Array.isArray(history) || history.length === 0) {
+    return { ok: false, error: 'Question is required.' };
+  }
+  if (history.length > HISTORY_MAX_TURNS) {
+    return { ok: false, error: 'Conversation too long — start a new one.' };
+  }
+  const last = history[history.length - 1];
+  if (last.role !== 'user') {
+    return { ok: false, error: 'Last turn must be a question.' };
+  }
+  const q = last.content.trim();
+  if (q.length === 0) return { ok: false, error: 'Question is empty.' };
+  if (q.length > QUESTION_MAX) {
+    return { ok: false, error: `Question too long (max ${QUESTION_MAX} chars).` };
+  }
+
+  try {
+    const digest = await getCoalitionWeeklyDigest({ windowDays: WINDOW_DAYS });
+    const result = await answerCoordinationQuestion(digest, history);
+
+    await logAuditEvent({
+      actorUserId: actor.id,
+      action: 'coordination_qa.answered',
+      targetTable: 'partner_service_events',
+      metadata: {
+        promptVersion: result.promptVersion,
+        turnCount: history.length,
+        questionLen: q.length,
+        crossOrgCount: digest.crossOrgTouchpoints.length,
+        windowDays: WINDOW_DAYS,
+      },
+    });
+    await recordAiGeneration({
+      actorUserId: actor.id,
+      resourceType: 'coordination_qa',
+      resourceId: 'cross_org_view',
+      model: result.modelId,
+      promptVersion: result.promptVersion,
+      metadata: { turnCount: history.length, windowDays: WINDOW_DAYS },
+    });
+
+    return { ok: true, answer: result.answer, promptVersion: result.promptVersion };
+  } catch (err) {
+    Sentry.captureException(err, { tags: { action: 'askCoordinationQuestionAction' } });
+    return { ok: false, error: 'Question answering failed. Try again in a moment.' };
+  }
+}

--- a/src/app/app/coalition/coordination/page.tsx
+++ b/src/app/app/coalition/coordination/page.tsx
@@ -1,4 +1,5 @@
 import Link from 'next/link';
+import { CoordinationQAPanel } from '@/components/coalition/coordination-qa-panel';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { listCrossOrgTouchpointsForViewer } from '@/db/queries/partner-service-events';
 import { requireRole } from '@/lib/auth';
@@ -94,6 +95,8 @@ export default async function CrossOrgCoordinationPage() {
           )}
         </CardContent>
       </Card>
+
+      <CoordinationQAPanel />
 
       <Card>
         <CardHeader>

--- a/src/components/coalition/coordination-qa-panel.tsx
+++ b/src/components/coalition/coordination-qa-panel.tsx
@@ -1,0 +1,160 @@
+'use client';
+
+import { useId, useRef, useState, useTransition } from 'react';
+import { askCoordinationQuestionAction } from '@/app/actions/coordination-qa';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import type { CoordinationQATurn } from '@/lib/coalition/coordination-qa';
+
+type LocalTurn = CoordinationQATurn & { id: string };
+
+let turnCounter = 0;
+const nextTurnId = () => {
+  turnCounter += 1;
+  return `t${turnCounter}`;
+};
+
+const SUGGESTIONS = [
+  'Which person stands out the most this window?',
+  'Are any partners getting overloaded?',
+  'What pattern is most worth raising at the next steering meeting?',
+];
+
+export function CoordinationQAPanel() {
+  const inputId = useId();
+  const [history, setHistory] = useState<LocalTurn[]>([]);
+  const [draft, setDraft] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [pending, startTransition] = useTransition();
+  const scrollRef = useRef<HTMLDivElement | null>(null);
+
+  const ask = (question: string) => {
+    const q = question.trim();
+    if (q.length === 0 || pending) return;
+    setError(null);
+    const userTurn: LocalTurn = { id: nextTurnId(), role: 'user', content: q };
+    const next = [...history, userTurn];
+    setHistory(next);
+    setDraft('');
+    const wireHistory: CoordinationQATurn[] = next.map((t) => ({
+      role: t.role,
+      content: t.content,
+    }));
+    startTransition(async () => {
+      const r = await askCoordinationQuestionAction(wireHistory);
+      if (!r.ok) {
+        setError(r.error);
+        setHistory(history);
+        setDraft(q);
+        return;
+      }
+      const assistantTurn: LocalTurn = {
+        id: nextTurnId(),
+        role: 'assistant',
+        content: r.answer,
+      };
+      setHistory([...next, assistantTurn]);
+      requestAnimationFrame(() => {
+        scrollRef.current?.scrollTo({ top: scrollRef.current.scrollHeight, behavior: 'smooth' });
+      });
+    });
+  };
+
+  const onSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    ask(draft);
+  };
+
+  const onReset = () => {
+    setHistory([]);
+    setDraft('');
+    setError(null);
+  };
+
+  return (
+    <Card>
+      <CardHeader className="flex flex-row items-baseline justify-between gap-2">
+        <CardTitle className="text-base">Ask Claude about coalition patterns</CardTitle>
+        {history.length > 0 ? (
+          <Button onClick={onReset} variant="ghost" size="sm" disabled={pending}>
+            Clear
+          </Button>
+        ) : null}
+      </CardHeader>
+      <CardContent className="space-y-3 text-sm">
+        {history.length === 0 ? (
+          <>
+            <p className="text-muted-foreground">
+              Multi-turn within this session. Claude sees aggregate counts, cross-org touchpoints,
+              and recent high-risk filings — no individual intake content, no clinical detail. Pair
+              with the weekly insights brief for one-shot read; use this for follow-up questions.
+            </p>
+            <div className="flex flex-wrap gap-2">
+              {SUGGESTIONS.map((s) => (
+                <Button
+                  key={s}
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  className="h-auto whitespace-normal py-1 text-xs"
+                  disabled={pending}
+                  onClick={() => ask(s)}
+                >
+                  {s}
+                </Button>
+              ))}
+            </div>
+          </>
+        ) : (
+          <div
+            ref={scrollRef}
+            className="max-h-[28rem] space-y-3 overflow-y-auto rounded-md border border-border bg-muted/20 p-3"
+          >
+            {history.map((t) => (
+              <div
+                key={t.id}
+                className={
+                  t.role === 'user'
+                    ? 'rounded-md bg-primary/10 p-2 text-sm'
+                    : 'rounded-md bg-card p-2 text-sm'
+                }
+              >
+                <div className="mb-1 text-[10px] uppercase tracking-wide text-muted-foreground">
+                  {t.role === 'user' ? 'You' : 'Claude'}
+                </div>
+                <p className="whitespace-pre-wrap leading-relaxed">{t.content}</p>
+              </div>
+            ))}
+            {pending ? (
+              <div className="rounded-md bg-card p-2 text-sm text-muted-foreground">
+                <div className="mb-1 text-[10px] uppercase tracking-wide">Claude</div>
+                <p className="italic">Thinking…</p>
+              </div>
+            ) : null}
+          </div>
+        )}
+
+        <form onSubmit={onSubmit} className="flex gap-2">
+          <label htmlFor={inputId} className="sr-only">
+            Ask a question about coalition patterns
+          </label>
+          <input
+            id={inputId}
+            type="text"
+            value={draft}
+            onChange={(e) => setDraft(e.target.value)}
+            placeholder="Ask a follow-up about the pattern…"
+            disabled={pending}
+            maxLength={1500}
+            className="flex-1 rounded-md border border-input bg-background px-3 py-2 text-sm"
+          />
+          <Button type="submit" size="sm" disabled={pending || draft.trim().length === 0}>
+            {pending ? 'Asking…' : 'Ask'}
+          </Button>
+        </form>
+
+        {error ? <p className="text-xs text-destructive">{error}</p> : null}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/lib/coalition/coordination-qa.ts
+++ b/src/lib/coalition/coordination-qa.ts
@@ -1,0 +1,70 @@
+import Anthropic from '@anthropic-ai/sdk';
+import {
+  buildCoordinationFactsBlock,
+  COORDINATION_QA_PROMPT_VERSION,
+  COORDINATION_QA_SYSTEM_PROMPT,
+} from '@/ai/prompts/coordination-qa';
+import type { CoalitionWeeklyDigest } from '@/db/queries/coalition-weekly-digest';
+
+let _client: Anthropic | null = null;
+function client(): Anthropic {
+  if (!_client) _client = new Anthropic();
+  return _client;
+}
+
+const MODEL_ID = 'claude-sonnet-4-6';
+const MAX_OUTPUT_TOKENS = 700;
+
+export type CoordinationQATurn = {
+  role: 'user' | 'assistant';
+  content: string;
+};
+
+export type CoordinationQAResult = {
+  answer: string;
+  modelId: string;
+  promptVersion: string;
+};
+
+const HISTORY_HARD_CAP = 30;
+
+export async function answerCoordinationQuestion(
+  digest: CoalitionWeeklyDigest,
+  history: CoordinationQATurn[],
+): Promise<CoordinationQAResult> {
+  if (history.length === 0) {
+    throw new Error('[coordination-qa] history must contain at least the user question');
+  }
+  if (history[history.length - 1].role !== 'user') {
+    throw new Error('[coordination-qa] last history turn must be the user question');
+  }
+  const trimmed = history.slice(-HISTORY_HARD_CAP);
+  const factsBlock = buildCoordinationFactsBlock(digest);
+
+  const response = await client().messages.create({
+    model: MODEL_ID,
+    max_tokens: MAX_OUTPUT_TOKENS,
+    system: [
+      {
+        type: 'text',
+        text: COORDINATION_QA_SYSTEM_PROMPT,
+        cache_control: { type: 'ephemeral' },
+      },
+      {
+        type: 'text',
+        text: factsBlock,
+        cache_control: { type: 'ephemeral' },
+      },
+    ],
+    messages: trimmed.map((t) => ({ role: t.role, content: t.content })),
+  });
+
+  const answer = response.content
+    .flatMap((c) => (c.type === 'text' ? [c.text] : []))
+    .join('\n')
+    .trim();
+  if (!answer) {
+    throw new Error(`[coordination-qa] empty response; stop_reason=${response.stop_reason}`);
+  }
+  return { answer, modelId: MODEL_ID, promptVersion: COORDINATION_QA_PROMPT_VERSION };
+}


### PR DESCRIPTION
## Summary
- New panel on \`/app/coalition/coordination\`. Multi-turn Q&A about coalition patterns (not per-person, not one-shot summary)
- Reuses \`CoalitionWeeklyDigest\` (#292) as the facts block — counts, cross-org touchpoints, action-blocked queues, recent high-risk filings, top partner event types
- AI does not see individual intake content, ED encounter detail, or anything outside the coalition data trust
- Suggestion pills: "Which person stands out the most this window?" / "Are any partners getting overloaded?" / "What pattern is most worth raising at the next steering meeting?"
- Pairs with the weekly insights brief: brief = morning read; Q&A = follow-up probing

## Test plan
- [ ] Open /app/coalition/coordination as caseworker → click a suggestion → response references the actual cross-org pattern in the data
- [ ] Ask a question requiring intake content ("what's their presenting issue?") → Claude says it's not in what it sees
- [ ] Multi-turn follow-ups preserve context
- [ ] Audit log shows \`coordination_qa.answered\` + \`ai.generated\`