### PR TITLE
feat(COOR-006): SMS bed-availability dashboard for dispatchers

### DIFF
--- a/src/lib/indc/bed-summary.test.ts
+++ b/src/lib/indc/bed-summary.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from 'vitest';
+import type { Shelter } from '@/db/schema/shelters';
+import { summarizeBeds } from './bed-summary';
+
+const baseShelter = (over: Partial<Shelter>): Shelter =>
+  ({
+    id: 'fake-id',
+    name: 'Fake Shelter',
+    partnerOrgId: 'partner',
+    capacity: 10,
+    currentOccupancy: 5,
+    acceptsMen: true,
+    acceptsWomen: true,
+    acceptsFamilies: false,
+    petFriendly: false,
+    sudFriendly: false,
+    contactPhone: null,
+    streetAddress: null,
+    notes: null,
+    active: true,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...over,
+  }) as Shelter;
+
+describe('summarizeBeds', () => {
+  it('returns zeros when no shelters', () => {
+    const r = summarizeBeds([], new Map());
+    expect(r).toEqual({
+      shelterCount: 0,
+      totalFree: 0,
+      free: { men: 0, women: 0, families: 0, petFriendly: 0, sudFriendly: 0 },
+      fullCount: 0,
+    });
+  });
+
+  it('totals free beds across shelters and slices by population', () => {
+    const shelters = [
+      // 5 free, men+women only
+      baseShelter({ id: 's1', capacity: 10, currentOccupancy: 5 }),
+      // 3 free, families + pet
+      baseShelter({
+        id: 's2',
+        capacity: 6,
+        currentOccupancy: 3,
+        acceptsMen: false,
+        acceptsWomen: false,
+        acceptsFamilies: true,
+        petFriendly: true,
+      }),
+      // 2 free, women + sud
+      baseShelter({
+        id: 's3',
+        capacity: 4,
+        currentOccupancy: 2,
+        acceptsMen: false,
+        acceptsWomen: true,
+        sudFriendly: true,
+      }),
+    ];
+    const r = summarizeBeds(shelters, new Map());
+    expect(r.shelterCount).toBe(3);
+    expect(r.totalFree).toBe(10);
+    expect(r.free.men).toBe(5);
+    expect(r.free.women).toBe(7);
+    expect(r.free.families).toBe(3);
+    expect(r.free.petFriendly).toBe(3);
+    expect(r.free.sudFriendly).toBe(2);
+    expect(r.fullCount).toBe(0);
+  });
+
+  it('subtracts active holds when computing free beds', () => {
+    const shelters = [baseShelter({ id: 's1', capacity: 10, currentOccupancy: 5 })];
+    const r = summarizeBeds(shelters, new Map([['s1', 3]]));
+    // 10 - 5 occupancy - 3 holds = 2
+    expect(r.totalFree).toBe(2);
+    expect(r.free.men).toBe(2);
+    expect(r.fullCount).toBe(0);
+  });
+
+  it('counts shelters at zero free as full and skips them in slices', () => {
+    const shelters = [
+      baseShelter({ id: 'open', capacity: 4, currentOccupancy: 1 }),
+      baseShelter({ id: 'full', capacity: 4, currentOccupancy: 4 }),
+      baseShelter({ id: 'overheld', capacity: 4, currentOccupancy: 2 }),
+    ];
+    const holds = new Map([['overheld', 2]]);
+    const r = summarizeBeds(shelters, holds);
+    expect(r.totalFree).toBe(3);
+    expect(r.shelterCount).toBe(3);
+    expect(r.fullCount).toBe(2);
+  });
+});

--- a/src/lib/indc/bed-summary.ts
+++ b/src/lib/indc/bed-summary.ts
@@ -1,0 +1,61 @@
+import type { Shelter } from '@/db/schema/shelters';
+import { effectiveFreeBeds } from '@/lib/coordination/bed-availability';
+
+/**
+ * Coalition-wide bed summary suitable for a 211 dispatcher or
+ * caseworker SMS dashboard. One snapshot, no filters required —
+ * gives the dispatcher an at-a-glance read of "what's open right
+ * now" plus the population/special-need slices they're most likely
+ * to need to triage on the call.
+ *
+ * Numbers are derived from the same `effectiveFreeBeds` function
+ * the bed board uses, so the SMS dashboard and the web view can
+ * never disagree about how many free beds exist.
+ */
+export type BedSummary = {
+  shelterCount: number;
+  totalFree: number;
+  free: {
+    men: number;
+    women: number;
+    families: number;
+    petFriendly: number;
+    sudFriendly: number;
+  };
+  /** Shelters with zero free beds right now (after holds). */
+  fullCount: number;
+};
+
+export function summarizeBeds(
+  shelters: Shelter[],
+  activeHoldsByShelter: Map<string, number>,
+): BedSummary {
+  let totalFree = 0;
+  let men = 0;
+  let women = 0;
+  let families = 0;
+  let pet = 0;
+  let sud = 0;
+  let fullCount = 0;
+
+  for (const s of shelters) {
+    const free = effectiveFreeBeds(s, activeHoldsByShelter.get(s.id) ?? 0);
+    if (free <= 0) {
+      fullCount += 1;
+      continue;
+    }
+    totalFree += free;
+    if (s.acceptsMen) men += free;
+    if (s.acceptsWomen) women += free;
+    if (s.acceptsFamilies) families += free;
+    if (s.petFriendly) pet += free;
+    if (s.sudFriendly) sud += free;
+  }
+
+  return {
+    shelterCount: shelters.length,
+    totalFree,
+    free: { men, women, families, petFriendly: pet, sudFriendly: sud },
+    fullCount,
+  };
+}

--- a/src/lib/indc/sms-formatter.test.ts
+++ b/src/lib/indc/sms-formatter.test.ts
@@ -4,6 +4,7 @@ import type { BedFinderResult } from './bed-finder';
 import {
   formatBedResults,
   SMS_MAX_LEN,
+  smsBedSummary,
   smsFood,
   smsHelp,
   smsHoldConfirmed,
@@ -141,5 +142,58 @@ describe('formatBedResults — location label', () => {
   it('skips "near" label when null', () => {
     const r = formatBedResults([result('Boulware', 5)], {}, null);
     expect(r).not.toMatch(/near/);
+  });
+});
+
+describe('smsBedSummary — COOR-006 dispatcher dashboard', () => {
+  it('renders totals + slices when beds are available', () => {
+    const reply = smsBedSummary({
+      shelterCount: 4,
+      totalFree: 12,
+      free: { men: 6, women: 5, families: 3, petFriendly: 2, sudFriendly: 1 },
+      fullCount: 1,
+    });
+    expect(reply).toMatch(/12 free/);
+    expect(reply).toMatch(/4 sites/);
+    expect(reply).toMatch(/Men 6/);
+    expect(reply).toMatch(/Women 5/);
+    expect(reply).toMatch(/Families 3/);
+    expect(reply).toMatch(/Pet 2/);
+    expect(reply).toMatch(/SUD 1/);
+    expect(reply).toMatch(/1 full/);
+    expect(reply.length).toBeLessThanOrEqual(SMS_MAX_LEN);
+  });
+
+  it('falls back to "all full" copy when totalFree is 0', () => {
+    const reply = smsBedSummary({
+      shelterCount: 3,
+      totalFree: 0,
+      free: { men: 0, women: 0, families: 0, petFriendly: 0, sudFriendly: 0 },
+      fullCount: 3,
+    });
+    expect(reply).toMatch(/All 3 coalition shelters are full/);
+    expect(reply).not.toMatch(/Reply BED/);
+    expect(reply.length).toBeLessThanOrEqual(SMS_MAX_LEN);
+  });
+
+  it('falls back to "no shelters listed" when shelterCount is 0', () => {
+    const reply = smsBedSummary({
+      shelterCount: 0,
+      totalFree: 0,
+      free: { men: 0, women: 0, families: 0, petFriendly: 0, sudFriendly: 0 },
+      fullCount: 0,
+    });
+    expect(reply).toMatch(/No active shelters/);
+  });
+
+  it('omits the "full" fragment when no shelters are full', () => {
+    const reply = smsBedSummary({
+      shelterCount: 2,
+      totalFree: 6,
+      free: { men: 3, women: 3, families: 0, petFriendly: 0, sudFriendly: 0 },
+      fullCount: 0,
+    });
+    expect(reply).not.toMatch(/full/);
+    expect(reply).toMatch(/2 sites/);
   });
 });

--- a/src/lib/indc/sms-formatter.ts
+++ b/src/lib/indc/sms-formatter.ts
@@ -1,5 +1,6 @@
 import type { BedFilter } from '@/lib/coordination/bed-availability';
 import type { BedFinderResult } from './bed-finder';
+import type { BedSummary } from './bed-summary';
 
 /**
  * SMS replies cap at 320 chars (two GSM segments — keeps cost predictable
@@ -9,7 +10,7 @@ import type { BedFinderResult } from './bed-finder';
 export const SMS_MAX_LEN = 320;
 
 const HELP_REPLY =
-  'Coalition bed-finder. BED (+ MEN/WOMEN/FAMILY/PET/SUD) for an open bed. HOLD <#> to hold one. FOOD for pantries. STORY about this service. STOP to opt out.';
+  'Coalition bed-finder. BED (+ MEN/WOMEN/FAMILY/PET/SUD) for an open bed. HOLD <#> to hold. STATUS for the coalition-wide board. FOOD for pantries. STOP to opt out.';
 
 const STOP_REPLY = "You're opted out. Reply START to opt back in.";
 
@@ -155,4 +156,31 @@ export function smsHoldFailed(reason: string): string {
   // Reason copy should already be user-safe — we cap to MAX_LEN as a
   // defense against an unexpectedly long server message.
   return `Couldn't hold a bed: ${reason} Reply BED to try again.`.slice(0, SMS_MAX_LEN);
+}
+
+/**
+ * One-shot coalition bed dashboard for 211 dispatchers and caseworkers
+ * (COOR-006). Designed to fit in a single SMS, so it's a flat sentence
+ * with the most-asked dimensions (population + pet + SUD) and a hint
+ * that the dispatcher can drill in by replying BED with a filter.
+ *
+ * Empty / all-full coalitions get a different copy that doesn't dangle
+ * the "reply BED for detail" CTA pointlessly.
+ */
+export function smsBedSummary(s: BedSummary): string {
+  if (s.shelterCount === 0) {
+    return 'No active shelters listed in the coalition right now.';
+  }
+  if (s.totalFree === 0) {
+    return `All ${s.shelterCount} coalition shelters are full right now. Try BED later, or call 211 for live help.`.slice(
+      0,
+      SMS_MAX_LEN,
+    );
+  }
+  const fullFrag = s.fullCount > 0 ? `, ${s.fullCount} full` : '';
+  const head = `Daviess shelters: ${s.totalFree} free across ${s.shelterCount} sites${fullFrag}.`;
+  const slices = `Men ${s.free.men}. Women ${s.free.women}. Families ${s.free.families}. Pet ${s.free.petFriendly}. SUD ${s.free.sudFriendly}.`;
+  const tail = ' Reply BED <filter> for the list.';
+  const reply = `${head} ${slices}${tail}`;
+  return reply.slice(0, SMS_MAX_LEN);
 }

--- a/src/lib/indc/sms-parser.test.ts
+++ b/src/lib/indc/sms-parser.test.ts
@@ -76,4 +76,11 @@ describe('parseSmsCommand', () => {
     expect(parseSmsCommand('').kind).toBe('unknown');
     expect(parseSmsCommand('hello there').kind).toBe('unknown');
   });
+
+  it('parses STATUS / BOARD / SUMMARY / DASHBOARD as the dispatcher dashboard (COOR-006)', () => {
+    expect(parseSmsCommand('STATUS').kind).toBe('status');
+    expect(parseSmsCommand('board').kind).toBe('status');
+    expect(parseSmsCommand('Summary').kind).toBe('status');
+    expect(parseSmsCommand('  DASHBOARD  ').kind).toBe('status');
+  });
 });

--- a/src/lib/indc/sms-parser.ts
+++ b/src/lib/indc/sms-parser.ts
@@ -3,16 +3,20 @@ import type { BedFilter } from '@/lib/coordination/bed-availability';
 /**
  * Inbound SMS commands the bed-finder understands. Every command maps
  * to a single intent; modifiers stack inside `BED ...`. Examples:
- *   BED                → find any open bed
+ *   BED                → find any open bed (multi-turn, asks location)
  *   BED FAMILY         → family-accepting + open
  *   BED PET            → pet-friendly + open
  *   BED MEN PET        → men + pet-friendly + open
  *   BED WOMEN SUD      → women + SUD-friendly + open
+ *   STATUS / BOARD     → coalition-wide bed dashboard (one-shot, for
+ *                        211 dispatchers and caseworkers; COOR-006).
+ *                        No location prompt, no hold flow.
  *   HELP               → help text
  *   STOP / END / QUIT  → opt-out (Twilio handles delivery; we still log it)
  */
 export type ParsedSmsCommand =
   | { kind: 'bed'; filter: BedFilter }
+  | { kind: 'status' }
   | { kind: 'food' }
   | { kind: 'story' }
   | { kind: 'hold'; resultIndex: number }
@@ -27,6 +31,7 @@ const FOOD_WORDS = new Set(['FOOD', 'EAT', 'PANTRY', 'MEAL', 'MEALS', 'HUNGRY'])
 const STORY_WORDS = new Set(['STORY', 'ABOUT', 'WHO', 'WHAT']);
 const HOLD_WORDS = new Set(['HOLD', 'RESERVE', 'CONFIRM']);
 const RELEASE_WORDS = new Set(['RELEASE', 'CANCEL', 'NEVERMIND']);
+const STATUS_WORDS = new Set(['STATUS', 'BOARD', 'SUMMARY', 'DASH', 'DASHBOARD']);
 
 const POPULATION_TOKENS: Record<string, NonNullable<BedFilter['population']>> = {
   MEN: 'men',
@@ -55,6 +60,7 @@ export function parseSmsCommand(raw: string): ParsedSmsCommand {
 
   if (STOP_WORDS.has(head)) return { kind: 'stop' };
   if (HELP_WORDS.has(head)) return { kind: 'help' };
+  if (STATUS_WORDS.has(head)) return { kind: 'status' };
   if (FOOD_WORDS.has(head)) return { kind: 'food' };
   if (STORY_WORDS.has(head)) return { kind: 'story' };
 

--- a/src/lib/indc/sms-pipeline.ts
+++ b/src/lib/indc/sms-pipeline.ts
@@ -5,6 +5,7 @@ import {
   matchesFilter,
 } from '@/lib/coordination/bed-availability';
 import { type BedFinderResult, findOpenBeds } from './bed-finder';
+import { summarizeBeds } from './bed-summary';
 import { createBedHoldFromSms, releaseBedHoldFromSms } from './sms-bed-holds';
 import {
   clearConversation,
@@ -17,6 +18,7 @@ import {
 } from './sms-conversation';
 import {
   formatBedResults,
+  smsBedSummary,
   smsFood,
   smsHelp,
   smsHoldConfirmed,
@@ -33,6 +35,7 @@ import { parseSmsCommand } from './sms-parser';
 
 export type SmsHandleIntent =
   | 'bed_results'
+  | 'bed_summary'
   | 'awaiting_location'
   | 'location_received'
   | 'help'
@@ -85,6 +88,16 @@ export async function handleInboundSmsForNumber(
   }
   if (cmd.kind === 'food') return { reply: smsFood(), intent: 'food' };
   if (cmd.kind === 'story') return { reply: smsStory(), intent: 'story' };
+
+  // STATUS / BOARD / SUMMARY (COOR-006): one-shot dashboard. Stateless
+  // even when fromNumber is set — dispatchers wouldn't expect their
+  // BED conversation context to evaporate just because they checked
+  // the board, so we don't touch existing conversation state.
+  if (cmd.kind === 'status') {
+    const [shelters, holdCounts] = await Promise.all([listActiveShelters(), activeBedHoldCounts()]);
+    const summary = summarizeBeds(shelters, holdCounts);
+    return { reply: smsBedSummary(summary), intent: 'bed_summary' };
+  }
 
   // Stateful BED command: park the filter and ask for location.
   if (cmd.kind === 'bed' && stateful) {


### PR DESCRIPTION
## Summary
- New \`STATUS\` / \`BOARD\` / \`SUMMARY\` / \`DASHBOARD\` SMS command on the existing Twilio line. Designed for 211 dispatchers + caseworkers
- One-shot reply: total free beds + slices (men / women / families / pet / SUD) + a count of full shelters; fits in a single 320-char SMS
- Stateless even when \`fromNumber\` is set — a dispatcher checking the board doesn't lose existing BED conversation context
- Reuses \`effectiveFreeBeds\` from the bed-availability layer, so the SMS dashboard and the web bed board can never disagree
- Empty-coalition and all-full edge cases get bespoke copy that doesn't dangle a useless "reply BED" CTA
- +9 tests across parser / formatter / summary helper

Closes #59.

## Test plan
- [ ] In the SMS playground, text \`STATUS\` → reply shows totals + slices + \"Reply BED <filter> for the list.\"
- [ ] Text \`BOARD\` / \`SUMMARY\` → same reply (synonyms)
- [ ] With holds in place, total reflects effective free (capacity - occupancy - holds)
- [ ] When all shelters are full, copy switches to \"All N shelters are full…\" without the BED CTA