### PR TITLE
feat(EVDT): outreach letter PDF export

### DIFF
--- a/src/app/actions/eviction.ts
+++ b/src/app/actions/eviction.ts
@@ -22,6 +22,7 @@ import { requireKlaAttorney, requireRole } from '@/lib/auth';
 import { recordAiGeneration } from '@/lib/dtrs/data-access';
 import { type AttorneyTriageResult, generateAttorneyTriage } from '@/lib/eviction/attorney-triage';
 import { answerCaseQuestion, type CaseQATurn } from '@/lib/eviction/case-qa';
+import { renderOutreachLetterPdf } from '@/lib/eviction/outreach-letter-pdf';
 import { renderPacketPdf } from '@/lib/eviction/packet-pdf';
 import { generateResponsePacket, validateDisclaimer } from '@/lib/eviction/response-packet';
 import { getLatestScore, scoreFiling } from '@/lib/eviction/risk-score';
@@ -184,6 +185,57 @@ export async function exportPacketPdfAction(packetId: string): Promise<ExportPac
   return {
     ok: true,
     filename: `packet-${safeCase}-${packet.id.slice(0, 8)}.pdf`,
+    base64: bytes.toString('base64'),
+  };
+}
+
+export type ExportOutreachLetterPdfResult =
+  | { ok: true; filename: string; base64: string }
+  | { ok: false; error: string };
+
+const OUTREACH_PDF_TEXT_MIN = 80;
+const OUTREACH_PDF_TEXT_MAX = 5000;
+
+export async function exportOutreachLetterPdfAction(
+  filingId: string,
+  letterText: string,
+): Promise<ExportOutreachLetterPdfResult> {
+  const user = await requireKlaAttorney();
+  const filing = await getFilingById(filingId);
+  if (!filing) return { ok: false, error: 'Filing not found.' };
+
+  const trimmed = letterText.trim();
+  if (trimmed.length < OUTREACH_PDF_TEXT_MIN) {
+    return { ok: false, error: `Letter too short (min ${OUTREACH_PDF_TEXT_MIN} chars).` };
+  }
+  if (trimmed.length > OUTREACH_PDF_TEXT_MAX) {
+    return { ok: false, error: `Letter too long (max ${OUTREACH_PDF_TEXT_MAX} chars).` };
+  }
+
+  let bytes: Buffer;
+  try {
+    bytes = await renderOutreachLetterPdf({ letterText: trimmed, filing });
+  } catch (err) {
+    Sentry.captureException(err, { tags: { action: 'exportOutreachLetterPdfAction', filingId } });
+    return { ok: false, error: 'PDF render failed.' };
+  }
+
+  await logAuditEvent({
+    actorUserId: user.id,
+    action: 'outreach_letter.pdf_exported',
+    targetTable: 'eviction_filings',
+    targetId: filing.id,
+    metadata: {
+      caseNumber: filing.caseNumber,
+      sizeBytes: bytes.byteLength,
+      letterChars: trimmed.length,
+    },
+  });
+
+  const safeCase = filing.caseNumber.replace(/[^a-zA-Z0-9_-]+/g, '-');
+  return {
+    ok: true,
+    filename: `outreach-${safeCase}.pdf`,
     base64: bytes.toString('base64'),
   };
 }

--- a/src/components/eviction/outreach-letter-panel.tsx
+++ b/src/components/eviction/outreach-letter-panel.tsx
@@ -1,7 +1,10 @@
 'use client';
 
 import { useId, useState, useTransition } from 'react';
-import { generateOutreachLetterAction } from '@/app/actions/eviction';
+import {
+  exportOutreachLetterPdfAction,
+  generateOutreachLetterAction,
+} from '@/app/actions/eviction';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 
@@ -33,6 +36,27 @@ export function OutreachLetterPanel({ filingId }: { filingId: string }) {
     } catch {
       setError('Copy failed — select the text manually.');
     }
+  };
+
+  const onExportPdf = () => {
+    setError(null);
+    startTransition(async () => {
+      const r = await exportOutreachLetterPdfAction(filingId, text);
+      if (!r.ok) {
+        setError(r.error);
+        return;
+      }
+      const bytes = Uint8Array.from(atob(r.base64), (c) => c.charCodeAt(0));
+      const blob = new Blob([bytes], { type: 'application/pdf' });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = r.filename;
+      document.body.appendChild(a);
+      a.click();
+      a.remove();
+      URL.revokeObjectURL(url);
+    });
   };
 
   return (
@@ -79,6 +103,15 @@ export function OutreachLetterPanel({ filingId }: { filingId: string }) {
             <div className="flex flex-wrap items-center gap-3">
               <Button type="button" size="sm" variant="outline" onClick={onCopy}>
                 {copied ? 'Copied ✓' : 'Copy to clipboard'}
+              </Button>
+              <Button
+                type="button"
+                size="sm"
+                variant="outline"
+                disabled={pending}
+                onClick={onExportPdf}
+              >
+                {pending ? 'Exporting…' : 'Export PDF'}
               </Button>
               <span className="text-xs text-muted-foreground">{text.length} chars</span>
               {error ? <span className="text-destructive text-xs">{error}</span> : null}

--- a/src/lib/eviction/outreach-letter-pdf.ts
+++ b/src/lib/eviction/outreach-letter-pdf.ts
@@ -1,0 +1,85 @@
+import PDFDocument from 'pdfkit';
+import type { EvictionFiling } from '@/db/schema/eviction-filings';
+
+const PAGE_MARGIN = 64;
+const FONT_BODY = 'Helvetica';
+const FONT_OBLIQUE = 'Helvetica-Oblique';
+
+interface RenderOpts {
+  letterText: string;
+  filing: EvictionFiling;
+}
+
+/**
+ * Render a tenant outreach letter to a one-page PDF the attorney can
+ * print and mail. Way leaner than the packet renderer (#21): the
+ * letter is just paragraphs of plain text, no markdown structure to
+ * walk. Header carries the date + case number; footer carries the
+ * "letter assisted by AI; reviewed by KLA-Owensboro" reminder.
+ *
+ * The attorney is expected to have replaced the `[KLA Owensboro phone]`
+ * placeholder before exporting; we do NOT enforce that — flagging
+ * unfilled placeholders is the attorney's job during review.
+ */
+export async function renderOutreachLetterPdf(opts: RenderOpts): Promise<Buffer> {
+  const { letterText, filing } = opts;
+  const doc = new PDFDocument({
+    size: 'LETTER',
+    margins: { top: PAGE_MARGIN, bottom: PAGE_MARGIN + 28, left: PAGE_MARGIN, right: PAGE_MARGIN },
+    info: {
+      Title: `Outreach letter — ${filing.caseNumber}`,
+      Author: 'Daviess Coalition Platform (AI-assisted)',
+      Subject: `KLA outreach to ${filing.defendantFirstName} ${filing.defendantLastName}`,
+      Keywords: 'outreach kla ai-assisted attorney-reviewed',
+    },
+  });
+
+  const chunks: Buffer[] = [];
+  const finished = new Promise<Buffer>((resolve, reject) => {
+    doc.on('data', (c) => chunks.push(c));
+    doc.on('end', () => resolve(Buffer.concat(chunks)));
+    doc.on('error', reject);
+  });
+
+  // Header: letterhead-light. The attorney pastes onto real letterhead
+  // most of the time; this PDF is the standalone fallback.
+  doc.font(FONT_BODY).fontSize(10).fillColor('#555');
+  doc.text('Kentucky Legal Aid — Owensboro Office', { align: 'left' });
+  doc.text(new Date().toLocaleDateString('en-US', { dateStyle: 'long' }), { align: 'left' });
+  doc.moveDown(0.5);
+  doc.fontSize(9).fillColor('#888');
+  doc.text(`Re: Case ${filing.caseNumber}`, { align: 'left' });
+  doc.moveDown(1.5);
+
+  // Body: paragraphs separated by blank lines. We split on \n\n to
+  // collapse Anthropic's prose into discrete paragraphs; single \n
+  // becomes a soft line break (rare in this kind of letter, but
+  // common when the attorney inserted an action-list).
+  doc.fontSize(11).fillColor('#000');
+  const paragraphs = letterText
+    .replace(/\r\n/g, '\n')
+    .split(/\n{2,}/)
+    .map((p) => p.trim())
+    .filter((p) => p.length > 0);
+
+  for (const para of paragraphs) {
+    doc.text(para, { align: 'left', lineGap: 2 });
+    doc.moveDown(0.7);
+  }
+
+  // Footer (every page, repeated by pdfkit if the letter ever spills).
+  const footerY = doc.page.height - PAGE_MARGIN;
+  doc
+    .font(FONT_OBLIQUE)
+    .fontSize(8)
+    .fillColor('#888')
+    .text(
+      `${filing.caseNumber} · Assisted by AI; reviewed by KLA-Owensboro before mailing.`,
+      PAGE_MARGIN,
+      footerY,
+      { align: 'center', width: doc.page.width - PAGE_MARGIN * 2 },
+    );
+
+  doc.end();
+  return finished;
+}


### PR DESCRIPTION
## Summary
- Parallel to the packet PDF export (#21). KLA attorney edits the AI-drafted outreach letter and clicks "Export PDF" → one-page printable PDF with date + case number header and AI-assisted disclaimer footer
- Action takes the textarea text directly (no persistence) — re-running the AI is cheap, attorneys edit in-place
- Lean renderer: \`\\n\\n\`-split paragraphs through pdfkit; no markdown walker (the letter is prose, not structured)
- Filename: \`outreach-{case-number}.pdf\`
- Audited as \`outreach_letter.pdf_exported\`

## Test plan
- [ ] Open a filing as KLA attorney, draft outreach, edit a bit, click "Export PDF" → verify a one-page PDF downloads with the edited content
- [ ] Header shows date + case number; footer shows AI-assisted disclaimer
- [ ] Re-export with the same edits → same content, no errors
- [ ] Audit log shows \`outreach_letter.pdf_exported\` with size + char count