### PR TITLE
feat(EVDT): plaintiff pattern detector on docket

### DIFF
--- a/src/ai/prompts/plaintiff-patterns.ts
+++ b/src/ai/prompts/plaintiff-patterns.ts
@@ -1,0 +1,71 @@
+import type { TopPlaintiff } from '@/db/queries/eviction-filings';
+
+/**
+ * Plaintiff pattern commentary prompt.
+ *
+ * The docket page surfaces a deterministic list of "top plaintiffs in
+ * the last N days" — purely SQL aggregation on public court records.
+ * The AI commentary is the "so what?" — 2-3 sentences in plain English
+ * for the coordinator about what the pattern might suggest. Bulk-
+ * filing landlords are the canonical signal; same-day mass filings,
+ * the same plaintiff every Monday, are others.
+ *
+ * The AI is told NOT to allege wrongdoing or imagine motives — these
+ * are public-record counts; legal interpretation is the attorney's
+ * job. The commentary is observational ("X has filed 14 cases in 14
+ * days, more than any other plaintiff this month — worth flagging").
+ */
+
+export const PLAINTIFF_PATTERNS_PROMPT_VERSION = 'plaintiff-patterns-v1@2026-04-26';
+
+export const PLAINTIFF_PATTERNS_SYSTEM_PROMPT = `You write a short observational commentary on a list of plaintiffs
+who have filed multiple eviction cases in the last N days in
+Daviess County, Kentucky. The audience is a coalition coordinator
+deciding whether to flag a plaintiff to the steering committee or
+to KLA's intake team for proactive outreach.
+
+Output: ONE paragraph, 2-4 sentences, ~80 words. Plain English.
+No headers. No bullets. No emoji.
+
+How to think about it:
+- Lead with the most striking pattern (highest count, or most
+  compressed time window).
+- If the top plaintiff is far ahead of the rest, say so.
+- If filings are clustered in a narrow date range, that's worth
+  flagging — bulk filings often mean a property-wide action.
+- If the spread is even (similar counts across plaintiffs), say
+  there's no standout this window.
+
+Hard rules:
+1. NEVER allege wrongdoing or imagine motives. These are public
+   counts; you don't know the legal merits.
+2. NEVER invent a name or count. Reference plaintiffs only as they
+   appear in the input.
+3. If the input is empty, say so plainly: "No plaintiff filed three
+   or more cases in this window." Then stop.
+4. Output ONLY the prose paragraph.`;
+
+export function buildPlaintiffPatternsUserPrompt(input: {
+  windowDays: number;
+  minCount: number;
+  plaintiffs: TopPlaintiff[];
+}): string {
+  const lines: string[] = [
+    `Window: last ${input.windowDays} days.`,
+    `Threshold: at least ${input.minCount} filings to appear in the list.`,
+    '',
+  ];
+  if (input.plaintiffs.length === 0) {
+    lines.push('No plaintiffs met the threshold this window.');
+  } else {
+    lines.push(`## Top plaintiffs (${input.plaintiffs.length})`);
+    for (const p of input.plaintiffs) {
+      const earliest = p.earliest.toISOString().slice(0, 10);
+      const latest = p.latest.toISOString().slice(0, 10);
+      lines.push(`- "${p.plaintiff}" · ${p.filings} filings · ${earliest} → ${latest}`);
+    }
+  }
+  lines.push('');
+  lines.push('Write the commentary now.');
+  return lines.join('\n');
+}

--- a/src/app/actions/eviction.ts
+++ b/src/app/actions/eviction.ts
@@ -7,7 +7,11 @@ import type { CaseFacts } from '@/ai/prompts/case-qa';
 import { CaseFilingsRoles } from '@/components/eviction/case-filings-roles';
 import { db } from '@/db/client';
 import { listTriageCandidates } from '@/db/queries/attorney-triage';
-import { getFilingById } from '@/db/queries/eviction-filings';
+import {
+  getFilingById,
+  listTopPlaintiffsRecent,
+  type TopPlaintiff,
+} from '@/db/queries/eviction-filings';
 import { clientIntakes } from '@/db/schema/client-intakes';
 import {
   type EvictionCaseOutcome,
@@ -24,6 +28,7 @@ import { type AttorneyTriageResult, generateAttorneyTriage } from '@/lib/evictio
 import { answerCaseQuestion, type CaseQATurn } from '@/lib/eviction/case-qa';
 import { renderOutreachLetterPdf } from '@/lib/eviction/outreach-letter-pdf';
 import { renderPacketPdf } from '@/lib/eviction/packet-pdf';
+import { commentOnPlaintiffPatterns } from '@/lib/eviction/plaintiff-patterns';
 import { generateResponsePacket, validateDisclaimer } from '@/lib/eviction/response-packet';
 import { getLatestScore, scoreFiling } from '@/lib/eviction/risk-score';
 import { generateOutreachLetter } from '@/lib/eviction/tenant-outreach';
@@ -595,6 +600,72 @@ export async function generateAttorneyTriageAction(): Promise<GenerateAttorneyTr
   } catch (err) {
     Sentry.captureException(err, { tags: { action: 'generateAttorneyTriageAction' } });
     return { ok: false, error: 'Triage generation failed. Please try again.' };
+  }
+}
+
+export type CommentOnPlaintiffPatternsResult =
+  | {
+      ok: true;
+      text: string;
+      modelId: string;
+      promptVersion: string;
+      plaintiffs: TopPlaintiff[];
+      windowDays: number;
+      minCount: number;
+    }
+  | { ok: false; error: string };
+
+const PATTERN_WINDOW_DAYS = 30;
+const PATTERN_MIN_COUNT = 3;
+const PATTERN_LIMIT = 10;
+
+export async function commentOnPlaintiffPatternsAction(): Promise<CommentOnPlaintiffPatternsResult> {
+  const user = await requireRole(CaseFilingsRoles);
+
+  try {
+    const plaintiffs = await listTopPlaintiffsRecent({
+      windowDays: PATTERN_WINDOW_DAYS,
+      minCount: PATTERN_MIN_COUNT,
+      limit: PATTERN_LIMIT,
+    });
+    const result = await commentOnPlaintiffPatterns({
+      windowDays: PATTERN_WINDOW_DAYS,
+      minCount: PATTERN_MIN_COUNT,
+      plaintiffs,
+    });
+
+    await logAuditEvent({
+      actorUserId: user.id,
+      action: 'plaintiff_patterns.commented',
+      targetTable: 'eviction_filings',
+      metadata: {
+        promptVersion: result.promptVersion,
+        windowDays: PATTERN_WINDOW_DAYS,
+        minCount: PATTERN_MIN_COUNT,
+        plaintiffCount: plaintiffs.length,
+      },
+    });
+    await recordAiGeneration({
+      actorUserId: user.id,
+      resourceType: 'plaintiff_patterns',
+      resourceId: 'docket_window',
+      model: result.modelId,
+      promptVersion: result.promptVersion,
+      metadata: { windowDays: PATTERN_WINDOW_DAYS },
+    });
+
+    return {
+      ok: true,
+      text: result.text,
+      modelId: result.modelId,
+      promptVersion: result.promptVersion,
+      plaintiffs,
+      windowDays: PATTERN_WINDOW_DAYS,
+      minCount: PATTERN_MIN_COUNT,
+    };
+  } catch (err) {
+    Sentry.captureException(err, { tags: { action: 'commentOnPlaintiffPatternsAction' } });
+    return { ok: false, error: 'Pattern detection failed. Please try again.' };
   }
 }
 

--- a/src/app/app/cases/filings/page.tsx
+++ b/src/app/app/cases/filings/page.tsx
@@ -1,11 +1,15 @@
 import Link from 'next/link';
 import { CaseFilingsRoles } from '@/components/eviction/case-filings-roles';
 import { FilingsTable } from '@/components/eviction/filings-table';
+import { PlaintiffPatternsCard } from '@/components/eviction/plaintiff-patterns-card';
 import { SourceFilter } from '@/components/eviction/source-filter';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
-import { listRecentFilingsForViewer } from '@/db/queries/eviction-filings';
+import { listRecentFilingsForViewer, listTopPlaintiffsRecent } from '@/db/queries/eviction-filings';
 import type { EvictionFilingSource } from '@/db/schema/enums';
 import { requireRole, userIsKlaAttorney } from '@/lib/auth';
+
+const PATTERN_WINDOW_DAYS = 30;
+const PATTERN_MIN_COUNT = 3;
 
 const ALLOWED_SOURCES: EvictionFilingSource[] = ['synthetic', 'manual', 'courtnet'];
 
@@ -18,9 +22,14 @@ export default async function FilingsPage({
 
   const params = await searchParams;
   const source = ALLOWED_SOURCES.find((s) => s === params.source);
-  const [filings, canTriage] = await Promise.all([
+  const [filings, canTriage, topPlaintiffs] = await Promise.all([
     listRecentFilingsForViewer({ limit: 50, source }, me.role),
     userIsKlaAttorney(me),
+    listTopPlaintiffsRecent({
+      windowDays: PATTERN_WINDOW_DAYS,
+      minCount: PATTERN_MIN_COUNT,
+      limit: 10,
+    }),
   ]);
 
   return (
@@ -43,6 +52,14 @@ export default async function FilingsPage({
       </header>
 
       <SourceFilter selected={source} />
+
+      {topPlaintiffs.length > 0 ? (
+        <PlaintiffPatternsCard
+          initialPlaintiffs={topPlaintiffs}
+          windowDays={PATTERN_WINDOW_DAYS}
+          minCount={PATTERN_MIN_COUNT}
+        />
+      ) : null}
 
       {filings.length === 0 ? (
         <Card>

--- a/src/components/eviction/plaintiff-patterns-card.tsx
+++ b/src/components/eviction/plaintiff-patterns-card.tsx
@@ -1,0 +1,96 @@
+'use client';
+
+import { useState, useTransition } from 'react';
+import { commentOnPlaintiffPatternsAction } from '@/app/actions/eviction';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import type { TopPlaintiff } from '@/db/queries/eviction-filings';
+
+const fmtDate = (d: Date | string) =>
+  new Intl.DateTimeFormat('en-US', { dateStyle: 'medium' }).format(new Date(d));
+
+export function PlaintiffPatternsCard({
+  initialPlaintiffs,
+  windowDays,
+  minCount,
+}: {
+  initialPlaintiffs: TopPlaintiff[];
+  windowDays: number;
+  minCount: number;
+}) {
+  const [pending, startTransition] = useTransition();
+  const [commentary, setCommentary] = useState<{
+    text: string;
+    modelId: string;
+    promptVersion: string;
+  } | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const onComment = () => {
+    setError(null);
+    startTransition(async () => {
+      const r = await commentOnPlaintiffPatternsAction();
+      if (!r.ok) {
+        setError(r.error);
+        return;
+      }
+      setCommentary({ text: r.text, modelId: r.modelId, promptVersion: r.promptVersion });
+    });
+  };
+
+  return (
+    <Card>
+      <CardHeader className="flex flex-row items-baseline justify-between gap-2">
+        <CardTitle className="text-base">
+          Bulk filers (last {windowDays} days, ≥{minCount} cases)
+        </CardTitle>
+        <Button onClick={onComment} disabled={pending} size="sm" variant="outline">
+          {pending ? 'Asking…' : commentary ? 'Re-comment' : 'Ask Claude'}
+        </Button>
+      </CardHeader>
+      <CardContent className="space-y-3 text-sm">
+        {initialPlaintiffs.length === 0 ? (
+          <p className="text-muted-foreground">
+            No plaintiff filed {minCount} or more cases in the last {windowDays} days.
+          </p>
+        ) : (
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b border-border text-left text-xs uppercase tracking-wide text-muted-foreground">
+                <th className="py-2">Plaintiff</th>
+                <th className="py-2 text-right">Filings</th>
+                <th className="py-2 text-right">Earliest</th>
+                <th className="py-2 text-right">Latest</th>
+              </tr>
+            </thead>
+            <tbody>
+              {initialPlaintiffs.map((p) => (
+                <tr key={p.plaintiff} className="border-b border-border last:border-0">
+                  <td className="py-2 pr-2 font-medium">{p.plaintiff}</td>
+                  <td className="py-2 text-right tabular-nums">{p.filings}</td>
+                  <td className="py-2 text-right text-muted-foreground">{fmtDate(p.earliest)}</td>
+                  <td className="py-2 text-right text-muted-foreground">{fmtDate(p.latest)}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+
+        {commentary ? (
+          <div className="rounded-md border border-primary/40 bg-primary/5 p-3 text-sm">
+            <p className="mb-1 text-[10px] uppercase tracking-wide text-muted-foreground">
+              Claude's read
+            </p>
+            <p className="leading-relaxed">{commentary.text}</p>
+            <p className="mt-2 text-[11px] text-muted-foreground">
+              Model: <span className="font-mono">{commentary.modelId}</span> · Prompt:{' '}
+              <span className="font-mono">{commentary.promptVersion}</span>
+            </p>
+          </div>
+        ) : null}
+
+        {error ? <p className="text-xs text-destructive">{error}</p> : null}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/db/queries/eviction-filings.ts
+++ b/src/db/queries/eviction-filings.ts
@@ -137,3 +137,49 @@ export async function listRankedDocketForViewer(
   if (viewerCanSeeDvAddresses(viewerRole)) return rows;
   return rows.map((r) => (r.filing.dvFlag ? { ...r, filing: redactAddress(r.filing, true) } : r));
 }
+
+export type TopPlaintiff = {
+  plaintiff: string;
+  filings: number;
+  windowDays: number;
+  earliest: Date;
+  latest: Date;
+};
+
+/**
+ * Plaintiffs who appear ≥ minCount times on filings ingested in the
+ * last windowDays. Ordered by filing count desc, then by latest
+ * filing desc. Public court records — no DV redaction needed at this
+ * aggregate level (the count itself doesn't reveal an address).
+ */
+export async function listTopPlaintiffsRecent(
+  opts: { windowDays?: number; minCount?: number; limit?: number } = {},
+): Promise<TopPlaintiff[]> {
+  const windowDays = opts.windowDays ?? 30;
+  const minCount = opts.minCount ?? 3;
+  const limit = opts.limit ?? 10;
+  const since = new Date();
+  since.setDate(since.getDate() - windowDays);
+
+  const rows = await db
+    .select({
+      plaintiff: evictionFilings.plaintiff,
+      filings: sql<number>`COUNT(*)::int`.as('filings'),
+      earliest: sql<Date>`MIN(${evictionFilings.filedAt})`.as('earliest'),
+      latest: sql<Date>`MAX(${evictionFilings.filedAt})`.as('latest'),
+    })
+    .from(evictionFilings)
+    .where(gte(evictionFilings.filedAt, since))
+    .groupBy(evictionFilings.plaintiff)
+    .having(sql`COUNT(*) >= ${minCount}`)
+    .orderBy(desc(sql`filings`), desc(sql`latest`))
+    .limit(limit);
+
+  return rows.map((r) => ({
+    plaintiff: r.plaintiff,
+    filings: Number(r.filings),
+    windowDays,
+    earliest: r.earliest instanceof Date ? r.earliest : new Date(r.earliest as unknown as string),
+    latest: r.latest instanceof Date ? r.latest : new Date(r.latest as unknown as string),
+  }));
+}

--- a/src/lib/eviction/plaintiff-patterns.ts
+++ b/src/lib/eviction/plaintiff-patterns.ts
@@ -1,0 +1,50 @@
+import Anthropic from '@anthropic-ai/sdk';
+import {
+  buildPlaintiffPatternsUserPrompt,
+  PLAINTIFF_PATTERNS_PROMPT_VERSION,
+  PLAINTIFF_PATTERNS_SYSTEM_PROMPT,
+} from '@/ai/prompts/plaintiff-patterns';
+import type { TopPlaintiff } from '@/db/queries/eviction-filings';
+
+let _client: Anthropic | null = null;
+function client(): Anthropic {
+  if (!_client) _client = new Anthropic();
+  return _client;
+}
+
+const MODEL_ID = 'claude-sonnet-4-6';
+const MAX_OUTPUT_TOKENS = 250;
+
+export type PlaintiffPatternsResult = {
+  text: string;
+  modelId: string;
+  promptVersion: string;
+};
+
+export async function commentOnPlaintiffPatterns(input: {
+  windowDays: number;
+  minCount: number;
+  plaintiffs: TopPlaintiff[];
+}): Promise<PlaintiffPatternsResult> {
+  const response = await client().messages.create({
+    model: MODEL_ID,
+    max_tokens: MAX_OUTPUT_TOKENS,
+    system: [
+      {
+        type: 'text',
+        text: PLAINTIFF_PATTERNS_SYSTEM_PROMPT,
+        cache_control: { type: 'ephemeral' },
+      },
+    ],
+    messages: [{ role: 'user', content: buildPlaintiffPatternsUserPrompt(input) }],
+  });
+
+  const text = response.content
+    .flatMap((c) => (c.type === 'text' ? [c.text] : []))
+    .join('\n')
+    .trim();
+  if (!text) {
+    throw new Error(`[plaintiff-patterns] empty response; stop_reason=${response.stop_reason}`);
+  }
+  return { text, modelId: MODEL_ID, promptVersion: PLAINTIFF_PATTERNS_PROMPT_VERSION };
+}


### PR DESCRIPTION
## Summary
- New "Bulk filers" card on the filings docket. Server-side SQL surfaces every plaintiff with ≥3 filings in the last 30 days; renders the table immediately
- Separate "Ask Claude" button generates a 1-paragraph observational commentary — which plaintiff is the standout, whether filings cluster narrowly, whether the spread is even
- Hard rule in the prompt: AI never alleges wrongdoing or imagines motives — these are public-record counts; legal interpretation is the attorney's job
- Card hidden when no plaintiff meets the threshold (clean docket during quiet windows)
- The deterministic SQL is the trust anchor; the AI commentary is the optional "so what?" overlay

## Test plan
- [ ] /app/cases/filings with seeded data → "Bulk filers" card appears above the docket with a table of top plaintiffs
- [ ] Click "Ask Claude" → 1-paragraph commentary renders below the table
- [ ] Re-comment works
- [ ] On a quiet window (no plaintiff hits ≥3), the card does not render
- [ ] Audit log shows \`plaintiff_patterns.commented\` + \`ai.generated\`