### PR TITLE
feat(EVDT-011): children-in-household detection on filings

### DIFF
--- a/src/ai/prompts/eviction-risk-score.ts
+++ b/src/ai/prompts/eviction-risk-score.ts
@@ -29,6 +29,8 @@ Risk factors that PUSH SCORE UP (more risk):
 - Filed close to court date (less time to organize defense)
 - Defendant has no attorney representation listed in notes
 - Repeat plaintiff filing many cases (institutional landlord, less flexible)
+- Children in the household (school disruption, McKinney-Vento exposure,
+  family-shelter routing — weight by detection confidence: high > medium > low)
 
 Risk factors that PUSH SCORE DOWN (less risk):
 - Status: dismissed (case is over)
@@ -57,8 +59,12 @@ export const buildRiskUserPrompt = (filing: {
   plaintiff: string;
   notes: string | null;
   attorney_represented: boolean | null;
-}) =>
-  `Score this filing.
+  children_signal: { detected: boolean; confidence: 'none' | 'low' | 'medium' | 'high' } | null;
+}) => {
+  const childrenLine = filing.children_signal?.detected
+    ? `Children in household: yes (signal confidence=${filing.children_signal.confidence})`
+    : 'Children in household: not detected in filing';
+  return `Score this filing.
 
 Case ${filing.case_number}
 Status: ${filing.status}
@@ -74,9 +80,11 @@ Defendant attorney: ${
         ? 'represented'
         : 'no counsel listed'
   }
+${childrenLine}
 Notes: ${filing.notes ?? '(none)'}
 
 Output the JSON object now.`;
+};
 
 export const RiskScoreSchema = z.object({
   score: z.number().int().min(0).max(100),
@@ -86,4 +94,4 @@ export const RiskScoreSchema = z.object({
 export type ScoredFiling = z.infer<typeof RiskScoreSchema>;
 
 /** Bumped any time the prompt or schema changes. Used as the cache key. */
-export const RISK_SCORE_MODEL_VERSION = 'risk-v1@2026-04-26';
+export const RISK_SCORE_MODEL_VERSION = 'risk-v2@2026-04-27';

--- a/src/components/eviction/filing-detail.tsx
+++ b/src/components/eviction/filing-detail.tsx
@@ -100,6 +100,7 @@ export function FilingDetail({
             <div className="text-xs uppercase tracking-wide text-muted-foreground">Source</div>
             <div className="font-mono text-xs">{filing.source}</div>
           </div>
+          <ChildrenSignalRow filing={filing} />
         </CardContent>
       </Card>
 
@@ -129,6 +130,41 @@ export function FilingDetail({
           ) : null}
         </Card>
       )}
+    </div>
+  );
+}
+
+const childrenChipClass: Record<'low' | 'medium' | 'high', string> = {
+  low: 'bg-muted text-muted-foreground',
+  medium: 'bg-amber-500/15 text-amber-700 dark:text-amber-400',
+  high: 'bg-amber-600/20 text-amber-800 dark:text-amber-300',
+};
+
+/** EVDT-011: surface the deterministic children-in-household signal
+ *  parsed from the filing's notes. Hidden when no signal is present
+ *  to keep the cardinal facts grid clean for the common case.
+ */
+function ChildrenSignalRow({ filing }: { filing: EvictionFiling }) {
+  const raw = filing.rawJson as Record<string, unknown> | null;
+  const signal = raw?.children_signal as
+    | { detected: boolean; confidence: 'none' | 'low' | 'medium' | 'high'; evidence: string | null }
+    | undefined;
+  if (!signal?.detected || signal.confidence === 'none') return null;
+  return (
+    <div className="col-span-2">
+      <div className="text-xs uppercase tracking-wide text-muted-foreground">
+        Children in household
+      </div>
+      <div className="mt-1 flex flex-wrap items-baseline gap-2 text-sm">
+        <span
+          className={`rounded px-2 py-0.5 text-xs font-medium ${childrenChipClass[signal.confidence]}`}
+        >
+          detected · {signal.confidence} confidence
+        </span>
+        {signal.evidence ? (
+          <span className="text-xs text-muted-foreground italic">"{signal.evidence}"</span>
+        ) : null}
+      </div>
     </div>
   );
 }

--- a/src/lib/eviction/children-detection.test.ts
+++ b/src/lib/eviction/children-detection.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from 'vitest';
+import { detectChildrenSignal } from './children-detection';
+
+describe('detectChildrenSignal', () => {
+  describe('high confidence', () => {
+    it('explicit "minor children" language', () => {
+      const r = detectChildrenSignal('Defendant resides at the property with two minor children.');
+      expect(r.detected).toBe(true);
+      expect(r.confidence).toBe('high');
+      expect(r.evidence).toMatch(/two minor children/);
+    });
+
+    it('singular "minor child"', () => {
+      const r = detectChildrenSignal('Tenant has one minor child living in the unit.');
+      expect(r.confidence).toBe('high');
+    });
+
+    it('"with his daughters" occupancy phrasing', () => {
+      const r = detectChildrenSignal(
+        'Defendant occupies the premises with his two daughters and a roommate.',
+      );
+      expect(r.confidence).toBe('high');
+    });
+
+    it('household-includes-children phrasing', () => {
+      const r = detectChildrenSignal('The household includes children of school age.');
+      expect(r.confidence).toBe('high');
+    });
+
+    it('"under the age of 18"', () => {
+      const r = detectChildrenSignal(
+        'Two of the occupants are under the age of 18 per the lease addendum.',
+      );
+      expect(r.confidence).toBe('high');
+    });
+  });
+
+  describe('medium confidence', () => {
+    it('defendant-lives-with-children phrasing', () => {
+      const r = detectChildrenSignal('Defendant lives at the unit with three kids.');
+      expect(r.confidence).toBe('medium');
+    });
+
+    it('"family with children"', () => {
+      const r = detectChildrenSignal('This is a family with children in the home.');
+      // The phrase "family with children" matches the medium pattern
+      expect(r.detected).toBe(true);
+      expect(['medium', 'high']).toContain(r.confidence);
+    });
+
+    it('numeric phrasing "2 kids in the home"', () => {
+      const r = detectChildrenSignal('There are 2 kids in the home according to neighbor.');
+      expect(r.detected).toBe(true);
+      expect(['medium', 'high']).toContain(r.confidence);
+    });
+  });
+
+  describe('low confidence', () => {
+    it('bare child noun without context', () => {
+      const r = detectChildrenSignal('Notes mention a son visiting on weekends.');
+      expect(r.detected).toBe(true);
+      expect(r.confidence).toBe('low');
+    });
+  });
+
+  describe('negations override everything', () => {
+    it('"no minor children"', () => {
+      const r = detectChildrenSignal('Defendant has no minor children in the household.');
+      expect(r.detected).toBe(false);
+      expect(r.confidence).toBe('none');
+    });
+
+    it('"no children in the household"', () => {
+      const r = detectChildrenSignal('Confirmed no children in the household at service.');
+      expect(r.detected).toBe(false);
+    });
+
+    it('"defendant reports no children"', () => {
+      const r = detectChildrenSignal('Defendant reports no children present.');
+      expect(r.detected).toBe(false);
+    });
+  });
+
+  describe('false-positive guardrails', () => {
+    it('"child support" alone does not trigger', () => {
+      const r = detectChildrenSignal('Defendant has child support obligations of $400/month.');
+      expect(r.detected).toBe(false);
+    });
+
+    it('"child support" + actual children-in-home language still detects', () => {
+      const r = detectChildrenSignal(
+        'Defendant pays child support and lives with two minor children at the unit.',
+      );
+      expect(r.detected).toBe(true);
+      expect(r.confidence).toBe('high');
+    });
+
+    it('"childcare expense" alone does not trigger', () => {
+      const r = detectChildrenSignal('Childcare expense is $200/week per defendant.');
+      expect(r.detected).toBe(false);
+    });
+  });
+
+  describe('empty / null input', () => {
+    it('null returns none', () => {
+      expect(detectChildrenSignal(null).detected).toBe(false);
+    });
+
+    it('empty string returns none', () => {
+      expect(detectChildrenSignal('').detected).toBe(false);
+    });
+
+    it('whitespace returns none', () => {
+      expect(detectChildrenSignal('   \n  ').detected).toBe(false);
+    });
+  });
+
+  describe('evidence snippet', () => {
+    it('returns a short window around the match', () => {
+      const r = detectChildrenSignal(
+        'Long preamble text that goes on and on. Defendant lives at the unit with two minor children. Then more text after.',
+      );
+      expect(r.detected).toBe(true);
+      expect(r.evidence).toMatch(/two minor children/);
+      expect(r.evidence?.length ?? 0).toBeLessThan(120);
+    });
+  });
+});

--- a/src/lib/eviction/children-detection.ts
+++ b/src/lib/eviction/children-detection.ts
@@ -1,0 +1,119 @@
+/**
+ * EVDT-011: detect a children-in-household signal in an eviction
+ * filing's free-text notes. Pure function; no DB / no AI.
+ *
+ * Court records don't have a structured "kids in unit" field, but the
+ * notes occasionally include language like "Defendant resides with
+ * minor children" or "household includes two children". When that
+ * language appears, a household-with-kids has measurably more at
+ * stake (school enrollment, McKinney-Vento status, family-shelter
+ * routing) and the risk score should reflect that.
+ *
+ * Conservative by design — false positives push the risk score in a
+ * direction that affects how KLA prioritizes the case, so we'd rather
+ * say "no signal" than flag wrongly. Confidence levels:
+ *
+ *  - 'high'   — explicit minor-child language ("minor children",
+ *               "minor child", "with her two daughters")
+ *  - 'medium' — child noun co-occurs with defendant/occupancy context
+ *               ("Defendant lives with three kids", "household has
+ *               children")
+ *  - 'low'    — child word appears but context is ambiguous
+ *  - 'none'   — no signal, OR an explicit negation ("no minor children")
+ */
+
+export type ChildrenSignal = {
+  detected: boolean;
+  confidence: 'none' | 'low' | 'medium' | 'high';
+  /** Short snippet of the matched evidence so the UI can show it. */
+  evidence: string | null;
+};
+
+const NEGATION_PATTERNS: RegExp[] = [
+  /\bno\s+(?:minor\s+)?children\b/i,
+  /\bno\s+children\s+in\s+the\s+household\b/i,
+  /\bdefendant\s+(?:has|reports)\s+no\s+children\b/i,
+  /\bzero\s+children\b/i,
+  /\bnone\s+of\s+the\s+(?:occupants|residents)\s+are\s+minors\b/i,
+];
+
+const HIGH_PATTERNS: RegExp[] = [
+  // Explicit minor-child language
+  /\bminor\s+child(?:ren)?\b/i,
+  /\b(?:Defendant|tenant|occupant)[^.\n]*\bwith\s+(?:her|his|their)\s+(?:\w+\s+){0,2}(?:son|daughter|sons|daughters|children|kids)\b/i,
+  // Occupancy phrasing
+  /\bhousehold\s+(?:includes?|contains?)\s+(?:minor|young)?\s*(?:children|child|kids)\b/i,
+  /\b(?:two|three|four|five|six)\s+minor\s+children\b/i,
+  /\b(?:school|grade)[ -](?:age|aged)\s+children\b/i,
+  /\bunder\s+(?:the\s+)?age\s+of\s+18\b/i,
+];
+
+const MEDIUM_PATTERNS: RegExp[] = [
+  // Child noun + defendant/occupancy context
+  /\b(?:Defendant|tenant|occupant)[^.\n]*\b(?:lives|resides|stays|with)\b[^.\n]*\b(?:children|child|kids)\b/i,
+  /\b(?:children|kids)[^.\n]*\b(?:reside|live|stay|are\s+at|in\s+the\s+(?:home|unit|premises))\b/i,
+  /\bfamily\s+with\s+(?:children|kids)\b/i,
+  /\b\d+\s+(?:children|kids)\s+(?:in\s+the\s+(?:home|unit|household))\b/i,
+];
+
+const LOW_PATTERNS: RegExp[] = [/\b(?:children|child|kids|son|daughter)\b/i];
+
+const FALSE_POSITIVE_PATTERNS: RegExp[] = [
+  // Legal/financial phrases that mention "child" but aren't about
+  // occupancy. "Child support" is a court-context noun phrase that
+  // commonly appears in eviction notes without implying kids in the
+  // unit (it's about the defendant's existing obligations).
+  /\bchild\s+support\b/i,
+  /\bchildcare\s+(?:payment|cost|expense)\b/i,
+];
+
+function trimEvidence(text: string, match: RegExpMatchArray): string {
+  const idx = match.index ?? 0;
+  const start = Math.max(0, idx - 24);
+  const end = Math.min(text.length, idx + match[0].length + 24);
+  const ellipsisL = start > 0 ? '…' : '';
+  const ellipsisR = end < text.length ? '…' : '';
+  return `${ellipsisL}${text.slice(start, end).trim()}${ellipsisR}`;
+}
+
+export function detectChildrenSignal(text: string | null | undefined): ChildrenSignal {
+  if (!text || text.trim().length === 0) {
+    return { detected: false, confidence: 'none', evidence: null };
+  }
+
+  // Negation wins — explicit "no children" language overrides everything.
+  for (const re of NEGATION_PATTERNS) {
+    if (re.test(text)) {
+      return { detected: false, confidence: 'none', evidence: null };
+    }
+  }
+
+  // Knock out false-positive contexts before counting low-confidence
+  // hits. We don't strip the matches; we just remove them from a
+  // stripped copy used for the LOW pass so "child support" alone
+  // doesn't lift to "low".
+  let stripped = text;
+  for (const re of FALSE_POSITIVE_PATTERNS) {
+    stripped = stripped.replace(re, '');
+  }
+
+  for (const re of HIGH_PATTERNS) {
+    const m = text.match(re);
+    if (m) return { detected: true, confidence: 'high', evidence: trimEvidence(text, m) };
+  }
+  for (const re of MEDIUM_PATTERNS) {
+    const m = text.match(re);
+    if (m) return { detected: true, confidence: 'medium', evidence: trimEvidence(text, m) };
+  }
+  for (const re of LOW_PATTERNS) {
+    const m = stripped.match(re);
+    if (m) {
+      // Map the match back to the original text for evidence display.
+      const origMatch = text.match(re);
+      const evidence = origMatch ? trimEvidence(text, origMatch) : null;
+      return { detected: true, confidence: 'low', evidence };
+    }
+  }
+
+  return { detected: false, confidence: 'none', evidence: null };
+}

--- a/src/lib/eviction/parser.test.ts
+++ b/src/lib/eviction/parser.test.ts
@@ -50,22 +50,31 @@ describe('parseEvictionFiling — happy path', () => {
     expect(result.ok).toBe(true);
   });
 
-  it('packs notes + attorney_represented into rawJson', () => {
+  it('packs notes + attorney_represented + children_signal into rawJson', () => {
     const result = parseEvictionFiling(validSynthetic);
     expect(result.ok).toBe(true);
     if (!result.ok) return;
-    expect(result.filing.rawJson).toEqual({
-      notes: validSynthetic.notes,
-      attorney_represented: false,
-    });
+    const raw = result.filing.rawJson as Record<string, unknown>;
+    expect(raw.notes).toBe(validSynthetic.notes);
+    expect(raw.attorney_represented).toBe(false);
+    // EVDT-011: children_signal is always present (computed from notes
+    // even when notes don't trip a detection — value = none).
+    expect(raw.children_signal).toBeDefined();
   });
 
-  it('omits rawJson when both source-extra fields are absent', () => {
+  it('still produces rawJson with children_signal even when notes / attorney_represented are absent', () => {
     const { notes: _n, attorney_represented: _a, ...minimal } = validSynthetic;
     const result = parseEvictionFiling(minimal);
     expect(result.ok).toBe(true);
     if (!result.ok) return;
-    expect(result.filing.rawJson).toBeUndefined();
+    const raw = result.filing.rawJson as Record<string, unknown>;
+    expect(raw.notes).toBeUndefined();
+    expect(raw.attorney_represented).toBeUndefined();
+    expect(raw.children_signal).toEqual({
+      detected: false,
+      confidence: 'none',
+      evidence: null,
+    });
   });
 
   it('passes through manual source', () => {

--- a/src/lib/eviction/parser.ts
+++ b/src/lib/eviction/parser.ts
@@ -5,6 +5,7 @@ import type {
   EvictionFilingStatus,
 } from '@/db/schema/enums';
 import type { NewEvictionFiling } from '@/db/schema/eviction-filings';
+import { detectChildrenSignal } from './children-detection';
 
 /**
  * Pure function: take a raw filing record from any supported source and
@@ -104,6 +105,13 @@ export function parseEvictionFiling(
   const rawJson: Record<string, unknown> = {};
   if (r.notes != null) rawJson.notes = r.notes;
   if (r.attorney_represented != null) rawJson.attorney_represented = r.attorney_represented;
+
+  // EVDT-011: deterministic children-in-household signal computed from
+  // the notes text at parse time. Stored on rawJson so we don't need a
+  // schema migration; the risk-score input + filing detail UI both
+  // read from here. Always present (never undefined) so downstream
+  // code can rely on the field shape.
+  rawJson.children_signal = detectChildrenSignal(r.notes ?? null);
 
   const filing: NewEvictionFiling = {
     caseNumber: r.case_number,

--- a/src/lib/eviction/risk-score.ts
+++ b/src/lib/eviction/risk-score.ts
@@ -29,6 +29,11 @@ function client(): Anthropic {
  * the prompt PHI-fence-clean by construction (CLAUDE.md).
  */
 function scrubForPrompt(filing: EvictionFiling) {
+  const raw = filing.rawJson as Record<string, unknown> | null;
+  const childrenSignal =
+    (raw?.children_signal as
+      | { detected: boolean; confidence: 'none' | 'low' | 'medium' | 'high' }
+      | undefined) ?? null;
   return {
     case_number: filing.caseNumber,
     status: filing.status,
@@ -37,12 +42,9 @@ function scrubForPrompt(filing: EvictionFiling) {
     filed_at: filing.filedAt.toISOString(),
     court_division: filing.courtDivision,
     plaintiff: filing.plaintiff,
-    notes:
-      ((filing.rawJson as Record<string, unknown> | null)?.notes as string | undefined) ?? null,
-    attorney_represented:
-      ((filing.rawJson as Record<string, unknown> | null)?.attorney_represented as
-        | boolean
-        | undefined) ?? null,
+    notes: (raw?.notes as string | undefined) ?? null,
+    attorney_represented: (raw?.attorney_represented as boolean | undefined) ?? null,
+    children_signal: childrenSignal,
   };
 }
 


### PR DESCRIPTION
## Summary
- Pure regex-based detector \`detectChildrenSignal(text)\` returns \`{ detected, confidence, evidence }\` with confidence laddered \`high\` / \`medium\` / \`low\` / \`none\`
- Hard rules: explicit negations override (\"no minor children\" → none); false-positive guardrails knock out \"child support\" / \"childcare expense\" before low-confidence keyword matching
- Wired in three places:
  1. Parser stashes signal on \`rawJson.children_signal\` always (never undefined) so downstream readers can rely on the shape
  2. Filing detail surfaces a confidence-tinted chip with the matched evidence snippet (only when detected — keeps the cardinal-facts grid clean for the common case)
  3. Risk score consumes the signal as an explicit prompt input + new system-prompt risk factor; \`RISK_SCORE_MODEL_VERSION\` bumped to \`risk-v2@2026-04-27\`
- +19 detection-helper tests, +2 updated parser tests

The risk-score version bump means filings without a v2 score will show as \"not scored yet\" until someone clicks Score again — by design (re-scoring on demand vs. force-backfill is the audit-friendlier path).

Closes #26.

## Test plan
- [ ] Run a filing through the parser with notes \"Defendant resides with two minor children\" → \`rawJson.children_signal.confidence === 'high'\`
- [ ] Notes \"Defendant has no minor children\" → \`detected === false\`
- [ ] Notes \"Defendant pays child support\" → \`detected === false\` (false-positive guardrail)
- [ ] Filing detail page shows the chip + evidence snippet for a high-confidence filing; hidden for none
- [ ] Re-score a filing → new row at \`risk-v2\` includes children_signal in the prompt