### PR TITLE
docs(FND-040c): docs/architecture.md — one-page system map

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,6 +33,7 @@ This platform serves a county-level homelessness coalition. It ingests public ev
 - **`STATE.md`** — open this first. Captures current focus, what just shipped, what's next, and known quirks. Refreshed at end of session; if it's stale, update it before doing anything else.
 - **GitHub Issues + [project board](https://github.com/users/DobbsBoldry/projects/1)** — source of truth for active work. Pick up the next open story from there.
 - **`BACKLOG.md`** — historical scaffolding (Phase 0/1 plan); kept for the strategic narrative (epic shape, phase sequencing). Don't try to plan against it.
+- **[`docs/architecture.md`](docs/architecture.md)** — one-page system map (layers, domain dependency graph, PHI fence, Phase-1 user journeys). Read this once; refer back when orienting.
 - **`docs/adr/`** — architecture decisions of record. Read these before fighting against an established pattern.
 - **`docs/`** — schema diagrams, design docs, KLA handouts.
 - **`README.md`** — local development setup.

--- a/STATE.md
+++ b/STATE.md
@@ -4,6 +4,8 @@
 
 This file is the cheap context file. Open it at the start of a session and you skip 5–10 minutes of "what was I doing." Two paragraphs, bullets, no essays. If a section gets long, summarize and link out.
 
+> Need the system map instead? See [`docs/architecture.md`](docs/architecture.md) — domain graph, PHI fence, user journeys.
+
 ## Current focus
 
 **Sprint 7 — Phase-1 hardening + maintainability foundation.** Cleaning up follow-ups and tightening the codebase substrate before pushing into the de-id pipeline (#247) and Phase 2.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,221 @@
+# Architecture — Daviess Coalition Platform
+
+**Audience:** anyone (you, future-you, future-Claude, an eventual second engineer) trying to build a mental map of this codebase in under 10 minutes.
+
+**Stance:** [modular monolith](adr/0001-modular-monolith.md). One Next.js app, one Postgres, eight domain folders, source-level boundaries enforced by `pnpm lint:boundaries`. We split a service only when there's a compliance or scale reason — not because the codebase has multiple domains.
+
+---
+
+## System layers
+
+```mermaid
+graph TB
+  subgraph ext[External services]
+    clerk[Clerk Auth]
+    twilio[Twilio SMS]
+    anthropic[Anthropic API]
+    resend[Resend Email]
+    inngest[Inngest Jobs]
+  end
+
+  subgraph app[Next.js app]
+    routes[App routes / pages<br/>src/app/]
+    actions[Server actions<br/>src/app/actions/]
+    domains[Domain logic<br/>src/lib/{domain}/]
+    prompts[AI prompts<br/>src/ai/prompts/]
+    queries[DB queries<br/>src/db/queries/]
+    schema[DB schema<br/>src/db/schema/]
+  end
+
+  pg[(Postgres<br/>Supabase → AWS RDS post-BAA)]
+
+  clerk --> routes
+  twilio --> routes
+  routes --> actions
+  actions --> domains
+  domains --> prompts
+  domains --> anthropic
+  domains --> queries
+  queries --> schema
+  schema --> pg
+  inngest --> domains
+  domains --> resend
+```
+
+**Reading the layers:**
+- **Routes + actions** = composition layer. Allowed to span domains; that's their job.
+- **`src/lib/{domain}/`** = domain logic. Cross-domain imports are gated by ADR 0001.
+- **`src/ai/prompts/`** = single source of truth for AI surfaces. No inline prompt strings anywhere else.
+- **`src/db/{schema,queries}/`** = persistence. Drizzle ORM; flat schema today, schema-per-domain split deferred to ESUC-002.
+
+---
+
+## Domain dependency graph
+
+```mermaid
+graph LR
+  coordination[coordination<br/>bed availability]
+  dtrs[dtrs<br/>consent · DV-blind · rate-limit]
+  eviction[eviction · EVDT]
+  cwt[cwt · Caseworker Tools]
+  esuc[esuc · ED Super-Utilizer]
+  indc[indc · SMS Companion]
+  coalition[coalition · ops + insights]
+  oprt[oprt · transparency rollups]
+
+  coalition --> coordination
+  cwt --> coordination
+  cwt --> dtrs
+  esuc --> coordination
+  esuc --> dtrs
+  eviction --> dtrs
+  indc --> coordination
+  oprt --> coalition
+  oprt --> coordination
+  oprt --> cwt
+  oprt --> esuc
+  oprt --> eviction
+  oprt --> indc
+```
+
+Mirrors the allow-list in `scripts/check-domain-boundaries.mts`. Anything not on this graph that tries to import across domains fails CI.
+
+**Two leaf domains:** `coordination` (bed availability) and `dtrs` (consent + access policy). Everything else either consumes them or rolls up into `oprt`.
+
+**Why `oprt` reaches into everything:** transparency / quarterly narrative is a read-only consumer of every domain's output. That's the one place the dependency graph fans wide on purpose.
+
+---
+
+## PHI fence
+
+```mermaid
+graph LR
+  subgraph clean[Clean — never PHI]
+    eviction2[eviction<br/>public court record]
+    coordination2[coordination<br/>bed counts]
+    coalition2[coalition<br/>aggregates]
+    oprt2[oprt<br/>aggregates only]
+    indc2[indc<br/>operational SMS]
+  end
+
+  subgraph fenced[PHI fence — synthetic-only pre-BAA]
+    cwt2[cwt<br/>caseworker intake + notes]
+    esuc2[esuc<br/>ED encounters + care plans]
+    dtrs2[dtrs<br/>consent records]
+  end
+
+  fenced -.unblocked by ESUC-002.-> phi[Real PHI<br/>HIPAA endpoint<br/>AWS RDS<br/>schema-per-domain split]
+```
+
+**The rule** (per [global CLAUDE.md](../CLAUDE.md#the-hipaa--phi-fence--do-not-cross-it)):
+- Pre-BAA: no real PHI in DB or AI prompts. Synthetic-only for `cwt`/`esuc`/`dtrs`.
+- ESUC-002 (post-BAA): switches to HIPAA-eligible Anthropic endpoint, splits PHI tables to a dedicated Postgres schema with separate role grants.
+
+**The de-id pipeline (#247)** is the strategic open ticket on this fence — it replaces the synthetic-data stub with a real de-identifier so production PHI can flow through extraction post-BAA.
+
+---
+
+## Phase-1 user journeys
+
+### J1 — KLA attorney: filing → response packet
+
+```mermaid
+sequenceDiagram
+  participant Cron as Inngest scheduler
+  participant Scrape as eviction/sources
+  participant Parse as eviction/parser
+  participant Risk as eviction/risk-score
+  participant Att as Attorney UI
+  participant Pkt as eviction/response-packet
+  participant Anthr as Anthropic
+
+  Cron->>Scrape: daily docket scrape
+  Scrape->>Parse: raw text
+  Parse->>Risk: structured filings
+  Risk->>Anthr: filing → risk score
+  Att->>Pkt: "draft answer for filing X"
+  Pkt->>Anthr: filing facts → answer markdown
+  Pkt-->>Att: draft packet (status=draft)
+  Att->>Pkt: review · edit · approve
+  Pkt-->>Att: status=approved → PDF
+```
+
+### J2 — Caseworker: intake → benefits screening (synthetic)
+
+```mermaid
+sequenceDiagram
+  participant CW as Caseworker UI
+  participant Intake as cwt/intake-extraction
+  participant Anthr as Anthropic
+  participant Bnf as cwt/benefits
+  participant Tri as cwt/triage
+
+  CW->>Intake: free-form transcript
+  Intake->>Anthr: transcript → structured fields
+  Anthr-->>Intake: name · housing · benefits · risks
+  Intake->>Bnf: structured intake
+  Bnf-->>CW: KTAP · SNAP · KCHIP · KY HEALTH eligibility
+  CW->>Tri: assign tier
+  Tri->>Anthr: cohort · history → high/medium/low
+  Tri-->>CW: tier + rationale
+```
+
+Pre-BAA: every "intake" here is synthetic (CWT-001 generator). Post-BAA: same flow, real client data, HIPAA endpoint.
+
+### J3 — Unhoused individual: SMS bed-finder
+
+```mermaid
+sequenceDiagram
+  participant U as User phone
+  participant Tw as Twilio
+  participant Hook as /api/webhooks/twilio
+  participant Pipe as indc/sms-pipeline
+  participant Bed as coordination/bed-availability
+  participant Hold as indc/sms-bed-holds
+
+  U->>Tw: "BED"
+  Tw->>Hook: POST (signed)
+  Hook->>Pipe: parse intent
+  Pipe->>Bed: filter shelters
+  Bed-->>Pipe: matching beds
+  Pipe-->>Tw: bed list reply
+  Tw-->>U: SMS
+
+  U->>Tw: "HOLD Boulware"
+  Tw->>Hook: POST
+  Hook->>Hold: create hold (TTL)
+  Hold-->>Tw: confirmation
+  Tw-->>U: "Held until 8pm"
+```
+
+Twilio webhook signature verified via `indc/twilio-signature.ts` (S5 e2e). Bed-hold expiration enforced by Inngest scheduler, not a Postgres trigger.
+
+---
+
+## Tech stack reference
+
+| Layer | Choice | Notes |
+|---|---|---|
+| Framework | Next.js 15 (App Router) + TypeScript strict | |
+| ORM | Drizzle | Migrations in `drizzle/migrations/` |
+| Auth | Clerk | Org/role-aware; middleware in `src/middleware.ts` |
+| Database | Postgres (Supabase → AWS RDS post-BAA) | citext, triggers, RLS later |
+| AI | Anthropic Claude (Sonnet 4.6 default) | HIPAA endpoint post-BAA |
+| SMS | Twilio | HIPAA-eligible account post-BAA |
+| Email | Resend | |
+| Background jobs | Inngest | Daily scrapers, hold expiration, digests |
+| Maps | Mapbox GL JS | |
+| Observability | Sentry + PostHog | |
+| Testing | Vitest (unit) + Playwright (e2e) | E2E DB on Docker Postgres |
+| Lint | Biome + custom boundary lint | |
+| Hosting | Railway (staging) → Vercel + AWS (prod post-BAA) | |
+
+---
+
+## Where to learn more
+
+- **`STATE.md`** — current focus + what's open today.
+- **Per-domain `src/lib/{domain}/CLAUDE.md`** — auto-loads when editing in that subdir.
+- **`docs/adr/`** — decision records for established patterns.
+- **`docs/access-control.md`** — role + partner-org policy details.
+- **`docs/schema.md`** — schema-level documentation as it accumulates.


### PR DESCRIPTION
Closes #343. Sub-task of [FND-040 epic (#338)](https://github.com/DobbsBoldry/homeless/issues/338).

## What

\`docs/architecture.md\` — the one-page mental map of this codebase. Mermaid diagrams (code-renderable, lives next to code, evolves with it).

**Reading time goal:** 10 minutes from "first time opening this repo" to "I know where things live."

## Sections

1. **System layers** — composition (routes/actions) → domain logic (\`src/lib/{domain}/\`) → data (\`src/db/\`) + external services (Clerk, Twilio, Anthropic, Resend, Inngest)
2. **Domain dependency graph** — mirrors ADR 0001's allow-list visually. The boundary lint and the docs now agree.
3. **PHI fence** — what's clean (eviction, coordination, oprt, etc.), what's behind the fence pre-BAA (cwt, esuc, dtrs), what unblocks via ESUC-002
4. **Three Phase-1 user journeys** — KLA attorney filing-to-packet, caseworker intake-to-screening, SMS bed-finder. Sequence diagrams.
5. **Tech stack reference table** — quick lookup of what's chosen for each layer

Plus links from CLAUDE.md and STATE.md so the doc is discoverable from any entry point.

## Length

221 lines including all diagrams. Slightly over my self-imposed 200-line cap, but the content is dense not padded — every section earns its space. Rather have a useful 221-line doc than a 195-line one with diagrams cut.

## Test plan

- [ ] CI green (pure docs change)
- [ ] Reviewer renders the markdown on GitHub and confirms all 4 mermaid graphs + 3 sequence diagrams render correctly
- [ ] Reviewer confirms the diagrams match their mental model — push back if any arrow is wrong
- [ ] On merge: card → done; **refresh STATE.md** to move #343 from "next pickup" → "just shipped"

## Remaining FND-040 epic

After this:
- 040b — per-domain \`index.ts\` + tighter boundary lint (3pt, **medium risk**)
- 040e — migration rename pass (1pt)

🤖 Generated with [Claude Code](https://claude.com/claude-code)