### PR TITLE
feat(DTRS-008): Catholic Charities aggregate intake form

### DIFF
--- a/src/app/actions/faith-aggregate-parse.ts
+++ b/src/app/actions/faith-aggregate-parse.ts
@@ -1,0 +1,102 @@
+/**
+ * Pure FormData parser for the DTRS-008 faith-aggregate intake form.
+ *
+ * Kept in a separate file (no 'use server' directive) so it can be
+ * imported and unit-tested by vitest without Next.js server-action
+ * wrapping. The action file (`faith-aggregate.ts`) re-exports the types
+ * and delegates to this function.
+ */
+import type { FaithAggregatePeriodKind } from '@/db/schema/enums';
+import { FAITH_BREAKOUT_DIMENSIONS, FAITH_METRIC_KEYS } from '@/lib/dtrs';
+
+export type ParsedIntakeInput = {
+  ministryId: string;
+  periodKind: FaithAggregatePeriodKind;
+  periodStart: Date;
+  periodEnd: Date;
+  notes: string | null;
+  metrics: Array<{ metricKey: string; value: number }>;
+  breakouts: Array<{ dimension: string; bucket: string; count: number }>;
+};
+
+/**
+ * Parse + validate a FormData from the faith-aggregate intake form.
+ *
+ * FormData shape (all values are strings; empty = not reported):
+ *   ministryId     — uuid
+ *   periodKind     — 'week' | 'month' | 'quarter'
+ *   periodStart    — YYYY-MM-DD
+ *   periodEnd      — YYYY-MM-DD
+ *   notes          — optional freetext (no individual identifiers)
+ *   metric_{key}   — one per FAITH_METRIC_KEYS; empty = omit; "0" = zero
+ *   breakout_{dim}_{bucket} — per FAITH_BREAKOUT_DIMENSIONS; empty = omit
+ */
+export function parseIntakeFormData(
+  formData: FormData,
+): { ok: true; input: ParsedIntakeInput } | { ok: false; error: string } {
+  // FormData.get() returns null in browsers, undefined in Node — normalise with ?? ''.
+  const ministryId = (formData.get('ministryId') ?? '').toString().trim();
+  if (!ministryId) return { ok: false, error: 'Ministry is required.' };
+
+  const periodKindRaw = (formData.get('periodKind') ?? '').toString().trim();
+  const PERIOD_KINDS: readonly FaithAggregatePeriodKind[] = ['week', 'month', 'quarter'];
+  if (!periodKindRaw || !PERIOD_KINDS.includes(periodKindRaw as FaithAggregatePeriodKind)) {
+    return { ok: false, error: 'Period kind must be week, month, or quarter.' };
+  }
+  const periodKind = periodKindRaw as FaithAggregatePeriodKind;
+
+  const periodStartStr = (formData.get('periodStart') ?? '').toString().trim();
+  const periodEndStr = (formData.get('periodEnd') ?? '').toString().trim();
+  if (!periodStartStr || !periodEndStr) {
+    return { ok: false, error: 'Period start and end are required.' };
+  }
+  const periodStart = new Date(periodStartStr);
+  const periodEnd = new Date(periodEndStr);
+  if (Number.isNaN(periodStart.getTime()) || Number.isNaN(periodEnd.getTime())) {
+    return { ok: false, error: 'Period dates are invalid.' };
+  }
+
+  const notesRaw = (formData.get('notes') ?? '').toString().trim();
+  const notes = notesRaw.length > 0 ? notesRaw : null;
+  if (notes && notes.length > 2000) {
+    return { ok: false, error: 'Notes must be 2 000 characters or fewer.' };
+  }
+
+  // Metrics: empty field = not reported (omit); "0" = explicitly zero.
+  // Note: FormData.get() returns null in browsers but undefined in Node —
+  // normalise both to a skip.
+  const metrics: Array<{ metricKey: string; value: number }> = [];
+  for (const key of FAITH_METRIC_KEYS) {
+    const raw = formData.get(`metric_${key}`);
+    const str = raw != null ? String(raw).trim() : '';
+    if (str === '') continue;
+    const parsed = Number(str);
+    if (!Number.isInteger(parsed) || parsed < 0) {
+      return { ok: false, error: `Metric "${key}" must be a non-negative whole number.` };
+    }
+    metrics.push({ metricKey: key, value: parsed });
+  }
+
+  // Breakouts: same empty = omit semantics.
+  const breakouts: Array<{ dimension: string; bucket: string; count: number }> = [];
+  for (const [dim, buckets] of Object.entries(FAITH_BREAKOUT_DIMENSIONS)) {
+    for (const bucket of buckets) {
+      const raw = formData.get(`breakout_${dim}_${bucket}`);
+      const str = raw != null ? String(raw).trim() : '';
+      if (str === '') continue;
+      const parsed = Number(str);
+      if (!Number.isInteger(parsed) || parsed < 0) {
+        return {
+          ok: false,
+          error: `Breakout "${dim} / ${bucket}" must be a non-negative whole number.`,
+        };
+      }
+      breakouts.push({ dimension: dim, bucket, count: parsed });
+    }
+  }
+
+  return {
+    ok: true,
+    input: { ministryId, periodKind, periodStart, periodEnd, notes, metrics, breakouts },
+  };
+}

--- a/src/app/actions/faith-aggregate.test.ts
+++ b/src/app/actions/faith-aggregate.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Unit tests for the `parseIntakeFormData` helper from the DTRS-008 server action.
+ *
+ * We test the pure parsing function directly — no mocking of auth or DB
+ * required. The DB-layer and suppression logic are already covered by
+ * DTRS-007's tests. The `submitFaithAggregateAction` itself is just a thin
+ * wrapper: parse → requireRole → createFaithAggregateSubmission.
+ */
+import { describe, expect, it } from 'vitest';
+import { parseIntakeFormData } from './faith-aggregate-parse';
+
+function makeFormData(overrides: Record<string, string> = {}): FormData {
+  const fd = new FormData();
+  fd.set('ministryId', 'min-uuid-001');
+  fd.set('periodKind', 'month');
+  fd.set('periodStart', '2026-04-01');
+  fd.set('periodEnd', '2026-04-30');
+  for (const [k, v] of Object.entries(overrides)) {
+    fd.set(k, v);
+  }
+  return fd;
+}
+
+describe('parseIntakeFormData', () => {
+  it('rejects missing ministryId', () => {
+    const r = parseIntakeFormData(makeFormData({ ministryId: '' }));
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toMatch(/ministry/i);
+  });
+
+  it('rejects invalid periodKind', () => {
+    const r = parseIntakeFormData(makeFormData({ periodKind: 'biannual' }));
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toMatch(/period kind/i);
+  });
+
+  it('rejects missing periodStart', () => {
+    const r = parseIntakeFormData(makeFormData({ periodStart: '' }));
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toMatch(/period/i);
+  });
+
+  it('rejects a negative metric value', () => {
+    const r = parseIntakeFormData(makeFormData({ metric_meals_served: '-5' }));
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toMatch(/meals_served/);
+  });
+
+  it('rejects a non-integer metric value', () => {
+    const r = parseIntakeFormData(makeFormData({ metric_meals_served: '12.5' }));
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toMatch(/meals_served/);
+  });
+
+  it('omits metrics whose fields are left blank (not reported)', () => {
+    const r = parseIntakeFormData(makeFormData({ metric_meals_served: '250' }));
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.input.metrics).toEqual([{ metricKey: 'meals_served', value: 250 }]);
+  });
+
+  it('includes a metric with value 0 (explicitly zero)', () => {
+    const r = parseIntakeFormData(makeFormData({ metric_visits_total: '0' }));
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.input.metrics).toEqual([{ metricKey: 'visits_total', value: 0 }]);
+  });
+
+  it('parses breakout entries', () => {
+    const r = parseIntakeFormData(makeFormData({ breakout_age_band_under_18: '45' }));
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.input.breakouts).toEqual([{ dimension: 'age_band', bucket: 'under_18', count: 45 }]);
+  });
+
+  it('passes notes through when provided', () => {
+    const r = parseIntakeFormData(
+      makeFormData({ notes: 'April data — Lenten meal program included' }),
+    );
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.input.notes).toBe('April data — Lenten meal program included');
+  });
+
+  it('treats empty notes as null', () => {
+    const r = parseIntakeFormData(makeFormData({ notes: '   ' }));
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.input.notes).toBeNull();
+  });
+
+  it('rejects notes longer than 2000 chars', () => {
+    const r = parseIntakeFormData(makeFormData({ notes: 'a'.repeat(2001) }));
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toMatch(/2 000/);
+  });
+
+  it('passes all three period kinds through', () => {
+    for (const kind of ['week', 'month', 'quarter'] as const) {
+      const r = parseIntakeFormData(makeFormData({ periodKind: kind }));
+      expect(r.ok).toBe(true);
+      if (!r.ok) continue;
+      expect(r.input.periodKind).toBe(kind);
+    }
+  });
+
+  it('parses periodStart and periodEnd as Date objects', () => {
+    const r = parseIntakeFormData(makeFormData());
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.input.periodStart).toBeInstanceOf(Date);
+    expect(r.input.periodEnd).toBeInstanceOf(Date);
+  });
+
+  it('rejects a negative breakout count', () => {
+    const r = parseIntakeFormData(makeFormData({ breakout_gender_male: '-1' }));
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toMatch(/gender/);
+  });
+});

--- a/src/app/actions/faith-aggregate.ts
+++ b/src/app/actions/faith-aggregate.ts
@@ -1,0 +1,43 @@
+'use server';
+
+import { revalidatePath } from 'next/cache';
+import { createFaithAggregateSubmission } from '@/db/queries/faith-aggregate';
+import { requireRole } from '@/lib/auth';
+import { parseIntakeFormData } from './faith-aggregate-parse';
+
+export type { ParsedIntakeInput } from './faith-aggregate-parse';
+
+export type SubmitFaithAggregateResult =
+  | { ok: true; submissionId: string; suppressedCount: number }
+  | { ok: false; error: string };
+
+/**
+ * Admin-only server action: parse the DTRS-008 intake FormData and persist
+ * via `createFaithAggregateSubmission` (cell-size suppression + audit log
+ * happen inside that query — see ADR 0003).
+ *
+ * Parsing is delegated to `parseIntakeFormData` (faith-aggregate-parse.ts)
+ * so the input validation logic can be unit-tested without Next.js
+ * server-action wrapping.
+ */
+export async function submitFaithAggregateAction(
+  formData: FormData,
+): Promise<SubmitFaithAggregateResult> {
+  const user = await requireRole(['admin']);
+
+  const parsed = parseIntakeFormData(formData);
+  if (!parsed.ok) return { ok: false, error: parsed.error };
+
+  try {
+    const submission = await createFaithAggregateSubmission({
+      ...parsed.input,
+      submittedByUserId: user.id,
+    });
+
+    revalidatePath('/app/admin/faith-aggregate');
+    return { ok: true, submissionId: submission.id, suppressedCount: 0 };
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : 'Submission failed.';
+    return { ok: false, error: msg };
+  }
+}

--- a/src/app/actions/faith-aggregate.ts
+++ b/src/app/actions/faith-aggregate.ts
@@ -1,10 +1,25 @@
 'use server';
 
+import * as Sentry from '@sentry/nextjs';
 import { revalidatePath } from 'next/cache';
 import { createFaithAggregateSubmission, getFaithMinistry } from '@/db/queries/faith-aggregate';
 import { requireRole } from '@/lib/auth';
 import { processBreakouts, processMetrics } from '@/lib/dtrs';
 import { parseIntakeFormData } from './faith-aggregate-parse';
+
+/**
+ * Known user-actionable error message prefixes from the domain / query layer.
+ * If the thrown error starts with one of these, we surface it verbatim.
+ * Everything else gets a generic message (plus Sentry + console for ops visibility).
+ */
+const KNOWN_DOMAIN_PREFIXES = [
+  'ministry not found',
+  'ministry ', // covers "ministry <name> cannot accept new submissions"
+  'unknown metric_key',
+  'unknown dimension',
+  'unknown bucket',
+  'period_start', // validatePeriod errors
+] as const;
 
 export type { ParsedIntakeInput } from './faith-aggregate-parse';
 
@@ -46,7 +61,13 @@ export async function submitFaithAggregateAction(
     revalidatePath('/app/admin/faith-aggregate');
     return { ok: true, submissionId: submission.id, suppressedCount };
   } catch (err) {
-    const msg = err instanceof Error ? err.message : 'Submission failed.';
-    return { ok: false, error: msg };
+    Sentry.captureException(err);
+    console.error('[faith-aggregate.submit] failed', err);
+    const raw = err instanceof Error ? err.message : '';
+    const isKnown = KNOWN_DOMAIN_PREFIXES.some((prefix) =>
+      raw.toLowerCase().startsWith(prefix.toLowerCase()),
+    );
+    const error = isKnown ? raw : 'Submission failed — please retry. The error has been logged.';
+    return { ok: false, error };
   }
 }

--- a/src/app/actions/faith-aggregate.ts
+++ b/src/app/actions/faith-aggregate.ts
@@ -1,8 +1,9 @@
 'use server';
 
 import { revalidatePath } from 'next/cache';
-import { createFaithAggregateSubmission } from '@/db/queries/faith-aggregate';
+import { createFaithAggregateSubmission, getFaithMinistry } from '@/db/queries/faith-aggregate';
 import { requireRole } from '@/lib/auth';
+import { processBreakouts, processMetrics } from '@/lib/dtrs';
 import { parseIntakeFormData } from './faith-aggregate-parse';
 
 export type { ParsedIntakeInput } from './faith-aggregate-parse';
@@ -29,13 +30,21 @@ export async function submitFaithAggregateAction(
   if (!parsed.ok) return { ok: false, error: parsed.error };
 
   try {
+    const ministry = await getFaithMinistry(parsed.input.ministryId);
+    if (!ministry) return { ok: false, error: 'Ministry not found.' };
+
+    const minCellSize = ministry.minCellSize;
+    const suppressedCount =
+      processMetrics(parsed.input.metrics, minCellSize).filter((m) => m.suppressed).length +
+      processBreakouts(parsed.input.breakouts, minCellSize).filter((b) => b.suppressed).length;
+
     const submission = await createFaithAggregateSubmission({
       ...parsed.input,
       submittedByUserId: user.id,
     });
 
     revalidatePath('/app/admin/faith-aggregate');
-    return { ok: true, submissionId: submission.id, suppressedCount: 0 };
+    return { ok: true, submissionId: submission.id, suppressedCount };
   } catch (err) {
     const msg = err instanceof Error ? err.message : 'Submission failed.';
     return { ok: false, error: msg };

--- a/src/app/app/admin/faith-aggregate/page.tsx
+++ b/src/app/app/admin/faith-aggregate/page.tsx
@@ -1,0 +1,54 @@
+import { FaithAggregateIntakeForm } from '@/components/dtrs/faith-aggregate-intake-form';
+import { listFaithMinistries } from '@/db/queries/faith-aggregate';
+import { requireRole } from '@/lib/auth';
+
+export const dynamic = 'force-dynamic';
+
+export default async function FaithAggregateAdminPage() {
+  await requireRole(['admin']);
+
+  const ministries = await listFaithMinistries({ status: 'opted_in' });
+
+  if (ministries.length === 0) {
+    return (
+      <div className="mx-auto max-w-2xl space-y-4 p-4 md:p-6">
+        <header>
+          <h1 className="font-serif text-3xl font-bold text-primary">Faith aggregate intake</h1>
+          <p className="mt-1 text-sm text-muted-foreground">
+            Enter aggregate service counts on behalf of an opted-in faith ministry.
+          </p>
+        </header>
+        <div className="rounded-md border border-border bg-muted/20 p-6 text-sm">
+          <p className="font-semibold">No opted-in ministries found.</p>
+          <p className="mt-2 text-muted-foreground">
+            Before this form can be used, at least one faith ministry must be added to the database
+            with <code className="font-mono">status = &apos;opted_in&apos;</code>. Adding ministries
+            is a partnership-team task — contact the coalition data steward. Running{' '}
+            <code className="font-mono">pnpm db:seed</code> will create the Catholic Charities seed
+            row if the database has not been seeded yet.
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  const ministryOptions = ministries.map((m) => ({
+    id: m.id,
+    name: m.name,
+    minCellSize: m.minCellSize,
+  }));
+
+  return (
+    <div className="mx-auto max-w-2xl space-y-4 p-4 md:p-6">
+      <header>
+        <h1 className="font-serif text-3xl font-bold text-primary">Faith aggregate intake</h1>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Enter aggregate service counts on behalf of an opted-in faith ministry. All data is
+          aggregate-only — no individual names, identifiers, or free-text demographics. Counts below
+          the ministry&apos;s cell-size threshold are automatically suppressed before storage.
+        </p>
+      </header>
+      <FaithAggregateIntakeForm ministries={ministryOptions} />
+    </div>
+  );
+}

--- a/src/components/dtrs/faith-aggregate-intake-form.tsx
+++ b/src/components/dtrs/faith-aggregate-intake-form.tsx
@@ -21,12 +21,28 @@ type MinistryOption = {
 
 type PeriodKind = 'week' | 'month' | 'quarter';
 
+function makeEmptyMetricValues(): Record<string, string> {
+  return Object.fromEntries(FAITH_METRIC_KEYS.map((k) => [k, '']));
+}
+
+function makeEmptyBreakoutValues(): Record<string, string> {
+  const init: Record<string, string> = {};
+  for (const [dim, buckets] of Object.entries(FAITH_BREAKOUT_DIMENSIONS)) {
+    for (const bucket of buckets) {
+      init[`${dim}_${bucket}`] = '';
+    }
+  }
+  return init;
+}
+
 /**
  * Checks whether a raw string value would be suppressed at the given threshold.
  * Returns true if the value is a valid non-negative integer below the threshold.
- * Returns false if the field is empty (not reported), invalid, or passes the threshold.
+ * Returns false if the field is empty (not reported), invalid, passes the threshold,
+ * or if no threshold is provided (cannot predict suppression without ministry config).
  */
-function wouldBeSupressed(raw: string, threshold: number): boolean {
+function wouldBeSuppressed(raw: string, threshold: number | undefined): boolean {
+  if (threshold === undefined) return false;
   if (raw.trim() === '') return false;
   const n = Number(raw);
   if (!Number.isInteger(n) || n < 0) return false;
@@ -55,19 +71,10 @@ export function FaithAggregateIntakeForm({ ministries }: { ministries: MinistryO
   const [notes, setNotes] = useState('');
 
   // metric_key → raw string value entered by user
-  const [metricValues, setMetricValues] = useState<Record<string, string>>(() =>
-    Object.fromEntries(FAITH_METRIC_KEYS.map((k) => [k, ''])),
-  );
+  const [metricValues, setMetricValues] = useState<Record<string, string>>(makeEmptyMetricValues);
   // `${dim}_${bucket}` → raw string value
-  const [breakoutValues, setBreakoutValues] = useState<Record<string, string>>(() => {
-    const init: Record<string, string> = {};
-    for (const [dim, buckets] of Object.entries(FAITH_BREAKOUT_DIMENSIONS)) {
-      for (const bucket of buckets) {
-        init[`${dim}_${bucket}`] = '';
-      }
-    }
-    return init;
-  });
+  const [breakoutValues, setBreakoutValues] =
+    useState<Record<string, string>>(makeEmptyBreakoutValues);
 
   const [pending, startTransition] = useTransition();
   const [result, setResult] = useState<
@@ -77,20 +84,14 @@ export function FaithAggregateIntakeForm({ ministries }: { ministries: MinistryO
   >(null);
 
   const selectedMinistry = ministries.find((m) => m.id === selectedMinistryId);
-  const threshold = selectedMinistry?.minCellSize ?? 10;
+  const threshold = selectedMinistry?.minCellSize;
 
   const resetForm = () => {
     setPeriodStart('');
     setPeriodEnd('');
     setNotes('');
-    setMetricValues(Object.fromEntries(FAITH_METRIC_KEYS.map((k) => [k, ''])));
-    setBreakoutValues(() => {
-      const init: Record<string, string> = {};
-      for (const [dim, buckets] of Object.entries(FAITH_BREAKOUT_DIMENSIONS)) {
-        for (const bucket of buckets) init[`${dim}_${bucket}`] = '';
-      }
-      return init;
-    });
+    setMetricValues(makeEmptyMetricValues());
+    setBreakoutValues(makeEmptyBreakoutValues());
     setResult(null);
   };
 
@@ -207,7 +208,7 @@ export function FaithAggregateIntakeForm({ ministries }: { ministries: MinistryO
           {FAITH_METRIC_KEYS.map((key) => {
             const inputId = `${formId}-metric-${key}`;
             const raw = metricValues[key] ?? '';
-            const suppressed = wouldBeSupressed(raw, threshold);
+            const suppressed = wouldBeSuppressed(raw, threshold);
             return (
               <div key={key} className="space-y-1">
                 <div className="flex items-center">
@@ -257,7 +258,7 @@ export function FaithAggregateIntakeForm({ ministries }: { ministries: MinistryO
                 const fieldKey = `${dim}_${bucket}`;
                 const inputId = `${formId}-breakout-${fieldKey}`;
                 const raw = breakoutValues[fieldKey] ?? '';
-                const suppressed = wouldBeSupressed(raw, threshold);
+                const suppressed = wouldBeSuppressed(raw, threshold);
                 return (
                   <div key={bucket} className="space-y-1">
                     <div className="flex items-center">
@@ -309,7 +310,11 @@ export function FaithAggregateIntakeForm({ ministries }: { ministries: MinistryO
         />
       </div>
 
-      {result && !result.ok ? <p className="text-sm text-destructive">{result.error}</p> : null}
+      {result && !result.ok ? (
+        <p role="alert" className="text-sm text-destructive">
+          {result.error}
+        </p>
+      ) : null}
 
       <div className="flex gap-2">
         <Button type="submit" disabled={pending}>

--- a/src/components/dtrs/faith-aggregate-intake-form.tsx
+++ b/src/components/dtrs/faith-aggregate-intake-form.tsx
@@ -108,13 +108,16 @@ export function FaithAggregateIntakeForm({ ministries }: { ministries: MinistryO
   };
 
   if (result?.ok) {
+    const { suppressedCount } = result;
     return (
       <div className="rounded-md border border-emerald-500/40 bg-emerald-500/5 p-4 text-sm">
         <p className="font-semibold text-emerald-700 dark:text-emerald-400">Submission recorded.</p>
-        <p className="mt-1 text-muted-foreground">
-          Aggregate data saved. Any counts below the ministry&apos;s cell-size threshold were
-          automatically suppressed before storage.
-        </p>
+        {suppressedCount > 0 && (
+          <p className="mt-1 text-muted-foreground">
+            {suppressedCount} cell{suppressedCount === 1 ? '' : 's'} suppressed at the
+            ministry&apos;s threshold.
+          </p>
+        )}
         <Button type="button" variant="outline" className="mt-3" onClick={() => setResult(null)}>
           Enter another submission
         </Button>

--- a/src/components/dtrs/faith-aggregate-intake-form.tsx
+++ b/src/components/dtrs/faith-aggregate-intake-form.tsx
@@ -1,0 +1,318 @@
+'use client';
+
+import { useId, useState, useTransition } from 'react';
+import { submitFaithAggregateAction } from '@/app/actions/faith-aggregate';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+// Deep import: 'use client' files are exempt from the barrel rule (ADR 0001 / FND-040b).
+// The barrel re-exports server-only code that would break in the client bundle.
+import {
+  applySuppression,
+  FAITH_BREAKOUT_DIMENSIONS,
+  FAITH_METRIC_KEYS,
+} from '@/lib/dtrs/faith-aggregate';
+
+type MinistryOption = {
+  id: string;
+  name: string;
+  minCellSize: number;
+};
+
+type PeriodKind = 'week' | 'month' | 'quarter';
+
+/**
+ * Checks whether a raw string value would be suppressed at the given threshold.
+ * Returns true if the value is a valid non-negative integer below the threshold.
+ * Returns false if the field is empty (not reported), invalid, or passes the threshold.
+ */
+function wouldBeSupressed(raw: string, threshold: number): boolean {
+  if (raw.trim() === '') return false;
+  const n = Number(raw);
+  if (!Number.isInteger(n) || n < 0) return false;
+  try {
+    return applySuppression(n, threshold).suppressed;
+  } catch {
+    return false;
+  }
+}
+
+function SuppressionBadge({ suppressed }: { suppressed: boolean }) {
+  if (!suppressed) return null;
+  return (
+    <span className="ml-2 rounded bg-amber-100 px-1.5 py-0.5 text-[10px] font-medium text-amber-700 dark:bg-amber-900/40 dark:text-amber-400">
+      would be suppressed
+    </span>
+  );
+}
+
+export function FaithAggregateIntakeForm({ ministries }: { ministries: MinistryOption[] }) {
+  const formId = useId();
+  const [selectedMinistryId, setSelectedMinistryId] = useState(ministries[0]?.id ?? '');
+  const [periodKind, setPeriodKind] = useState<PeriodKind>('month');
+  const [periodStart, setPeriodStart] = useState('');
+  const [periodEnd, setPeriodEnd] = useState('');
+  const [notes, setNotes] = useState('');
+
+  // metric_key → raw string value entered by user
+  const [metricValues, setMetricValues] = useState<Record<string, string>>(() =>
+    Object.fromEntries(FAITH_METRIC_KEYS.map((k) => [k, ''])),
+  );
+  // `${dim}_${bucket}` → raw string value
+  const [breakoutValues, setBreakoutValues] = useState<Record<string, string>>(() => {
+    const init: Record<string, string> = {};
+    for (const [dim, buckets] of Object.entries(FAITH_BREAKOUT_DIMENSIONS)) {
+      for (const bucket of buckets) {
+        init[`${dim}_${bucket}`] = '';
+      }
+    }
+    return init;
+  });
+
+  const [pending, startTransition] = useTransition();
+  const [result, setResult] = useState<
+    | { ok: true; submissionId: string; suppressedCount: number }
+    | { ok: false; error: string }
+    | null
+  >(null);
+
+  const selectedMinistry = ministries.find((m) => m.id === selectedMinistryId);
+  const threshold = selectedMinistry?.minCellSize ?? 10;
+
+  const resetForm = () => {
+    setPeriodStart('');
+    setPeriodEnd('');
+    setNotes('');
+    setMetricValues(Object.fromEntries(FAITH_METRIC_KEYS.map((k) => [k, ''])));
+    setBreakoutValues(() => {
+      const init: Record<string, string> = {};
+      for (const [dim, buckets] of Object.entries(FAITH_BREAKOUT_DIMENSIONS)) {
+        for (const bucket of buckets) init[`${dim}_${bucket}`] = '';
+      }
+      return init;
+    });
+    setResult(null);
+  };
+
+  const onSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    setResult(null);
+
+    const fd = new FormData(e.currentTarget);
+
+    startTransition(async () => {
+      const r = await submitFaithAggregateAction(fd);
+      setResult(r);
+      if (r.ok) resetForm();
+    });
+  };
+
+  if (result?.ok) {
+    return (
+      <div className="rounded-md border border-emerald-500/40 bg-emerald-500/5 p-4 text-sm">
+        <p className="font-semibold text-emerald-700 dark:text-emerald-400">Submission recorded.</p>
+        <p className="mt-1 text-muted-foreground">
+          Aggregate data saved. Any counts below the ministry&apos;s cell-size threshold were
+          automatically suppressed before storage.
+        </p>
+        <Button type="button" variant="outline" className="mt-3" onClick={() => setResult(null)}>
+          Enter another submission
+        </Button>
+      </div>
+    );
+  }
+
+  return (
+    <form onSubmit={onSubmit} className="space-y-6">
+      {/* Ministry */}
+      <div className="space-y-1">
+        <Label htmlFor={`${formId}-ministry`}>Ministry</Label>
+        <select
+          id={`${formId}-ministry`}
+          name="ministryId"
+          value={selectedMinistryId}
+          onChange={(e) => setSelectedMinistryId(e.target.value)}
+          disabled={pending}
+          className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        >
+          {ministries.map((m) => (
+            <option key={m.id} value={m.id}>
+              {m.name} (min cell size: {m.minCellSize})
+            </option>
+          ))}
+        </select>
+      </div>
+
+      {/* Period kind */}
+      <fieldset className="space-y-2">
+        <legend className="text-sm font-medium">Period kind</legend>
+        <div className="flex gap-4">
+          {(['week', 'month', 'quarter'] as PeriodKind[]).map((k) => (
+            <label key={k} className="flex items-center gap-1.5 text-sm">
+              <input
+                type="radio"
+                name="periodKind"
+                value={k}
+                checked={periodKind === k}
+                onChange={() => setPeriodKind(k)}
+                disabled={pending}
+                className="h-4 w-4"
+              />
+              {k.charAt(0).toUpperCase() + k.slice(1)}
+            </label>
+          ))}
+        </div>
+      </fieldset>
+
+      {/* Period dates */}
+      <div className="grid gap-4 sm:grid-cols-2">
+        <div className="space-y-1">
+          <Label htmlFor={`${formId}-start`}>Period start</Label>
+          <Input
+            id={`${formId}-start`}
+            name="periodStart"
+            type="date"
+            value={periodStart}
+            onChange={(e) => setPeriodStart(e.target.value)}
+            required
+            disabled={pending}
+          />
+        </div>
+        <div className="space-y-1">
+          <Label htmlFor={`${formId}-end`}>Period end</Label>
+          <Input
+            id={`${formId}-end`}
+            name="periodEnd"
+            type="date"
+            value={periodEnd}
+            onChange={(e) => setPeriodEnd(e.target.value)}
+            required
+            disabled={pending}
+          />
+        </div>
+      </div>
+
+      {/* Metrics */}
+      <section className="space-y-3">
+        <h2 className="text-sm font-semibold">
+          Metrics{' '}
+          <span className="font-normal text-muted-foreground">
+            (leave blank = not reported; 0 = explicitly zero)
+          </span>
+        </h2>
+        <div className="grid gap-2 sm:grid-cols-2">
+          {FAITH_METRIC_KEYS.map((key) => {
+            const inputId = `${formId}-metric-${key}`;
+            const raw = metricValues[key] ?? '';
+            const suppressed = wouldBeSupressed(raw, threshold);
+            return (
+              <div key={key} className="space-y-1">
+                <div className="flex items-center">
+                  <Label htmlFor={inputId} className="text-xs">
+                    {key.replace(/_/g, ' ')}
+                  </Label>
+                  <SuppressionBadge suppressed={suppressed} />
+                </div>
+                <Input
+                  id={inputId}
+                  name={`metric_${key}`}
+                  type="number"
+                  min="0"
+                  step="1"
+                  value={raw}
+                  onChange={(e) => setMetricValues((prev) => ({ ...prev, [key]: e.target.value }))}
+                  disabled={pending}
+                  placeholder=""
+                  className="text-sm"
+                />
+              </div>
+            );
+          })}
+        </div>
+      </section>
+
+      {/* Breakouts */}
+      <section className="space-y-4">
+        <h2 className="text-sm font-semibold">
+          Demographic breakouts{' '}
+          <span className="font-normal text-muted-foreground">
+            (leave blank = not reported; 0 = explicitly zero)
+          </span>
+        </h2>
+        {(
+          Object.entries(FAITH_BREAKOUT_DIMENSIONS) as [
+            keyof typeof FAITH_BREAKOUT_DIMENSIONS,
+            readonly string[],
+          ][]
+        ).map(([dim, buckets]) => (
+          <div key={dim} className="space-y-2">
+            <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+              {dim.replace(/_/g, ' ')}
+            </p>
+            <div className="grid gap-2 sm:grid-cols-3">
+              {buckets.map((bucket) => {
+                const fieldKey = `${dim}_${bucket}`;
+                const inputId = `${formId}-breakout-${fieldKey}`;
+                const raw = breakoutValues[fieldKey] ?? '';
+                const suppressed = wouldBeSupressed(raw, threshold);
+                return (
+                  <div key={bucket} className="space-y-1">
+                    <div className="flex items-center">
+                      <Label htmlFor={inputId} className="text-xs">
+                        {bucket.replace(/_/g, ' ')}
+                      </Label>
+                      <SuppressionBadge suppressed={suppressed} />
+                    </div>
+                    <Input
+                      id={inputId}
+                      name={`breakout_${dim}_${bucket}`}
+                      type="number"
+                      min="0"
+                      step="1"
+                      value={raw}
+                      onChange={(e) =>
+                        setBreakoutValues((prev) => ({ ...prev, [fieldKey]: e.target.value }))
+                      }
+                      disabled={pending}
+                      placeholder=""
+                      className="text-sm"
+                    />
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+        ))}
+      </section>
+
+      {/* Notes */}
+      <div className="space-y-1">
+        <Label htmlFor={`${formId}-notes`}>
+          Notes{' '}
+          <span className="font-normal text-muted-foreground text-xs">
+            (optional — no individual names or identifiers)
+          </span>
+        </Label>
+        <textarea
+          id={`${formId}-notes`}
+          name="notes"
+          rows={3}
+          value={notes}
+          onChange={(e) => setNotes(e.target.value)}
+          disabled={pending}
+          maxLength={2000}
+          className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50"
+          placeholder="Optional context about this reporting period (no individual identifiers)"
+        />
+      </div>
+
+      {result && !result.ok ? <p className="text-sm text-destructive">{result.error}</p> : null}
+
+      <div className="flex gap-2">
+        <Button type="submit" disabled={pending}>
+          {pending ? 'Submitting…' : 'Submit aggregate data'}
+        </Button>
+      </div>
+    </form>
+  );
+}

--- a/src/db/seed.ts
+++ b/src/db/seed.ts
@@ -12,6 +12,7 @@ import { eq } from 'drizzle-orm';
 import { db } from './client';
 import { auditLog } from './schema/audit-log';
 import type { UserRole } from './schema/enums';
+import { faithMinistries } from './schema/faith-ministries';
 import { orgMemberships } from './schema/org-memberships';
 import { type NewPartnerOrg, partnerOrgs } from './schema/partner-orgs';
 import { type NewPartnerServiceEvent, partnerServiceEvents } from './schema/partner-service-events';
@@ -840,6 +841,29 @@ async function main() {
     console.log('[seed]   + 3 audit entries');
   } else {
     console.log('[seed]   = audit entries (exist)');
+  }
+
+  // ---- DTRS-008: Catholic Charities faith ministry seed ----
+  // One opted-in ministry so the faith-aggregate intake form (DTRS-008)
+  // is usable immediately in dev/e2e without a manual DB insert.
+  // min_cell_size = 10 matches the OMU standard from strategy/data.html.
+  const CATHOLIC_CHARITIES_NAME = 'Catholic Charities of the Diocese of Owensboro';
+  const [existingMinistry] = await db
+    .select({ id: faithMinistries.id })
+    .from(faithMinistries)
+    .where(eq(faithMinistries.name, CATHOLIC_CHARITIES_NAME))
+    .limit(1);
+  if (!existingMinistry) {
+    await db.insert(faithMinistries).values({
+      name: CATHOLIC_CHARITIES_NAME,
+      status: 'opted_in',
+      minCellSize: 10,
+      notes:
+        'Phase-2 pilot faith-data partner. Coordinates parish-level social services across 32 western-KY counties.',
+    });
+    console.log('[seed]   + faith ministry: Catholic Charities of the Diocese of Owensboro');
+  } else {
+    console.log('[seed]   = faith ministry: Catholic Charities (exists)');
   }
 
   console.log('[seed] done.');


### PR DESCRIPTION
## Summary

Admin-only intake form that lets a coalition-side admin enter aggregate-only data on behalf of a faith ministry and submit it via DTRS-007's `createFaithAggregateSubmission`. Closes [#138](https://github.com/DobbsBoldry/homeless/issues/138). Sprint 8, story 2 of 3.

## What lands

- **Server action** ([`src/app/actions/faith-aggregate.ts`](src/app/actions/faith-aggregate.ts)) — admin-gated, parses FormData, computes real `suppressedCount`, calls `createFaithAggregateSubmission`, revalidates the path.
- **Pure parser** ([`src/app/actions/faith-aggregate-parse.ts`](src/app/actions/faith-aggregate-parse.ts)) extracted so vitest can test it without the Next.js `'use server'` build wrapper. 14 unit tests.
- **Admin page** ([`src/app/app/admin/faith-aggregate/page.tsx`](src/app/app/admin/faith-aggregate/page.tsx)) — server component, lists opted-in ministries, renders form or empty state.
- **Client form** ([`src/components/dtrs/faith-aggregate-intake-form.tsx`](src/components/dtrs/faith-aggregate-intake-form.tsx)) — `'use client'`, ministry select, period inputs, metric grid (per `FAITH_METRIC_KEYS`), breakout grid (per `FAITH_BREAKOUT_DIMENSIONS`), live suppression preview, success/error states with screen-reader-friendly alert.
- **Seed** — Catholic Charities of the Diocese of Owensboro added to `faith_ministries` (idempotent by name).

## Privacy posture (per ADR 0003)

- Demographic-bucket inputs are **constrained to the controlled vocabulary** (no free-text fields).
- Live suppression preview shows per-cell which values would be stripped to `NULL` at the ministry's `min_cell_size` threshold — operator sees the privacy contract in action.
- Success message reports **count of suppressed cells**, never values.
- Server-action errors: known domain errors surface verbatim (user-actionable); unknown errors return a generic message with `Sentry.captureException` + `console.error` for debugging.

## Test plan

- [x] `pnpm exec biome check` — clean (395 files)
- [x] `pnpm exec tsc --noEmit` — clean
- [x] `pnpm test` — 301/301 (14 new parser tests)
- [x] `pnpm lint:boundaries` — clean (`'use client'` form deep-imports per ADR 0001 exemption; server-side files use barrel)
- [ ] Staging: walk through the form with the seeded Catholic Charities ministry, confirm a submission lands + audit-log entry written

## Followups (deferred from code review, not blocking)

- Double-pass on `processMetrics`/`processBreakouts` (server action + query layer) — small redundancy worth consolidating later
- `period_start`/`period_end` Date-vs-`YYYY-MM-DD`-string indirection — round-trips fine today, but the UTC implicit-conversion is a footgun
- `seed.ts` is 876 lines — split per-domain seeders into `src/db/seed/{domain}.ts` someday
- Action-level happy-path test (parser is well-tested; full-action coverage would be nice-to-have)

## Built with subagent-driven development

This is the first ticket built using the [subagent-driven-development](https://github.com/jasonkneen/superpowers) skill — fresh implementer subagent + spec-compliance reviewer + code-quality reviewer, two review loops. Spec reviewer caught a hardcoded `suppressedCount = 0`; quality reviewer caught a typo, error-leak, and a11y miss. Both rounds resolved before this PR opened.

🤖 Generated with [Claude Code](https://claude.com/claude-code)