### PR TITLE
feat(DTRS-007): faith-aggregate schema + cell-size suppression + ADR 0003

### DIFF
--- a/docs/adr/0003-faith-aggregate-privacy-contract.md
+++ b/docs/adr/0003-faith-aggregate-privacy-contract.md
@@ -1,0 +1,86 @@
+# ADR 0003 — Faith-aggregate privacy contract
+
+**Status:** Accepted — 2026-04-27
+**Driver:** DTRS-007 (#137). Phase 2 entry priority per `strategy/data.html` § 6 and `product-vision/roadmap.html` "What ships in Phase 2 — New partner integrations."
+
+## Context
+
+Phase 2 begins with faith-based opt-in. Catholic Charities Owensboro (the umbrella) and individual parish ministries (Aid the Homeless, Feeding Our Friends, etc.) will share service data with the coalition. Two non-negotiables drive the design:
+
+1. **The Diocese will not consent to a flow that names individuals.** From `strategy/partnerships.html`: "Pluralism preservation, mission accommodation, no obligation to enroll in HMIS, voluntary participation throughout. Lead with respect, not pitch." Faith partners participate via aggregate counts only — never individual records, never identifiers.
+
+2. **Small cells leak.** A Tuesday-evening parish counsel of 3 visitors, broken out by veteran status, can effectively identify a person. The standard mitigation is k-anonymity at the cell level (see the OMU-utility flow in `strategy/data.html`: "N>10 minimum cell-size for any reported value").
+
+This ADR captures the contract the schema (DTRS-007), intake form (DTRS-008), and coordination signals (DTRS-009) all hang on.
+
+## Decision
+
+### Aggregate-only at the schema level
+
+Four tables, all under `src/db/schema/`:
+
+| Table | Owns |
+|---|---|
+| `faith_ministries` | Opted-in ministries (umbrella + parishes). Per-ministry `min_cell_size` threshold (default 10). |
+| `faith_aggregate_submissions` | One row per (ministry, period). Period bounds + the coalition-side user who entered the form. |
+| `faith_aggregate_metrics` | Counts by `metric_key` (`meals_served`, `visits_total`, etc.). `value` is `NULL` when suppressed. |
+| `faith_aggregate_breakouts` | Demographic counts by `(dimension, bucket)`. Same suppression contract. |
+
+**There is no individual-record table.** No `synthetic_person_ref`, no opaque identifier. The data model itself cannot represent individual-level data — privacy by structural impossibility, not by policy alone.
+
+### Cell-size suppression — applied client-side, enforced in code
+
+`src/lib/dtrs/faith-aggregate.ts::applySuppression(raw, threshold)`: if `raw < threshold`, return `{ value: null, suppressed: true }`. The raw small-cell value is never written to the DB.
+
+Strict reading of "the raw value is never stored": the suppression function runs in the form handler (DTRS-008), which sees the raw count momentarily on the request path, then hands the suppressed cell to the query layer. Knowledge of the small cell exists in process memory for ~milliseconds, then is discarded. Server-process memory under signed MOU governance is the trust boundary; anything written to the database is the artifact.
+
+Threshold is per-ministry (`faith_ministries.min_cell_size`, default 10). Ministries with sensitive populations (e.g. a small recovery group at a parish) can set higher; nobody can set lower than 1.
+
+### DB-level CHECK constraints back the contract
+
+```sql
+CHECK ((value IS NOT NULL AND suppressed = false)
+    OR (value IS NULL AND suppressed = true))
+CHECK (value IS NULL OR value >= 0)
+```
+
+Either the value is concrete and not-suppressed, or it's NULL and suppressed. No "stored a small value but didn't mark it suppressed" loophole. Same for breakouts.
+
+### Controlled vocabulary, not free text
+
+Both metric keys and breakout dimensions/buckets are fixed at the application layer (`FAITH_METRIC_KEYS`, `FAITH_BREAKOUT_DIMENSIONS`). Adding a new metric is a deliberate change touching the lib + the form + the lookups. This:
+
+- Keeps the macro demand picture comparable across ministries (the strategy doc's main use case).
+- Prevents "free-text demographic field" privacy bombs (e.g. "single mom on disability in east end" as a bucket).
+- Forces a review when new categories enter the system.
+
+## Consequences
+
+**What we get:**
+
+- Faith partners can sign an MOU that says "the platform structurally cannot store individual records about your visitors" — and that's true, not just policy.
+- The k-anonymity threshold is a single configurable knob. If the Diocese asks for higher, change the default + push a per-ministry override.
+- Coordination signals back to ministries (DTRS-009) are bound to the same aggregate constraints — any reverse data flow inherits the contract automatically.
+
+**What we don't get:**
+
+- We can never deduplicate across ministries. If three parishes each report 12 first-time visitors, we count 36 — even if they're the same 12 people. This is the *intended* trade-off — deduplication requires identifiers we explicitly don't collect.
+- Cross-signal correlation with EVDT/ESUC/CWT is impossible at the individual level. Faith data is a separate macro layer.
+- DTRS-007's data is operational stewardship only; it does not roll into the per-person consent flow under DTRS or the post-BAA PHI surface.
+
+**What we should watch for:**
+
+1. **Pressure to add a "person token" for dedup.** This would void the contract. Hold the line.
+2. **A ministry reporting only suppressed values for a period** — that's a signal the threshold is too high for their volume. Either accept the lossiness or split their reporting cadence. Don't lower the threshold without privacy-advisor review.
+3. **Phase 3 coordination signals (DTRS-009 back-channel).** Aggregate-only there too, or the contract collapses.
+
+## Implementation checklist (DTRS-007)
+
+- [x] Drizzle schema for all four tables (`src/db/schema/faith-ministries.ts`, `faith-aggregate-submissions.ts`).
+- [x] Migration `0034_DTRS-007_faith_aggregate_schema.sql` following the FND-040e naming convention.
+- [x] Domain logic in `src/lib/dtrs/faith-aggregate.ts`: `applySuppression`, `processMetrics`, `processBreakouts`, `validatePeriod`, controlled vocabulary.
+- [x] Unit tests covering suppression, vocabulary validation, period coherence.
+- [x] Query layer in `src/db/queries/faith-aggregate.ts`: ministry CRUD plus a transactional `createFaithAggregateSubmission` that runs suppression up-front, inserts submission + metrics + breakouts, writes a `faith_aggregate.submitted` audit-log entry.
+- [x] Barrel re-export in `src/lib/dtrs/index.ts`.
+- [ ] DTRS-008 (#138) — Catholic Charities intake form — picks up where this ends.
+- [ ] DTRS-009 (#139) — per-ministry coordination signals.

--- a/drizzle/migrations/0034_DTRS-007_faith_aggregate_schema.sql
+++ b/drizzle/migrations/0034_DTRS-007_faith_aggregate_schema.sql
@@ -1,0 +1,123 @@
+-- DTRS-007 — faith-friendly aggregate-only data schema
+-- See ADR 0003 for the privacy contract.
+--
+-- Four tables:
+--   faith_ministries                 — opted-in ministries (Catholic Charities umbrella + parishes)
+--   faith_aggregate_submissions      — one row per (ministry, period)
+--   faith_aggregate_metrics          — counts per metric_key (NULL when suppressed)
+--   faith_aggregate_breakouts        — demographic breakouts (NULL when suppressed)
+--
+-- Cell-size suppression is enforced at the application layer (see
+-- src/lib/dtrs/faith-aggregate.ts); the DB just expresses the contract
+-- via CHECK constraints: value-or-suppressed is exclusive, suppressed-NULL
+-- is well-formed, and counts can never be negative.
+CREATE TYPE "public"."faith_ministry_status" AS ENUM('opted_in', 'paused', 'opted_out');--> statement-breakpoint
+CREATE TYPE "public"."faith_aggregate_period_kind" AS ENUM('week', 'month', 'quarter');--> statement-breakpoint
+
+CREATE TABLE "faith_ministries" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"partner_org_id" uuid,
+	"name" text NOT NULL,
+	"umbrella_ministry_id" uuid,
+	"contact_name" text,
+	"contact_email" text,
+	"contact_phone" text,
+	"status" "faith_ministry_status" DEFAULT 'opted_in' NOT NULL,
+	"min_cell_size" integer DEFAULT 10 NOT NULL,
+	"opted_in_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"opted_out_at" timestamp with time zone,
+	"notes" text,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+
+ALTER TABLE "faith_ministries"
+  ADD CONSTRAINT "faith_ministries_partner_org_id_fk"
+  FOREIGN KEY ("partner_org_id") REFERENCES "public"."partner_orgs"("id") ON DELETE SET NULL;
+--> statement-breakpoint
+
+ALTER TABLE "faith_ministries"
+  ADD CONSTRAINT "faith_ministries_umbrella_ministry_id_fk"
+  FOREIGN KEY ("umbrella_ministry_id") REFERENCES "public"."faith_ministries"("id") ON DELETE SET NULL;
+--> statement-breakpoint
+
+CREATE UNIQUE INDEX "faith_ministries_name_idx" ON "faith_ministries" USING btree ("name");--> statement-breakpoint
+CREATE INDEX "faith_ministries_umbrella_idx" ON "faith_ministries" USING btree ("umbrella_ministry_id");--> statement-breakpoint
+CREATE INDEX "faith_ministries_status_idx" ON "faith_ministries" USING btree ("status");--> statement-breakpoint
+
+CREATE TABLE "faith_aggregate_submissions" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"ministry_id" uuid NOT NULL,
+	"period_kind" "faith_aggregate_period_kind" NOT NULL,
+	"period_start" date NOT NULL,
+	"period_end" date NOT NULL,
+	"submitted_by_user_id" uuid,
+	"submitted_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"notes" text,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "faith_aggregate_submissions_period_order" CHECK (period_start <= period_end)
+);
+--> statement-breakpoint
+
+ALTER TABLE "faith_aggregate_submissions"
+  ADD CONSTRAINT "faith_aggregate_submissions_ministry_id_fk"
+  FOREIGN KEY ("ministry_id") REFERENCES "public"."faith_ministries"("id") ON DELETE CASCADE;
+--> statement-breakpoint
+
+ALTER TABLE "faith_aggregate_submissions"
+  ADD CONSTRAINT "faith_aggregate_submissions_user_id_fk"
+  FOREIGN KEY ("submitted_by_user_id") REFERENCES "public"."users"("id") ON DELETE SET NULL;
+--> statement-breakpoint
+
+CREATE UNIQUE INDEX "faith_aggregate_submissions_period_idx"
+  ON "faith_aggregate_submissions" USING btree ("ministry_id", "period_start", "period_end");--> statement-breakpoint
+CREATE INDEX "faith_aggregate_submissions_ministry_idx"
+  ON "faith_aggregate_submissions" USING btree ("ministry_id");--> statement-breakpoint
+CREATE INDEX "faith_aggregate_submissions_period_start_idx"
+  ON "faith_aggregate_submissions" USING btree ("period_start");--> statement-breakpoint
+
+CREATE TABLE "faith_aggregate_metrics" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"submission_id" uuid NOT NULL,
+	"metric_key" text NOT NULL,
+	"value" integer,
+	"suppressed" boolean DEFAULT false NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "faith_aggregate_metrics_value_or_suppressed"
+	  CHECK ((value IS NOT NULL AND suppressed = false) OR (value IS NULL AND suppressed = true)),
+	CONSTRAINT "faith_aggregate_metrics_value_nonneg"
+	  CHECK (value IS NULL OR value >= 0)
+);
+--> statement-breakpoint
+
+ALTER TABLE "faith_aggregate_metrics"
+  ADD CONSTRAINT "faith_aggregate_metrics_submission_id_fk"
+  FOREIGN KEY ("submission_id") REFERENCES "public"."faith_aggregate_submissions"("id") ON DELETE CASCADE;
+--> statement-breakpoint
+
+CREATE UNIQUE INDEX "faith_aggregate_metrics_key_idx"
+  ON "faith_aggregate_metrics" USING btree ("submission_id", "metric_key");--> statement-breakpoint
+
+CREATE TABLE "faith_aggregate_breakouts" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"submission_id" uuid NOT NULL,
+	"dimension" text NOT NULL,
+	"bucket" text NOT NULL,
+	"count" integer,
+	"suppressed" boolean DEFAULT false NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "faith_aggregate_breakouts_count_or_suppressed"
+	  CHECK ((count IS NOT NULL AND suppressed = false) OR (count IS NULL AND suppressed = true)),
+	CONSTRAINT "faith_aggregate_breakouts_count_nonneg"
+	  CHECK (count IS NULL OR count >= 0)
+);
+--> statement-breakpoint
+
+ALTER TABLE "faith_aggregate_breakouts"
+  ADD CONSTRAINT "faith_aggregate_breakouts_submission_id_fk"
+  FOREIGN KEY ("submission_id") REFERENCES "public"."faith_aggregate_submissions"("id") ON DELETE CASCADE;
+--> statement-breakpoint
+
+CREATE UNIQUE INDEX "faith_aggregate_breakouts_dim_idx"
+  ON "faith_aggregate_breakouts" USING btree ("submission_id", "dimension", "bucket");

--- a/drizzle/migrations/meta/_journal.json
+++ b/drizzle/migrations/meta/_journal.json
@@ -239,6 +239,13 @@
       "when": 1777325665808,
       "tag": "0033_users_email_citext",
       "breakpoints": true
+    },
+    {
+      "idx": 34,
+      "version": "7",
+      "when": 1777338159000,
+      "tag": "0034_DTRS-007_faith_aggregate_schema",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/queries/faith-aggregate.ts
+++ b/src/db/queries/faith-aggregate.ts
@@ -1,0 +1,193 @@
+import { desc, count as drizzleCount, eq } from 'drizzle-orm';
+import type { PgColumn } from 'drizzle-orm/pg-core';
+import { db } from '@/db/client';
+import {
+  type FaithAggregateSubmission,
+  type FaithMinistry,
+  faithAggregateBreakouts,
+  faithAggregateMetrics,
+  faithAggregateSubmissions,
+  faithMinistries,
+} from '@/db/schema';
+import type { FaithAggregatePeriodKind } from '@/db/schema/enums';
+import { logAuditEvent } from '@/lib/audit';
+import {
+  processBreakouts,
+  processMetrics,
+  type RawBreakoutInput,
+  type RawMetricInput,
+  validatePeriod,
+} from '@/lib/dtrs';
+
+export type FaithAggregatePeriodKindLocal = FaithAggregatePeriodKind;
+
+export interface CreateSubmissionInput {
+  ministryId: string;
+  periodKind: FaithAggregatePeriodKind;
+  periodStart: Date;
+  periodEnd: Date;
+  submittedByUserId: string | null;
+  notes?: string | null;
+  metrics: readonly RawMetricInput[];
+  breakouts: readonly RawBreakoutInput[];
+}
+
+export type SubmissionWithCounts = FaithAggregateSubmission & {
+  ministryName: string;
+  metricCount: number;
+  breakoutCount: number;
+};
+
+/**
+ * List opted-in ministries (status = 'opted_in'), most recently opted-in
+ * first. Includes paused/opted-out only when `status` is passed.
+ */
+export async function listFaithMinistries(
+  opts: { status?: 'opted_in' | 'paused' | 'opted_out' | 'any' } = {},
+): Promise<FaithMinistry[]> {
+  const status = opts.status ?? 'opted_in';
+  const where = status === 'any' ? undefined : eq(faithMinistries.status, status);
+  const q = db.select().from(faithMinistries).orderBy(desc(faithMinistries.optedInAt));
+  return where ? q.where(where) : q;
+}
+
+export async function getFaithMinistry(id: string): Promise<FaithMinistry | null> {
+  const rows = await db.select().from(faithMinistries).where(eq(faithMinistries.id, id)).limit(1);
+  return rows[0] ?? null;
+}
+
+/**
+ * Insert a submission + its metrics + its breakouts in one transaction.
+ * Suppression is applied BEFORE the rows are constructed; raw small-cell
+ * counts never reach the DB. See ADR 0003 for the privacy contract.
+ *
+ * Audit-log entry written inside the transaction so a write failure
+ * rolls back both the data and the log entry — keeps "what landed in
+ * the trust" and "what we said landed in the trust" consistent.
+ */
+export async function createFaithAggregateSubmission(
+  input: CreateSubmissionInput,
+): Promise<FaithAggregateSubmission> {
+  validatePeriod(input.periodStart, input.periodEnd);
+
+  const ministry = await getFaithMinistry(input.ministryId);
+  if (!ministry) throw new Error(`ministry not found: ${input.ministryId}`);
+  if (ministry.status !== 'opted_in') {
+    throw new Error(
+      `ministry ${ministry.name} is ${ministry.status}; cannot accept new submissions`,
+    );
+  }
+
+  // Apply suppression up-front. processMetrics/processBreakouts also
+  // validate the controlled vocabulary — if any key/dimension is bad,
+  // we throw before opening the transaction.
+  const metricRows = processMetrics(input.metrics, ministry.minCellSize);
+  const breakoutRows = processBreakouts(input.breakouts, ministry.minCellSize);
+
+  return db.transaction(async (tx) => {
+    const [submission] = await tx
+      .insert(faithAggregateSubmissions)
+      .values({
+        ministryId: input.ministryId,
+        periodKind: input.periodKind,
+        periodStart: input.periodStart.toISOString().slice(0, 10),
+        periodEnd: input.periodEnd.toISOString().slice(0, 10),
+        submittedByUserId: input.submittedByUserId,
+        notes: input.notes ?? null,
+      })
+      .returning();
+    if (!submission) throw new Error('faith_aggregate_submissions insert returned no row');
+
+    if (metricRows.length > 0) {
+      await tx.insert(faithAggregateMetrics).values(
+        metricRows.map((m) => ({
+          submissionId: submission.id,
+          metricKey: m.metricKey,
+          value: m.value,
+          suppressed: m.suppressed,
+        })),
+      );
+    }
+    if (breakoutRows.length > 0) {
+      await tx.insert(faithAggregateBreakouts).values(
+        breakoutRows.map((b) => ({
+          submissionId: submission.id,
+          dimension: b.dimension,
+          bucket: b.bucket,
+          count: b.count,
+          suppressed: b.suppressed,
+        })),
+      );
+    }
+
+    await logAuditEvent({
+      actorUserId: input.submittedByUserId,
+      action: 'faith_aggregate.submitted',
+      targetTable: 'faith_aggregate_submissions',
+      targetId: submission.id,
+      metadata: {
+        ministryId: input.ministryId,
+        ministryName: ministry.name,
+        periodKind: input.periodKind,
+        periodStart: input.periodStart.toISOString().slice(0, 10),
+        periodEnd: input.periodEnd.toISOString().slice(0, 10),
+        metricCount: metricRows.length,
+        suppressedMetricCount: metricRows.filter((m) => m.suppressed).length,
+        breakoutCount: breakoutRows.length,
+        suppressedBreakoutCount: breakoutRows.filter((b) => b.suppressed).length,
+      },
+    });
+
+    return submission;
+  });
+}
+
+/** All submissions for a ministry, most recent first. */
+export async function listSubmissionsForMinistry(
+  ministryId: string,
+  opts: { limit?: number } = {},
+): Promise<FaithAggregateSubmission[]> {
+  const { limit = 50 } = opts;
+  return db
+    .select()
+    .from(faithAggregateSubmissions)
+    .where(eq(faithAggregateSubmissions.ministryId, ministryId))
+    .orderBy(desc(faithAggregateSubmissions.periodStart))
+    .limit(limit);
+}
+
+/** Single submission + child counts, for the admin detail view. */
+export async function getSubmissionWithCounts(
+  submissionId: string,
+): Promise<SubmissionWithCounts | null> {
+  const row = await db
+    .select({
+      submission: faithAggregateSubmissions,
+      ministryName: faithMinistries.name,
+    })
+    .from(faithAggregateSubmissions)
+    .innerJoin(faithMinistries, eq(faithMinistries.id, faithAggregateSubmissions.ministryId))
+    .where(eq(faithAggregateSubmissions.id, submissionId))
+    .limit(1);
+  if (!row[0]) return null;
+
+  const [{ count: metricCount }] = await db
+    .select({ count: countExpr(faithAggregateMetrics.id) })
+    .from(faithAggregateMetrics)
+    .where(eq(faithAggregateMetrics.submissionId, submissionId));
+  const [{ count: breakoutCount }] = await db
+    .select({ count: countExpr(faithAggregateBreakouts.id) })
+    .from(faithAggregateBreakouts)
+    .where(eq(faithAggregateBreakouts.submissionId, submissionId));
+
+  return {
+    ...row[0].submission,
+    ministryName: row[0].ministryName,
+    metricCount: Number(metricCount),
+    breakoutCount: Number(breakoutCount),
+  };
+}
+
+function countExpr(col: PgColumn) {
+  return drizzleCount(col).as('count');
+}

--- a/src/db/schema/enums.ts
+++ b/src/db/schema/enums.ts
@@ -185,6 +185,22 @@ export const clientIntakeStatusEnum = pgEnum('client_intake_status', [
 
 export type ClientIntakeStatus = (typeof clientIntakeStatusEnum.enumValues)[number];
 
+export const faithMinistryStatusEnum = pgEnum('faith_ministry_status', [
+  'opted_in',
+  'paused',
+  'opted_out',
+]);
+
+export type FaithMinistryStatus = (typeof faithMinistryStatusEnum.enumValues)[number];
+
+export const faithAggregatePeriodKindEnum = pgEnum('faith_aggregate_period_kind', [
+  'week',
+  'month',
+  'quarter',
+]);
+
+export type FaithAggregatePeriodKind = (typeof faithAggregatePeriodKindEnum.enumValues)[number];
+
 export const partnerServiceEventTypeEnum = pgEnum('partner_service_event_type', [
   'food_pantry',
   'shelter_intake',

--- a/src/db/schema/faith-aggregate-submissions.ts
+++ b/src/db/schema/faith-aggregate-submissions.ts
@@ -1,0 +1,123 @@
+import { sql } from 'drizzle-orm';
+import {
+  boolean,
+  check,
+  date,
+  index,
+  integer,
+  pgTable,
+  text,
+  timestamp,
+  uniqueIndex,
+  uuid,
+} from 'drizzle-orm/pg-core';
+import { faithAggregatePeriodKindEnum } from './enums';
+import { faithMinistries } from './faith-ministries';
+import { users } from './users';
+
+/**
+ * One row per (ministry, period) aggregate submission. The submission
+ * carries no individual-level data — only counts split across the
+ * `faith_aggregate_metrics` and `faith_aggregate_breakouts` child
+ * tables. See ADR 0003 for the privacy contract.
+ *
+ * `submitted_by_user_id` is the coalition-side user who entered the
+ * intake form (DTRS-008) — never a person from the ministry. The
+ * ministry's identity-preservation principle means we never even
+ * mint a Clerk user for them.
+ */
+export const faithAggregateSubmissions = pgTable(
+  'faith_aggregate_submissions',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    ministryId: uuid('ministry_id')
+      .notNull()
+      .references(() => faithMinistries.id, { onDelete: 'cascade' }),
+    periodKind: faithAggregatePeriodKindEnum('period_kind').notNull(),
+    periodStart: date('period_start').notNull(),
+    periodEnd: date('period_end').notNull(),
+    submittedByUserId: uuid('submitted_by_user_id').references(() => users.id, {
+      onDelete: 'set null',
+    }),
+    submittedAt: timestamp('submitted_at', { withTimezone: true }).notNull().defaultNow(),
+    notes: text('notes'),
+    createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+  },
+  (t) => [
+    uniqueIndex('faith_aggregate_submissions_period_idx').on(
+      t.ministryId,
+      t.periodStart,
+      t.periodEnd,
+    ),
+    index('faith_aggregate_submissions_ministry_idx').on(t.ministryId),
+    index('faith_aggregate_submissions_period_start_idx').on(t.periodStart),
+    check('faith_aggregate_submissions_period_order', sql`period_start <= period_end`),
+  ],
+);
+
+export type FaithAggregateSubmission = typeof faithAggregateSubmissions.$inferSelect;
+export type NewFaithAggregateSubmission = typeof faithAggregateSubmissions.$inferInsert;
+
+/**
+ * One metric value per (submission, metric_key). Suppression rule: if
+ * the partner reports a value below the ministry's `min_cell_size`,
+ * the value is NULL and `suppressed = true`. The raw count is never
+ * stored — suppression is applied at the entry point (DTRS-008 form
+ * handler) before insert. Privacy contract enforced in code, not
+ * just docs.
+ */
+export const faithAggregateMetrics = pgTable(
+  'faith_aggregate_metrics',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    submissionId: uuid('submission_id')
+      .notNull()
+      .references(() => faithAggregateSubmissions.id, { onDelete: 'cascade' }),
+    metricKey: text('metric_key').notNull(),
+    value: integer('value'),
+    suppressed: boolean('suppressed').notNull().default(false),
+    createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+  },
+  (t) => [
+    uniqueIndex('faith_aggregate_metrics_key_idx').on(t.submissionId, t.metricKey),
+    check(
+      'faith_aggregate_metrics_value_or_suppressed',
+      sql`(value IS NOT NULL AND suppressed = false) OR (value IS NULL AND suppressed = true)`,
+    ),
+    check('faith_aggregate_metrics_value_nonneg', sql`value IS NULL OR value >= 0`),
+  ],
+);
+
+export type FaithAggregateMetric = typeof faithAggregateMetrics.$inferSelect;
+export type NewFaithAggregateMetric = typeof faithAggregateMetrics.$inferInsert;
+
+/**
+ * Demographic breakouts — same suppression rule as metrics. `dimension`
+ * + `bucket` are a controlled vocabulary at the application layer
+ * (see src/lib/dtrs/faith-aggregate.ts FAITH_BREAKOUT_DIMENSIONS).
+ */
+export const faithAggregateBreakouts = pgTable(
+  'faith_aggregate_breakouts',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    submissionId: uuid('submission_id')
+      .notNull()
+      .references(() => faithAggregateSubmissions.id, { onDelete: 'cascade' }),
+    dimension: text('dimension').notNull(),
+    bucket: text('bucket').notNull(),
+    count: integer('count'),
+    suppressed: boolean('suppressed').notNull().default(false),
+    createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+  },
+  (t) => [
+    uniqueIndex('faith_aggregate_breakouts_dim_idx').on(t.submissionId, t.dimension, t.bucket),
+    check(
+      'faith_aggregate_breakouts_count_or_suppressed',
+      sql`(count IS NOT NULL AND suppressed = false) OR (count IS NULL AND suppressed = true)`,
+    ),
+    check('faith_aggregate_breakouts_count_nonneg', sql`count IS NULL OR count >= 0`),
+  ],
+);
+
+export type FaithAggregateBreakout = typeof faithAggregateBreakouts.$inferSelect;
+export type NewFaithAggregateBreakout = typeof faithAggregateBreakouts.$inferInsert;

--- a/src/db/schema/faith-ministries.ts
+++ b/src/db/schema/faith-ministries.ts
@@ -1,0 +1,54 @@
+import type { AnyPgColumn } from 'drizzle-orm/pg-core';
+import { index, integer, pgTable, text, timestamp, uniqueIndex, uuid } from 'drizzle-orm/pg-core';
+import { faithMinistryStatusEnum } from './enums';
+import { partnerOrgs } from './partner-orgs';
+
+/**
+ * A faith-based ministry that has opted in to share aggregate-only data
+ * with the coalition. Per ADR 0003 (and `strategy/data.html` § 6 — Faith-
+ * based aggregate data), this is the only data flow that does NOT carry
+ * individual identifiers under any circumstance — counts only.
+ *
+ * `partner_org_id` is optional. The Catholic Charities umbrella will
+ * exist in `partner_orgs`, but many small parish ministries opt in
+ * without a formal partner-org row. `umbrella_ministry_id` lets us
+ * roll sub-ministries (Aid the Homeless, Feeding Our Friends) up to
+ * their parent.
+ *
+ * `min_cell_size` is the per-ministry k-anonymity threshold applied at
+ * submission time. Default 10 (the OMU standard from `strategy/data.html`);
+ * sensitive ministries may set higher. Counts < this are stored as NULL
+ * with `suppressed=true` in the metrics/breakouts tables.
+ */
+export const faithMinistries = pgTable(
+  'faith_ministries',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    partnerOrgId: uuid('partner_org_id').references(() => partnerOrgs.id, {
+      onDelete: 'set null',
+    }),
+    name: text('name').notNull(),
+    umbrellaMinistryId: uuid('umbrella_ministry_id').references(
+      (): AnyPgColumn => faithMinistries.id,
+      { onDelete: 'set null' },
+    ),
+    contactName: text('contact_name'),
+    contactEmail: text('contact_email'),
+    contactPhone: text('contact_phone'),
+    status: faithMinistryStatusEnum('status').notNull().default('opted_in'),
+    minCellSize: integer('min_cell_size').notNull().default(10),
+    optedInAt: timestamp('opted_in_at', { withTimezone: true }).notNull().defaultNow(),
+    optedOutAt: timestamp('opted_out_at', { withTimezone: true }),
+    notes: text('notes'),
+    createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),
+  },
+  (t) => [
+    uniqueIndex('faith_ministries_name_idx').on(t.name),
+    index('faith_ministries_umbrella_idx').on(t.umbrellaMinistryId),
+    index('faith_ministries_status_idx').on(t.status),
+  ],
+);
+
+export type FaithMinistry = typeof faithMinistries.$inferSelect;
+export type NewFaithMinistry = typeof faithMinistries.$inferInsert;

--- a/src/db/schema/index.ts
+++ b/src/db/schema/index.ts
@@ -13,6 +13,8 @@ export * from './eviction-filing-risk-scores';
 export * from './eviction-filings';
 export * from './eviction-response-packets';
 export * from './fag-members';
+export * from './faith-aggregate-submissions';
+export * from './faith-ministries';
 export * from './health-check';
 export * from './org-memberships';
 export * from './outbound-messages-test';

--- a/src/lib/dtrs/faith-aggregate.test.ts
+++ b/src/lib/dtrs/faith-aggregate.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from 'vitest';
+import {
+  applySuppression,
+  FAITH_BREAKOUT_DIMENSIONS,
+  FAITH_METRIC_KEYS,
+  processBreakouts,
+  processMetrics,
+  validatePeriod,
+} from './faith-aggregate';
+
+describe('applySuppression', () => {
+  it('suppresses values below the threshold', () => {
+    expect(applySuppression(9, 10)).toEqual({ value: null, suppressed: true });
+    expect(applySuppression(0, 10)).toEqual({ value: null, suppressed: true });
+    expect(applySuppression(1, 10)).toEqual({ value: null, suppressed: true });
+  });
+
+  it('passes values at or above the threshold', () => {
+    expect(applySuppression(10, 10)).toEqual({ value: 10, suppressed: false });
+    expect(applySuppression(99, 10)).toEqual({ value: 99, suppressed: false });
+  });
+
+  it('respects ministry-specific threshold', () => {
+    expect(applySuppression(20, 25)).toEqual({ value: null, suppressed: true });
+    expect(applySuppression(25, 25)).toEqual({ value: 25, suppressed: false });
+  });
+
+  it('rejects bad input', () => {
+    expect(() => applySuppression(-1, 10)).toThrow('non-negative');
+    expect(() => applySuppression(1.5, 10)).toThrow('non-negative integer');
+    expect(() => applySuppression(10, 0)).toThrow('positive integer');
+    expect(() => applySuppression(10, -1)).toThrow('positive integer');
+  });
+});
+
+describe('processMetrics', () => {
+  it('applies suppression and validates metric_key', () => {
+    const out = processMetrics(
+      [
+        { metricKey: 'meals_served', value: 250 },
+        { metricKey: 'first_time_visits', value: 4 },
+      ],
+      10,
+    );
+    expect(out).toEqual([
+      { metricKey: 'meals_served', value: 250, suppressed: false },
+      { metricKey: 'first_time_visits', value: null, suppressed: true },
+    ]);
+  });
+
+  it('rejects unknown metric_key', () => {
+    expect(() => processMetrics([{ metricKey: 'mystery_count', value: 100 }], 10)).toThrow(
+      'unknown metric_key: mystery_count',
+    );
+  });
+
+  it('every key in FAITH_METRIC_KEYS is acceptable', () => {
+    for (const k of FAITH_METRIC_KEYS) {
+      const out = processMetrics([{ metricKey: k, value: 100 }], 10);
+      expect(out[0]).toMatchObject({ metricKey: k, value: 100, suppressed: false });
+    }
+  });
+});
+
+describe('processBreakouts', () => {
+  it('applies suppression and validates dimension+bucket', () => {
+    const out = processBreakouts(
+      [
+        { dimension: 'age_band', bucket: '25_44', count: 60 },
+        { dimension: 'gender', bucket: 'female', count: 7 },
+      ],
+      10,
+    );
+    expect(out).toEqual([
+      { dimension: 'age_band', bucket: '25_44', count: 60, suppressed: false },
+      { dimension: 'gender', bucket: 'female', count: null, suppressed: true },
+    ]);
+  });
+
+  it('rejects unknown dimension', () => {
+    expect(() =>
+      processBreakouts([{ dimension: 'eye_color', bucket: 'blue', count: 50 }], 10),
+    ).toThrow('unknown dimension: eye_color');
+  });
+
+  it('rejects bucket not in dimension allowlist', () => {
+    expect(() =>
+      processBreakouts([{ dimension: 'gender', bucket: 'martian', count: 50 }], 10),
+    ).toThrow('unknown bucket "martian" for dimension "gender"');
+  });
+
+  it('every (dimension, bucket) combo in the controlled vocab is acceptable', () => {
+    for (const [dim, buckets] of Object.entries(FAITH_BREAKOUT_DIMENSIONS)) {
+      for (const bucket of buckets) {
+        const out = processBreakouts([{ dimension: dim, bucket, count: 50 }], 10);
+        expect(out[0]).toMatchObject({ dimension: dim, bucket, count: 50, suppressed: false });
+      }
+    }
+  });
+});
+
+describe('validatePeriod', () => {
+  it('accepts well-formed periods', () => {
+    expect(() => validatePeriod(new Date('2026-04-01'), new Date('2026-04-07'))).not.toThrow();
+    expect(() => validatePeriod(new Date('2026-04-01'), new Date('2026-04-01'))).not.toThrow(); // single-day period is fine
+  });
+
+  it('rejects start after end', () => {
+    expect(() => validatePeriod(new Date('2026-04-08'), new Date('2026-04-01'))).toThrow(
+      'must be <= period_end',
+    );
+  });
+
+  it('rejects invalid dates', () => {
+    expect(() => validatePeriod(new Date('not-a-date'), new Date('2026-04-01'))).toThrow(
+      'valid dates',
+    );
+  });
+});

--- a/src/lib/dtrs/faith-aggregate.ts
+++ b/src/lib/dtrs/faith-aggregate.ts
@@ -1,0 +1,152 @@
+/**
+ * Faith-aggregate domain logic — DTRS-007.
+ *
+ * The privacy contract (ADR 0003) is enforced here, not in the
+ * database. Two halves:
+ *
+ *   1. Controlled vocabulary. Metric keys and breakout dimensions are
+ *      a fixed set; partners can't introduce new ones via the form.
+ *      Keeps the macro demand picture comparable across ministries.
+ *
+ *   2. Cell-size suppression. Counts below the ministry's `min_cell_size`
+ *      are stripped to NULL with `suppressed: true` BEFORE insert. The
+ *      raw small-cell value never lands in the DB. Suppression is a
+ *      pure function of (rawValue, threshold) — see `applySuppression`.
+ */
+
+/** Controlled vocabulary for `faith_aggregate_metrics.metric_key`. */
+export const FAITH_METRIC_KEYS = [
+  'meals_served',
+  'visits_total',
+  'first_time_visits',
+  'households_served',
+  'households_with_children',
+  'beds_provided',
+  'utility_assistance_count',
+  'rent_assistance_count',
+  'food_pantry_visits',
+  'counseling_visits',
+] as const;
+
+export type FaithMetricKey = (typeof FAITH_METRIC_KEYS)[number];
+
+/**
+ * Controlled vocabulary for `faith_aggregate_breakouts`. Each dimension
+ * has a fixed bucket set; partners pick from these on the intake form.
+ * Adding a new bucket is a deliberate change (touches the form, the
+ * lookup, and the audit story).
+ */
+export const FAITH_BREAKOUT_DIMENSIONS = {
+  age_band: ['under_18', '18_24', '25_44', '45_64', '65_plus', 'unknown'],
+  family_status: ['single_adult', 'family_with_children', 'unaccompanied_youth', 'unknown'],
+  gender: ['male', 'female', 'nonbinary', 'declined', 'unknown'],
+  veteran_status: ['veteran', 'non_veteran', 'unknown'],
+} as const satisfies Record<string, readonly string[]>;
+
+export type FaithBreakoutDimension = keyof typeof FAITH_BREAKOUT_DIMENSIONS;
+
+/** Cell after suppression has been applied. */
+export type SuppressedCell =
+  | { value: number; suppressed: false }
+  | { value: null; suppressed: true };
+
+/**
+ * The privacy primitive. If `raw` is below `threshold` (or negative,
+ * which would be a bug), strip it to a suppressed NULL. Otherwise pass
+ * through as a non-suppressed value.
+ *
+ * Threshold semantics: a count of *exactly* `threshold` is fine — the
+ * cell represents at-least-`threshold` people. We suppress when raw <
+ * threshold, matching the OMU "N>10 minimum cell-size" framing
+ * (interpreted as "10 or more is reportable"; 9 or fewer is suppressed).
+ */
+export function applySuppression(raw: number, threshold: number): SuppressedCell {
+  if (!Number.isInteger(raw) || raw < 0) {
+    throw new Error(`raw count must be a non-negative integer, got ${raw}`);
+  }
+  if (!Number.isInteger(threshold) || threshold < 1) {
+    throw new Error(`threshold must be a positive integer, got ${threshold}`);
+  }
+  if (raw < threshold) return { value: null, suppressed: true };
+  return { value: raw, suppressed: false };
+}
+
+export type RawMetricInput = { metricKey: string; value: number };
+export type RawBreakoutInput = { dimension: string; bucket: string; count: number };
+
+export type ValidatedMetric = {
+  metricKey: FaithMetricKey;
+  value: number | null;
+  suppressed: boolean;
+};
+
+export type ValidatedBreakout = {
+  dimension: FaithBreakoutDimension;
+  bucket: string;
+  count: number | null;
+  suppressed: boolean;
+};
+
+/**
+ * Validate + suppress a batch of metrics. Throws on unknown metric_key
+ * or non-integer / negative input. Returns DB-ready rows. Never stores
+ * the raw small-cell value.
+ */
+export function processMetrics(
+  raws: readonly RawMetricInput[],
+  minCellSize: number,
+): ValidatedMetric[] {
+  return raws.map((r) => {
+    if (!FAITH_METRIC_KEYS.includes(r.metricKey as FaithMetricKey)) {
+      throw new Error(
+        `unknown metric_key: ${r.metricKey} (allowed: ${FAITH_METRIC_KEYS.join(', ')})`,
+      );
+    }
+    const cell = applySuppression(r.value, minCellSize);
+    return {
+      metricKey: r.metricKey as FaithMetricKey,
+      value: cell.value,
+      suppressed: cell.suppressed,
+    };
+  });
+}
+
+/** Same shape as processMetrics, for demographic breakouts. */
+export function processBreakouts(
+  raws: readonly RawBreakoutInput[],
+  minCellSize: number,
+): ValidatedBreakout[] {
+  return raws.map((r) => {
+    if (!(r.dimension in FAITH_BREAKOUT_DIMENSIONS)) {
+      throw new Error(
+        `unknown dimension: ${r.dimension} (allowed: ${Object.keys(FAITH_BREAKOUT_DIMENSIONS).join(', ')})`,
+      );
+    }
+    const dim = r.dimension as FaithBreakoutDimension;
+    const allowed: readonly string[] = FAITH_BREAKOUT_DIMENSIONS[dim];
+    if (!allowed.includes(r.bucket)) {
+      throw new Error(
+        `unknown bucket "${r.bucket}" for dimension "${dim}" (allowed: ${allowed.join(', ')})`,
+      );
+    }
+    const cell = applySuppression(r.count, minCellSize);
+    return { dimension: dim, bucket: r.bucket, count: cell.value, suppressed: cell.suppressed };
+  });
+}
+
+/**
+ * Validate the submission's period coherence. Period bounds must form
+ * a sensible date range; the period_kind labels which kind of bucket
+ * (week/month/quarter) — we don't enforce alignment with calendar
+ * boundaries (a parish week may run Tue-Mon).
+ */
+export function validatePeriod(periodStart: Date, periodEnd: Date): void {
+  if (Number.isNaN(periodStart.getTime()) || Number.isNaN(periodEnd.getTime())) {
+    throw new Error('period_start and period_end must be valid dates');
+  }
+  if (periodStart > periodEnd) {
+    throw new Error(
+      `period_start (${periodStart.toISOString()}) must be <= period_end (${periodEnd.toISOString()})`,
+    );
+  }
+}

--- a/src/lib/dtrs/index.ts
+++ b/src/lib/dtrs/index.ts
@@ -8,6 +8,7 @@ export * from './consent-text';
 export * from './consent-token';
 export * from './data-access';
 export * from './dv-blind';
+export * from './faith-aggregate';
 export * from './fiscal-court-brief';
 export * from './rate-limit';
 export * from './transparency-report';


### PR DESCRIPTION
## Summary

Receiving infrastructure for Phase-2 faith-based opt-in. Per `strategy/data.html` § 6, faith partners (Catholic Charities + parish ministries) participate via aggregate-only counts with **no individual identifiers** — and the data model is now incapable of representing anything else.

Closes [#137](https://github.com/DobbsBoldry/homeless/issues/137). First story of Sprint 8.

## What lands

**Four new tables:**

| Table | Owns |
|---|---|
| `faith_ministries` | Opted-in ministries (umbrella + parishes); per-ministry `min_cell_size` threshold (default 10) |
| `faith_aggregate_submissions` | One row per (ministry, period) |
| `faith_aggregate_metrics` | Counts per `metric_key` (`meals_served`, `first_time_visits`, ...) |
| `faith_aggregate_breakouts` | Demographic counts per `(dimension, bucket)` |

**Privacy contract** (full reasoning in [ADR 0003](docs/adr/0003-faith-aggregate-privacy-contract.md)):

1. **No individual-record table.** Privacy by structural impossibility, not policy alone. There's no `synthetic_person_ref` to leak through.
2. **Cell-size suppression at the entry point.** `applySuppression(raw, threshold)` returns `NULL + suppressed=true` when `raw < threshold`. Raw small-cell values never reach the DB.
3. **DB-level CHECK constraints back the contract** — `(value IS NOT NULL AND suppressed=false) OR (value IS NULL AND suppressed=true)`, plus `value >= 0`. No loophole for "stored a small value without marking it suppressed."
4. **Controlled vocabulary.** `FAITH_METRIC_KEYS` and `FAITH_BREAKOUT_DIMENSIONS` are fixed at the application layer; partners can't introduce new categories via the form.

**Domain logic + tests** in `src/lib/dtrs/faith-aggregate.ts` (+ 14 unit tests). **Transactional insert** in `src/db/queries/faith-aggregate.ts` that runs suppression up-front, inserts submission + metrics + breakouts in one tx, and writes a `faith_aggregate.submitted` audit event with suppression-count metadata (we can see how often the threshold is biting).

## Why now

Phase 2 begins per `product-vision/roadmap.html` "What ships in Phase 2 — New partner integrations." Sequencing principle #2: "Faith-based engagement begins Day 1, but data flow is Phase 2." FND-040 just closed; codebase substrate is ready. DTRS-007 is the foundation for [#138 DTRS-008](https://github.com/DobbsBoldry/homeless/issues/138) (intake form) and [#139 DTRS-009](https://github.com/DobbsBoldry/homeless/issues/139) (coordination signals).

## Migration

`drizzle/migrations/0034_DTRS-007_faith_aggregate_schema.sql` follows the FND-040e naming convention. No snapshot — matches the hand-authored pattern (0008/0032/0033). Drizzle hashes SQL content, so the file is good to apply directly.

## Test plan

- [x] `pnpm exec biome check` — clean (390 files)
- [x] `pnpm exec tsc --noEmit` — clean
- [x] `pnpm test` — 287/287 passing (was 273 + 14 new)
- [x] `pnpm lint:boundaries` — clean
- [ ] Staging: apply migration, smoke-test by inserting a synthetic ministry + submission via psql

🤖 Generated with [Claude Code](https://claude.com/claude-code)