### PR TITLE
feat(EVDT-227): trigger to auto-bump response_packets.updated_at + BACKLOG banner

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -2,6 +2,8 @@
 
 **Owner:** Bo (solo MVP build) · **Methodology:** Fibonacci story points, 2-week sprints · **Tracking:** GitHub Issues + Projects · **Last updated:** April 2026
 
+> **⚠️ Status — 2026-04-27.** This document is now **historical scaffolding**, not the active plan. The original sprint-by-sprint structure below got us through Phase 0 + Phase 1 MVP delivery, but reality has diverged: most stories named here are shipped, and the active backlog lives entirely in [GitHub Issues](https://github.com/DobbsBoldry/homeless/issues) + the [project board](https://github.com/users/DobbsBoldry/projects/1). Sprint planning happens against open issues, not against this file. Kept around for the strategic narrative (epic shape, phase sequencing, cross-cutting decisions) — those are still useful. Don't try to keep the sprint tables in sync.
+
 This is the comprehensive engineering plan from Phase 0 through Phase 4. It assumes solo development for personal validation, with Phase 1 use cases as the priority horizon and later phases scoped at decreasing granularity (more refinement happens once Phase 1 ships).
 
 ---

--- a/drizzle/migrations/0032_response_packet_touch_updated_at.sql
+++ b/drizzle/migrations/0032_response_packet_touch_updated_at.sql
@@ -1,0 +1,27 @@
+-- #227 — guarantee `updated_at` advances on every UPDATE to
+-- eviction_response_packets, even if a future code path forgets to set it.
+--
+-- Today the two writers (savePacketAction, changePacketStatusAction in
+-- src/app/actions/eviction.ts) both set updatedAt: new Date() explicitly,
+-- so this trigger is a belt-and-suspenders guarantee — not a bug fix.
+-- It exists so that adding a third writer later can't silently leave
+-- updated_at stale, which downstream metrics (queries/metrics.ts uses
+-- updated_at as the activity dimension) would silently miscount.
+--
+-- App-code vs trigger: same DRY argument as the audit-log trigger in
+-- 0008_audit_log_append_only.sql — when invariants matter, enforce them
+-- at the layer no caller can route around.
+
+CREATE OR REPLACE FUNCTION set_updated_at_now()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  NEW.updated_at := NOW();
+  RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER eviction_response_packets_touch_updated_at
+BEFORE UPDATE ON eviction_response_packets
+FOR EACH ROW EXECUTE FUNCTION set_updated_at_now();

--- a/drizzle/migrations/meta/_journal.json
+++ b/drizzle/migrations/meta/_journal.json
@@ -225,6 +225,13 @@
       "when": 1777261609196,
       "tag": "0031_shiny_ultimates",
       "breakpoints": true
+    },
+    {
+      "idx": 32,
+      "version": "7",
+      "when": 1777324911073,
+      "tag": "0032_response_packet_touch_updated_at",
+      "breakpoints": true
     }
   ]
 }

--- a/e2e/smoke/response-packet-touch.spec.ts
+++ b/e2e/smoke/response-packet-touch.spec.ts
@@ -1,0 +1,65 @@
+/**
+ * S7 — eviction_response_packets.updated_at auto-bumps on UPDATE.
+ *
+ * The application code (savePacketAction, changePacketStatusAction) sets
+ * updatedAt explicitly on every write. Migration 0032 layers a BEFORE
+ * UPDATE trigger underneath so a future writer that forgets cannot leave
+ * updated_at stale and silently miscount activity in the metrics queries.
+ *
+ * This test exercises the trigger directly: insert a packet with a
+ * back-dated updated_at, run an UPDATE that touches a different column,
+ * and assert updated_at advanced.
+ */
+
+import { dbClient } from '../fixtures/db';
+import { expect, test } from '../fixtures/test-base';
+
+test.describe('S7 response packet updated_at trigger', () => {
+  test('UPDATE without setting updated_at still advances it', async () => {
+    const sql = dbClient();
+    try {
+      // Parent filing — packet has FK to eviction_filings.
+      const filing = await sql`
+        insert into eviction_filings
+          (case_number, filed_at, plaintiff, defendant_first_name,
+           defendant_last_name, cause_type, source)
+        values
+          ('S7-TEST-' || gen_random_uuid()::text, now(), 'Test Plaintiff',
+           'Test', 'Tenant', 'non_payment', 'synthetic')
+        returning id
+      `;
+      const filingId = filing[0]?.id;
+      expect(filingId).toBeTruthy();
+
+      // Packet with a deliberately back-dated updated_at.
+      const inserted = await sql`
+        insert into eviction_response_packets
+          (filing_id, packet_md, prompt_version, updated_at)
+        values
+          (${filingId}, 'placeholder packet md', 's7-v1',
+           '2024-01-01T00:00:00Z'::timestamptz)
+        returning id, updated_at
+      `;
+      const id = inserted[0]?.id;
+      const before = inserted[0]?.updated_at as Date;
+      expect(id).toBeTruthy();
+
+      // UPDATE that does NOT mention updated_at — the trigger has to do it.
+      await sql`update eviction_response_packets set status = 'rejected' where id = ${id}`;
+
+      const after = await sql`
+        select updated_at from eviction_response_packets where id = ${id}
+      `;
+      const afterTs = after[0]?.updated_at as Date;
+      expect(afterTs.getTime()).toBeGreaterThan(before.getTime());
+      // And it should be recent — sanity-check the trigger used NOW(),
+      // not some constant. Within 60s of the test running.
+      expect(Date.now() - afterTs.getTime()).toBeLessThan(60_000);
+
+      // Cleanup — cascade deletes the packet via filing FK.
+      await sql`delete from eviction_filings where id = ${filingId}`;
+    } finally {
+      await sql.end({ timeout: 1 });
+    }
+  });
+});


### PR DESCRIPTION
Closes #227.

Spawned from sprint-7 planning realization: BACKLOG.md was stale, GitHub issues are the real plan, and #227 was a 1-pt warm-up follow-up to EVDT-012 still open in the queue.

## Two changes

### 1. Migration 0032 — `eviction_response_packets` updated_at trigger

Belt-and-suspenders: the two existing writers (`savePacketAction`, `changePacketStatusAction` in `src/app/actions/eviction.ts`) already set `updatedAt: new Date()` explicitly. The trigger guarantees a *third* writer that forgets can't silently leave it stale. Downstream `queries/metrics.ts` uses `updated_at` as the activity dimension, so a missed bump = a miscount.

**Decision (per the issue's AC):** trigger, not app-only convention. Same DRY argument as `0008_audit_log_append_only.sql` — invariants matter, enforce at the layer no caller can route around. Function is named generically (`set_updated_at_now`) so it can be reused on other tables when their AC asks for it.

Verified against the e2e DB:
```
before: 2024-01-01T00:00:00.000Z   (back-dated insert)
after : 2026-04-27T21:26:24.947Z   (UPDATE that omits updated_at)
advanced? true
```

E2E smoke test added (`e2e/smoke/response-packet-touch.spec.ts`) following the `audit-log.spec.ts` pattern.

### 2. BACKLOG.md historical banner

While planning Sprint 7 we discovered BACKLOG.md is significantly out of sync with reality — sprint stories named in the file are mostly shipped, and the active queue lives entirely in [GitHub issues](https://github.com/DobbsBoldry/homeless/issues) + the [project board](https://github.com/users/DobbsBoldry/projects/1). Added a banner at the top noting this so future readers don't try to plan against a stale artifact. Strategic narrative below the banner stays intact (epic shape, phase sequencing, cross-cutting decisions are still useful).

Also closed five zombie Phase-0 issues during the same audit (#10, #11, #13, #15, #18) — work shipped, issue never closed; comments point to the merged PR.

## Test plan

- [ ] CI green (lint, boundaries, typecheck, test, build, e2e)
- [ ] Reviewer confirms the trigger matches the audit-log pattern
- [ ] Manual: nothing — DB-level guarantee, no UI surface
- [ ] On merge: card → done

🤖 Generated with [Claude Code](https://claude.com/claude-code)