### PR TITLE
docs(INDC-270): rate-limit deployment matrix + Vercel runtime warning

### DIFF
--- a/src/lib/dtrs/rate-limit.ts
+++ b/src/lib/dtrs/rate-limit.ts
@@ -1,21 +1,64 @@
 /**
- * In-memory token-bucket rate limiter for the public consent surface.
+ * In-memory token-bucket rate limiter for the public consent surface
+ * and inbound SMS pipeline.
  *
- * The Phase-1 deployment is a single Next.js process behind Vercel /
- * Railway, so an in-process Map is sufficient. When the surface
- * scales out (multiple workers, edge caching), this module gets
- * swapped for a Redis / Upstash backend. Until then the same shape
- * means the swap is a one-line change.
+ * ## Deployment matrix (#270)
+ *
+ * | Target                   | Behavior                                  |
+ * |--------------------------|-------------------------------------------|
+ * | Local dev (single proc)  | ✓ works                                   |
+ * | Railway staging          | ✓ works, bucket lost on every redeploy    |
+ * | Vercel serverless        | ✗ BROKEN — per-invocation memory          |
+ * | Vercel + edge functions  | ✗ BROKEN                                  |
+ * | Multi-worker / horiz.    | ✗ BROKEN — buckets are per-process        |
+ *
+ * Phase 1 lives on Railway, where the bucket-loss-on-redeploy is
+ * acceptable: deploys are infrequent and the bucket is per-subject,
+ * so the worst case is "an attacker gets one extra batch of tries
+ * around the moment of deploy." Documented and accepted.
+ *
+ * **Do not promote this surface to Vercel without swapping the
+ * backend first.** The serverless-function model gives each
+ * invocation a fresh module-scope, so this Map is effectively empty
+ * on every request and the limiter degrades to no-op.
+ *
+ * ## Future Redis swap
+ *
+ * The public API (`rateLimit(key, limit, windowMs) → RateLimitResult`)
+ * is the contract; the Map is the implementation. A Redis/Upstash
+ * backend implements the same signature using Lua scripts or
+ * atomic INCR + TTL, no callsite changes:
+ *
+ *   - `RATE_LIMIT_BACKEND=memory` (default) — current code
+ *   - `RATE_LIMIT_BACKEND=upstash`           — future: Lua-script bucket
+ *
+ * The swap-trigger is whichever lands first: Vercel promotion,
+ * multi-worker scale-out, or edge caching in front of a consent
+ * surface. None of those are in flight today.
+ *
+ * ## Keying convention
  *
  * The keying is intentional: a `synthetic_person_ref` IS the auth
  * boundary in Phase 1, so the bucket is per-ref. Once token auth is
- * required (this PR), we can also key on token to make brute-force
- * exponentially harder.
+ * required, we also key on token to make brute-force exponentially
+ * harder.
  */
 
 type Bucket = { count: number; resetAt: number };
 
 const buckets = new Map<string, Bucket>();
+
+// Loud warning at module load if we're running in an environment where
+// the in-memory backend is silently broken. Better a deploy-time noise
+// than a quietly-disabled rate limit.
+if (process.env.VERCEL === '1' && process.env.NODE_ENV !== 'test') {
+  console.warn(
+    '[rate-limit] WARNING: in-memory token bucket is non-functional on ' +
+      'Vercel serverless (per-invocation memory). Rate limiting is effectively ' +
+      'disabled until the Redis/Upstash backend swap (#270 plan). Do not rely ' +
+      'on rateLimit() for security on this deployment.',
+  );
+}
 
 export type RateLimitResult = { ok: true; remaining: number } | { ok: false; retryAfterMs: number };
 
@@ -24,6 +67,9 @@ export type RateLimitResult = { ok: true; remaining: number } | { ok: false; ret
  * Returns the result and decrements the bucket atomically (single-
  * threaded JS — Node event loop guarantees the read-modify-write
  * doesn't tear).
+ *
+ * **Backend (#270):** in-memory Map. Keep the signature stable; the
+ * Redis swap when it lands replaces the body, not the contract.
  */
 export function rateLimit(key: string, limit: number, windowMs: number): RateLimitResult {
   const now = Date.now();


### PR DESCRIPTION
Closes #270.

## What

The issue says \"document and plan the swap,\" not \"implement Redis.\" Doing exactly that:

1. **Beefed-up header docstring** with explicit deployment matrix:

   | Target | Behavior |
   |---|---|
   | Local dev (single proc) | ✓ works |
   | Railway staging | ✓ works, bucket lost on every redeploy |
   | Vercel serverless | ✗ BROKEN — per-invocation memory |
   | Vercel + edge functions | ✗ BROKEN |
   | Multi-worker / horiz. | ✗ BROKEN — buckets are per-process |

   …and the swap-trigger conditions (whichever lands first: Vercel promotion, multi-worker scale-out, or edge caching in front of consent surface).

2. **Loud console.warn at module load** if \`process.env.VERCEL === '1'\` and \`NODE_ENV !== 'test'\`. So a Vercel promotion can't quietly disable rate limiting — the deploy logs will scream about it.

3. **Stable public-API contract** documented in the function docstring (\`rateLimit(key, limit, windowMs) → RateLimitResult\`). The Redis backend implements the same signature; future swap is body-only, no callsite changes.

## What's NOT in here

- Actual Redis / Upstash backend. Per the issue: \"document and plan the swap.\" The swap-trigger isn't in flight today.
- A \`RATE_LIMIT_BACKEND=memory|upstash\` env var. Mentioned in the docstring as the future shape, not implemented — adding the env-var with no implementation is dead config.

## Verified

- 3/3 unit tests still pass (\`src/lib/dtrs/rate-limit.test.ts\`)
- \`pnpm typecheck\` clean, boundaries clean

## Test plan

- [ ] CI green
- [ ] Reviewer confirms \"docs + warning\" is the right interpretation of the issue's \"document and plan\"
- [ ] On merge: card → done

🤖 Generated with [Claude Code](https://claude.com/claude-code)