### PR TITLE
fix(EVDT-238): latest-outcome-wins for rate calculations

### DIFF
--- a/e2e/smoke/metrics-latest-outcome.spec.ts
+++ b/e2e/smoke/metrics-latest-outcome.spec.ts
@@ -1,0 +1,84 @@
+/**
+ * S9 — getMetricsRates uses latest-outcome-wins (#238).
+ *
+ * A filing with two outcome rows (e.g. an initial default_judgment that was
+ * later corrected/re-filed and ended in settled) must count in only one
+ * bucket — its most-recent — never both. Without this, default-judgment
+ * rate + favorable-outcome rate could exceed 100% for the same cohort.
+ *
+ * This test exercises the SQL directly (not the Drizzle export) — it
+ * validates the WHERE-FILTER + DISTINCT ON pattern in metrics.ts and is
+ * resilient to refactors of the surrounding TypeScript.
+ */
+
+import { dbClient } from '../fixtures/db';
+import { expect, test } from '../fixtures/test-base';
+
+test.describe('S9 metrics — latest outcome wins', () => {
+  test('filing with two outcomes counts only in its latest bucket', async () => {
+    const sql = dbClient();
+    try {
+      // Isolate this run: tag every row with a marker, restrict the rates
+      // query to that tag so other seeded data doesn't pollute.
+      const tag = `s9-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+
+      // Two filings — one will get a single default_judgment outcome
+      // (control), the other gets default_judgment FIRST then settled
+      // (the corrected case).
+      const filings = await sql`
+        insert into eviction_filings
+          (case_number, filed_at, plaintiff, defendant_first_name,
+           defendant_last_name, cause_type, source)
+        values
+          (${`${tag}-control`}, now(), 'P', 'Control', 'T', 'non_payment', 'synthetic'),
+          (${`${tag}-corrected`}, now(), 'P', 'Corrected', 'T', 'non_payment', 'synthetic')
+        returning id, case_number
+      `;
+      const control = filings.find((f) => f.case_number === `${tag}-control`)!;
+      const corrected = filings.find((f) => f.case_number === `${tag}-corrected`)!;
+
+      // Control: one outcome.
+      await sql`
+        insert into eviction_case_outcomes (filing_id, outcome, created_at)
+        values (${control.id}, 'default_judgment', now() - interval '2 days')
+      `;
+      // Corrected: default_judgment first (older), then settled (newer).
+      await sql`
+        insert into eviction_case_outcomes (filing_id, outcome, created_at)
+        values
+          (${corrected.id}, 'default_judgment', now() - interval '2 days'),
+          (${corrected.id}, 'settled', now() - interval '1 hour')
+      `;
+
+      // The latest-outcome-wins query, scoped to this test's filings.
+      // Should report: total=2, default_judgment=1 (control only),
+      // favorable=1 (corrected, since 'settled' is its latest).
+      const rows = await sql`
+        WITH latest AS (
+          SELECT DISTINCT ON (filing_id) filing_id, outcome
+          FROM eviction_case_outcomes
+          WHERE filing_id IN (${control.id}, ${corrected.id})
+          ORDER BY filing_id, created_at DESC
+        )
+        SELECT
+          COUNT(*)::int AS total,
+          COUNT(*) FILTER (WHERE outcome = 'default_judgment')::int AS default_judgment,
+          COUNT(*) FILTER (WHERE outcome IN ('dismissed', 'judgment_for_defendant', 'settled'))::int AS favorable
+        FROM latest
+      `;
+      const r = rows[0] as { total: number; default_judgment: number; favorable: number };
+
+      expect(r.total).toBe(2);
+      expect(r.default_judgment).toBe(1);
+      expect(r.favorable).toBe(1);
+      // The contract: rates can never sum to >100% — the same filing is
+      // never in both numerators.
+      expect(r.default_judgment + r.favorable).toBeLessThanOrEqual(r.total);
+
+      // Cleanup.
+      await sql`delete from eviction_filings where id in (${control.id}, ${corrected.id})`;
+    } finally {
+      await sql.end({ timeout: 1 });
+    }
+  });
+});

--- a/src/app/app/metrics/page.tsx
+++ b/src/app/app/metrics/page.tsx
@@ -75,12 +75,12 @@ export default async function MetricsPage() {
         <Kpi
           label="Default-judgment rate"
           value={fmtPct(rates.defaultJudgmentRate)}
-          hint="Of cases with any recorded outcome"
+          hint="Of cases with any recorded outcome (latest outcome wins)"
         />
         <Kpi
           label="Favorable outcomes"
           value={fmtPct(rates.favorableOutcomeRate)}
-          hint="Dismissed, defendant judgment, or settled"
+          hint="Dismissed, defendant judgment, or settled (latest outcome wins)"
         />
       </section>
 

--- a/src/db/queries/metrics.ts
+++ b/src/db/queries/metrics.ts
@@ -101,31 +101,41 @@ export async function getMetricsRates(windowDays = 30): Promise<MetricsRates> {
     .innerJoin(evictionFilings, eq(evictionFilings.id, evictionResponsePackets.filingId))
     .where(gte(evictionFilings.filedAt, since));
 
-  const [outcomeFilingsRow] = await db
-    .select({ value: countDistinct(evictionCaseOutcomes.filingId) })
-    .from(evictionCaseOutcomes);
-
-  const [defaultJudgmentRow] = await db
-    .select({ value: countDistinct(evictionCaseOutcomes.filingId) })
-    .from(evictionCaseOutcomes)
-    .where(eq(evictionCaseOutcomes.outcome, 'default_judgment'));
-
-  const [favorableRow] = await db
-    .select({ value: countDistinct(evictionCaseOutcomes.filingId) })
-    .from(evictionCaseOutcomes)
-    .where(
-      sql`${evictionCaseOutcomes.outcome} IN (${sql.join(
-        FAVORABLE_OUTCOMES.map((o) => sql`${o}`),
-        sql`, `,
-      )})`,
-    );
+  // Latest-outcome-wins (#238): a filing with two outcome rows
+  // (e.g. default_judgment then settled — corrected/re-filed) counts
+  // only in the bucket of its most-recent row, never in two buckets at
+  // once. Without this, default-judgment and favorable-outcome rates
+  // could sum to >100% because the same filing was counted in both.
+  // DISTINCT ON (filing_id) + ORDER BY created_at DESC collapses to one
+  // outcome per filing, then COUNT FILTER buckets in a single pass.
+  const favorableSet = sql.join(
+    FAVORABLE_OUTCOMES.map((o) => sql`${o}`),
+    sql`, `,
+  );
+  const [outcomeRow] = await db.execute<{
+    total: number;
+    default_judgment: number;
+    favorable: number;
+  }>(sql`
+    WITH latest AS (
+      SELECT DISTINCT ON (filing_id) filing_id, outcome
+      FROM ${evictionCaseOutcomes}
+      ORDER BY filing_id, created_at DESC
+    )
+    SELECT
+      COUNT(*)::int AS total,
+      COUNT(*) FILTER (WHERE outcome = 'default_judgment')::int AS default_judgment,
+      COUNT(*) FILTER (WHERE outcome IN (${favorableSet}))::int AS favorable
+    FROM latest
+  `);
 
   const safeRatio = (num: number, denom: number) => (denom === 0 ? null : num / denom);
+  const total = outcomeRow?.total ?? 0;
 
   return {
     representationRate: safeRatio(withPacketRow.value, filingsRow.value),
-    defaultJudgmentRate: safeRatio(defaultJudgmentRow.value, outcomeFilingsRow.value),
-    favorableOutcomeRate: safeRatio(favorableRow.value, outcomeFilingsRow.value),
+    defaultJudgmentRate: safeRatio(outcomeRow?.default_judgment ?? 0, total),
+    favorableOutcomeRate: safeRatio(outcomeRow?.favorable ?? 0, total),
   };
 }
 


### PR DESCRIPTION
Closes #238.

## Bug

Three queries in \`getMetricsRates\` each ran \`countDistinct(filing_id)\` against the eviction_case_outcomes table — one for total, one filtered to default_judgment, one filtered to favorable. A filing with **two** outcome rows (e.g. an initial default_judgment that was later corrected to settled) counted in **both** numerators, so the two displayed rates could sum to >100%.

Schema allows multiple outcome rows per filing on purpose (corrections happen by writing a new row, not editing the old one — see comment in \`eviction-case-outcomes.ts\`). The schema's stated convention is "outcomes UI shows the most recent first." The metrics page now honors that.

## Fix

Single CTE replaces the three separate queries:

\`\`\`sql
WITH latest AS (
  SELECT DISTINCT ON (filing_id) filing_id, outcome
  FROM eviction_case_outcomes
  ORDER BY filing_id, created_at DESC
)
SELECT
  COUNT(*) AS total,
  COUNT(*) FILTER (WHERE outcome = 'default_judgment') AS default_judgment,
  COUNT(*) FILTER (WHERE outcome IN ('dismissed', 'judgment_for_defendant', 'settled')) AS favorable
FROM latest
\`\`\`

Each filing collapses to one row before bucketing — a filing can never be in two numerators.

KPI tooltips on the metrics page now explicitly say "(latest outcome wins)" so the attorney knows which row is being attributed to.

## Verified locally

Inserted a control filing (single \`default_judgment\`) and a corrected filing (\`default_judgment\` then \`settled\`):

\`\`\`
result:   { total: 2, default_judgment: 1, favorable: 1 }
expected: total=2, default_judgment=1, favorable=1
\`\`\`

Without the fix the corrected filing would land in both buckets → `default_judgment=2, favorable=1` — violating `default + favorable ≤ total`.

## Test plan

- [ ] CI green (lint, boundaries, typecheck, test, build, e2e — including new S9 smoke test)
- [ ] Reviewer confirms latest-wins matches the schema comment intent
- [ ] Manual: load `/app/metrics`, confirm rates render and tooltips read "(latest outcome wins)"
- [ ] On merge: card → done

🤖 Generated with [Claude Code](https://claude.com/claude-code)