### PR TITLE
feat(FND-003b): users.email is case-insensitive (citext)

### DIFF
--- a/drizzle/migrations/0033_users_email_citext.sql
+++ b/drizzle/migrations/0033_users_email_citext.sql
@@ -1,0 +1,15 @@
+-- #192 / FND-003b — make users.email case-insensitive.
+--
+-- No callsite queries email by value today (email comes from Clerk and is
+-- a display field), but eventual admin lookups and cross-event reconciliation
+-- will, and the moment someone writes WHERE email = ? against plain text,
+-- case-sensitivity bites silently. citext does the work at the column type
+-- level so no caller has to remember to LOWER().
+--
+-- Supabase ships citext; AWS RDS Postgres includes it as a contrib extension
+-- and CREATE EXTENSION is permitted by the rds_superuser role we'll have
+-- post-BAA. No portability risk.
+
+CREATE EXTENSION IF NOT EXISTS citext;
+
+ALTER TABLE users ALTER COLUMN email TYPE citext USING email::citext;

--- a/drizzle/migrations/meta/_journal.json
+++ b/drizzle/migrations/meta/_journal.json
@@ -232,6 +232,20 @@
       "when": 1777324911073,
       "tag": "0032_response_packet_touch_updated_at",
       "breakpoints": true
+    },
+    {
+      "idx": 33,
+      "version": "7",
+      "when": 1777325665808,
+      "tag": "0033_users_email_citext",
+      "breakpoints": true
+    },
+    {
+      "idx": 34,
+      "version": "7",
+      "when": 1777325788755,
+      "tag": "0034_windy_sir_ram",
+      "breakpoints": true
     }
   ]
 }

--- a/e2e/smoke/users-email-citext.spec.ts
+++ b/e2e/smoke/users-email-citext.spec.ts
@@ -1,0 +1,48 @@
+/**
+ * S8 — users.email is case-insensitive (FND-003b / #192).
+ *
+ * Migration 0033 changes the column type to citext. Insert a row with
+ * mixed-case email, query in all-lowercase, assert match. If the column
+ * ever regresses to text, this test fails immediately.
+ */
+
+import { dbClient } from '../fixtures/db';
+import { expect, test } from '../fixtures/test-base';
+
+test.describe('S8 users.email citext', () => {
+  test('mixed-case insert is found by lowercase WHERE', async () => {
+    const sql = dbClient();
+    try {
+      const tag = `s8-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+      const mixed = `Mixed.Case.${tag}@Example.COM`;
+      const lower = mixed.toLowerCase();
+
+      const inserted = await sql`
+        insert into users (clerk_user_id, email)
+        values (${`clerk_${tag}`}, ${mixed})
+        returning id, email
+      `;
+      const id = inserted[0]?.id;
+      expect(id).toBeTruthy();
+
+      // The whole point: query with a different casing than what was inserted.
+      const found = await sql`
+        select id from users where email = ${lower}
+      `;
+      expect(found.length, 'lowercase query did not match mixed-case insert').toBe(1);
+      expect(found[0]?.id).toBe(id);
+
+      // And confirm the column type itself, so a future migration that
+      // accidentally reverts to text fails this test loudly.
+      const colType = await sql`
+        select data_type, udt_name from information_schema.columns
+        where table_name = 'users' and column_name = 'email'
+      `;
+      expect(colType[0]?.udt_name).toBe('citext');
+
+      await sql`delete from users where id = ${id}`;
+    } finally {
+      await sql.end({ timeout: 1 });
+    }
+  });
+});

--- a/src/db/schema/users.ts
+++ b/src/db/schema/users.ts
@@ -6,6 +6,16 @@ export const users = pgTable(
   {
     id: uuid('id').primaryKey().defaultRandom(),
     clerkUserId: text('clerk_user_id').notNull(),
+    /**
+     * Underlying column type is `citext` (case-insensitive text), enforced
+     * by migration 0033. Drizzle's `text` is wire-compatible with `citext`
+     * (both are strings client-side), and we keep the schema typed as
+     * `text` here because Drizzle's `customType` for citext produces a
+     * spurious `"undefined"."citext"` diff on every `db:generate`. The
+     * citext invariant is asserted by `e2e/smoke/users-email-citext.spec.ts`
+     * — if a future migration regresses the column to plain text, that
+     * smoke test fails loudly.
+     */
     email: text('email').notNull(),
     firstName: text('first_name'),
     lastName: text('last_name'),


### PR DESCRIPTION
Closes #192.

## Why

Email is preventive. Today nothing queries `users.email` by value (it comes from Clerk and is a display field), but the first `WHERE email = ?` someone writes will silently miss when casing differs from what Clerk sent. Cheaper to fix now than refactor later.

## What

Migration 0033 changes the column to Postgres `citext`. Comparisons fold case at the type level — no per-callsite discipline needed.

```sql
CREATE EXTENSION IF NOT EXISTS citext;
ALTER TABLE users ALTER COLUMN email TYPE citext USING email::citext;
```

Supabase ships citext; AWS RDS Postgres (post-BAA target) includes it as a contrib extension.

## Drizzle quirk

I tried a `customType` for citext first. Drizzle 0.45's diff generator produces a spurious `ALTER TABLE ... SET DATA TYPE "undefined"."citext"` migration on every `db:generate` — a known schema-qualifier bug for user-defined types. Not worth fighting for a 1-pt story.

Going with the cleaner trade-off: keep the Drizzle schema typed as `text` (wire-compatible with citext at the driver level — both are strings), and let the e2e smoke test be the citext invariant guardian:

```ts
const colType = await sql`
  select udt_name from information_schema.columns
  where table_name = 'users' and column_name = 'email'
`;
expect(colType[0]?.udt_name).toBe('citext');
```

If a future migration accidentally reverts the column type, that smoke test fails immediately. The schema field has a comment pointing at this guard so the next person to touch it knows.

## Verified locally

```
inserted as : Bo.Test.verify-...@Example.COM
lower match : true → Bo.Test.verify-...@Example.COM
upper match : true → Bo.Test.verify-...@Example.COM
column type : citext
```

## Test plan

- [ ] CI green (lint, boundaries, typecheck, test, build, e2e — including new S8 smoke test)
- [ ] Reviewer confirms the schema-comment + smoke-test approach is acceptable vs. fighting the Drizzle customType
- [ ] On merge: card → done

🤖 Generated with [Claude Code](https://claude.com/claude-code)