### PR TITLE
feat(CWT): batch pre-meeting briefings on caseworker triage

### DIFF
--- a/src/app/actions/cwt-triage.ts
+++ b/src/app/actions/cwt-triage.ts
@@ -6,10 +6,13 @@ import {
   listCwtTriageCandidates,
   summarizeIntakeForTriage,
 } from '@/db/queries/cwt-triage';
+import { getPersonProfileDelta } from '@/db/queries/person-profile';
 import { logAuditEvent } from '@/lib/audit';
 import { requireRole } from '@/lib/auth';
 import { type CwtTriageResult, generateCwtTriage } from '@/lib/cwt/cwt-triage';
+import { generatePreMeetingSummary } from '@/lib/cwt/pre-meeting-summary';
 import { recordAiGeneration } from '@/lib/dtrs/data-access';
+import { isValidSyntheticPersonRef } from '@/lib/synthetic-person';
 
 const ROLES = ['caseworker', 'shelter_staff', 'admin'] as const;
 
@@ -70,6 +73,95 @@ export async function generateCwtTriageAction(): Promise<GenerateCwtTriageResult
     Sentry.captureException(err, { tags: { action: 'generateCwtTriageAction' } });
     return { ok: false, error: 'Triage generation failed. Please try again.' };
   }
+}
+
+export type BatchBriefingItem =
+  | { ok: true; syntheticPersonRef: string; text: string; modelId: string }
+  | { ok: false; syntheticPersonRef: string; error: string };
+
+export type GenerateBatchBriefingsResult =
+  | { ok: true; items: BatchBriefingItem[] }
+  | { ok: false; error: string };
+
+const BATCH_BRIEFINGS_MAX = 5;
+const BRIEFING_LOOKBACK_DAYS = 30;
+
+/**
+ * Run `generatePreMeetingSummary` for a list of synthetic person
+ * refs in parallel. Used by the caseworker morning-triage page to
+ * draft a 30-second briefing for every person-kind pick at once.
+ *
+ * Per-item failures don't fail the batch (Promise.allSettled), and
+ * a missing/invalid ref surfaces as a per-item error rather than
+ * killing the whole call.
+ */
+export async function generateBatchPreMeetingBriefingsAction(
+  refs: string[],
+): Promise<GenerateBatchBriefingsResult> {
+  const actor = await requireRole(ROLES);
+
+  if (!Array.isArray(refs) || refs.length === 0) {
+    return { ok: false, error: 'No persons provided.' };
+  }
+  if (refs.length > BATCH_BRIEFINGS_MAX) {
+    return {
+      ok: false,
+      error: `Batch too large (max ${BATCH_BRIEFINGS_MAX}). Trim the picks and try again.`,
+    };
+  }
+  const seen = new Set<string>();
+  const unique = refs.filter((r) => {
+    if (seen.has(r)) return false;
+    seen.add(r);
+    return true;
+  });
+
+  const since = new Date();
+  since.setDate(since.getDate() - BRIEFING_LOOKBACK_DAYS);
+
+  const settled = await Promise.allSettled(
+    unique.map(async (syntheticPersonRef): Promise<BatchBriefingItem> => {
+      if (!isValidSyntheticPersonRef(syntheticPersonRef)) {
+        return { ok: false, syntheticPersonRef, error: 'Invalid synthetic-person reference.' };
+      }
+      try {
+        const delta = await getPersonProfileDelta(syntheticPersonRef, since);
+        const result = await generatePreMeetingSummary(delta);
+        await logAuditEvent({
+          actorUserId: actor.id,
+          action: 'pre_meeting_summary.generated',
+          targetTable: 'partner_service_events',
+          targetId: syntheticPersonRef,
+          metadata: {
+            promptVersion: result.modelId,
+            daysBack: BRIEFING_LOOKBACK_DAYS,
+            via: 'triage_batch',
+          },
+        });
+        await recordAiGeneration({
+          actorUserId: actor.id,
+          resourceType: 'pre_meeting_summary',
+          resourceId: syntheticPersonRef,
+          model: result.modelId,
+          promptVersion: result.modelId,
+          metadata: { daysBack: BRIEFING_LOOKBACK_DAYS, via: 'triage_batch' },
+        });
+        return { ok: true, syntheticPersonRef, text: result.text, modelId: result.modelId };
+      } catch (err) {
+        Sentry.captureException(err, {
+          tags: { action: 'generateBatchPreMeetingBriefingsAction', ref: syntheticPersonRef },
+        });
+        return { ok: false, syntheticPersonRef, error: 'Briefing generation failed.' };
+      }
+    }),
+  );
+
+  const items: BatchBriefingItem[] = settled.map((s, i) => {
+    if (s.status === 'fulfilled') return s.value;
+    return { ok: false, syntheticPersonRef: unique[i], error: 'Unexpected failure.' };
+  });
+
+  return { ok: true, items };
 }
 
 function candidateMeta(c: CwtTriageCandidate): CwtTriageCandidateMeta {

--- a/src/components/cwt/morning-triage-panel.tsx
+++ b/src/components/cwt/morning-triage-panel.tsx
@@ -3,8 +3,10 @@
 import Link from 'next/link';
 import { useState, useTransition } from 'react';
 import {
+  type BatchBriefingItem,
   type CwtTriageCandidateMeta,
   type GenerateCwtTriageResult,
+  generateBatchPreMeetingBriefingsAction,
   generateCwtTriageAction,
 } from '@/app/actions/cwt-triage';
 import { Button } from '@/components/ui/button';
@@ -22,10 +24,43 @@ const urgencyClass: Record<string, string> = {
 
 type SuccessResult = Extract<GenerateCwtTriageResult, { ok: true }>;
 
+function BriefingBlock({
+  briefing,
+  pending,
+}: {
+  briefing: BatchBriefingItem | undefined;
+  pending: boolean;
+}) {
+  if (!briefing) {
+    if (pending) {
+      return <p className="mt-2 text-[11px] text-muted-foreground italic">Drafting briefing…</p>;
+    }
+    return null;
+  }
+  if (!briefing.ok) {
+    return (
+      <p className="mt-2 rounded border border-destructive/40 bg-destructive/5 px-2 py-1 text-[11px] text-destructive">
+        Couldn't draft briefing: {briefing.error}
+      </p>
+    );
+  }
+  return (
+    <div className="mt-3 rounded-md border border-primary/40 bg-primary/5 p-2">
+      <p className="text-[10px] uppercase tracking-wide text-muted-foreground">
+        Pre-meeting briefing
+      </p>
+      <p className="mt-1 whitespace-pre-wrap text-sm leading-relaxed">{briefing.text}</p>
+    </div>
+  );
+}
+
 export function MorningTriagePanel() {
   const [pending, startTransition] = useTransition();
+  const [batchPending, startBatchTransition] = useTransition();
   const [data, setData] = useState<SuccessResult | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [batchError, setBatchError] = useState<string | null>(null);
+  const [briefingByRef, setBriefingByRef] = useState<Record<string, BatchBriefingItem>>({});
 
   const onClick = () => {
     setError(null);
@@ -36,6 +71,22 @@ export function MorningTriagePanel() {
         return;
       }
       setData(r);
+      setBriefingByRef({});
+      setBatchError(null);
+    });
+  };
+
+  const onBatchBriefings = (refs: string[]) => {
+    setBatchError(null);
+    startBatchTransition(async () => {
+      const r = await generateBatchPreMeetingBriefingsAction(refs);
+      if (!r.ok) {
+        setBatchError(r.error);
+        return;
+      }
+      const next: Record<string, BatchBriefingItem> = {};
+      for (const item of r.items) next[item.syntheticPersonRef] = item;
+      setBriefingByRef(next);
     });
   };
 
@@ -87,22 +138,53 @@ export function MorningTriagePanel() {
             No candidates need attention today out of {result.candidateCount} on the queue.
           </p>
         ) : (
-          <ol className="space-y-3">
-            {sortedPicks.map((p) => {
-              const c = candById.get(p.candidate_id);
-              if (!c) return null;
+          <>
+            {(() => {
+              const personPicks = sortedPicks.filter((p) => p.kind === 'person');
+              if (personPicks.length === 0) return null;
               return (
-                <li
-                  key={p.candidate_id}
-                  className="rounded-md border border-border bg-card p-3 text-sm"
-                >
-                  <PickHeader pick={p} candidate={c} />
-                  <p className="text-sm leading-relaxed">{p.rationale}</p>
-                  <PickFooter candidate={c} />
-                </li>
+                <div className="flex flex-wrap items-center gap-3 rounded-md border border-primary/40 bg-primary/5 p-3">
+                  <div className="flex-1 text-xs text-muted-foreground">
+                    Draft a 30-second pre-meeting briefing for the {personPicks.length} person-kind
+                    pick{personPicks.length === 1 ? '' : 's'} at once. Intake-kind picks (no person
+                    ref yet) skip this batch.
+                  </div>
+                  <Button
+                    onClick={() => onBatchBriefings(personPicks.map((p) => p.candidate_id))}
+                    disabled={batchPending}
+                    size="sm"
+                  >
+                    {batchPending
+                      ? `Drafting ${personPicks.length}…`
+                      : `Draft briefings for ${personPicks.length}`}
+                  </Button>
+                  {batchError ? (
+                    <span className="w-full text-xs text-destructive">{batchError}</span>
+                  ) : null}
+                </div>
               );
-            })}
-          </ol>
+            })()}
+            <ol className="space-y-3">
+              {sortedPicks.map((p) => {
+                const c = candById.get(p.candidate_id);
+                if (!c) return null;
+                const briefing = p.kind === 'person' ? briefingByRef[p.candidate_id] : undefined;
+                return (
+                  <li
+                    key={p.candidate_id}
+                    className="rounded-md border border-border bg-card p-3 text-sm"
+                  >
+                    <PickHeader pick={p} candidate={c} />
+                    <p className="text-sm leading-relaxed">{p.rationale}</p>
+                    <PickFooter candidate={c} />
+                    {p.kind === 'person' ? (
+                      <BriefingBlock briefing={briefing} pending={batchPending} />
+                    ) : null}
+                  </li>
+                );
+              })}
+            </ol>
+          </>
         )}
 
         <div className="flex flex-wrap gap-x-4 gap-y-1 text-[11px] text-muted-foreground">


### PR DESCRIPTION
## Summary
- After running caseworker morning triage, person-kind picks get a batch CTA: "Draft briefings for N"
- Click → \`generatePreMeetingSummary\` for every person pick in parallel via Promise.allSettled
- Each briefing renders inline under its pick (with pending / error fallbacks)
- Intake-kind picks skip the batch — they don't have a synthetic_person_ref yet, so a briefing isn't applicable. CTA copy is explicit about that
- Cap of 5; 30-day lookback matches the single-person briefing default
- Each generation audited with \`via=triage_batch\` metadata so DTRS can split single from batch

Completes the batch-orchestration triple: attorney triage → batch outreach (#293), ED triage → batch care plans (#298), caseworker triage → batch briefings (this).

## Test plan
- [ ] Run caseworker morning triage with at least one person-kind pick → "Draft briefings for N" CTA visible (excluding intake picks)
- [ ] Click → briefings appear inline under each person pick
- [ ] Intake-kind picks have NO briefing block
- [ ] Audit log shows N rows of \`pre_meeting_summary.generated\` with \`via=triage_batch\`
- [ ] Re-running triage clears the briefings