### PR TITLE
docs(sprint-9): ADR 0004 + ADR 0005 — schools-entry architectural spike

### DIFF
--- a/STATE.md
+++ b/STATE.md
@@ -1,6 +1,6 @@
 # STATE.md — what's now
 
-**Last updated:** 2026-04-27 — FND-040 epic closed (refreshed at end of session — keep it that way)
+**Last updated:** 2026-04-27 — Sprint 8 closed (faith-based opt-in foundation shipped)
 
 This file is the cheap context file. Open it at the start of a session and you skip 5–10 minutes of "what was I doing." Two paragraphs, bullets, no essays. If a section gets long, summarize and link out.
 
@@ -8,12 +8,21 @@ This file is the cheap context file. Open it at the start of a session and you s
 
 ## Current focus
 
-**FND-040 epic closed** ([#338](https://github.com/DobbsBoldry/homeless/issues/338)). All five sub-stories shipped — codebase substrate is now ready for Phase 2 / ESUC-002 PHI work. Per-domain barrels (#352) plus the migration rename pass (#351) landed in this session; e2e exposed and we fixed a real architectural pitfall along the way (`export *` barrels are incompatible with `'use client'` components — the lint now exempts them).
+**Sprint 8 closed — faith-based opt-in foundation.** All three DTRS stories shipped: schema + privacy contract (#354 / [ADR 0003](docs/adr/0003-faith-aggregate-privacy-contract.md)), Catholic Charities admin intake form (#355), per-ministry coordination signals read view + queries (#356). The platform can now receive aggregate-only data from faith partners without ever modeling individual records — privacy by structural impossibility, not just policy. Phase 3 reverse-channel (signals back to ministries) explicitly deferred per the strategy doc.
 
-**Open work:** [#12 OPRT-002 MOU registry](https://github.com/DobbsBoldry/homeless/issues/12) (net-new, unsized — schema + admin-only CRUD when partnerships need it). Otherwise the queue is Phase-2 stories on the project board.
+This was the first sprint built using the [`superpowers:subagent-driven-development`](https://github.com/jasonkneen/superpowers) skill — implementer subagent + spec-compliance reviewer + code-quality reviewer per ticket. Spec reviewer caught a hardcoded `suppressedCount=0` on DTRS-008; quality reviewer caught a typo + error-leak + a11y miss on DTRS-008, and partial-coverage signaling + window-boundary exclusion on DTRS-009. All resolved before merge.
+
+**Sprint 9 candidate** (per `product-vision/roadmap.html` "What ships in Phase 2"): schools integration. [#125 PRVN-003](https://github.com/DobbsBoldry/homeless/issues/125) (McKinney-Vento liaison referral receiver, 5pt) + [#126 PRVN-004](https://github.com/DobbsBoldry/homeless/issues/126) (closed-loop reporting school↔coalition, 5pt) + [#140 DTRS-010](https://github.com/DobbsBoldry/homeless/issues/140) (FERPA-compliant school data agreement template, 5pt). 15pt total. Faith partnerships now have receiving infrastructure; schools are the next entry per the strategy doc's sequence.
+
+**Other open work:** [#12 OPRT-002 MOU registry](https://github.com/DobbsBoldry/homeless/issues/12) (net-new, unsized) — every faith ministry will eventually need an MOU; ship this when partnerships need it.
+
+**Sync items to address:** ESUC-001/002 closed as `NOT_PLANNED` on 2026-04-27 (project-board cleanup) — but the PHI fence is still real. Either reopen them or update CLAUDE.md/ADR-0002 to reflect that the BAA actually closed. Bo's call — flagged but not yet acted on.
 
 ## Just shipped (most recent first)
 
+- **#356** — DTRS-009 per-ministry coordination signals (admin read view + queries). Seven privacy-respecting reads + two pure aggregator helpers. `compareMinistryWindows` carries a `partial` flag so all-suppressed windows don't get misread as "trending down." Overlap window semantics so monthly submissions aren't dropped by trailing 28-day filters.
+- **#355** — DTRS-008 Catholic Charities aggregate intake form. Admin-gated form with live cell-size suppression preview + audit-logged submit. Catholic Charities of the Diocese of Owensboro seeded as the first opted-in ministry.
+- **#354** — DTRS-007 faith-aggregate schema + cell-size suppression + [ADR 0003](docs/adr/0003-faith-aggregate-privacy-contract.md). Four tables, no individual-record column anywhere — privacy by structural impossibility.
 - **#352** — FND-040b per-domain `index.ts` barrels + barrel-only boundary lint. 60+ consumers migrated to `@/lib/{domain}` barrel imports. `'use client'` files exempt (deep imports OK there — barrels would drag postgres into the browser bundle). [ADR 0001](docs/adr/0001-modular-monolith.md) amended.
 - **#351** — FND-040e migration rename pass. 30 auto-named migrations → `NNNN_STORYID_descr.sql`. Also dropped a stale `0034_windy_sir_ram` journal orphan that would have failed `pnpm db:migrate` on any fresh environment.
 - **#349** — ESUC-247 real de-id pipeline + [ADR 0002](docs/adr/0002-deidentification-strategy.md). Belt + suspenders (ingest + prompt-build), 16 leak-vector eval, regex-now-AWS-later strategy.
@@ -33,8 +42,11 @@ This file is the cheap context file. Open it at the start of a session and you s
 
 | # | Pts | What | Notes |
 |---|---|---|---|
-| 12 | ? | OPRT-002 MOU registry | Net-new — schema + admin-only CRUD. Pull when partnerships need it. |
-| Phase 2 | many | Open Phase-2 stories per project board | FND-040 just closed; coordinate with strategy doc on which epic ships next. |
+| [#125](https://github.com/DobbsBoldry/homeless/issues/125) PRVN-003 | 5 | McKinney-Vento liaison referral receiver | Sprint 9 candidate (schools entry per roadmap.html). |
+| [#126](https://github.com/DobbsBoldry/homeless/issues/126) PRVN-004 | 5 | Closed-loop reporting school↔coalition | Sprint 9 candidate; pairs with PRVN-003. |
+| [#140](https://github.com/DobbsBoldry/homeless/issues/140) DTRS-010 | 5 | FERPA-compliant school data agreement template + intake | Sprint 9 candidate; receiving-infra equivalent of DTRS-008 for schools. |
+| [#12](https://github.com/DobbsBoldry/homeless/issues/12) OPRT-002 | ? | MOU registry | Net-new, unsized; ship when partnerships need MOU tracking. |
+| Sprint 10+ | many | DCBS / foster aging-out (SUBP-001/002/003 + DTRS-011) | Per roadmap.html sequence after schools. |
 
 ## Known quirks (check here first)
 
@@ -47,6 +59,8 @@ This file is the cheap context file. Open it at the start of a session and you s
 - **Date params in raw Drizzle `sql` templates** — pass `.toISOString()`, not the `Date` directly. `postgres-js` v3.4 throws `TypeError: ... Received an instance of Date` otherwise. The typed query builder (`gte(col, dateValue)`) handles coercion correctly; only raw `sql` is affected. See [#346](https://github.com/DobbsBoldry/homeless/pull/346) and the docstring atop `src/db/queries/public-outcomes.ts`.
 - **Rate-limit broken on Vercel** — in-memory token bucket is no-op on serverless. Module logs a warning at load time if `VERCEL=1`. Don't promote to Vercel without the Redis swap. Deployment matrix in `src/lib/dtrs/rate-limit.ts` docstring.
 - **Barrels (`export *`) are incompatible with `'use client'`** — `src/lib/{domain}/index.ts` aggregates server-only code (postgres, AI clients, audit glue) that Next.js can't tree-shake out of the browser bundle. Build fails with `Module not found: Can't resolve 'tls' / 'perf_hooks'`. Client components must use deep imports (e.g. `from '@/lib/cwt/triage'`, not `from '@/lib/cwt'`). The boundary lint exempts files starting with `'use client'`. Unit tests + typecheck + biome all pass with the broken setup — only e2e (`pnpm e2e`) catches it. See [#352](https://github.com/DobbsBoldry/homeless/pull/352#issuecomment-4331515841) and [ADR 0001](docs/adr/0001-modular-monolith.md) Amendment 2026-04-27.
+- **Next.js `'use server'` × vitest** — modules with `'use server'` get transformed at build time so all exports become server-action stubs that can't be called synchronously from a vitest test. To unit-test FormData parsing or other action helpers, extract pure logic to a sibling file (no `'use server'`) and have the action import + call it. See [`src/app/actions/faith-aggregate-parse.ts`](src/app/actions/faith-aggregate-parse.ts) for the pattern (DTRS-008).
+- **Faith-aggregate privacy contract** ([ADR 0003](docs/adr/0003-faith-aggregate-privacy-contract.md)) — never coerce a suppressed cell to zero in any read query, never reverse-engineer a suppressed value from sums-vs-breakouts. The DB CHECK constraint guarantees `(value NULL ↔ suppressed=true)` — read paths must propagate that, not collapse it. Use `partial: true` flags or `suppressedMinistries` counts to surface partial coverage instead.
 
 ## How to refresh this file
 

--- a/docs/adr/0004-partner-agreements-registry.md
+++ b/docs/adr/0004-partner-agreements-registry.md
@@ -1,0 +1,130 @@
+# ADR 0004 — Partner-agreements registry (one table, multiple agreement kinds)
+
+**Status:** Accepted — 2026-04-28
+**Driver:** Sprint 9 pre-flight. DTRS-010 (FERPA agreement template + intake) and OPRT-002 (MOU registry) overlap structurally — both are "we have a signed agreement with this partner; here are its terms and dates." Decide once whether they share a table or each gets its own.
+
+## Context
+
+Sprint 8 shipped the faith-aggregate flow under DTRS-007/008/009. Sprint 9 starts schools, which requires a FERPA-compliant data-sharing agreement per `strategy/data.html` § 4. Separately, [#12 OPRT-002](https://github.com/DobbsBoldry/homeless/issues/12) has been open since Sprint 0 — a generic MOU registry for any partner-org.
+
+Both features answer the same question: *"What's the current legal basis for our data flow with this partner?"*
+
+- **DTRS-010** wants: FERPA agreement effective dates, signed-by names, scope (which data classes), the rendered template the district reviewed, and a way for an admin to mark it active/expired.
+- **OPRT-002** wants: MOU effective dates, signed-by names, the kitchen-cabinet commitments, withdrawal terms, and a way to track which partners have an active MOU.
+
+Other agreement kinds will follow:
+
+- **BAA** (Business Associate Agreement) for Owensboro Health post-ESUC-001/002
+- **QSOA** (Qualified Service Organization Agreement) for substance-use-treatment partners under 42 CFR Part 2
+- **DSA** (Data-Sharing Agreement) for DCBS, KY DOC (DTRS-011, -012)
+- **Parental consent** for individual-level student data (separate from FERPA's institutional agreement — see ADR 0005)
+
+If we build a separate table per kind we end up with 4–6 nearly-identical tables differing only in their kind-specific JSON payload. That fights against the "neutral steward" principle from ADR 0001 and the "one source of truth" instinct from `data.html`.
+
+## Decision
+
+**One table: `partner_agreements`.** A polymorphic registry with an `agreement_kind` enum and a JSONB `terms` column for kind-specific structured data. Each row is *the agreement* — the rendered template, the effective dates, the signed-by metadata, and the kind-specific terms.
+
+### Schema
+
+```sql
+CREATE TYPE partner_agreement_kind AS ENUM (
+  'mou',          -- generic Phase 0 MOU (OPRT-002)
+  'ferpa',        -- school-district FERPA agreement (DTRS-010)
+  'baa',          -- HIPAA Business Associate Agreement (post ESUC-001/002)
+  'qsoa',         -- 42 CFR Part 2 Qualified Service Organization Agreement
+  'dsa',          -- generic state/agency Data-Sharing Agreement (DTRS-011/012)
+  'memo_of_cooperation'  -- non-HMIS faith-partner agreement (per data.html § 6)
+);
+
+CREATE TYPE partner_agreement_status AS ENUM (
+  'draft',        -- being negotiated, no force yet
+  'active',       -- signed and in force
+  'expired',      -- past end_date and not renewed
+  'terminated',   -- ended early per withdrawal clause
+  'superseded'    -- replaced by a newer agreement (status flips when next active row covers same scope)
+);
+
+CREATE TABLE partner_agreements (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  partner_org_id uuid NOT NULL REFERENCES partner_orgs(id) ON DELETE RESTRICT,
+  kind partner_agreement_kind NOT NULL,
+  status partner_agreement_status NOT NULL DEFAULT 'draft',
+  effective_date date,
+  end_date date,                              -- nullable: open-ended
+  signed_by_partner text,                     -- name + role of partner signatory
+  signed_by_coalition_user_id uuid REFERENCES users(id) ON DELETE SET NULL,
+  template_version text,                      -- e.g. "ferpa-v1", "mou-phase0-v2"
+  template_rendered text,                     -- the actual rendered text the partner saw + signed
+  terms jsonb NOT NULL DEFAULT '{}'::jsonb,    -- kind-specific structured data
+  notes text,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  CHECK (effective_date IS NULL OR end_date IS NULL OR effective_date <= end_date)
+);
+
+CREATE INDEX partner_agreements_partner_idx ON partner_agreements(partner_org_id);
+CREATE INDEX partner_agreements_kind_status_idx ON partner_agreements(kind, status);
+CREATE INDEX partner_agreements_active_idx ON partner_agreements(status) WHERE status = 'active';
+```
+
+Why JSONB for `terms` and not per-kind tables:
+
+- The structured terms are **descriptive metadata**, not the legal instrument itself. The legal instrument is `template_rendered` (immutable text, signed). The `terms` column is for the admin UI to display "FERPA scope: attendance + address-changes + McKinney-Vento identification" in a structured way — not for query-on-shape decisions.
+- Different agreement kinds have wildly different shapes (FERPA scope vs. MOU withdrawal terms vs. BAA security controls). A polymorphic table without JSONB would mean a wide row of mostly-NULL columns or a separate side-table per kind. JSONB collapses this cleanly and is queryable when you need it (`terms->>'scope'`).
+- Application code validates the `terms` shape per kind via a discriminated union type (`PartnerAgreementTerms`). The DB stores the JSON; the lib enforces the shape. Same pattern as how we keep `audit_log.metadata` typed at the call site.
+
+### Naming
+
+`partner_agreements` (plural, snake_case) — matches the rest of the schema. The library code under `src/lib/oprt/` (operations tooling — MOU-flavored work) or `src/lib/dtrs/` (data-trust — FERPA-flavored work) decides which terms shape to validate. Each domain owns its kind:
+
+- `oprt` owns: `mou`, `memo_of_cooperation`
+- `dtrs` owns: `ferpa`, `baa`, `qsoa`, `dsa`
+
+That keeps the privacy-critical agreement kinds (FERPA, BAA, QSOA, DSA) in the dtrs domain (most security-critical per `src/lib/dtrs/CLAUDE.md`), while the lighter MOUs live in `oprt`.
+
+### Migration / API surface
+
+A single migration creates the table + enums. No data backfill needed — `partner_orgs.dataSharingTier` (existing column) remains the runtime tier flag; this new table is the *paper trail*.
+
+Public API (initial):
+
+```ts
+// src/db/queries/partner-agreements.ts
+listAgreementsForPartner(partnerOrgId: string, opts?: { status? })
+getActiveAgreementByKind(partnerOrgId: string, kind: PartnerAgreementKind)
+recordAgreement(input: NewPartnerAgreement)        // admin-only, audit-logged
+updateAgreementStatus(id, status, by_user_id)      // admin-only, audit-logged
+```
+
+Each domain (`oprt`, `dtrs`) exposes its own kind-specific helpers on top.
+
+## Consequences
+
+**What we get:**
+
+- DTRS-010 ships against this table; OPRT-002 closes opportunistically (one row per Phase-0 MOU). Both stories collapse to "build this table + a kind-specific intake form" — DTRS-010 includes the table and FERPA intake; a future small story adds the MOU intake.
+- One coherent admin surface for "what agreements exist?" — listing, filtering by kind/status, drill-down to the rendered template. Sprint 9 only ships the FERPA intake side, but the architecture supports the full set.
+- BAA / QSOA / DSA work later just adds enum values + intake forms; no schema churn.
+- The `template_rendered` column is the legal artifact — once an agreement is signed, this is what was agreed to. Mutating it later is a forensic bug; treat as append-only by convention (no triggers — this isn't audit_log).
+
+**What we don't get:**
+
+- Per-kind type safety at the DB layer. `terms` is `jsonb`; nothing in Postgres enforces "FERPA terms must contain `scope: string[]`." That's the price of the polymorphic table. We get type safety in the lib via `PartnerAgreementTerms` discriminated union.
+- The agreement is *separate from* the data flow it authorizes. A signed FERPA agreement doesn't automatically open the spigot on `school_referrals` — the application code still has to check that an active FERPA agreement exists for the receiving partner before accepting referrals. That gating logic lives in the domain.
+
+**What we should watch for:**
+
+1. **Drift between `partner_orgs.dataSharingTier` and the active-agreement view.** The tier column predates this ADR; it's a runtime flag. Going forward, the source of truth for "can data flow" should be the existence of an active agreement of the right kind. Either deprecate `dataSharingTier` or make it derived. Tracked as a follow-up — out of scope for Sprint 9.
+2. **Templates become living documents.** If we let admins edit the template *after* it's been rendered+signed, we lose the legal artifact. Convention: `template_rendered` is set once at signing and treated as immutable. Editing the template-version goes through a new agreement row, not an update.
+3. **Multiple active agreements of the same kind for the same partner.** Pathological for FERPA / BAA (only one active at a time), fine for memos (multiple project-specific ones). Don't enforce uniqueness at the DB; let the domain decide.
+
+## Implementation checklist (DTRS-010 picks this up)
+
+- [ ] Migration `0035_DTRS-010_partner_agreements.sql` (NNNN_STORYID_descr.sql per FND-040e).
+- [ ] Drizzle schema `src/db/schema/partner-agreements.ts` + enum entries in `src/db/schema/enums.ts`.
+- [ ] `src/db/queries/partner-agreements.ts` with the 4 functions above.
+- [ ] `src/lib/dtrs/partner-agreements.ts` — discriminated-union types for the `terms` JSON, `validateFerpaTerms`, audit-log integration.
+- [ ] FERPA intake form at `src/app/app/admin/agreements/ferpa/page.tsx` (admin-only). Closes [#140](https://github.com/DobbsBoldry/homeless/issues/140).
+- [ ] FERPA template page at `src/app/agreements/ferpa/template/page.tsx` (public, no auth — districts review before signing).
+- [ ] Closes [#12](https://github.com/DobbsBoldry/homeless/issues/12) opportunistically by accepting `kind = 'mou'` in the registry; a follow-up story adds the MOU intake form (out of Sprint 9).

--- a/docs/adr/0005-ferpa-student-referral-consent.md
+++ b/docs/adr/0005-ferpa-student-referral-consent.md
@@ -1,0 +1,120 @@
+# ADR 0005 — FERPA consent model for student-referral data
+
+**Status:** Accepted — 2026-04-28
+**Driver:** Sprint 9 pre-flight. PRVN-003 (McKinney-Vento liaison referral receiver, [#125](https://github.com/DobbsBoldry/homeless/issues/125)) introduces the first inbound flow carrying minor-student identifying data. FERPA, not HIPAA, is the governing regime — and the existing dtrs consent infrastructure was built for HIPAA-shaped flows. Decide upfront whether to extend or fork.
+
+## Context
+
+The existing consent surface (`consents` table, `dtrs/consent-text.ts`, `/p/[ref]/consent/grant` flow) was designed for the post-BAA HIPAA flow:
+
+- Adult patient grants consent for cross-coalition data sharing
+- One consent record per (subject, type, partner-scope)
+- Versioned text via `CURRENT_CONSENT_VERSION`
+- Token-bearer access via `consent_access_tokens`
+
+FERPA's regime for student records is different:
+
+| | HIPAA (current dtrs surface) | FERPA (new for PRVN-003) |
+|---|---|---|
+| Who consents | The data subject themselves | Parent/guardian (under 18) or eligible student (18+) |
+| Default disclosure rule | Forbidden without authorization | Forbidden without consent **except** for "directory information" (name, address, attendance dates) which can be disclosed unless parents opt out |
+| Special exceptions | Treatment, payment, operations | Studies exception (school can share for research aligned with educational interests); School Officials exception; Health/safety emergency |
+| McKinney-Vento twist | n/a | Liaisons may share *minimum-necessary* information with service providers without parental consent when the disclosure is to "facilitate access to housing or related services" — explicitly authorized by the McKinney-Vento Homeless Assistance Act |
+| Data minor | n/a | Yes — separate child-protection considerations |
+| Audit-log expectation | Per-access auditing for PHI | Annual disclosure log accessible to parents on request (FERPA § 99.32) |
+
+The McKinney-Vento authorization is the load-bearing piece for Sprint 9: it means a school liaison can refer a homeless student's family to coalition services *without parental consent*, as long as the referral is for housing-related services. That's a narrow exception, not a general one.
+
+## Decision
+
+**Fork the consent surface, don't extend.** Build a separate `school_referral_consents` (and a separate consent-text version line) rather than reusing the existing `consents` table. The two regimes have enough divergence — different consenters, different default rules, different exception frameworks, different audit-log obligations — that conflating them would force every read query to disambiguate "is this a HIPAA consent or a FERPA consent?" in code.
+
+### What "fork" looks like
+
+**Three new tables:**
+
+```sql
+-- The legal-basis row: every school referral records WHY it was authorized to flow
+CREATE TYPE school_referral_basis AS ENUM (
+  'mckinney_vento_authorization',  -- the liaison invoked the M-V act exception
+  'parental_consent',              -- parent/guardian explicitly consented to share
+  'eligible_student_consent',      -- student 18+ consented
+  'directory_info_only',           -- disclosure limited to FERPA directory info
+  'health_safety_emergency'        -- FERPA § 99.31(a)(10) — narrow, time-bound
+);
+
+CREATE TABLE school_referrals (...);  -- the actual referral data — see PRVN-003
+
+CREATE TABLE school_referral_consents (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  referral_id uuid NOT NULL REFERENCES school_referrals(id) ON DELETE CASCADE,
+  basis school_referral_basis NOT NULL,
+  consenter_relationship text,                -- 'parent', 'guardian', 'self' (eligible student)
+  consenter_name text,                        -- redacted in non-admin views
+  consent_text_version text NOT NULL,         -- e.g. 'ferpa-parental-v1'
+  signed_at timestamptz,                      -- null when basis is m-v authorization (no consent collected)
+  signed_method text,                         -- 'in_person', 'web_form', 'phone'
+  scope jsonb NOT NULL DEFAULT '{}'::jsonb,    -- which data classes, which partners, which time window
+  expires_at timestamptz,
+  revoked_at timestamptz,
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+
+-- Annual disclosure log — FERPA § 99.32 requires this for non-directory-info
+-- disclosures. One row per access; surfaced to the parent on request.
+CREATE TABLE school_referral_disclosures (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  referral_id uuid NOT NULL REFERENCES school_referrals(id) ON DELETE CASCADE,
+  accessed_by_user_id uuid REFERENCES users(id),
+  accessed_by_partner_org_id uuid REFERENCES partner_orgs(id),
+  purpose text NOT NULL,                      -- structured purpose string
+  basis school_referral_basis NOT NULL,       -- which authorization permitted this access
+  accessed_at timestamptz NOT NULL DEFAULT now(),
+  data_classes_disclosed jsonb NOT NULL DEFAULT '[]'::jsonb
+);
+```
+
+**Consent text:** new versioned strings under `src/lib/dtrs/ferpa-consent-text.ts`. Sibling to `consent-text.ts`. Each version corresponds to one regulatory shape (parental consent, eligible-student consent). The McKinney-Vento authorization basis carries no consent text — it's a statutory authorization, not a consent record.
+
+**Domain logic** in `src/lib/dtrs/school-referral-policy.ts` (new, FERPA-specific):
+
+- `canAccessSchoolReferral(viewer, referral) → { allow: boolean, basis, requireDisclosureLog }` — the policy gate. Always logs to `school_referral_disclosures` when `allow=true` and the referral isn't directory-info-only.
+- `validateMcKinneyVentoBasis(referral)` — sanity check that the referral payload is consistent with M-V authorization (e.g. student must be flagged homeless; service routing must be housing-related).
+
+### What we do NOT change
+
+- The existing `consents` table, `dtrs/consent.ts`, `dtrs/consent-text.ts`, `consent-form.tsx`, and `/p/[ref]/consent/grant` surface — all stay as-is. They remain the HIPAA-shaped consent path for adult coalition clients.
+- The `audit_log` table — both regimes use it. FERPA disclosures additionally land in `school_referral_disclosures` (FERPA-specific obligation; audit_log is the cross-system record).
+- ADR 0001 boundaries — schools work lives in `dtrs` (privacy-critical) with `prvn` consuming. No new domain.
+
+## Consequences
+
+**What we get:**
+
+- Each regime gets its own data model, audit obligation, and consent vocabulary. Reading a referral's authorization story is one table lookup, not a discriminated union scan.
+- McKinney-Vento authorization is a first-class basis — not shoved into a "type=other" bucket. The narrowness of the exception is structurally honored.
+- FERPA's annual disclosure log is built in from day one, not bolted on later when a parent requests their child's record.
+- Future privacy-distinct regimes (DCBS foster-care confidentiality under KY KRS Chapter 620, KY DOC reentry data under 42 CFR Part 2) follow the same fork pattern — each gets its own consent table.
+
+**What we don't get:**
+
+- A single "show me everyone who has consent for X" query. We accept this — FERPA and HIPAA consents aren't comparable; aggregating them produces a wrong-shaped answer.
+- Code-reuse of the consent-form component. The `<ConsentForm>` in `src/components/consent/` is HIPAA-shaped. Sprint 9's school-referral form will be its own component (`<SchoolReferralForm>`) — same shadcn primitives, different vocabulary and validation. ~80% of the React is duplicated. Acceptable cost; over-abstracting consent UX has bitten teams before.
+
+**What we should watch for:**
+
+1. **Mistaking M-V authorization for general consent.** If a service provider downstream of the coalition wants to forward a school referral to *another* provider, M-V authorization doesn't automatically extend. The disclosure-log row should make this visible — every onward access requires its own basis check.
+2. **Directory-info disclosures still get logged.** FERPA technically allows directory info without parental consent and without a disclosure-log row, *but* parents can opt out of directory disclosure entirely. Safer pattern: log every access regardless of basis; suppress the row from the parent-facing report only if the basis is `directory_info_only` and no opt-out is on file.
+3. **18th-birthday eligibility flip.** A student under 18 has parents as the consent-holder; on their 18th birthday they become "eligible students" and consent transfers to them. SUBP-001 (foster aging-out countdown engine) already deals with this concept — we should align the date-flip logic when SUBP-001 ships.
+
+## Implementation checklist (PRVN-003 picks this up)
+
+- [ ] Migration `0036_PRVN-003_school_referrals.sql` — three tables + enum.
+- [ ] Drizzle schema in `src/db/schema/school-referrals.ts` + corresponding consent/disclosure schema files.
+- [ ] `src/lib/dtrs/ferpa-consent-text.ts` — versioned consent text strings.
+- [ ] `src/lib/dtrs/school-referral-policy.ts` — `canAccessSchoolReferral`, `validateMcKinneyVentoBasis`, disclosure-log writers.
+- [ ] `src/db/queries/school-referrals.ts` — CRUD with the policy gate.
+- [ ] Liaison-facing referral form — admin-style page under `/app/app/partner/school-referral/intake/page.tsx` (or similar; auth via partner-org membership).
+- [ ] At least one happy-path test exercising M-V authorization basis end-to-end.
+
+COOR-014 (closed-loop confirmation) and PRVN-004 (aggregate reporting) read from these tables but don't extend the consent surface — they inherit the policy gate.


### PR DESCRIPTION
## Summary

Two pre-flight ADRs for Sprint 9 (schools entry). Land ahead of code so review catches architectural mistakes before they're encoded in migrations.

### ADR 0004 — Partner-agreements registry

DTRS-010 ([#140](https://github.com/DobbsBoldry/homeless/issues/140)) and OPRT-002 ([#12](https://github.com/DobbsBoldry/homeless/issues/12)) are structurally the same shape (a signed agreement with a partner). One polymorphic `partner_agreements` table with `agreement_kind` enum (`mou | ferpa | baa | qsoa | dsa | memo_of_cooperation`) + JSONB `terms` for kind-specific data. DTRS-010 lands the table + the FERPA intake side; future BAA/QSOA/DSA work just adds enum values.

OPRT-002 closes opportunistically — the registry accepts `kind='mou'` from day one; a follow-up small story adds the MOU intake form.

### ADR 0005 — FERPA consent model

PRVN-003 ([#125](https://github.com/DobbsBoldry/homeless/issues/125)) introduces the first inbound flow carrying minor-student data. FERPA, not HIPAA, governs — and the existing dtrs consents table was built HIPAA-shaped. Decision: **fork**, don't extend.

Three new tables (`school_referrals`, `school_referral_consents`, `school_referral_disclosures`) plus a McKinney-Vento authorization basis as a first-class consent kind (statutory authorization, no consent record collected). FERPA § 99.32 annual disclosure log built in from day one. Existing `/p/[ref]/consent/grant` HIPAA path unchanged.

## Why land separately from the implementation PRs

Two reasons:

1. **Reviewability.** The architectural calls are dense; reviewing them in the same PR as 600+ lines of migration + queries makes both worse.
2. **Risk surface.** Either ADR could be wrong. Catching that here costs minutes; catching it after PRVN-003 has shipped costs days.

## Test plan

- [x] Markdown renders cleanly on GitHub
- [x] Cross-links resolve (ADR-0001/0002/0003, the Sprint 9 issues)
- [ ] No objection from anyone before DTRS-010 starts implementation against ADR 0004

## Closes

Nothing on its own — the implementation tickets are still open. ADRs 0004 and 0005 are added to `docs/adr/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)