### PR TITLE
docs(FND-040a): per-domain CLAUDE.md × 8

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,11 +30,14 @@ This platform serves a county-level homelessness coalition. It ingests public ev
 
 ## How to read this codebase
 
-- **`BACKLOG.md`** — the source of truth for what to build, in what order, with story-point estimates. Read it any time you're picking up new work.
-- **`docs/`** — architecture decisions, ADRs, schema diagrams as they accumulate.
+- **GitHub Issues + [project board](https://github.com/users/DobbsBoldry/projects/1)** — source of truth for active work. Pick up the next open story from there.
+- **`BACKLOG.md`** — historical scaffolding (Phase 0/1 plan); kept for the strategic narrative (epic shape, phase sequencing). Don't try to plan against it.
+- **`docs/adr/`** — architecture decisions of record. Read these before fighting against an established pattern.
+- **`docs/`** — schema diagrams, design docs, KLA handouts.
 - **`README.md`** — local development setup.
-- **`scripts/`** — operational scripts (GitHub setup, data imports, etc.). Not application code.
-- **`src/`** — Next.js application code (created by FND-001).
+- **`scripts/`** — operational scripts (GitHub setup, data imports, status moves). Not application code.
+- **`src/lib/{domain}/CLAUDE.md`** — per-domain context (auto-loaded when editing files in that subdir). Read these before diving into a domain you haven't touched recently.
+- **`src/`** — Next.js application code.
 
 ## Conventions
 

--- a/src/lib/coalition/CLAUDE.md
+++ b/src/lib/coalition/CLAUDE.md
@@ -1,0 +1,38 @@
+# CLAUDE.md — `coalition` domain
+
+## What this domain owns
+
+Coalition-level operations: weekly insights digest, steering committee agenda generation, AI Q&A over coordination data for coalition staff. Aggregate views and AI-assisted ops, not individual case work.
+
+## Key files
+
+- `weekly-insights.ts` — Claude-drafted weekly digest (filings, beds, super-utilizer signals) for coalition leadership.
+- `steering-agenda.ts` — Claude-drafted Steering Committee meeting agenda from recent activity.
+- `coordination-qa.ts` — AI Q&A surface over the bed-availability dataset (asked by coalition staff, *not* by clients — that's `indc`).
+
+## AI prompts
+
+In `src/ai/prompts/`:
+- `coalition-insights.ts`
+- `steering-agenda.ts`
+- `coordination-qa.ts`
+
+Pattern: each `<feature>.ts` here calls Anthropic and imports `<feature>_PROMPT_VERSION`, `<feature>_SYSTEM_PROMPT`, and the user-prompt builder from the matching prompts file. Bumping `_PROMPT_VERSION` in the prompts file is how we version-control AI surfaces.
+
+## Cross-domain dependencies
+
+**Imports from (per ADR 0001):** `coordination` only.
+**Imported by:** `oprt` (which rolls everything up for transparency reports).
+
+## PHI status
+
+**Clean** in Phase 1. Coalition aggregate views never resolve to individual people. Post-BAA, this stays clean — PHI lives in `esuc` and `dtrs`, never bleeds here.
+
+## Conventions
+
+- Prompts read aggregated facts blocks (e.g. `buildCoordinationFactsBlock()`) — never raw query results inlined into the prompt.
+- All AI outputs are versioned via the prompt version constant; downstream stores record which version produced the artifact.
+
+## Gotchas
+
+- This domain is named `coalition` (singular) but lives next to `coordination` — easy typo in import paths. Boundary lint catches cross-domain imports but not typos within a domain.

--- a/src/lib/coordination/CLAUDE.md
+++ b/src/lib/coordination/CLAUDE.md
@@ -1,0 +1,33 @@
+# CLAUDE.md — `coordination` domain
+
+## What this domain owns
+
+Real-time bed availability across the three anchor shelters (Boulware Mission, St. Benedict's, Daniel Pitino). The "is there a bed open right now" capability — not the conversation that uses it (that's `indc`), not the rolled-up dashboards (that's `coalition`).
+
+## Key files
+
+- `bed-availability.ts` — single source of truth: `freeBeds()`, `effectiveFreeBeds()` (subtracts active holds), `BedFilter` parsing, occupancy math.
+
+That's the whole domain right now. It's a leaf.
+
+## AI prompts
+
+None directly. `coordination-qa.ts` (an AI Q&A over coordination data) lives in `coalition/`, not here, because it's a coalition-facing capability that *uses* coordination data.
+
+## Cross-domain dependencies
+
+**Imports from:** none. This is a leaf — the boundary lint enforces nothing imports inward.
+**Exported to (per ADR 0001):** `coalition`, `cwt`, `esuc`, `indc`, `oprt`. The bed-availability data model is the most-shared primitive in the codebase.
+
+## PHI status
+
+**Clean.** Bed counts and shelter capacity are operational data, never PHI. Stays this way post-BAA.
+
+## Conventions
+
+- All bed math goes through `effectiveFreeBeds()` — never compute `capacity - occupancy` inline. Active bed holds (from `bed_holds` schema) must be subtracted.
+- Filters parse defensively from URL params (`parseBedFilterParams`) — clients can send anything; we coerce to known shelter feature flags.
+
+## Gotchas
+
+- The `bed_count_updates` table is the source of truth for occupancy (append-only history); current occupancy is the latest row per shelter. Don't UPDATE shelter occupancy in place.

--- a/src/lib/cwt/CLAUDE.md
+++ b/src/lib/cwt/CLAUDE.md
@@ -1,0 +1,46 @@
+# CLAUDE.md — `cwt` domain (Caseworker Tools)
+
+## What this domain owns
+
+Caseworker-facing tooling: conversational client intake, AI case-note drafting, document extraction, benefits screening, triage tier assignment, follow-up SMS, pre/post-meeting AI summaries.
+
+## Key files
+
+**Intake + extraction:**
+- `intake-extraction.ts` — Claude extracts structured fields from a free-form intake transcript.
+- `intake-to-screener.ts` — feeds extracted intake into the benefits screener.
+- `document-extraction.ts` — Claude extracts data from uploaded docs (KY ID, paystub, lease, etc.) — see `client_document_kind` enum for the supported set.
+
+**Triage + benefits:**
+- `triage.ts` + `cwt-triage.ts` — assign high/medium/low tier with AI rationale.
+- `benefits.ts` — benefits screener (KTAP, SNAP, KCHIP, KY HEALTH).
+
+**Notes + comms:**
+- `case-note-generator.ts` — Claude-drafted case note from session transcript.
+- `person-qa.ts` — AI Q&A over a single client's record.
+- `post-meeting-notes.ts` + `pre-meeting-summary.ts` — meeting prep + recap drafts.
+- `followup-sms.ts` — Claude-drafted follow-up SMS to client.
+
+## AI prompts
+
+In `src/ai/prompts/`: `case-note-generator.ts`, `cwt-triage.ts`, `document-extraction.ts`, `followup-sms.ts`, `intake-extraction.ts`, `person-qa.ts`, `post-meeting-notes.ts`, `pre-meeting-summary.ts`, `synthetic-intake.ts`.
+
+## Cross-domain dependencies
+
+**Imports from (per ADR 0001):** `coordination`, `dtrs`. **Imported by:** `oprt`.
+
+## PHI status
+
+**Phase 1: synthetic-only.** All caseworker work runs against synthetic data (CWT-001 generator). No real PHI lands here pre-BAA. Once ESUC-002 ships and the BAA is signed, `client_intakes`, `client_documents`, `client_case_notes`, etc. become real-PHI tables and route through the HIPAA-eligible Anthropic endpoint.
+
+## Conventions
+
+- Every Claude call here is gated: in dev/e2e, it returns a deterministic stub via `E2E_MOCK_OUTBOUND`; in prod (post-BAA), routes through the HIPAA endpoint with a different API key.
+- Case notes are versioned (CWT-005 history) — never overwrite an old note; insert a new version and supersede.
+- Document extraction status flow: `uploaded → extracting → extracted | failed`.
+- Intake transcript handling: transcript is PHI; extraction output is structured PHI; both live behind `dtrs.data-access` policy gates.
+
+## Gotchas
+
+- The triage tier UI is FAG-defined (per the strategy doc) — what counts as "high" is configurable per agency. Don't hardcode thresholds in this code.
+- Synthetic intake transcripts (`synthetic-intake.ts` prompt) are intentionally messy — that's how we test extraction robustness. Don't "clean them up."

--- a/src/lib/dtrs/CLAUDE.md
+++ b/src/lib/dtrs/CLAUDE.md
@@ -1,0 +1,43 @@
+# CLAUDE.md — `dtrs` domain (Data Trust)
+
+## What this domain owns
+
+The consent surface, the consent-text version-control, abuser-blind protections (DV-survivor address redaction), data-access policy gating, and the rate-limit primitive that protects consent submission. The "what data are we allowed to use, for whom, on what surfaces" layer.
+
+**This is the most security-critical domain in the codebase.** Touch carefully.
+
+## Key files
+
+- `consent.ts` — consent record CRUD; the `CURRENT_CONSENT_VERSION` lives in `consent-text.ts` (bump on wording changes; advisor review per `docs/dtrs-005-advisor-review.md`).
+- `consent-text.ts` — current and historical consent wording. Versioned. Never inline consent text anywhere else.
+- `consent-token.ts` — opaque ref tokens for the `/p/[ref]/...` consent surfaces (no auth required, capability-bearer URL).
+- `data-access.ts` — central policy gate: given `(viewer, target, data_class)` returns allow/deny. Every PHI read should route through this.
+- `dv-blind.ts` — DV-survivor address redaction (`redactForRole`). Threat model: abuser obtaining survivor's new location through a coalition data leak.
+- `rate-limit.ts` — bucketed rate-limit; in-memory today (#270 tracks Railway-restart persistence).
+- `transparency-report.ts` — anonymized counts for the public transparency surface.
+- `fiscal-court-brief.ts` — Claude-drafted fiscal court brief from quarterly outcomes.
+
+## AI prompts
+
+In `src/ai/prompts/`: `quarterly-narrative.ts` (used by `oprt` not us — but the brief here uses similar patterns).
+
+## Cross-domain dependencies
+
+**Imports from:** none. Leaf domain. **Imported by:** `cwt`, `esuc`, plus the consent surfaces in `src/app/p/[ref]/`.
+
+## PHI status
+
+**Will-be-PHI post-BAA.** `consent_records` link to people once ESUC-002 lands. The DV-blind tables already model PHI-adjacent risk (location data is PHI in DV context).
+
+## Conventions
+
+- Bumping consent wording = bump `CURRENT_CONSENT_VERSION` AND record a new `consents.consent_text_version` value on every new consent record. Old consents stay tied to the wording the person actually agreed to.
+- DV redaction is server-authority. Don't rely on client-side hiding for `defendant_address` when `dv_flagged = true`.
+- Rate-limit buckets are keyed by hashed phone (never raw phone) — see `consent-form.tsx` and Twilio-webhook code.
+- Audit log every consent grant/revoke via `logAuditEvent` from `@/lib/audit`. The audit-log triggers (#198) make those rows immutable.
+
+## Gotchas
+
+- The consent surfaces at `/p/[ref]/...` run *unauthenticated* — the ref token is the capability. Don't add a Clerk gate; that breaks the use case.
+- `INDC_CONSENT_OPEN_MODE` env flag bypasses token validation in dev/e2e — never `true` in prod.
+- `rate-limit.ts` is in-memory; restart blows the bucket (real bug, tracked at #270).

--- a/src/lib/esuc/CLAUDE.md
+++ b/src/lib/esuc/CLAUDE.md
@@ -1,0 +1,44 @@
+# CLAUDE.md — `esuc` domain (ED Super-Utilizer Care)
+
+## What this domain owns
+
+ED super-utilizer pipeline: ingest ED encounter signals → rank patients by super-utilizer-ness → AI-graded triage → AI-drafted care plan → care-plan review/edit → care coordination handoff. The other Phase 1 flagship besides eviction.
+
+**Highest-PHI domain.** Real ED encounters are PHI; nothing here lands pre-BAA.
+
+## Key files
+
+- `super-utilizer-ranking.ts` — score patients by 12-month ED visit pattern.
+- `ed-triage.ts` — Claude-graded triage tier from encounter signals.
+- `care-plan.ts` — Claude-drafted care intervention plan. Status flow: `draft → approved → active → archived`.
+- `patient-qa.ts` — AI Q&A over a single patient's encounter history.
+
+## AI prompts
+
+In `src/ai/prompts/`: `ed-triage.ts`, `esuc-care-plan.ts`, `patient-qa.ts`, `synthetic-ed-encounters.ts`.
+
+## Cross-domain dependencies
+
+**Imports from (per ADR 0001):** `coordination`, `dtrs`. **Imported by:** `oprt`.
+
+## PHI status
+
+**Hard PHI fence.** Until the Owensboro Health BAA is signed and ESUC-002 (HIPAA migration) lands:
+- No real PHI in the database
+- No real PHI through any AI call
+- All work runs on synthetic encounters (`scripts/gen-synthetic-ed-encounters.ts`)
+
+ESUC-002 trigger conditions also justify the schema-per-domain Postgres split discussed in ADR 0001 — the PHI tables (`ed_encounters`, `esuc_care_plans`, `client_documents`, `client_intakes`) move to a dedicated `phi.*` schema with separate role grants.
+
+## Conventions
+
+- Every Claude call routes through the HIPAA-eligible Anthropic endpoint post-BAA. The dev/synthetic path uses the standard endpoint.
+- Care plans are versioned (every approval bumps version); old versions stay queryable.
+- Triage overrides (`triage_overrides` table) capture human disagreement with AI grading — that's a feedback signal for prompt iteration, not a bug.
+- Real de-identification of free-text clinical notes is open work (#247) — current pipeline is a stub. Until that ships, no production PHI through extraction.
+
+## Gotchas
+
+- Super-utilizer ranking has cohort thresholds (e.g. 4+ visits / 12 months). Those are policy choices, not magic numbers — change with care; document the change in an ADR or care-plan note.
+- The synthetic ED encounter prompt deliberately includes messy formatting and OCR artifacts — that's the test for downstream robustness. Don't sanitize.
+- Super-utilizer status itself is sensitive (it implies frequent ED use, which intersects mental health / SUD / housing instability) — even *aggregate* counts can deanonymize in a county this size. Aggregate-only displays must use the `dtrs.transparency-report` k-anon thresholds.

--- a/src/lib/eviction/CLAUDE.md
+++ b/src/lib/eviction/CLAUDE.md
@@ -1,0 +1,49 @@
+# CLAUDE.md — `eviction` domain (EVDT)
+
+## What this domain owns
+
+End-to-end eviction defense pipeline: scrape the daily docket → upsert filings → risk-score → AI-draft response packet → render PDF → attorney triage view → outcome tracking → metrics. The Phase 1 flagship.
+
+## Key files
+
+**Ingestion:**
+- `sources/` — pluggable scraper sources (synthetic, future CourtNet).
+- `parser.ts` — parse raw docket text → `EvictionFiling` shape.
+- `upsert.ts` + `upsert-rules.ts` — dedup logic; multiple sources may produce a row for the same case (uniqueness on `case_number, source`).
+
+**Risk + triage:**
+- `risk-score.ts` + `risk-band.ts` — Claude-graded risk score → low/medium/high band.
+- `plaintiff-patterns.ts` — repeat-plaintiff detection.
+- `children-detection.ts` — heuristic: does this household have minors? (no PHI; pattern-matched off public docket text).
+- `docket-ranking.ts` — daily attorney triage queue ordering.
+- `attorney-triage.ts` — KLA-attorney decision capture.
+
+**Response packet:**
+- `response-packet.ts` — Claude-drafted Answer to Forcible Detainer Complaint. Disclaimer fragments are non-negotiable; validated post-generation. Status flow: `draft → approved → filed | rejected`.
+- `packet-pdf.ts` — PDFKit render.
+- `outreach-letter-pdf.ts` + `tenant-outreach.ts` — proactive tenant outreach letter.
+- `case-qa.ts` — AI Q&A over a single filing.
+
+## AI prompts
+
+In `src/ai/prompts/`: `attorney-triage.ts`, `case-qa.ts`, `eviction-response-packet.ts`, `eviction-risk-score.ts`, `eviction-tenant-outreach.ts`, `plaintiff-patterns.ts`, `synthetic-eviction-filings.ts`.
+
+## Cross-domain dependencies
+
+**Imports from:** `dtrs` only. **Imported by:** `oprt` (rate metrics, narrative).
+
+## PHI status
+
+**Clean.** Eviction filings are public court record. Defendant name + address are public via the docket. We segregate `defendant_*` columns from any future client-linked tables — the join to a real client row only happens post-BAA, mediated by a consent record.
+
+## Conventions
+
+- Multiple sources can produce the same filing; dedup is explicit via `(case_number, source)` uniqueness. Don't dedupe at query time — let upsert handle it.
+- Response packets are versioned by `prompt_version`. Re-running the generator with the same version no-ops; bumping it inserts a new row alongside the old (attorney can compare).
+- `eviction_response_packets.updated_at` is auto-bumped by trigger (migration 0032). Status writers don't have to remember.
+- Outcomes are append-only; "latest outcome wins" is the convention for rate calculations (see `getMetricsRates` in `src/db/queries/metrics.ts`).
+
+## Gotchas
+
+- DV-flagged filings need address redaction for non-attorney roles — done via `dv-blind.ts` in `dtrs`. Always go through that helper.
+- The disclaimer fragments live in `response-packet.ts`; bumping them requires bumping `EVICTION_RESPONSE_PACKET_PROMPT_VERSION` so old packets stay tied to the disclaimer they were generated under.

--- a/src/lib/indc/CLAUDE.md
+++ b/src/lib/indc/CLAUDE.md
@@ -1,0 +1,48 @@
+# CLAUDE.md — `indc` domain (Individual Companion)
+
+## What this domain owns
+
+The SMS interface for unhoused individuals. Inbound text arrives → parse intent → look up beds (via `coordination`) → format reply → send. Plus bed-hold flow (user texts, shelter holds a bed for them) and stateful conversation (`awaiting_location` etc.).
+
+The only end-user-facing surface that runs over Twilio.
+
+## Key files
+
+- `sms-pipeline.ts` — orchestrator: webhook → parse → respond → record.
+- `sms-parser.ts` — parse inbound text into intents (`bed`, `where`, `help`, location response, etc.).
+- `sms-conversation.ts` — conversation state machine (`idle | awaiting_location`).
+- `sms-formatter.ts` — outbound message formatting (length-aware, no PHI leakage).
+- `bed-finder.ts` — query `coordination/bed-availability` for matching shelters.
+- `bed-summary.ts` — render bed list in SMS-friendly form.
+- `sms-bed-holds.ts` — bed-hold creation/expiration flow (S6 e2e covers expiration).
+- `twilio-signature.ts` — verify inbound webhook signature.
+
+## AI prompts
+
+None directly today — the SMS surface is intentionally rule-based for predictability. Future text-shorthand expansion (INDC-019) might add a small Claude classifier; that'd be a deliberate decision.
+
+## Cross-domain dependencies
+
+**Imports from (per ADR 0001):** `coordination` only (bed lookups). **Imported by:** `oprt`.
+
+The `indc → coordination` dep is the single legitimate cross-domain import in the codebase pre-ADR-0001. It's why the allow-list isn't empty.
+
+## PHI status
+
+**Sensitive-not-PHI in Phase 1.** SMS messages and conversation state are stored, but content is operational ("BED" / "downtown" / "Boulware accepts pets") not clinical. Phone numbers are hashed, never raw, in any cross-table reference.
+
+Post-BAA: `sms_messages.body` could contain user-disclosed PHI (e.g. "I have diabetes, do they have insulin storage?"). Treatment of PHI in SMS body is a Phase 2 design decision — see INDC-007 (privacy-respecting log) and INDC-018.
+
+## Conventions
+
+- All Twilio webhook handlers verify the X-Twilio-Signature header via `twilio-signature.ts`. CI test (`twilio-signature.spec.ts`) catches bypasses.
+- Phone numbers are hashed before any cross-table key. Raw phone never persists outside `sms_messages`.
+- `E2E_MOCK_OUTBOUND=1` skips actual Twilio API calls — used by e2e setup. Don't accidentally remove this gate.
+- SMS responses are length-bounded to fit a single 160-char segment when possible; multi-segment is acceptable for bed lists but should be flagged in tests.
+- `INDC_CONSENT_OPEN_MODE` is dev-only — bypasses ref-token validation on the consent surface.
+
+## Gotchas
+
+- Twilio sends multi-value params (multi-line `Body`); webhook hygiene (#269 follow-up) is open work.
+- The rate-limit bucket protecting inbound SMS lives in `dtrs/rate-limit.ts` and is in-memory — Railway restarts blow it (#270).
+- Bed-hold expiration is enforced by an Inngest scheduled function, NOT a Postgres trigger. If you change the expiration window, update both the Inngest schedule and the test fixture.

--- a/src/lib/oprt/CLAUDE.md
+++ b/src/lib/oprt/CLAUDE.md
@@ -1,0 +1,36 @@
+# CLAUDE.md — `oprt` domain (Operations / Transparency / Reporting)
+
+## What this domain owns
+
+Cross-domain rollups for transparency, accountability, and outside-facing narratives: quarterly outcomes report, fiscal court brief, narrative drafting. The "everything in aggregate, told as a story" layer.
+
+## Key files
+
+- `quarterly-narrative.ts` — Claude-drafted quarterly outcomes narrative pulling from every domain.
+
+(Domain is small today; more files land as Phase 1 reporting expands.)
+
+## AI prompts
+
+In `src/ai/prompts/`: `quarterly-narrative.ts` (this file's pair).
+
+## Cross-domain dependencies
+
+**Imports from (per ADR 0001):** `coalition`, `coordination`, `cwt`, `esuc`, `eviction`, `indc`. The widest allow-list of any domain — and that's by design. Operations/transparency is *the* read-only consumer of every other domain's output.
+
+**Imported by:** none. Top of the dependency graph.
+
+## PHI status
+
+**Clean by construction.** Everything that flows into `oprt` rollups is either aggregate counts or already-anonymized. Per the `dtrs.transparency-report` k-anon thresholds, no oprt output should resolve to a single individual.
+
+## Conventions
+
+- Read-only against every upstream domain. Never mutate state owned by another domain from here.
+- Aggregate first, then narrate. The Claude prompts in this domain receive *facts blocks* (counts, rates, named buckets) — never raw rows. If you find yourself feeding a row dump into the prompt, refactor the upstream query.
+- Public-facing narratives go through the same disclaimer/citation discipline as `eviction/response-packet.ts` — track which prompt version produced which artifact.
+
+## Gotchas
+
+- Quarterly narrative pulls from many domains; if any one of them changes its public API (e.g. a `getMetricsRates` signature change), oprt callsites need updating. The boundary lint catches the import path; tests catch the signature.
+- The fiscal-court-brief surface lives in `dtrs/` (because it's about the data-trust accountability story), not here. Don't get them confused.


### PR DESCRIPTION
First sub-task of the [FND-040 epic (#338)](https://github.com/DobbsBoldry/homeless/issues/338) — codebase-maintainability foundation. Closes #339.

## Why

Every story today starts with `grep` + `find` to reconstruct "where does X live in this domain." Per-domain `CLAUDE.md` files put that map next to the code so it auto-loads when Claude touches a file in the subdirectory. Saves ~5–10 minutes of context-gathering per story; compounds across the remaining ~40+ Phase-1 hardening + Phase-2 stories.

## What's in here

8 files: `src/lib/{coalition,coordination,cwt,dtrs,esuc,eviction,indc,oprt}/CLAUDE.md`. Each follows the same template:

- **What this domain owns** — 1-3 sentences
- **Key files** — one-line descriptions
- **AI prompts** — pointers to `src/ai/prompts/`
- **Cross-domain dependencies** — mirrors ADR 0001 allow-list (so the boundary lint and the docs agree)
- **PHI status** — clean / will-be-PHI-after-BAA / hard-fence (esuc)
- **Conventions** — domain-specific things that aren't in the global CLAUDE.md
- **Gotchas** — things I/we have actually hit

All 8 files are 33–49 lines. Hard cap was 50. Pointers, not essays.

Plus a global CLAUDE.md update:
- GitHub issues + project board promoted to source-of-truth
- BACKLOG.md demoted to historical (matches the banner already on it)
- `docs/adr/` called out as read-before-fighting-a-pattern
- Per-domain CLAUDE.md pattern documented in the entry-point file so the system is discoverable

## Verified

- `pnpm exec biome check` clean on all 9 touched files
- `pnpm lint:boundaries` clean
- `pnpm typecheck` clean

## Test plan

- [ ] CI green
- [ ] Reviewer reads one or two domain files (suggest `eviction` and `dtrs` — the most content-rich) and confirms the template hits the right level of detail
- [ ] On merge: card → done; #338 epic moves to its next sub-task

## What's next in the epic

- FND-040b — per-domain `index.ts` + tighter boundary lint (3pt)
- FND-040c — `docs/architecture.md` (2pt)
- FND-040d — `STATE.md` (1pt)
- FND-040e — migration rename pass (1pt)

🤖 Generated with [Claude Code](https://claude.com/claude-code)