### PR TITLE
feat(OPRT): AI quarterly narrative on transparency report

### DIFF
--- a/src/ai/prompts/quarterly-narrative.ts
+++ b/src/ai/prompts/quarterly-narrative.ts
@@ -1,0 +1,109 @@
+/**
+ * Quarterly narrative prompt.
+ *
+ * Coalition coordinator opens the public quarterly outcomes page
+ * and clicks "Draft narrative". Claude reads the same suppression-
+ * safe aggregates that drive the structured numbers + the Fiscal
+ * Court brief, and writes a 3-4 paragraph plain-English summary
+ * suitable for a community newsletter, Fiscal Court appendix, or
+ * partner-org email update.
+ *
+ * Output is prose, not numbers. The page already has the numbers.
+ * This is the "what does it mean" companion.
+ */
+
+import type {
+  CoalitionAggregate,
+  GovernanceCountsForQuarter,
+  Quarter,
+  QuarterlyEvictionAggregate,
+} from '@/db/queries/public-outcomes';
+
+export const QUARTERLY_NARRATIVE_PROMPT_VERSION = 'quarterly-narrative-v1@2026-04-26';
+
+export const QUARTERLY_NARRATIVE_SYSTEM_PROMPT = `You write a 3-4 paragraph public-facing narrative summarizing
+one quarter of the Daviess County homelessness coalition's
+outcomes. The audience is the Fiscal Court, the Steering
+Committee, partner orgs, and an interested public — read aloud at
+a community meeting kind of voice.
+
+Structure (no headers, just paragraphs):
+
+PARAGRAPH 1 — eviction defense.
+Lead with the household-impact headline. How many filings did
+KLA reach with a drafted-and-reviewed response? What did the
+default-judgment number look like — the metric we're trying to
+pull down? If counts are suppressed (the input shows them as
+'fewer than 5'), say so plainly; don't invent a number.
+
+PARAGRAPH 2 — coalition reach.
+The partner count, the shelter capacity, and the rolling-90-day
+service events. The 90-day window is wider than the quarter on
+purpose: it shows the coalition's working memory, not just the
+quarter's churn.
+
+PARAGRAPH 3 — governance.
+Consent grants, revocations, and access-log volume. The framing
+is "we did this with consent and a paper trail" — that's the
+point of the data trust.
+
+PARAGRAPH 4 (optional) — what's next.
+1-2 sentences on what the coordinator wants stakeholders to know
+heading into next quarter. If nothing changed materially, you can
+omit this paragraph.
+
+Hard rules:
+1. NEVER invent a count. The numbers in the input are the only
+   numbers you have. Suppressed (null) means "fewer than 5";
+   write that out, don't approximate.
+2. Don't editorialize beyond what the numbers support. Don't say
+   "great progress" if the numbers don't show it.
+3. Don't reference individual people, filings, or partners by
+   name. The transparency report deliberately operates at the
+   aggregate.
+4. Plain English, 8th-grade reading level. No legal jargon.
+5. Output ONLY the prose. No headers, no bullets, no preamble.`;
+
+const fmtCount = (n: number | null): string => (n === null ? 'fewer than 5' : n.toLocaleString());
+
+const fmtPct = (a: number | null, b: number | null): string => {
+  if (a === null || b === null || b === 0) return 'unavailable';
+  return `${Math.round((a / b) * 100)}%`;
+};
+
+export function buildQuarterlyNarrativeUserPrompt(input: {
+  quarter: Quarter;
+  evictionForQuarter: QuarterlyEvictionAggregate;
+  coalitionSnapshot: CoalitionAggregate;
+  governanceForQuarter: GovernanceCountsForQuarter;
+}): string {
+  const { quarter, evictionForQuarter, coalitionSnapshot, governanceForQuarter } = input;
+  const repRate = fmtPct(evictionForQuarter.filingsWithPacket, evictionForQuarter.filingsIngested);
+
+  const lines = [
+    `Quarter: ${quarter.label}`,
+    '',
+    '## Eviction defense',
+    `- Filings ingested: ${fmtCount(evictionForQuarter.filingsIngested)}`,
+    `- Filings with attorney-reviewed response packet: ${fmtCount(evictionForQuarter.filingsWithPacket)}`,
+    `- Outcomes recorded: ${fmtCount(evictionForQuarter.outcomesRecorded)}`,
+    `- Default-judgment outcomes: ${fmtCount(evictionForQuarter.defaultJudgments)}`,
+    `- Packet representation rate (packets / filings): ${repRate}`,
+    '',
+    '## Coalition (rolling 90 days)',
+    `- Active partner orgs: ${coalitionSnapshot.partnerCount}`,
+    `- Partners actively sharing data: ${coalitionSnapshot.partnersSharing}`,
+    `- Active shelters: ${coalitionSnapshot.shelterCount}`,
+    `- Total shelter capacity: ${coalitionSnapshot.totalShelterCapacity}`,
+    `- Service events in window: ${fmtCount(coalitionSnapshot.serviceEventsRolling)}`,
+    `- Unique people touched: ${fmtCount(coalitionSnapshot.uniquePeopleRolling)}`,
+    '',
+    '## Governance',
+    `- Consent grants this quarter: ${fmtCount(governanceForQuarter.consentGrants)}`,
+    `- Consent revocations this quarter: ${fmtCount(governanceForQuarter.consentRevocations)}`,
+    `- Data-access events this quarter: ${fmtCount(governanceForQuarter.dataAccessEvents)}`,
+    '',
+    'Write the narrative now.',
+  ];
+  return lines.join('\n');
+}

--- a/src/app/actions/quarterly-narrative.ts
+++ b/src/app/actions/quarterly-narrative.ts
@@ -1,0 +1,83 @@
+'use server';
+
+import * as Sentry from '@sentry/nextjs';
+import {
+  getCoalitionAggregate,
+  getGovernanceCountsForQuarter,
+  listQuarterlyEvictionAggregates,
+  type Quarter,
+} from '@/db/queries/public-outcomes';
+import { logAuditEvent } from '@/lib/audit';
+import { requireUser } from '@/lib/auth';
+import { recordAiGeneration } from '@/lib/dtrs/data-access';
+import { generateQuarterlyNarrative } from '@/lib/oprt/quarterly-narrative';
+
+export type GenerateQuarterlyNarrativeResult =
+  | { ok: true; text: string; modelId: string; promptVersion: string }
+  | { ok: false; error: string };
+
+export async function generateQuarterlyNarrativeAction(
+  year: number,
+  quarter: 1 | 2 | 3 | 4,
+): Promise<GenerateQuarterlyNarrativeResult> {
+  const actor = await requireUser();
+
+  if (!Number.isInteger(year) || year < 2024 || year > 2100) {
+    return { ok: false, error: 'Invalid year.' };
+  }
+  if (![1, 2, 3, 4].includes(quarter)) {
+    return { ok: false, error: 'Invalid quarter.' };
+  }
+
+  const q: Quarter = { year, quarter, label: `${year} Q${quarter}` };
+
+  try {
+    const [eviction, coalitionSnapshot, governanceForQuarter] = await Promise.all([
+      listQuarterlyEvictionAggregates([q]),
+      getCoalitionAggregate(90),
+      getGovernanceCountsForQuarter(q),
+    ]);
+    const evictionForQuarter = eviction[0];
+    if (!evictionForQuarter) {
+      return { ok: false, error: 'No eviction aggregate available for this quarter.' };
+    }
+
+    const result = await generateQuarterlyNarrative({
+      quarter: q,
+      evictionForQuarter,
+      coalitionSnapshot,
+      governanceForQuarter,
+    });
+
+    await logAuditEvent({
+      actorUserId: actor.id,
+      action: 'quarterly_narrative.generated',
+      targetTable: 'eviction_filings',
+      metadata: {
+        promptVersion: result.promptVersion,
+        year,
+        quarter,
+      },
+    });
+    await recordAiGeneration({
+      actorUserId: actor.id,
+      resourceType: 'quarterly_narrative',
+      resourceId: q.label,
+      model: result.modelId,
+      promptVersion: result.promptVersion,
+      metadata: { year, quarter },
+    });
+
+    return {
+      ok: true,
+      text: result.text,
+      modelId: result.modelId,
+      promptVersion: result.promptVersion,
+    };
+  } catch (err) {
+    Sentry.captureException(err, {
+      tags: { action: 'generateQuarterlyNarrativeAction', quarter: q.label },
+    });
+    return { ok: false, error: 'Narrative generation failed. Please try again.' };
+  }
+}

--- a/src/app/outcomes/q/[year]/[quarter]/page.tsx
+++ b/src/app/outcomes/q/[year]/[quarter]/page.tsx
@@ -1,6 +1,8 @@
+import { auth } from '@clerk/nextjs/server';
 import Link from 'next/link';
 import { notFound } from 'next/navigation';
 import { PrintButton } from '@/components/coordination/print-button';
+import { QuarterlyNarrativePanel } from '@/components/operations/quarterly-narrative-panel';
 import { Card, CardContent } from '@/components/ui/card';
 import {
   getCoalitionAggregate,
@@ -39,13 +41,15 @@ export default async function QuarterlyReportPage({
   const quarter = parseQuarter(year, q);
   if (!quarter) notFound();
 
-  const [eviction, coalitionSnapshot, governanceForQuarter] = await Promise.all([
+  const [eviction, coalitionSnapshot, governanceForQuarter, session] = await Promise.all([
     listQuarterlyEvictionAggregates([quarter]),
     getCoalitionAggregate(90),
     getGovernanceCountsForQuarter(quarter),
+    auth(),
   ]);
   const evictionForQuarter = eviction[0];
   const generatedAt = new Date();
+  const signedIn = Boolean(session.userId);
 
   const repRate = fmtPct(evictionForQuarter.filingsWithPacket, evictionForQuarter.filingsIngested);
 
@@ -162,6 +166,12 @@ export default async function QuarterlyReportPage({
           staff lands in an append-only audit trail. Revocations are honored immediately.
         </p>
       </section>
+
+      {signedIn ? (
+        <section className="print:hidden">
+          <QuarterlyNarrativePanel year={quarter.year} quarter={quarter.quarter} />
+        </section>
+      ) : null}
 
       <section className="space-y-3 rounded-md border border-border bg-muted/20 p-4 text-xs print:hidden">
         <h2 className="font-serif text-base font-semibold">Share this report</h2>

--- a/src/components/operations/quarterly-narrative-panel.tsx
+++ b/src/components/operations/quarterly-narrative-panel.tsx
@@ -1,0 +1,90 @@
+'use client';
+
+import { useState, useTransition } from 'react';
+import { generateQuarterlyNarrativeAction } from '@/app/actions/quarterly-narrative';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+
+export function QuarterlyNarrativePanel({
+  year,
+  quarter,
+}: {
+  year: number;
+  quarter: 1 | 2 | 3 | 4;
+}) {
+  const [pending, startTransition] = useTransition();
+  const [data, setData] = useState<{ text: string; modelId: string; promptVersion: string } | null>(
+    null,
+  );
+  const [error, setError] = useState<string | null>(null);
+  const [copied, setCopied] = useState(false);
+
+  const onClick = () => {
+    setError(null);
+    setCopied(false);
+    startTransition(async () => {
+      const r = await generateQuarterlyNarrativeAction(year, quarter);
+      if (!r.ok) {
+        setError(r.error);
+        return;
+      }
+      setData({ text: r.text, modelId: r.modelId, promptVersion: r.promptVersion });
+    });
+  };
+
+  const onCopy = async () => {
+    if (!data) return;
+    try {
+      await navigator.clipboard.writeText(data.text);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      setError('Copy failed — select the text manually.');
+    }
+  };
+
+  return (
+    <Card>
+      <CardHeader className="flex flex-row items-baseline justify-between gap-2">
+        <CardTitle className="text-base">Plain-English narrative</CardTitle>
+        {data ? (
+          <Button onClick={onClick} disabled={pending} size="sm" variant="outline">
+            {pending ? 'Re-drafting…' : 'Re-draft'}
+          </Button>
+        ) : null}
+      </CardHeader>
+      <CardContent className="space-y-3 text-sm">
+        {!data ? (
+          <>
+            <p className="text-muted-foreground">
+              Claude reads the same suppression-safe aggregates above and writes a 3-4 paragraph
+              prose summary suitable for a community newsletter, Fiscal Court appendix, or partner
+              email update. Counts under 5 stay suppressed (printed as "fewer than 5") rather than
+              padded.
+            </p>
+            <div className="flex items-center gap-3">
+              <Button onClick={onClick} disabled={pending} size="sm">
+                {pending ? 'Drafting…' : 'Draft narrative'}
+              </Button>
+              {error ? <span className="text-xs text-destructive">{error}</span> : null}
+            </div>
+          </>
+        ) : (
+          <>
+            <p className="whitespace-pre-wrap leading-relaxed">{data.text}</p>
+            <div className="flex flex-wrap items-center justify-between gap-3 text-[11px] text-muted-foreground">
+              <Button type="button" size="sm" variant="outline" onClick={onCopy}>
+                {copied ? 'Copied ✓' : 'Copy text'}
+              </Button>
+              <span>
+                Model: <span className="font-mono">{data.modelId}</span> · Prompt:{' '}
+                <span className="font-mono">{data.promptVersion}</span>
+              </span>
+              {error ? <span className="w-full text-destructive">{error}</span> : null}
+            </div>
+          </>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/lib/oprt/quarterly-narrative.ts
+++ b/src/lib/oprt/quarterly-narrative.ts
@@ -1,0 +1,56 @@
+import Anthropic from '@anthropic-ai/sdk';
+import {
+  buildQuarterlyNarrativeUserPrompt,
+  QUARTERLY_NARRATIVE_PROMPT_VERSION,
+  QUARTERLY_NARRATIVE_SYSTEM_PROMPT,
+} from '@/ai/prompts/quarterly-narrative';
+import type {
+  CoalitionAggregate,
+  GovernanceCountsForQuarter,
+  Quarter,
+  QuarterlyEvictionAggregate,
+} from '@/db/queries/public-outcomes';
+
+let _client: Anthropic | null = null;
+function client(): Anthropic {
+  if (!_client) _client = new Anthropic();
+  return _client;
+}
+
+const MODEL_ID = 'claude-sonnet-4-6';
+const MAX_OUTPUT_TOKENS = 700;
+
+export type QuarterlyNarrativeResult = {
+  text: string;
+  modelId: string;
+  promptVersion: string;
+};
+
+export async function generateQuarterlyNarrative(input: {
+  quarter: Quarter;
+  evictionForQuarter: QuarterlyEvictionAggregate;
+  coalitionSnapshot: CoalitionAggregate;
+  governanceForQuarter: GovernanceCountsForQuarter;
+}): Promise<QuarterlyNarrativeResult> {
+  const response = await client().messages.create({
+    model: MODEL_ID,
+    max_tokens: MAX_OUTPUT_TOKENS,
+    system: [
+      {
+        type: 'text',
+        text: QUARTERLY_NARRATIVE_SYSTEM_PROMPT,
+        cache_control: { type: 'ephemeral' },
+      },
+    ],
+    messages: [{ role: 'user', content: buildQuarterlyNarrativeUserPrompt(input) }],
+  });
+
+  const text = response.content
+    .flatMap((c) => (c.type === 'text' ? [c.text] : []))
+    .join('\n')
+    .trim();
+  if (!text) {
+    throw new Error(`[quarterly-narrative] empty response; stop_reason=${response.stop_reason}`);
+  }
+  return { text, modelId: MODEL_ID, promptVersion: QUARTERLY_NARRATIVE_PROMPT_VERSION };
+}


### PR DESCRIPTION
## Summary
- New "Plain-English narrative" panel on \`/outcomes/q/[year]/[quarter]\` that drafts a 3-4 paragraph prose summary alongside the existing structured numbers
- Reuses the suppression-safe Eviction / Coalition / Governance aggregate triple — no new queries
- Hard rule in the prompt: never invent counts; suppressed counts (n<5) print as the literal phrase "fewer than 5"
- Visible only to signed-in viewers (the page is public, but only coalition staff need the drafter); print:hidden so the printable report stays clean
- Output is copy-to-clipboard; coordinator pastes into a newsletter / Fiscal Court appendix / partner email

Companion to the structured DTRS-013 transparency report and the PCYI-001 Fiscal Court brief — same data, prose framing.

## Test plan
- [ ] Visit /outcomes/q/2026/2 signed in → "Draft narrative" button → verify 3-4 paragraphs render with counts that match the structured data above
- [ ] Try a quarter with suppressed counts → verify the AI prints "fewer than 5" rather than fabricating
- [ ] Sign out → confirm the panel is hidden but the rest of the report still renders
- [ ] Audit log shows \`quarterly_narrative.generated\` + \`ai.generated\`