### PR TITLE
feat(ESUC/CWT): refer patient to caseworker queue

### DIFF
--- a/src/app/actions/care.ts
+++ b/src/app/actions/care.ts
@@ -4,7 +4,9 @@ import * as Sentry from '@sentry/nextjs';
 import { eq } from 'drizzle-orm';
 import { revalidatePath } from 'next/cache';
 import { db } from '@/db/client';
+import { listEncountersForPatient } from '@/db/queries/ed-encounters';
 import { listEdTriageCandidates } from '@/db/queries/ed-triage';
+import { clientIntakes } from '@/db/schema/client-intakes';
 import { type EsucCarePlanStatus, esucCarePlanStatusEnum } from '@/db/schema/enums';
 import { esucCarePlans } from '@/db/schema/esuc-care-plans';
 import { logAuditEvent } from '@/lib/audit';
@@ -161,6 +163,104 @@ export async function generateCarePlansBatchAction(
   });
 
   return { ok: true, items };
+}
+
+export type ReferPatientToCaseworkerResult =
+  | { ok: true; intakeId: string; alreadyExisted: boolean }
+  | { ok: false; error: string };
+
+const housingNarrative: Record<string, string> = {
+  unsheltered: 'unsheltered',
+  shelter: 'staying in a shelter',
+  doubled_up: 'doubled-up with friends or family',
+  housed: 'housed',
+  unknown: 'in unclear housing',
+};
+
+/**
+ * ED coordinator refers a super-utilizer to the caseworker queue.
+ * Symmetric to the EVDT→CWT bridge: spawns a `client_intakes` row
+ * with a templated referral narrative summarizing the patient's ED
+ * pattern (visit count + housing status + recent chief complaints).
+ * The caseworker reads, edits, runs extraction, and the intake
+ * flows through the regular chain.
+ *
+ * Idempotent on patientId: label = `ESUC-REF:{patientId}` matches
+ * exactly, so re-clicking surfaces the existing intake.
+ */
+export async function referPatientToCaseworkerAction(
+  patientId: string,
+): Promise<ReferPatientToCaseworkerResult> {
+  const user = await requireRole(CARE_ROLES);
+
+  if (!/^[A-Za-z0-9_-]{6,}$/.test(patientId)) {
+    return { ok: false, error: 'Invalid patient identifier.' };
+  }
+
+  const refTag = `ESUC-REF:${patientId}`;
+
+  const [existing] = await db
+    .select({ id: clientIntakes.id })
+    .from(clientIntakes)
+    .where(eq(clientIntakes.label, refTag))
+    .limit(1);
+  if (existing) {
+    return { ok: true, intakeId: existing.id, alreadyExisted: true };
+  }
+
+  const encounters = await listEncountersForPatient(patientId);
+  if (encounters.length === 0) {
+    return { ok: false, error: 'No encounters on file for this patient.' };
+  }
+
+  const latest = encounters[0];
+  const recentComplaints = encounters
+    .slice(0, 3)
+    .map((e) => `"${e.chiefComplaint}"`)
+    .join(', ');
+  const housingFrag = housingNarrative[latest.housingStatus] ?? 'in unclear housing';
+  const latestDate = latest.arrivedAt.toISOString().slice(0, 10);
+
+  const narrative = [
+    'Referral from the ED super-utilizer care coordinator.',
+    '',
+    `This patient has ${encounters.length} ED encounter${encounters.length === 1 ? '' : 's'} on file. Most recent visit was ${latestDate} for ${latest.chiefComplaint.toLowerCase()}; they are currently ${housingFrag}. Recent chief complaints: ${recentComplaints}.`,
+    '',
+    "Referring to the caseworker side because the ED is the wrong setting for what's actually going on — repeat visits are housing-driven and stabilizing housing is a coordinator job, not an ER one. Run the benefits screener; depending on what they tell you, this may also be a candidate for a coordinated care plan with the partner who has the strongest existing relationship.",
+    '',
+    `(The patient identifier ${patientId} is opaque on this platform — names live in Epic. When you meet the patient, you'll learn the name; the AI extraction works fine on either real or synthetic name.)`,
+    '',
+    `(Edit this transcript with what the patient tells you, then run extraction. Or replace it entirely with a fresh recording.)`,
+  ].join('\n');
+
+  try {
+    const [created] = await db
+      .insert(clientIntakes)
+      .values({
+        label: refTag,
+        transcriptMd: narrative,
+        recordedByUserId: user.id,
+        status: 'transcribed',
+      })
+      .returning({ id: clientIntakes.id });
+
+    await logAuditEvent({
+      actorUserId: user.id,
+      action: 'patient.referred_to_caseworker',
+      targetTable: 'ed_encounters',
+      targetId: patientId,
+      metadata: {
+        intakeId: created.id,
+        encounterCount: encounters.length,
+        latestHousingStatus: latest.housingStatus,
+      },
+    });
+
+    return { ok: true, intakeId: created.id, alreadyExisted: false };
+  } catch (err) {
+    Sentry.captureException(err, { tags: { action: 'referPatientToCaseworkerAction', patientId } });
+    return { ok: false, error: 'Referral failed. Please try again.' };
+  }
 }
 
 export type SaveCarePlanResult = { ok: true } | { ok: false; error: string };

--- a/src/app/app/care/patients/[id]/page.tsx
+++ b/src/app/app/care/patients/[id]/page.tsx
@@ -2,7 +2,10 @@ import Link from 'next/link';
 import { notFound } from 'next/navigation';
 import { CarePlanPanel } from '@/components/esuc/care-plan-panel';
 import { PatientQAPanel } from '@/components/esuc/patient-qa-panel';
+import { ReferPatientToCaseworkerPanel } from '@/components/esuc/refer-patient-to-caseworker-panel';
+import { LinkedIntakePanel } from '@/components/eviction/linked-intake-panel';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { getReferralIntakeForPatient } from '@/db/queries/client-intakes';
 import { listEncountersForPatient } from '@/db/queries/ed-encounters';
 import { requireRole } from '@/lib/auth';
 import { getCarePlanByPatient } from '@/lib/esuc/care-plan';
@@ -18,9 +21,10 @@ export default async function PatientDetailPage({ params }: { params: Promise<{ 
   // a hashed value. Either way they should be ≥ 6 chars of safe characters.
   if (!/^[A-Za-z0-9_-]{6,}$/.test(patientId)) notFound();
 
-  const [encounters, carePlan] = await Promise.all([
+  const [encounters, carePlan, linkedIntake] = await Promise.all([
     listEncountersForPatient(patientId),
     getCarePlanByPatient(patientId),
+    getReferralIntakeForPatient(patientId),
   ]);
   if (encounters.length === 0) notFound();
 
@@ -64,6 +68,8 @@ export default async function PatientDetailPage({ params }: { params: Promise<{ 
       </Card>
 
       <PatientQAPanel patientId={patientId} />
+      {linkedIntake ? <LinkedIntakePanel intake={linkedIntake} /> : null}
+      {!linkedIntake ? <ReferPatientToCaseworkerPanel patientId={patientId} /> : null}
       <CarePlanPanel patientId={patientId} plan={carePlan} />
     </div>
   );

--- a/src/components/esuc/refer-patient-to-caseworker-panel.tsx
+++ b/src/components/esuc/refer-patient-to-caseworker-panel.tsx
@@ -1,0 +1,44 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { useState, useTransition } from 'react';
+import { referPatientToCaseworkerAction } from '@/app/actions/care';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent } from '@/components/ui/card';
+
+export function ReferPatientToCaseworkerPanel({ patientId }: { patientId: string }) {
+  const router = useRouter();
+  const [pending, startTransition] = useTransition();
+  const [error, setError] = useState<string | null>(null);
+
+  const onClick = () => {
+    setError(null);
+    startTransition(async () => {
+      const r = await referPatientToCaseworkerAction(patientId);
+      if (!r.ok) {
+        setError(r.error);
+        return;
+      }
+      router.push(`/app/clients/intakes/${r.intakeId}`);
+    });
+  };
+
+  return (
+    <Card className="border-primary/40 bg-primary/5">
+      <CardContent className="flex flex-wrap items-center justify-between gap-3 text-sm">
+        <div>
+          <p className="font-medium">Refer this patient to the caseworker queue</p>
+          <p className="mt-1 text-xs text-muted-foreground">
+            Drops a pre-filled intake into the queue with a templated note summarizing the ED
+            pattern. Coordinator still owns the medical side; the caseworker picks up benefits,
+            housing path, and partner coordination.
+          </p>
+          {error ? <p className="mt-1 text-xs text-destructive">{error}</p> : null}
+        </div>
+        <Button onClick={onClick} disabled={pending} size="sm" className="shrink-0">
+          {pending ? 'Referring…' : 'Refer to caseworker →'}
+        </Button>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/db/queries/client-intakes.ts
+++ b/src/db/queries/client-intakes.ts
@@ -17,13 +17,24 @@ export async function getClientIntakeById(id: string): Promise<ClientIntake | nu
  * referFilingToCaseworkerAction (`EVDT-REF:{filingId}`) so the join
  * is exact and free of collisions.
  */
-export async function getReferralIntakeForFiling(
-  filingId: string,
-): Promise<ClientIntake | null> {
+export async function getReferralIntakeForFiling(filingId: string): Promise<ClientIntake | null> {
   const [row] = await db
     .select()
     .from(clientIntakes)
     .where(eq(clientIntakes.label, `EVDT-REF:${filingId}`))
+    .limit(1);
+  return row ?? null;
+}
+
+/**
+ * Symmetric to getReferralIntakeForFiling, for the ESUC→CWT bridge.
+ * Match on `ESUC-REF:{patientId}`.
+ */
+export async function getReferralIntakeForPatient(patientId: string): Promise<ClientIntake | null> {
+  const [row] = await db
+    .select()
+    .from(clientIntakes)
+    .where(eq(clientIntakes.label, `ESUC-REF:${patientId}`))
     .limit(1);
   return row ?? null;
 }


### PR DESCRIPTION
## Summary
- Symmetric to the EVDT→CWT bridge (#288). ED coordinator clicks one button on the patient detail page → spawns a pre-filled \`client_intakes\` row with a templated referral narrative (visit count + housing + recent chief complaints), redirects to the intake
- Idempotent on patientId via label \`ESUC-REF:{patientId}\` (distinct from the EVDT \`EVDT-REF:\` prefix so bridges don't collide)
- Once a referral exists, the CTA is hidden and the existing LinkedIntakePanel takes the slot — same UX as the filing detail
- PHI fence stays clean: opaque patient id, chief complaints from encounter rows; no name or MRN

This closes the cross-domain referral symmetry: filings → caseworker (EVDT→CWT), patients → caseworker (ESUC→CWT). All roads lead through the existing intake → screener → person view chain.

## Test plan
- [ ] Open a patient detail as ed_coordinator → "Refer to caseworker" CTA visible
- [ ] Click → redirects to a new intake with the templated ED narrative
- [ ] Reload the patient detail → CTA gone, LinkedIntakePanel shows status=transcribed
- [ ] Run extraction on the intake → reload patient → presenting issue surfaces in the linked panel