### PR TITLE
feat(ESUC-247): real de-id pipeline + ADR 0002

### DIFF
--- a/docs/adr/0002-deidentification-strategy.md
+++ b/docs/adr/0002-deidentification-strategy.md
@@ -1,0 +1,69 @@
+# ADR 0002 — Clinical-note de-identification strategy
+
+**Status:** Accepted — 2026-04-27
+**Driver:** ESUC-002 BAA work + #247 (real de-id pipeline). Replaces the four-line regex stub that shipped with ESUC-011.
+
+## Context
+
+Pre-BAA, all ESUC work runs on synthetic data, so the de-id stub in `care-plan.ts` (4 regex patterns: phone, email, SSN, honorific+name) hasn't bitten anyone. Post-BAA, `ed_encounters.notes` will receive Epic FHIR-derived text that routinely carries PHI in patterns the stub misses:
+
+- Provider names without honorifics ("signed off by Smith")
+- Family-relationship + name ("daughter Mary present at bedside")
+- Address fragments ("currently living at 123 Main")
+- MRN-shaped strings (`MRN: 9876543`)
+- Specific dates that combined with a diagnosis are reidentifying
+
+Two questions to answer:
+1. **Engine** — what scrubs the text?
+2. **Application timing** — where in the pipeline does it run?
+
+We considered four engines (regex, Microsoft Presidio, AWS Comprehend Medical, Claude API scrub-only call) and three timing options (prompt-only, ingest-only, both).
+
+## Decision
+
+**Engine: regex now, AWS Comprehend Medical post-BAA.**
+
+| Pre-BAA (now) | Post-BAA |
+|---|---|
+| Pattern-based regex in `src/lib/esuc/scrub.ts`. Covers all leak vectors named in #247. Self-contained, zero deps, deterministic, free. | AWS Comprehend Medical de-identify API. HIPAA-eligible, NER-based, highest recall on contextual reidentifiers. The regex layer stays as a defense-in-depth pre-pass. |
+
+Rationale for the staged approach:
+- Pre-BAA we have no real PHI and no AWS BAA. Building an AWS integration now means paying for an AWS service we won't actually exercise on real data for months. Regex is enough for the synthetic case.
+- Post-BAA, AWS Comprehend Medical (a) is HIPAA-eligible, (b) has the highest recall on the classes the regex deliberately misses (standalone names without honorifics or context, free-form addresses, misspelled relationship words, non-US identifiers), and (c) is a one-day integration when we're ready.
+- We rejected Microsoft Presidio — strong recall, but self-hosting another service for one capability is operational drag we don't need on a solo team.
+- We rejected Claude-API-scrub-only — extra round-trip latency on every care-plan generation, and the LLM-as-scrubber pattern has known failure modes (hallucinated redactions, missed-because-context-too-long).
+
+**Timing: belt + suspenders — ingest AND prompt-build.**
+
+| Layer | Where | Purpose |
+|---|---|---|
+| Ingest | `scripts/load-ed-encounters.ts` and the future Epic FHIR webhook | Primary line of defense. `ed_encounters.notes` never contains raw PHI — the column stores already-redacted text. Issue's AC explicitly requires this. |
+| Prompt-build | `src/lib/esuc/care-plan.ts` (and any future caller) | Defense-in-depth. A regression in the ingest layer or a backdoor write through some other code path can't quietly leak PHI into a Claude prompt. |
+
+The redundancy is the point. A regex regression that misses a vector at ingest will, at most, leak into a prompt where the (still-running) prompt-time scrub catches it. A regression in both layers is a very loud alarm — eval suite fails.
+
+**Eval coverage.** `src/lib/esuc/scrub.test.ts` is the leak-vector eval. Every entry in `LEAK_VECTORS` is a realistic-but-synthetic note fragment containing a known-leaky pattern. The test asserts (a) the leak token is gone from the output and (b) the expected `[REDACTED-*]` marker is present. New leak vectors discovered in production (post-BAA) get a new entry. Build fails if any expected redaction is missed.
+
+## Consequences
+
+**What we get:**
+- Synthetic-data Phase 1 is well-defended without AWS dependency.
+- The post-BAA upgrade path is explicit and one-day-scoped — swap the engine inside `scrub.ts`, keep the public API stable, eval suite confirms no regression.
+- Belt + suspenders means a single bug doesn't leak PHI.
+
+**What we don't get:**
+- True NER recall today. The regex misses standalone-name-without-context, misspelled relationship words, free-form addresses, and non-US identifiers. These are the classes that warrant the AWS upgrade.
+- Idempotency guarantees against external write paths. If something other than `load-ed-encounters.ts` writes to `ed_encounters.notes`, it must call `scrubClinicalNote` itself. The boundary lint can't catch missed scrub calls — only `notes` writers in this domain can.
+
+**Watch for:**
+- A new `notes` writer landing without scrub. Every PR that touches `ed_encounters` insert/update should be reviewed for this.
+- Eval suite becoming a maintenance burden. If the suite > 50 entries and every PR adds three more, refactor to fixture files.
+- Post-BAA promotion. When the AWS BAA closes and Epic FHIR data flows, the `scrub.ts` engine swap is the implementation work; this ADR is what authorizes it.
+
+## Implementation reference
+
+- **Engine module:** `src/lib/esuc/scrub.ts` (regex implementation; `scrubClinicalNote(s)` is the public API)
+- **Eval suite:** `src/lib/esuc/scrub.test.ts` (15+ leak vectors)
+- **Ingest callsite:** `scripts/load-ed-encounters.ts:toRow()` (scrub before INSERT)
+- **Prompt-build callsite:** `src/lib/esuc/care-plan.ts` (defense-in-depth)
+- **AWS upgrade trigger:** ESUC BAA closure + Epic FHIR webhook (ESUC-005) reaching real data

--- a/scripts/load-ed-encounters.ts
+++ b/scripts/load-ed-encounters.ts
@@ -19,6 +19,7 @@ import {
 } from '@/ai/prompts/synthetic-ed-encounters';
 import { db } from '@/db/client';
 import { edEncounters, type NewEdEncounter } from '@/db/schema/ed-encounters';
+import { scrubClinicalNote } from '@/lib/esuc/scrub';
 
 config({ path: ['.env.local', '.env'], override: true });
 
@@ -40,7 +41,11 @@ function toRow(e: SyntheticEdEncounter): NewEdEncounter {
     disposition: e.disposition,
     housingStatus: e.housing_status,
     chargeCents: e.charge_cents,
-    notes: e.notes,
+    // Ingest-time scrub (#247 / ADR 0002). The DB column never sees
+    // raw clinical notes — names, addresses, phones, MRNs, dates are
+    // redacted before INSERT. care-plan.ts re-scrubs at prompt-build
+    // as defense-in-depth.
+    notes: scrubClinicalNote(e.notes ?? null),
     source: 'synthetic',
     rawJson: e as unknown as Record<string, unknown>,
   };
@@ -71,6 +76,7 @@ async function main() {
           disposition: row.disposition,
           chiefComplaint: row.chiefComplaint,
           chargeCents: row.chargeCents,
+          // `row.notes` is already scrubbed by toRow() — see #247.
           notes: row.notes,
           dischargedAt: row.dischargedAt,
           updatedAt: new Date(),

--- a/src/lib/esuc/care-plan.ts
+++ b/src/lib/esuc/care-plan.ts
@@ -16,6 +16,7 @@ import {
   esucCarePlans,
   type NewEsucCarePlan,
 } from '@/db/schema/esuc-care-plans';
+import { scrubClinicalNote } from './scrub';
 
 let _client: Anthropic | null = null;
 function client(): Anthropic {
@@ -56,34 +57,15 @@ export function validateCarePlanDisclaimer(
   return { ok: true };
 }
 
-/**
- * Defensive scrub of an encounter `notes` field before it enters the
- * Claude prompt. Phase 1: synthetic data, this is mostly a no-op
- * stub. **TODO(ESUC-002):** when Epic FHIR data flows post-BAA,
- * replace with a proper de-identification pipeline (Microsoft Presidio
- * or equivalent — name/address/phone/MRN/email recognition + redaction).
- *
- * Today's stub catches the most blatant patterns so a developer who
- * accidentally pastes a real name into a synthetic fixture gets
- * a "[REDACTED]" in the prompt rather than passing it through.
- */
-function scrubClinicalNote(s: string | null): string | null {
-  if (!s) return s;
-  return (
-    s
-      // Phone numbers (US-shaped)
-      .replace(/\+?1?[\s-]?\(?\d{3}\)?[\s-]?\d{3}[\s-]?\d{4}/g, '[REDACTED-PHONE]')
-      // Email-shaped
-      .replace(/[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}/g, '[REDACTED-EMAIL]')
-      // SSN-shaped
-      .replace(/\b\d{3}-\d{2}-\d{4}\b/g, '[REDACTED-SSN]')
-      // Honorifics + name
-      .replace(
-        /\b(Mr|Mrs|Ms|Dr|Mr\.|Mrs\.|Ms\.|Dr\.)\s+[A-Z][a-z]+(?:\s+[A-Z][a-z]+)?/g,
-        '[REDACTED-NAME]',
-      )
-  );
-}
+// Defense-in-depth scrub at prompt-build time. The primary scrub now
+// runs at INGEST (`scripts/load-ed-encounters.ts` and the future Epic
+// FHIR webhook), so `ed_encounters.notes` reaching this code path is
+// already redacted. Re-running the scrub here is intentional — a
+// regression in the ingest layer or a backdoor write through some
+// other path can't quietly leak PHI into a Claude prompt.
+//
+// Implementation lives in `./scrub.ts`. See ADR 0002 for the
+// regex-now-AWS-Comprehend-later strategy.
 
 function fillDisclaimer(planMd: string, generatedAt: Date): string {
   return planMd

--- a/src/lib/esuc/scrub.test.ts
+++ b/src/lib/esuc/scrub.test.ts
@@ -1,0 +1,211 @@
+import { describe, expect, it } from 'vitest';
+import { scrubClinicalNote } from './scrub';
+
+/**
+ * #247 ESUC de-id eval. Every entry is a realistic-but-synthetic clinical
+ * note fragment containing a known leak vector. The test asserts:
+ *   - The leak token (`leak`) is removed from the output
+ *   - The expected redaction marker is present
+ *
+ * If a future regression in the scrubber misses any of these, the build
+ * fails loudly. New leak vectors get a new entry — that's how this file
+ * grows over time.
+ */
+
+type LeakCase = {
+  name: string;
+  input: string;
+  /** Substring that MUST be gone from the output. */
+  leak: string;
+  /** [REDACTED-*] marker that MUST be present in the output. */
+  expectedMarker: string;
+};
+
+const LEAK_VECTORS: LeakCase[] = [
+  // 1-3. The classics from the original stub.
+  {
+    name: 'phone (parens, dash)',
+    input: 'Call back at (502) 555-1234 if pain returns.',
+    leak: '555-1234',
+    expectedMarker: '[REDACTED-PHONE]',
+  },
+  {
+    name: 'phone (continuous digits)',
+    input: 'Patient cell 5025551234.',
+    leak: '5025551234',
+    expectedMarker: '[REDACTED-PHONE]',
+  },
+  {
+    name: 'email',
+    input: 'Discharge summary sent to jane.doe@hospital.org.',
+    leak: 'jane.doe@hospital.org',
+    expectedMarker: '[REDACTED-EMAIL]',
+  },
+  {
+    name: 'ssn',
+    input: 'SSN on file: 123-45-6789.',
+    leak: '123-45-6789',
+    expectedMarker: '[REDACTED-SSN]',
+  },
+
+  // 4-5. Honorifics — covered by the old stub but tightened.
+  {
+    name: 'honorific Dr.',
+    input: 'Patient discussed history with Dr. Smith.',
+    leak: 'Smith',
+    expectedMarker: '[REDACTED-NAME]',
+  },
+  {
+    name: 'honorific without dot',
+    input: 'Mrs Jones reports improving symptoms.',
+    leak: 'Jones',
+    expectedMarker: '[REDACTED-NAME]',
+  },
+
+  // 6-8. Family-relationship + name (named in the issue).
+  {
+    name: 'family — daughter present',
+    input: 'On exam: alert, oriented x3. Daughter Mary present at bedside.',
+    leak: 'Mary',
+    expectedMarker: '[REDACTED-FAMILY-NAME]',
+  },
+  {
+    name: 'family — son with two-part name',
+    input: 'Per son Jonathan Doe, patient lives independently.',
+    leak: 'Jonathan Doe',
+    expectedMarker: '[REDACTED-FAMILY-NAME]',
+  },
+  {
+    name: 'family — wife',
+    input: 'Wife Patricia confirms the medication list.',
+    leak: 'Patricia',
+    expectedMarker: '[REDACTED-FAMILY-NAME]',
+  },
+
+  // 9-10. Honorific-less provider names (named in the issue).
+  {
+    name: 'provider — signed off by',
+    input: 'Plan signed off by Patel.',
+    leak: 'Patel',
+    expectedMarker: '[REDACTED-PROVIDER]',
+  },
+  {
+    name: 'provider — attending',
+    input: 'Attending Williams ordered CBC and BMP.',
+    leak: 'Williams',
+    expectedMarker: '[REDACTED-PROVIDER]',
+  },
+
+  // 11-12. Address fragments and full street addresses.
+  {
+    name: 'address fragment — living at',
+    input: 'Currently living at 123 Main, sleeping on couch.',
+    leak: '123 Main',
+    expectedMarker: '[REDACTED-ADDRESS]',
+  },
+  {
+    name: 'street address with suffix',
+    input: 'Discharged to 456 Frederica St.',
+    leak: '456 Frederica St',
+    expectedMarker: '[REDACTED-ADDRESS]',
+  },
+
+  // 13. MRN-shaped strings.
+  {
+    name: 'MRN explicit label',
+    input: 'MRN: 1234567 — duplicate of prior visit.',
+    leak: '1234567',
+    expectedMarker: '[REDACTED-MRN]',
+  },
+
+  // 14-15. Specific dates (ISO and US formats).
+  {
+    name: 'ISO date',
+    input: 'Last hospitalization 2024-03-15 for similar complaint.',
+    leak: '2024-03-15',
+    expectedMarker: '[REDACTED-DATE]',
+  },
+  {
+    name: 'US date',
+    input: 'Patient seen 3/15/2024 in clinic.',
+    leak: '3/15/2024',
+    expectedMarker: '[REDACTED-DATE]',
+  },
+
+  // 16. Realistic combined note — every leak vector at once.
+  {
+    name: 'combined — multi-vector reidentifying note',
+    input:
+      'Patient seen 2024-03-15 by Dr. Smith. Daughter Mary present. ' +
+      'Currently living at 789 Walnut Ave. Phone 502-555-1234, ' +
+      'email m.smith@example.com. MRN: 9876543. SSN 111-22-3333.',
+    // Just assert one token from each vector is gone.
+    leak: 'Smith',
+    expectedMarker: '[REDACTED-NAME]',
+  },
+];
+
+describe('scrubClinicalNote — leak-vector eval', () => {
+  for (const c of LEAK_VECTORS) {
+    it(`redacts: ${c.name}`, () => {
+      const out = scrubClinicalNote(c.input);
+      expect(out, `case "${c.name}" returned null`).not.toBeNull();
+      expect(out, `leak token "${c.leak}" survived in output: ${out}`).not.toContain(c.leak);
+      expect(out, `expected marker "${c.expectedMarker}" missing in output: ${out}`).toContain(
+        c.expectedMarker,
+      );
+    });
+  }
+
+  it('the combined case strips every named leak', () => {
+    // Re-run the multi-vector case against ALL the markers, not just one.
+    const c = LEAK_VECTORS[LEAK_VECTORS.length - 1];
+    const out = scrubClinicalNote(c.input)!;
+    for (const tok of [
+      'Smith',
+      'Mary',
+      '789 Walnut Ave',
+      '502-555-1234',
+      'm.smith@example.com',
+      '9876543',
+      '111-22-3333',
+      '2024-03-15',
+    ]) {
+      expect(out, `leak "${tok}" survived in combined case: ${out}`).not.toContain(tok);
+    }
+  });
+});
+
+describe('scrubClinicalNote — edge cases', () => {
+  it('returns null for null input', () => {
+    expect(scrubClinicalNote(null)).toBeNull();
+  });
+
+  it('returns empty string for empty input', () => {
+    expect(scrubClinicalNote('')).toBe('');
+  });
+
+  it('is idempotent — scrubbing already-scrubbed text is a no-op', () => {
+    const once = scrubClinicalNote('Dr. Smith and daughter Mary at 123 Main St.');
+    const twice = scrubClinicalNote(once);
+    expect(twice).toBe(once);
+  });
+
+  it('preserves clinical content that is not PII', () => {
+    const note = 'Diagnosis: COPD exacerbation. Started on prednisone 40mg PO QD x5d.';
+    expect(scrubClinicalNote(note)).toBe(note);
+  });
+
+  it('handles a long realistic note without crashing', () => {
+    const note = `
+      CHIEF COMPLAINT: Chest pain.
+      HPI: 58yo M presents with left-sided chest pain x 2 hours.
+      PMH: HTN, T2DM. PSH: appendectomy 2010.
+      MEDS: lisinopril 20mg daily, metformin 1000mg BID.
+      VITALS: BP 142/89, HR 88, RR 16, SpO2 97% RA.
+      EXAM: alert, oriented x3. Lungs CTAB. Heart RRR.
+      PLAN: ECG, troponin, CXR. Admit to obs.
+    `;
+    expect(() => scrubClinicalNote(note)).not.toThrow();
+  });
+});

--- a/src/lib/esuc/scrub.ts
+++ b/src/lib/esuc/scrub.ts
@@ -1,0 +1,217 @@
+/**
+ * Clinical-note de-identification (#247).
+ *
+ * Phase 1 strategy: pattern-based (regex) scrub. Pre-BAA we run on
+ * synthetic data only, so the goal is "every leak vector named in the
+ * issue is caught with a deterministic pattern" — not "matches AWS
+ * Comprehend Medical's recall." Per ADR 0002, the upgrade path post-BAA
+ * is AWS Comprehend Medical (HIPAA-eligible, NER-based), with this
+ * regex layer staying as a defense-in-depth pre-pass.
+ *
+ * Applied at TWO points (belt + suspenders):
+ *   1. Ingest — `scripts/load-ed-encounters.ts` and the future Epic FHIR
+ *      webhook scrub `notes` BEFORE INSERT. Raw PHI never lands in
+ *      `ed_encounters.notes`.
+ *   2. Prompt-build — `care-plan.ts` re-scrubs at build time as
+ *      defense-in-depth. A regression in either layer fails closed.
+ *
+ * The leak vectors covered (each with a corresponding test):
+ *   - Honorific + name           ("Dr. Smith")
+ *   - Honorific-less provider    ("signed off by Smith")
+ *   - Family-relationship + name ("daughter Mary")
+ *   - Phone numbers
+ *   - Email addresses
+ *   - SSNs
+ *   - Address fragments          ("living at 123 Main")
+ *   - Street addresses           ("123 Main St")
+ *   - MRN-shaped strings         (MRN: 1234567 / "Medical Record Number")
+ *   - Specific dates             (YYYY-MM-DD, MM/DD/YYYY) — combined with
+ *                                a diagnosis these are reidentifying
+ *
+ * What this DOESN'T catch (deliberate gaps; AWS Comprehend would):
+ *   - Standalone names without an honorific or context word
+ *   - Misspellings of relationship words
+ *   - Free-form addresses that don't match street-suffix patterns
+ *   - Non-US phone formats
+ *   - International ID formats
+ *   These are the classes that warrant the AWS upgrade post-BAA.
+ */
+
+// Order matters: more-specific patterns run first so they don't get
+// fragmented by broader replacements (e.g. SSN before generic digit runs).
+type Rule = { name: string; re: RegExp; replacement: string };
+
+const FAMILY_RELATIONSHIPS = [
+  'mother',
+  'father',
+  'son',
+  'daughter',
+  'sister',
+  'brother',
+  'wife',
+  'husband',
+  'spouse',
+  'partner',
+  'aunt',
+  'uncle',
+  'cousin',
+  'grandmother',
+  'grandfather',
+  'grandson',
+  'granddaughter',
+  'mom',
+  'dad',
+  'parent',
+  'child',
+  'kid',
+];
+
+const PROVIDER_CONTEXT_VERBS = [
+  'signed off by',
+  'signed by',
+  'authored by',
+  'attending',
+  'reviewed by',
+  'consulted',
+  'seen by',
+  'discussed with',
+  'per',
+];
+
+const STREET_SUFFIXES = [
+  'st',
+  'street',
+  'ave',
+  'avenue',
+  'rd',
+  'road',
+  'blvd',
+  'boulevard',
+  'dr',
+  'drive',
+  'ln',
+  'lane',
+  'ct',
+  'court',
+  'pl',
+  'place',
+  'way',
+  'pkwy',
+  'parkway',
+  'ter',
+  'terrace',
+];
+
+const RULES: Rule[] = [
+  // SSN — most specific shape; do first.
+  { name: 'ssn', re: /\b\d{3}-\d{2}-\d{4}\b/g, replacement: '[REDACTED-SSN]' },
+
+  // Email
+  {
+    name: 'email',
+    re: /[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}/g,
+    replacement: '[REDACTED-EMAIL]',
+  },
+
+  // Phone — US-shaped, before MRN's digit pattern.
+  {
+    name: 'phone',
+    re: /\+?1?[\s-]?\(?\d{3}\)?[\s-]?\d{3}[\s-]?\d{4}/g,
+    replacement: '[REDACTED-PHONE]',
+  },
+
+  // MRN — explicit "MRN: 12345" or "Medical Record Number 12345"
+  {
+    name: 'mrn',
+    re: /\b(?:MRN|medical\s+record\s+(?:number|no\.?|#))[\s:#]*\d{4,}\b/gi,
+    replacement: '[REDACTED-MRN]',
+  },
+
+  // Specific dates — ISO 8601 (2024-03-15) and US (3/15/2024 or 03/15/2024).
+  // Combined with a diagnosis these are a reidentification vector.
+  {
+    name: 'iso-date',
+    re: /\b\d{4}-\d{2}-\d{2}\b/g,
+    replacement: '[REDACTED-DATE]',
+  },
+  {
+    name: 'us-date',
+    re: /\b(0?[1-9]|1[0-2])\/(0?[1-9]|[12]\d|3[01])\/\d{2,4}\b/g,
+    replacement: '[REDACTED-DATE]',
+  },
+
+  // Street addresses — number + name + suffix from the list above.
+  {
+    name: 'street-address',
+    re: new RegExp(
+      String.raw`\b\d+\s+[A-Z][a-zA-Z]*(?:\s+[A-Z][a-zA-Z]*)?\s+(?:${STREET_SUFFIXES.join('|')})\b\.?`,
+      'gi',
+    ),
+    replacement: '[REDACTED-ADDRESS]',
+  },
+
+  // Address fragments — "(living|residing|stays|located) at <number> <word>"
+  {
+    name: 'address-fragment',
+    re: /\b(?:living|residing|stays|stayed|stay|resides|located|residence)\s+at\s+\d+[A-Za-z\s]*?(?=[.,;]|$)/gi,
+    replacement: '[REDACTED-ADDRESS]',
+  },
+
+  // Honorific + name (Dr. Smith, Mrs. Jones-Patel, Dr Smith without dot).
+  {
+    name: 'honorific-name',
+    re: /\b(?:Mr|Mrs|Ms|Mx|Dr|Prof|Rev)\.?\s+[A-Z][a-zA-Z'-]+(?:\s+[A-Z][a-zA-Z'-]+)?/g,
+    replacement: '[REDACTED-NAME]',
+  },
+
+  // Family-relationship + name ("daughter Mary", "son Jonathan Doe-Smith").
+  {
+    name: 'family-name',
+    re: new RegExp(
+      String.raw`\b(?:${FAMILY_RELATIONSHIPS.join('|')})\s+(?:[A-Z][a-zA-Z'-]+(?:\s+[A-Z][a-zA-Z'-]+)?)`,
+      'gi',
+    ),
+    replacement: '[REDACTED-FAMILY-NAME]',
+  },
+
+  // Honorific-less provider name with context verb
+  // ("signed off by Smith", "attending Patel-Williams").
+  {
+    name: 'provider-name',
+    re: new RegExp(
+      String.raw`\b(?:${PROVIDER_CONTEXT_VERBS.join('|')})\s+(?:[A-Z][a-zA-Z'-]+(?:\s+[A-Z][a-zA-Z'-]+)?)`,
+      'gi',
+    ),
+    replacement: '[REDACTED-PROVIDER]',
+  },
+];
+
+/**
+ * Scrub a clinical note in-place. Returns null for null input (preserves
+ * the column's nullability). Order is significant — more-specific patterns
+ * run first so a SSN doesn't get fragmented by a generic digit-run match.
+ *
+ * Idempotent: scrubbing already-scrubbed text is a no-op (the [REDACTED-*]
+ * tokens don't match any of the patterns).
+ */
+export function scrubClinicalNote(s: string | null): string | null {
+  if (s == null) return s;
+  let out = s;
+  for (const { re, replacement } of RULES) {
+    out = out.replace(re, replacement);
+  }
+  return out;
+}
+
+/**
+ * Test/debug helper: returns the first rule that matches `s`, or null.
+ * Used by tests to assert *which* pattern caught a leak vector, not just
+ * "something redacted it."
+ */
+export function firstMatchingRule(s: string): string | null {
+  for (const r of RULES) {
+    r.re.lastIndex = 0;
+    if (r.re.test(s)) return r.name;
+  }
+  return null;
+}


### PR DESCRIPTION
Closes #247.

## What changes

The four-line regex stub in \`care-plan.ts\` (phone / email / SSN / honorific+name) is replaced with a real de-identification module covering every leak vector named in the issue:

| Pattern | Example caught |
|---|---|
| Provider name without honorific | \`signed off by Smith\` → \`signed off by [REDACTED-PROVIDER]\` |
| Family relationship + name | \`daughter Mary present\` → \`[REDACTED-FAMILY-NAME] present\` |
| Address fragment | \`living at 123 Main\` → \`[REDACTED-ADDRESS]\` |
| Full street address | \`456 Frederica St.\` → \`[REDACTED-ADDRESS]\` |
| MRN | \`MRN: 9876543\` → \`[REDACTED-MRN]\` |
| ISO date | \`2024-03-15\` → \`[REDACTED-DATE]\` |
| US date | \`3/15/2024\` → \`[REDACTED-DATE]\` |
| (Plus the originals) | phone, email, SSN, honorific+name |

## Engine choice

**Regex now, AWS Comprehend Medical post-BAA.** Documented in [ADR 0002](docs/adr/0002-deidentification-strategy.md). Rationale:

- Pre-BAA we run on synthetic data; building the AWS integration now means paying for a service we won't exercise for months.
- Regex catches every vector the issue named.
- AWS Comprehend Medical's strength is the *contextual* recall regex deliberately can't reach (standalone names without context, free-form addresses, misspelled relationship words, non-US identifiers). That recall earns its keep when real Epic FHIR data flows.
- Engine swap is a one-day change inside \`scrub.ts\` — public API stable, eval suite confirms no regression.

## Timing

**Belt + suspenders** — the issue explicitly required ingest-time scrub, and we kept the prompt-build scrub as defense-in-depth:

| Layer | Where | Purpose |
|---|---|---|
| Ingest | \`scripts/load-ed-encounters.ts:toRow()\` (and future Epic FHIR webhook) | \`ed_encounters.notes\` never holds raw PHI |
| Prompt-build | \`src/lib/esuc/care-plan.ts\` | A regression in ingest can't quietly leak to a Claude prompt |

## Eval coverage

\`src/lib/esuc/scrub.test.ts\` — 16 named leak vectors + a combined multi-vector note + 5 edge cases (null, empty, idempotent, non-PII passthrough, long realistic note). Every leak case asserts BOTH the leak token is gone AND the expected \`[REDACTED-*]\` marker is present. Build fails if any vector regresses.

## Verified

- 23/23 new scrub tests pass on first run
- Full suite: 273/273 (was 250 + 23 new)
- \`pnpm typecheck\` clean
- \`pnpm lint:boundaries\` clean (same-domain import \`care-plan.ts → ./scrub\` is fine; scripts/ not gated)

## Test plan

- [ ] CI green
- [ ] Reviewer reads ADR 0002 and confirms the regex-now-AWS-later position is the right call (vs. committing to AWS today, or vs. punting until BAA)
- [ ] Reviewer reads \`scrub.test.ts\` LEAK_VECTORS list and pushes back if any case is unrealistic or any major vector is missing
- [ ] Reviewer confirms ingest-time scrubbing in \`load-ed-encounters.ts\` is in the right place (before INSERT, not after)
- [ ] On merge: card → done

## What's deferred

- AWS Comprehend Medical integration — gated on BAA closure, ESUC-005 Epic FHIR webhook reaching real data.
- A new \`notes\` writer landing without scrub: the boundary lint can't catch this. Reviewer discipline on any PR touching \`ed_encounters\` insert/update is the only check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)