### PR TITLE
feat(OPRT): AI steering committee agenda drafter

### DIFF
--- a/src/ai/prompts/steering-agenda.ts
+++ b/src/ai/prompts/steering-agenda.ts
@@ -1,0 +1,119 @@
+/**
+ * Steering committee agenda drafter.
+ *
+ * Coordinator about to chair a steering meeting opens this and asks
+ * Claude to draft an agenda based on (a) the prior meeting's open
+ * action items, and (b) recent coalition activity (the same digest
+ * the weekly insights brief uses). Output is short markdown the
+ * coordinator pastes into the agenda field of the meeting record.
+ */
+
+import type { CoalitionWeeklyDigest } from '@/db/queries/coalition-weekly-digest';
+import type { SteeringMeeting } from '@/db/schema/steering-meetings';
+
+export const STEERING_AGENDA_PROMPT_VERSION = 'steering-agenda-v1@2026-04-26';
+
+export const STEERING_AGENDA_SYSTEM_PROMPT = `You draft a steering committee agenda for a Daviess County
+homelessness coalition. The coordinator chairs the meeting; the
+agenda runs ~45 minutes. Your job is to surface what actually needs
+the steering committee's attention this meeting.
+
+You see two inputs:
+1. The most recent posted meeting's action items + decisions
+   (unfinished business is the strongest signal).
+2. A coalition activity digest (volume counts + cross-org
+   touchpoints + action-blocked queues + recent high-risk filings).
+
+Write the agenda as Markdown. Structure:
+
+## Open from last meeting
+- 1-3 bullets pulled from the prior action items. If an item looks
+  like it's already done based on the new digest (e.g. "draft a
+  packet for case X" and the digest shows packets are caught up),
+  say so explicitly and propose closing it. If there's no prior
+  meeting or no action items, write "_No prior action items to
+  carry forward._" and skip the section.
+
+## What changed since last meeting
+- 2-4 bullets from the digest. Lead with what most needs
+  steering's attention: cross-org pattern, action-blocked queue
+  growth, consent revocations spike, etc. Pure number recitations
+  don't belong here — pick the signal.
+
+## Decisions to make today
+- 1-3 specific decisions the committee should resolve today.
+  Examples: "Approve KLA capacity ask", "Decide whether to expand
+  the cross-org touch threshold from 2 to 3 partners". Phrase as
+  decision questions, not problem statements.
+
+## Standing items
+- 2 fixed bullets: "Coordinator update (5 min)" and "Partner
+  round-robin (10 min)".
+
+Hard rules:
+1. NEVER invent action items. Only carry forward items present in
+   the prior meeting's text.
+2. NEVER invent counts. The digest counts are the only counts.
+3. If the digest is mostly empty (everything 0 or near it), write
+   a much shorter agenda ("Quiet window — light agenda") rather
+   than padding.
+4. Keep it short — under 200 words total. Steering's time matters.
+5. Output ONLY the Markdown. No preamble like "Here's the agenda:".`;
+
+export type SteeringAgendaInputs = {
+  meetingTitle: string;
+  meetingHeldOn: string;
+  priorMeeting: SteeringMeeting | null;
+  digest: CoalitionWeeklyDigest;
+};
+
+export function buildSteeringAgendaUserPrompt(inputs: SteeringAgendaInputs): string {
+  const lines: string[] = [`Meeting: ${inputs.meetingTitle}`, `Date: ${inputs.meetingHeldOn}`, ''];
+
+  if (inputs.priorMeeting) {
+    lines.push(`## Prior meeting (${inputs.priorMeeting.heldOn}): "${inputs.priorMeeting.title}"`);
+    lines.push('');
+    lines.push('### Action items (verbatim from the prior minutes)');
+    lines.push(inputs.priorMeeting.actionItemsMd.trim() || '_(none recorded)_');
+    lines.push('');
+    lines.push('### Decisions');
+    lines.push(inputs.priorMeeting.decisionsMd.trim() || '_(none recorded)_');
+    lines.push('');
+  } else {
+    lines.push('## Prior meeting: none on file (this is the first or earliest meeting).');
+    lines.push('');
+  }
+
+  lines.push('## Coalition activity digest');
+  lines.push(
+    `Window: last ${inputs.digest.windowDays} days (since ${inputs.digest.since.toISOString().slice(0, 10)})`,
+  );
+  lines.push('');
+  lines.push('Volume:');
+  lines.push(`- New filings: ${inputs.digest.newFilings}`);
+  lines.push(`- New intakes: ${inputs.digest.newIntakes}`);
+  lines.push(`- New service events: ${inputs.digest.newServiceEvents}`);
+  lines.push(`- New consent grants: ${inputs.digest.newConsentGrants}`);
+  lines.push(`- New consent revocations: ${inputs.digest.newConsentRevocations}`);
+  lines.push('');
+  lines.push('Action-blocked:');
+  lines.push(`- Urgent extracted intakes: ${inputs.digest.urgentExtractedIntakes}`);
+  lines.push(`- High-risk filings without packet: ${inputs.digest.highScoreFilingsNoPacket}`);
+  lines.push('');
+  lines.push(`Cross-org touchpoints (≥2 partners): ${inputs.digest.crossOrgTouchpoints.length}`);
+  for (const p of inputs.digest.crossOrgTouchpoints) {
+    lines.push(`- ${p.uniqueOrgs} partners · ${p.totalEvents} events · ${p.orgNames.join(', ')}`);
+  }
+  lines.push('');
+
+  if (inputs.digest.recentHighRiskFilings.length > 0) {
+    lines.push('Recent high-risk filings:');
+    for (const f of inputs.digest.recentHighRiskFilings) {
+      lines.push(`- ${f.caseNumber} score ${f.score}, packet=${f.packetStatus ?? 'none'}`);
+    }
+    lines.push('');
+  }
+
+  lines.push('Draft the agenda now.');
+  return lines.join('\n');
+}

--- a/src/app/actions/steering-agenda.ts
+++ b/src/app/actions/steering-agenda.ts
@@ -1,0 +1,77 @@
+'use server';
+
+import * as Sentry from '@sentry/nextjs';
+import { getCoalitionWeeklyDigest } from '@/db/queries/coalition-weekly-digest';
+import { getMostRecentPostedMeeting, getSteeringMeetingById } from '@/db/queries/steering-meetings';
+import { logAuditEvent } from '@/lib/audit';
+import { requireRole } from '@/lib/auth';
+import { draftSteeringAgenda } from '@/lib/coalition/steering-agenda';
+import { recordAiGeneration } from '@/lib/dtrs/data-access';
+
+export type DraftSteeringAgendaResult =
+  | { ok: true; agendaMd: string; modelId: string; promptVersion: string }
+  | { ok: false; error: string };
+
+const ROLES = ['admin', 'attorney', 'caseworker', 'ed_coordinator', 'shelter_staff'] as const;
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+const WINDOW_DAYS = 14;
+
+export async function draftSteeringAgendaAction(
+  meetingId: string,
+): Promise<DraftSteeringAgendaResult> {
+  const actor = await requireRole(ROLES);
+
+  if (!UUID_RE.test(meetingId)) {
+    return { ok: false, error: 'Invalid meeting id.' };
+  }
+
+  const meeting = await getSteeringMeetingById(meetingId);
+  if (!meeting) return { ok: false, error: 'Meeting not found.' };
+
+  try {
+    const [priorMeeting, digest] = await Promise.all([
+      getMostRecentPostedMeeting(meetingId),
+      getCoalitionWeeklyDigest({ windowDays: WINDOW_DAYS }),
+    ]);
+
+    const result = await draftSteeringAgenda({
+      meetingTitle: meeting.title,
+      meetingHeldOn: meeting.heldOn,
+      priorMeeting,
+      digest,
+    });
+
+    await logAuditEvent({
+      actorUserId: actor.id,
+      action: 'steering_agenda.drafted',
+      targetTable: 'steering_meetings',
+      targetId: meeting.id,
+      metadata: {
+        promptVersion: result.promptVersion,
+        priorMeetingId: priorMeeting?.id ?? null,
+        windowDays: WINDOW_DAYS,
+        digestCrossOrgCount: digest.crossOrgTouchpoints.length,
+      },
+    });
+    await recordAiGeneration({
+      actorUserId: actor.id,
+      resourceType: 'steering_agenda',
+      resourceId: meeting.id,
+      model: result.modelId,
+      promptVersion: result.promptVersion,
+      metadata: { priorMeetingId: priorMeeting?.id ?? null },
+    });
+
+    return {
+      ok: true,
+      agendaMd: result.agendaMd,
+      modelId: result.modelId,
+      promptVersion: result.promptVersion,
+    };
+  } catch (err) {
+    Sentry.captureException(err, { tags: { action: 'draftSteeringAgendaAction', meetingId } });
+    return { ok: false, error: 'Agenda draft failed. Please try again.' };
+  }
+}

--- a/src/app/app/coalition/steering/[id]/page.tsx
+++ b/src/app/app/coalition/steering/[id]/page.tsx
@@ -1,6 +1,7 @@
 import Link from 'next/link';
 import { notFound } from 'next/navigation';
 import ReactMarkdown from 'react-markdown';
+import { SteeringAgendaDraftPanel } from '@/components/coalition/steering-agenda-draft-panel';
 import { SteeringMeetingForm } from '@/components/coalition/steering-meeting-form';
 import { SteeringPostButton } from '@/components/coalition/steering-post-button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
@@ -131,6 +132,8 @@ export default async function SteeringMeetingDetailPage({
               </article>
             </CardContent>
           </Card>
+
+          {!meeting.postedAt ? <SteeringAgendaDraftPanel meetingId={meeting.id} /> : null}
 
           <Card>
             <CardHeader>

--- a/src/components/coalition/steering-agenda-draft-panel.tsx
+++ b/src/components/coalition/steering-agenda-draft-panel.tsx
@@ -1,0 +1,86 @@
+'use client';
+
+import { useState, useTransition } from 'react';
+import ReactMarkdown from 'react-markdown';
+import { draftSteeringAgendaAction } from '@/app/actions/steering-agenda';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+
+export function SteeringAgendaDraftPanel({ meetingId }: { meetingId: string }) {
+  const [pending, startTransition] = useTransition();
+  const [draft, setDraft] = useState<{ md: string; modelId: string; promptVersion: string } | null>(
+    null,
+  );
+  const [error, setError] = useState<string | null>(null);
+  const [copied, setCopied] = useState(false);
+
+  const onDraft = () => {
+    setError(null);
+    setCopied(false);
+    startTransition(async () => {
+      const r = await draftSteeringAgendaAction(meetingId);
+      if (!r.ok) {
+        setError(r.error);
+        return;
+      }
+      setDraft({ md: r.agendaMd, modelId: r.modelId, promptVersion: r.promptVersion });
+    });
+  };
+
+  const onCopy = async () => {
+    if (!draft) return;
+    try {
+      await navigator.clipboard.writeText(draft.md);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      setError('Copy failed — select the text manually.');
+    }
+  };
+
+  return (
+    <Card className="border-primary/40 bg-primary/5">
+      <CardHeader className="flex flex-row items-baseline justify-between gap-2">
+        <CardTitle className="text-base">Draft an agenda</CardTitle>
+        {draft ? (
+          <Button onClick={onDraft} disabled={pending} size="sm" variant="outline">
+            {pending ? 'Re-drafting…' : 'Re-draft'}
+          </Button>
+        ) : null}
+      </CardHeader>
+      <CardContent className="space-y-3 text-sm">
+        {!draft ? (
+          <>
+            <p className="text-muted-foreground">
+              Claude reads the most recent posted meeting's action items and the last 14 days of
+              coalition activity, then drafts a 4-section markdown agenda you paste into the agenda
+              field above. Re-run any time the docket changes.
+            </p>
+            <div className="flex items-center gap-3">
+              <Button onClick={onDraft} disabled={pending} size="sm">
+                {pending ? 'Drafting…' : 'Draft agenda'}
+              </Button>
+              {error ? <span className="text-xs text-destructive">{error}</span> : null}
+            </div>
+          </>
+        ) : (
+          <>
+            <article className="prose prose-sm max-w-none rounded-md border border-border bg-card p-3 dark:prose-invert">
+              <ReactMarkdown>{draft.md}</ReactMarkdown>
+            </article>
+            <div className="flex flex-wrap items-center justify-between gap-3 text-[11px] text-muted-foreground">
+              <Button type="button" size="sm" variant="outline" onClick={onCopy}>
+                {copied ? 'Copied ✓' : 'Copy markdown'}
+              </Button>
+              <span>
+                Model: <span className="font-mono">{draft.modelId}</span> · Prompt:{' '}
+                <span className="font-mono">{draft.promptVersion}</span>
+              </span>
+              {error ? <span className="w-full text-destructive">{error}</span> : null}
+            </div>
+          </>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/db/queries/steering-meetings.ts
+++ b/src/db/queries/steering-meetings.ts
@@ -1,4 +1,4 @@
-import { desc, eq } from 'drizzle-orm';
+import { and, desc, eq, isNotNull, ne } from 'drizzle-orm';
 import { db } from '@/db/client';
 import { type SteeringMeeting, steeringMeetings } from '@/db/schema/steering-meetings';
 
@@ -11,6 +11,23 @@ export async function getSteeringMeetingById(id: string): Promise<SteeringMeetin
     .select()
     .from(steeringMeetings)
     .where(eq(steeringMeetings.id, id))
+    .limit(1);
+  return row ?? null;
+}
+
+/**
+ * Most recent posted meeting other than `excludeId`. Used by the
+ * agenda drafter to surface unfinished business — open action items
+ * are the strongest signal for next-meeting topics.
+ */
+export async function getMostRecentPostedMeeting(
+  excludeId: string,
+): Promise<SteeringMeeting | null> {
+  const [row] = await db
+    .select()
+    .from(steeringMeetings)
+    .where(and(isNotNull(steeringMeetings.postedAt), ne(steeringMeetings.id, excludeId)))
+    .orderBy(desc(steeringMeetings.heldOn))
     .limit(1);
   return row ?? null;
 }

--- a/src/lib/coalition/steering-agenda.ts
+++ b/src/lib/coalition/steering-agenda.ts
@@ -1,0 +1,48 @@
+import Anthropic from '@anthropic-ai/sdk';
+import {
+  buildSteeringAgendaUserPrompt,
+  STEERING_AGENDA_PROMPT_VERSION,
+  STEERING_AGENDA_SYSTEM_PROMPT,
+  type SteeringAgendaInputs,
+} from '@/ai/prompts/steering-agenda';
+
+let _client: Anthropic | null = null;
+function client(): Anthropic {
+  if (!_client) _client = new Anthropic();
+  return _client;
+}
+
+const MODEL_ID = 'claude-sonnet-4-6';
+const MAX_OUTPUT_TOKENS = 800;
+
+export type SteeringAgendaResult = {
+  agendaMd: string;
+  modelId: string;
+  promptVersion: string;
+};
+
+export async function draftSteeringAgenda(
+  inputs: SteeringAgendaInputs,
+): Promise<SteeringAgendaResult> {
+  const response = await client().messages.create({
+    model: MODEL_ID,
+    max_tokens: MAX_OUTPUT_TOKENS,
+    system: [
+      {
+        type: 'text',
+        text: STEERING_AGENDA_SYSTEM_PROMPT,
+        cache_control: { type: 'ephemeral' },
+      },
+    ],
+    messages: [{ role: 'user', content: buildSteeringAgendaUserPrompt(inputs) }],
+  });
+
+  const agendaMd = response.content
+    .flatMap((c) => (c.type === 'text' ? [c.text] : []))
+    .join('\n')
+    .trim();
+  if (!agendaMd) {
+    throw new Error(`[steering-agenda] empty response; stop_reason=${response.stop_reason}`);
+  }
+  return { agendaMd, modelId: MODEL_ID, promptVersion: STEERING_AGENDA_PROMPT_VERSION };
+}


### PR DESCRIPTION
## Summary
- New "Draft agenda" panel on any un-posted steering meeting detail page (\`/app/coalition/steering/{id}\`)
- Claude reads the most recent posted meeting's action items + decisions and the 14-day coalition digest, writes a 4-section markdown agenda: "Open from last meeting" / "What changed" / "Decisions to make today" / "Standing items"
- Hard rules: never invent action items (only carry-forward from prior minutes), never invent counts (digest is the only source), shrink the agenda when the window is quiet rather than padding
- Coordinator reviews, copies markdown into the agenda field
- Reuses the existing weekly-insights digest data shape (#292)

## Test plan
- [ ] Open an un-posted steering meeting → "Draft agenda" panel visible
- [ ] Click "Draft agenda" → agenda appears with 4 sections, references the prior meeting's action items if any
- [ ] Re-draft works
- [ ] On a posted meeting, the panel does NOT render
- [ ] First-ever meeting (no prior posted) → agenda still drafts; "Open from last meeting" is suppressed
- [ ] Audit log shows \`steering_agenda.drafted\` + \`ai.generated\`