### PR TITLE
feat(FND-020): domain-boundary lint + ADR 0001 (modular monolith)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,9 @@ jobs:
       - name: Lint
         run: pnpm run lint
 
+      - name: Domain boundaries
+        run: pnpm run lint:boundaries
+
       - name: Typecheck
         run: pnpm run typecheck
 

--- a/docs/adr/0001-modular-monolith.md
+++ b/docs/adr/0001-modular-monolith.md
@@ -1,0 +1,112 @@
+# ADR 0001 — Modular monolith over microservices
+
+**Status:** Accepted — 2026-04-26
+**Driver:** Bo (solo dev). Question raised in Sprint 7 planning: "do we need microservices to make this maintainable as it grows?"
+
+## Context
+
+Six sprints in (~50 PRs, six product domains: EVDT, ESUC, CWT, COAL, INDC, OPRT). The codebase is one Next.js 15 app on Vercel/Railway. We're a one-developer team with a HIPAA migration ahead of us (ESUC-002, post-BAA).
+
+The instinct toward microservices is real: domain boundaries are already visible in `src/lib/{domain}/` and the schema list is getting long. But the operational cost of splitting — service deploys, inter-service auth, distributed tracing, schema-coordination across services, network failure modes — is multiplicative on a solo team. We'd buy ~10% cleaner boundaries at 5x the ops surface area. That trade-off kills velocity.
+
+A scan of cross-domain imports today shows exactly **one** real coupling between `src/lib/{domain}/` folders:
+
+- `indc → coordination` (6 imports, all from `@/lib/coordination/bed-availability`) — SMS bed lookups need the bed-availability data model.
+
+That is small. The codebase is already mostly modular by accident. We should make it modular on purpose, in the same process, not split it across services.
+
+## Decision
+
+**Build a modular monolith.** Keep one Next.js app, one deploy, one Postgres. Enforce domain boundaries at the source level via tooling, not the network.
+
+Three concrete moves:
+
+### 1. Domain folders are hard boundaries
+
+`src/lib/{domain}/` is the unit of ownership. Today's domains: `coalition`, `coordination`, `cwt`, `dtrs`, `esuc`, `eviction` (= EVDT), `indc`, `oprt`. Each owns its server-side logic, AI prompts, and types.
+
+**Rule:** a file under `src/lib/A/` may not import from `src/lib/B/` *unless* B is on A's allow-list. The allow-list lives in `scripts/check-domain-boundaries.mts` and is intentionally short:
+
+| Domain | May import from |
+|---|---|
+| `coordination` | (none) — leaf |
+| `coalition` | `coordination` |
+| `cwt` | `coordination`, `dtrs` |
+| `dtrs` | (none) — leaf |
+| `esuc` | `coordination`, `dtrs` |
+| `eviction` | `dtrs` |
+| `indc` | `coordination` (existing real dep — bed lookups) |
+| `oprt` | `coalition`, `coordination`, `cwt`, `esuc`, `eviction`, `indc` (read-only — narrative/transparency rolls everything up) |
+
+Cross-domain imports outside this allow-list = boundary violation = CI fail. New entries to the allow-list require an ADR amendment (one line in this file is fine — boundary changes are decisions worth recording).
+
+`src/lib/utils.ts`, `src/lib/audit.ts`, `src/lib/auth.ts`, etc. (non-domain shared code at the top of `src/lib/`) are importable from anywhere — they're the common kernel.
+
+### 2. Lint rule via a script, not Biome
+
+Biome (our linter) doesn't yet support path-based import restrictions; ESLint's `no-restricted-paths` does, but adding ESLint just for this is overkill. We get equivalent enforcement from a ~50-line script:
+
+```ts
+// scripts/check-domain-boundaries.mts
+const ALLOW: Record<string, string[]> = {
+  coordination: [],
+  coalition: ['coordination'],
+  cwt: ['coordination', 'dtrs'],
+  dtrs: [],
+  esuc: ['coordination', 'dtrs'],
+  eviction: ['dtrs'],
+  indc: ['coordination'],
+  oprt: ['coalition', 'coordination', 'cwt', 'esuc', 'eviction', 'indc'],
+};
+// walk src/lib/{domain}/**, parse `from '@/lib/X/...'`,
+// fail if X not in ALLOW[domain] and X !== domain.
+```
+
+Wire it into:
+- `package.json` → `"lint:boundaries": "tsx scripts/check-domain-boundaries.mts"`.
+- CI (`.github/workflows/ci.yml`) — runs after `pnpm lint`, before typecheck.
+- Local pre-push discipline: run alongside `pnpm exec biome check` (this repo doesn't use a husky hook; the strict-lint-before-push convention is documented in CLAUDE.md memory).
+
+**Scope:** the lint runs only against `src/lib/{domain}/`. Server actions (`src/app/actions/*.ts`) and components (`src/components/{domain}/*`) are the *composition layer* — they're allowed to span domains, because that's their job. The boundary that matters is at the domain-logic layer, where business rules live; if `src/lib/eviction/` can't reach into `src/lib/esuc/`, the architectural property holds regardless of what an action wires up.
+
+### 3. Postgres schema-per-domain — deferred, opt-in
+
+Drizzle supports `pgSchema('evdt').table(...)` for namespaced tables. Migrating today's flat `public.*` to per-domain schemas (`evdt.*`, `esuc.*`, `indc.*`, `coord.*`, `cwt.*`, `coal.*`, `oprt.*`, `dtrs.*`) would be roughly a one-day migration: regenerate Drizzle schema, write a single `ALTER TABLE ... SET SCHEMA` migration, update the `src/db/schema/index.ts` re-exports.
+
+**We're not doing this now.** Reasons:
+- Zero functional benefit today; the lint rule already gives us logical isolation.
+- Schema-per-domain pays off when there's an auth-on-the-DB-layer story (row-level security per domain, separate read replicas, separate backup policies). None of that is on the near roadmap.
+- Touching every `src/db/schema/*.ts` and re-running CI for every story for a week is a real cost.
+
+**Trigger to revisit:** ESUC-002 (HIPAA migration, post-BAA). At that point the PHI tables (`ed_encounters`, `esuc_care_plans`, `client_documents`, `client_intakes`, plus `dtrs.*` consent tables) want to live in a dedicated `phi` schema with its own role grants — *that's* the right moment to do the schema split, because it's compliance-driven and the migration cost is amortized against work we're already doing.
+
+## Consequences
+
+**What we get:**
+- A boundary-violation today fails CI — same blast-radius guarantee microservices give us at the network layer, achieved at compile time, with zero ops cost.
+- Domain folders are real units. `src/lib/eviction/` could be lifted into a separate package or service later with mechanical effort, because nothing outside its allow-list reaches in.
+- The PHI fence (CLAUDE.md) is reinforced: `dtrs` and `esuc` are leaf-ish, hard to accidentally pull from elsewhere.
+
+**What we don't get:**
+- Independent deploys. If `indc` ships a bug, the whole app rolls back. Acceptable on a solo team.
+- Independent scaling. Vercel scales the app horizontally; per-domain CPU/memory profiles can't diverge. Not a problem yet — heavy AI work is already async via Inngest (FND-009), which *is* a real isolation boundary for the workloads that need it.
+- Polyglot domains. Everything stays TypeScript. Not a feature we'd want even if we could have it.
+
+**What we should watch for as the trigger to actually split a service:**
+1. **HIPAA blast radius (likely):** post-BAA, PHI handlers may want a separate VPC + separate logs + separate audit trail. Candidate: an `esuc-phi` service that owns ED encounter ingestion and care-plan AI calls. *This is the one I'd actually predict happens.*
+2. **SMS pipeline scale (possible):** if `indc` Twilio volume gets to where Inngest queues + Vercel functions stop being enough, an SMS worker process is a clean carve-out — `lib/indc` already has a narrow surface and one external dep.
+3. **OPRT report rendering (unlikely):** if quarterly narratives become hour-long jobs. We'd push to a worker before splitting a service.
+
+Anything outside those three is almost certainly the wrong reason.
+
+## Implementation checklist
+
+Treating this as a small story (call it `FND-020` if we file it) — should be ~3 points:
+
+- [x] `scripts/check-domain-boundaries.mts` — walks files, parses imports, checks allow-list.
+- [x] `package.json` script `lint:boundaries`.
+- [x] CI step (`.github/workflows/ci.yml`) after Lint, before Typecheck.
+- [x] Allow-list snapshotted inline in the script with a pointer back here.
+- [x] Verified clean against `main` (only `indc → coordination`, whitelisted).
+
+Schema split is not on this checklist. It's queued behind ESUC-002.

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "start": "node scripts/migrate-prod.mjs && next start",
     "lint": "biome check .",
     "lint:fix": "biome check --write .",
+    "lint:boundaries": "tsx scripts/check-domain-boundaries.mts",
     "format": "biome format --write .",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",

--- a/scripts/check-domain-boundaries.mts
+++ b/scripts/check-domain-boundaries.mts
@@ -1,0 +1,124 @@
+#!/usr/bin/env tsx
+/**
+ * FND-020 — domain-boundary lint
+ *
+ * Enforces ADR 0001 (docs/adr/0001-modular-monolith.md): a file under
+ * src/lib/{domain}/ may not import from src/lib/{otherDomain}/ unless
+ * otherDomain is on this domain's allow-list below.
+ *
+ * Files outside src/lib/{domain}/ (server actions, components, app routes)
+ * are the composition layer and may import any domain — they are not
+ * checked. Same-domain imports and imports of non-domain shared code at
+ * the top of src/lib/ (utils.ts, audit.ts, auth.ts, etc.) are always fine.
+ *
+ * Run via: pnpm lint:boundaries
+ *
+ * To add a new allowed cross-domain dep: amend ADR 0001 first, then add
+ * here. The ADR is the source of truth; this file enforces it.
+ */
+
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { join, relative } from 'node:path';
+
+const REPO_ROOT = new URL('..', import.meta.url).pathname;
+const LIB_ROOT = join(REPO_ROOT, 'src/lib');
+
+const ALLOW: Record<string, readonly string[]> = {
+  coordination: [],
+  coalition: ['coordination'],
+  cwt: ['coordination', 'dtrs'],
+  dtrs: [],
+  esuc: ['coordination', 'dtrs'],
+  eviction: ['dtrs'],
+  indc: ['coordination'],
+  oprt: ['coalition', 'coordination', 'cwt', 'esuc', 'eviction', 'indc'],
+};
+
+const DOMAINS = new Set(Object.keys(ALLOW));
+
+const IMPORT_RE = /from\s+['"]@\/lib\/([a-z][a-z0-9-]*)(?:\/[^'"]*)?['"]/g;
+
+type Violation = {
+  file: string;
+  fromDomain: string;
+  toDomain: string;
+  line: number;
+};
+
+function walk(dir: string, out: string[] = []): string[] {
+  for (const name of readdirSync(dir)) {
+    const full = join(dir, name);
+    const s = statSync(full);
+    if (s.isDirectory()) {
+      walk(full, out);
+    } else if (
+      (full.endsWith('.ts') || full.endsWith('.tsx')) &&
+      !full.endsWith('.test.ts') &&
+      !full.endsWith('.test.tsx')
+    ) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+function check(): Violation[] {
+  const violations: Violation[] = [];
+
+  for (const domain of DOMAINS) {
+    const domainDir = join(LIB_ROOT, domain);
+    let files: string[];
+    try {
+      files = walk(domainDir);
+    } catch {
+      continue; // domain folder doesn't exist yet — fine
+    }
+
+    const allowed = new Set([domain, ...ALLOW[domain]]);
+
+    for (const file of files) {
+      const src = readFileSync(file, 'utf8');
+      const lines = src.split('\n');
+
+      for (let i = 0; i < lines.length; i++) {
+        const line = lines[i];
+        IMPORT_RE.lastIndex = 0;
+        let m = IMPORT_RE.exec(line);
+        while (m !== null) {
+          const target = m[1];
+          if (DOMAINS.has(target) && !allowed.has(target)) {
+            violations.push({
+              file: relative(REPO_ROOT, file),
+              fromDomain: domain,
+              toDomain: target,
+              line: i + 1,
+            });
+          }
+          m = IMPORT_RE.exec(line);
+        }
+      }
+    }
+  }
+
+  return violations;
+}
+
+function main() {
+  const violations = check();
+  if (violations.length === 0) {
+    console.log('✓ domain boundaries clean');
+    return;
+  }
+
+  console.error(`✗ ${violations.length} domain-boundary violation(s):\n`);
+  for (const v of violations) {
+    console.error(`  ${v.file}:${v.line}  ${v.fromDomain} → ${v.toDomain}  (not on allow-list)`);
+  }
+  console.error(
+    '\nSee docs/adr/0001-modular-monolith.md. To add an allowed dep,' +
+      ' amend the ADR and update ALLOW in scripts/check-domain-boundaries.mts.',
+  );
+  process.exit(1);
+}
+
+main();

--- a/scripts/set-card-status.py
+++ b/scripts/set-card-status.py
@@ -40,13 +40,21 @@ def gh_graphql(query):
 
 
 def find_item_id(issue_num):
-    r = gh(["project", "item-list", str(PROJECT_NUM),
-            "--owner", OWNER, "--limit", "300", "--format", "json"])
-    items = json.loads(r.stdout)["items"]
-    for it in items:
-        c = it.get("content") or {}
-        if c.get("number") == issue_num:
-            return it["id"]
+    # Avoid `gh project item-list` — it silently caps at 100 items regardless
+    # of --limit, so issues past the first page are invisible to it. Query
+    # the issue's project memberships directly via GraphQL instead.
+    query = (
+        'query { repository(owner: "%s", name: "homeless") { '
+        'issue(number: %d) { projectItems(first: 10) { nodes { '
+        'id project { number } } } } } }'
+    ) % (OWNER, issue_num)
+    data = gh_graphql(query)
+    issue = (data.get("data", {}).get("repository") or {}).get("issue")
+    if not issue:
+        return None
+    for node in issue["projectItems"]["nodes"]:
+        if node["project"]["number"] == PROJECT_NUM:
+            return node["id"]
     return None
 
 


### PR DESCRIPTION
Closes #332.

## Why

Bo asked whether we should microservice this codebase. ADR 0001 says no — the operational tax is too high for a solo team — and instead establishes a **modular monolith** enforced at the source layer. This PR is that enforcement.

## What's in here

1. **`docs/adr/0001-modular-monolith.md`** — the architecture decision, the allow-list table, and the trigger conditions for ever revisiting (PHI isolation post-BAA being the most likely).
2. **`scripts/check-domain-boundaries.mts`** — walks `src/lib/{domain}/`, parses `from '@/lib/X/...'` imports, fails if X isn't on the allow-list. ~120 lines, zero deps.
3. **`package.json`** — `pnpm lint:boundaries`.
4. **`.github/workflows/ci.yml`** — runs after Lint, before Typecheck.
5. **`scripts/set-card-status.py`** — drive-by fix: `gh project item-list --limit 300` silently caps at 100, so the script couldn't move any card past issue #100. Now uses a direct GraphQL query, surfaced while moving #332 to in-progress.

## Scope decision (vs. earlier ADR draft)

The ADR initially said the boundary lint should also cover `src/app/actions/{domain}/*` and `src/components/{domain}/*`. Cut that: actions are flat files (`src/app/actions/eviction.ts`, etc.), not folders, and components are the composition layer. The architectural property holds as long as `src/lib/eviction/` can't reach into `src/lib/esuc/` — actions wiring multiple domains together is *their job*. ADR updated to reflect this.

## Verification

- Canary-tested: synthetic violation under `src/lib/eviction/__canary__/canary.ts` produced
  ```
  ✗ 1 domain-boundary violation(s):
    src/lib/eviction/__canary__/canary.ts:1  eviction → esuc  (not on allow-list)
  ```
  …and exited 1. Removed; current tree exits 0.
- Confirmed clean against `main` — only existing cross-domain dep is `indc → coordination`, which is whitelisted (SMS bed lookups, 6 imports).
- `pnpm typecheck` and `pnpm exec biome check` both pass on the touched files.

## Test plan

- [ ] CI passes (lint, boundaries, typecheck, test, build)
- [ ] Reviewer reads the ADR — that's the actual artifact, the script is the enforcement
- [ ] Confirm the allow-list matches mental model of how domains relate
- [ ] On merge: card → done via `python3 scripts/set-card-status.py 332 done`

🤖 Generated with [Claude Code](https://claude.com/claude-code)