### PR TITLE
feat(DTRS-011): DCBS data-sharing agreement workflow + ADR 0006

### DIFF
--- a/docs/adr/0006-dcbs-data-sharing-privacy-contract.md
+++ b/docs/adr/0006-dcbs-data-sharing-privacy-contract.md
@@ -1,0 +1,75 @@
+# ADR 0006 — DCBS data-sharing privacy contract (individual-record under guardian authority)
+
+**Status:** Accepted — 2026-04-28
+**Driver:** Sprint 10. DTRS-011 ([#141](https://github.com/DobbsBoldry/homeless/issues/141)) introduces the first inbound flow that carries individually identifying records about minors *with state custody as the legal basis* — different from FERPA (parental consent → first-initial only, ADR 0005), and different from faith-aggregate (identification-impossible by structure, ADR 0003). The DCBS DSA must be specified before SUBP-001 (foster aging-out countdown) ingests any youth records.
+
+## Context
+
+Sprint 9 closed the schools entry: PRVN-003 (school-referral receiver) operates under a FERPA-fork consent model where parental consent is *not* sought for the McKinney-Vento exception, so the receiver only persists `student_first_initial` plus partner-side identifiers — never DOB, never last name. That worked because federal McKinney-Vento authority narrowly authorizes minimum-necessary disclosure to housing-service providers without parental consent.
+
+Sprint 10 starts the DCBS / foster-aging-out pathway. The use case demands more:
+
+- **SUBP-001** computes "days until 18th birthday" per youth and fires alerts at 90/60/30/14/7-day milestones. *Day-precision DOB is required.*
+- **SUBP-002** pre-fills the TEAMKY Former Foster Youth Medicaid extension application — full legal name, DCBS case number, eligibility detail.
+- **Caseworker coordination** with the assigned DCBS worker happens at individual-youth granularity ("how is Aaron doing on housing? has Devyn filed Medicaid yet?").
+
+These are individual-record flows. The platform has not done that for minors before.
+
+The legal regime is materially different from FERPA:
+
+| | FERPA (ADR 0005) | DCBS DSA (this ADR) |
+|---|---|---|
+| Consenter | Parent or eligible student (18+) | The state, as legal guardian under KRS 620.140 |
+| Default rule | Forbidden without consent | Authorized to share with service providers acting on the agency's behalf |
+| Identifiable data | Forbidden under directory rule unless McKinney-Vento exception narrowly applies | Authorized when the DSA is in force and `individual_records_authorized=true` |
+| Retention | Per FERPA studies-exception (§ 99.31(a)(6)): destroy when no longer needed | Per Cabinet data-handling standards; configurable: on_termination / 3yr / 5yr |
+| Audit obligation | District-side § 99.32 disclosure log; coalition-side audit log | Coalition-side audit log + cooperation with DCBS audits |
+
+The structural difference: in foster care, *the state is the legal guardian.* When DCBS executes a DSA authorizing the coalition to receive identifying records on behalf of youth in custody, that is not a workaround — it is the agency exercising its custodial authority on the youth's behalf, in the same way a parent does for a minor not in foster care. The privacy contract has to be designed around that fact, not against it.
+
+## Decision
+
+**Use the existing `partner_agreements` registry (ADR 0004) with `kind='dsa'` and a structured `agency='dcbs'` discriminator on the JSONB terms shape.** Persist individual youth records (DOB, legal name, DCBS case number) under the gate of an active DCBS DSA whose `individual_records_authorized` flag is `true`. Treat the DSA as the runtime feature flag for individual-record ingest in SUBP-001/002.
+
+### Privacy contract — five rules
+
+1. **No individual youth record may be persisted without an active DCBS DSA.** SUBP-001's ingest path reads `getActiveAgreementByKind(dcbsPartnerOrgId, 'dsa')` before every write batch and fails closed if no active agreement exists. Same gate applies on every read for reporting.
+
+2. **`individual_records_authorized` is the on/off switch.** Even with an active DSA, if the flag is `false`, the coalition treats the agreement as informational/aggregate-only and does *not* persist DOB or other PII. (Sprint 10 forms default to `true`; the field exists for future restricted DSAs.)
+
+3. **Never re-disclose to non-DSA partners.** The `dtrs/data-access.ts` policy gate must block reads of foster-youth records by viewers whose role is not in `{admin, dcbs_caseworker, coalition_caseworker}`. Cross-partner reads (e.g. a faith ministry asking about a specific youth) are denied at policy regardless of the requesting partner's separate agreements.
+
+4. **Audit every read.** Per § 4.3 of the template: every individual-record read is audit-logged via `logAuditEvent`. The audit table is the source of truth for the cooperation obligation in § 6.3 of the template (DCBS may request a trail).
+
+5. **Population focus is locked at the schema layer.** `population_focus` is currently constrained to `'foster_aging_out'` only (other values throw in the validator). Expanding to additional DCBS populations — youth with active dependency cases, kinship placements, etc. — requires (a) a written amendment to the DSA, and (b) an explicit code change to widen the validator. Schema-level lock prevents accidental scope creep.
+
+### What does NOT change
+
+- ADR 0003 (faith-aggregate privacy contract) is unchanged. Faith partners remain aggregate-only with structural impossibility of identification. DCBS is a different relationship; identifiability is permitted because the legal basis is different.
+- ADR 0005 (FERPA fork) is unchanged. Schools remain on the McKinney-Vento exception with `student_first_initial` only. DCBS is a separate regime, separate registry kind, separate scope vocabulary.
+
+### Why this design and not alternatives
+
+**Alternative A — separate `dcbs_youth_records` table outside the partner-agreements registry.** Rejected: re-litigates ADR 0004's "one agreement registry" decision and creates a parallel agreement-tracking surface. The agreement is the agreement; only the *data flowing under it* differs.
+
+**Alternative B — store full PII in DCBS DSA terms JSONB, retrieve at runtime.** Rejected: terms is for the agreement's *structured commitments*, not for case data. Case data goes in a separate domain table (foster_youth, owned by `subp` domain) gated by the DSA.
+
+**Alternative C — fork a third privacy regime for DCBS like ADR 0005 did for FERPA.** Considered. The FERPA fork was structurally necessary because the consent surface (one consent record per subject) doesn't model FERPA's "parent consents on behalf of minor" + McKinney-Vento exception layering. DCBS doesn't need a fork: there is no consent surface here, just a state-guardian DSA. The agreement registry already accommodates this.
+
+## Consequences
+
+- SUBP-001's first migration adds `foster_youth` table in the `subp` domain. Reads/writes gate on `getActiveAgreementByKind(..., 'dsa')`. Synthetic-only fixtures during pilot (PHI fence in CLAUDE.md still applies; switch to real data is a later-sprint decision when DCBS BAA + technical integration are both ready).
+- The audit log is now load-bearing for compliance with the template's § 6.3 cooperation clause. Don't disable audit-logging on individual-record reads, even temporarily for tests.
+- Future DSAs (KY DOC under DTRS-012, others) will reuse the `kind='dsa'` shape with their own `agency` value. The validator dispatcher already routes on `agency`; adding KY DOC means adding a `validateKyDocDsaTerms` function and an `agency: 'ky_doc'` arm to the `DsaTerms` union.
+- If the DSA is revoked or expires, ingest stops and existing youth records enter the destruction window per § 5 of the executed agreement. The destruction workflow itself is **not** automated by Sprint 10 — manual operations procedure documented separately. Tracked as a follow-up.
+
+## References
+
+- [ADR 0001](0001-modular-monolith.md) — modular monolith, neutral data steward
+- [ADR 0003](0003-faith-aggregate-privacy-contract.md) — privacy by structural impossibility (faith)
+- [ADR 0004](0004-partner-agreements-registry.md) — one agreement table, multiple kinds
+- [ADR 0005](0005-ferpa-student-referral-consent.md) — FERPA fork for student referrals
+- John H. Chafee Foster Care Program, 42 U.S.C. § 677
+- Family First Prevention Services Act, Pub. L. 115-123
+- KRS Chapter 620 — Kentucky dependency, neglect, and abuse
+- 42 U.S.C. § 1396a(a)(10)(A)(i)(IX) — Former Foster Youth Medicaid extension to age 26

--- a/src/app/actions/partner-agreements-parse.ts
+++ b/src/app/actions/partner-agreements-parse.ts
@@ -1,15 +1,17 @@
 /**
- * Pure FormData parser for the DTRS-010 FERPA agreement intake form.
+ * Pure FormData parsers for partner-agreement intake forms — DTRS-010 (FERPA),
+ * DTRS-011 (DCBS DSA).
  *
- * No 'use server' directive — kept pure so it can be imported and
+ * No 'use server' directive — kept pure so functions can be imported and
  * unit-tested by vitest without Next.js server-action wrapping.
- * The action file (`partner-agreements.ts`) delegates to this function.
+ * The action file (`partner-agreements.ts`) delegates to these.
  * See STATE.md known quirk: Next.js 'use server' × vitest incompatibility.
  */
 
-import { FERPA_SCOPE_OPTIONS } from '@/lib/dtrs';
+import { DCBS_DSA_SCOPE_OPTIONS, FERPA_SCOPE_OPTIONS } from '@/lib/dtrs';
 
 const FERPA_SCOPE_VALUES = FERPA_SCOPE_OPTIONS.map((o) => o.value);
+const DCBS_DSA_SCOPE_VALUES = DCBS_DSA_SCOPE_OPTIONS.map((o) => o.value);
 
 export type ParsedFerpaAgreementInput = {
   partnerOrgId: string;
@@ -147,6 +149,151 @@ export function parsePartnerAgreementForm(
           phone: liaison_phone,
         },
         studies_exception_invoked,
+        data_destruction_due,
+      },
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// DTRS-011 — DCBS DSA parser
+// ---------------------------------------------------------------------------
+
+export type ParsedDcbsDsaAgreementInput = {
+  partnerOrgId: string;
+  effectiveDate: string;
+  endDate: string | null;
+  signedByPartner: string | null;
+  notes: string | null;
+  terms: {
+    kind: 'dsa';
+    agency: 'dcbs';
+    scope: string[];
+    agency_legal_name: string;
+    state_contact: { name: string; title: string; email: string; phone?: string };
+    population_focus: 'foster_aging_out';
+    individual_records_authorized: boolean;
+    data_destruction_due: 'on_termination' | 'after_3_years' | 'after_5_years';
+  };
+};
+
+/**
+ * Parse + validate a FormData from the DCBS DSA agreement intake form.
+ *
+ * FormData shape:
+ *   partnerOrgId                       — uuid of the DCBS partner_org
+ *   effectiveDate                      — YYYY-MM-DD (required)
+ *   endDate                            — YYYY-MM-DD (optional)
+ *   signedByPartner                    — text (optional)
+ *   notes                              — text (optional)
+ *   agency_legal_name                  — text (required)
+ *   state_contact_name                 — text (required)
+ *   state_contact_title                — text (required)
+ *   state_contact_email                — text (required, basic format check)
+ *   state_contact_phone                — text (optional)
+ *   scope_{value}                      — checkbox "on" when checked
+ *   individual_records_authorized      — "true" | "false"
+ *   data_destruction_due               — 'on_termination' | 'after_3_years' | 'after_5_years'
+ */
+export function parseDcbsDsaAgreementForm(
+  formData: FormData,
+): { ok: true; input: ParsedDcbsDsaAgreementInput } | { ok: false; error: string } {
+  const str = (key: string) => (formData.get(key) ?? '').toString().trim();
+
+  const partnerOrgId = str('partnerOrgId');
+  if (!partnerOrgId) return { ok: false, error: 'DCBS partner is required.' };
+
+  const effectiveDateRaw = str('effectiveDate');
+  if (!effectiveDateRaw) return { ok: false, error: 'Effective date is required.' };
+  if (Number.isNaN(Date.parse(effectiveDateRaw))) {
+    return { ok: false, error: 'Effective date is not a valid date.' };
+  }
+
+  const endDateRaw = str('endDate');
+  let endDate: string | null = null;
+  if (endDateRaw) {
+    if (Number.isNaN(Date.parse(endDateRaw))) {
+      return { ok: false, error: 'End date is not a valid date.' };
+    }
+    if (endDateRaw < effectiveDateRaw) {
+      return { ok: false, error: 'End date must be on or after effective date.' };
+    }
+    endDate = endDateRaw;
+  }
+
+  const signedByPartner = str('signedByPartner') || null;
+
+  const notes = str('notes') || null;
+  if (notes && notes.length > 2000) {
+    return { ok: false, error: 'Notes must be 2 000 characters or fewer.' };
+  }
+
+  const agency_legal_name = str('agency_legal_name');
+  if (!agency_legal_name) {
+    return { ok: false, error: 'Agency legal name is required.' };
+  }
+
+  const sc_name = str('state_contact_name');
+  if (!sc_name) return { ok: false, error: 'State contact name is required.' };
+
+  const sc_title = str('state_contact_title');
+  if (!sc_title) return { ok: false, error: 'State contact title is required.' };
+
+  const sc_email = str('state_contact_email');
+  if (!sc_email) return { ok: false, error: 'State contact email is required.' };
+  if (!sc_email.includes('@')) {
+    return { ok: false, error: 'State contact email must be a valid email address.' };
+  }
+
+  const sc_phone_raw = str('state_contact_phone');
+  const sc_phone = sc_phone_raw || undefined;
+
+  const scope: string[] = [];
+  for (const opt of DCBS_DSA_SCOPE_VALUES) {
+    const val = formData.get(`scope_${opt}`);
+    if (val === 'on' || val === 'true' || val === opt) {
+      scope.push(opt);
+    }
+  }
+  if (scope.length === 0) {
+    return { ok: false, error: 'At least one data scope must be selected.' };
+  }
+
+  const indivAuthRaw = str('individual_records_authorized');
+  if (indivAuthRaw !== 'true' && indivAuthRaw !== 'false') {
+    return { ok: false, error: 'Individual-records authorization selection is required.' };
+  }
+  const individual_records_authorized = indivAuthRaw === 'true';
+
+  const VALID_DESTRUCTION = ['on_termination', 'after_3_years', 'after_5_years'] as const;
+  type DestructionValue = (typeof VALID_DESTRUCTION)[number];
+  const destructionRaw = str('data_destruction_due');
+  if (!VALID_DESTRUCTION.includes(destructionRaw as DestructionValue)) {
+    return { ok: false, error: 'Data destruction policy selection is required.' };
+  }
+  const data_destruction_due = destructionRaw as DestructionValue;
+
+  return {
+    ok: true,
+    input: {
+      partnerOrgId,
+      effectiveDate: effectiveDateRaw,
+      endDate,
+      signedByPartner,
+      notes,
+      terms: {
+        kind: 'dsa',
+        agency: 'dcbs',
+        scope,
+        agency_legal_name,
+        state_contact: {
+          name: sc_name,
+          title: sc_title,
+          email: sc_email,
+          phone: sc_phone,
+        },
+        population_focus: 'foster_aging_out',
+        individual_records_authorized,
         data_destruction_due,
       },
     },

--- a/src/app/actions/partner-agreements.test.ts
+++ b/src/app/actions/partner-agreements.test.ts
@@ -6,7 +6,7 @@
  * See STATE.md known quirk: Next.js 'use server' × vitest incompatibility.
  */
 import { describe, expect, it } from 'vitest';
-import { parsePartnerAgreementForm } from './partner-agreements-parse';
+import { parseDcbsDsaAgreementForm, parsePartnerAgreementForm } from './partner-agreements-parse';
 
 function makeFormData(overrides: Record<string, string> = {}): FormData {
   const fd = new FormData();
@@ -199,5 +199,168 @@ describe('parsePartnerAgreementForm', () => {
     expect(r.ok).toBe(true);
     if (!r.ok) return;
     expect(r.input.terms.liaison_contact.phone).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseDcbsDsaAgreementForm (DTRS-011)
+// ---------------------------------------------------------------------------
+
+function makeDcbsFormData(overrides: Record<string, string> = {}): FormData {
+  const fd = new FormData();
+  fd.set('partnerOrgId', 'dcbs-uuid-001');
+  fd.set('effectiveDate', '2026-09-01');
+  fd.set(
+    'agency_legal_name',
+    'Kentucky Cabinet for Health and Family Services, Department for Community Based Services',
+  );
+  fd.set('state_contact_name', 'Robin Davis');
+  fd.set('state_contact_title', 'Service Region Administrator');
+  fd.set('state_contact_email', 'robin.davis@ky.gov');
+  fd.set('scope_foster_aging_out_roster', 'on');
+  fd.set('individual_records_authorized', 'true');
+  fd.set('data_destruction_due', 'on_termination');
+  for (const [k, v] of Object.entries(overrides)) {
+    if (v === '__DELETE__') {
+      fd.delete(k);
+    } else {
+      fd.set(k, v);
+    }
+  }
+  return fd;
+}
+
+describe('parseDcbsDsaAgreementForm', () => {
+  it('returns ok:true for a valid form', () => {
+    const r = parseDcbsDsaAgreementForm(makeDcbsFormData());
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.input.partnerOrgId).toBe('dcbs-uuid-001');
+    expect(r.input.effectiveDate).toBe('2026-09-01');
+    expect(r.input.endDate).toBeNull();
+    expect(r.input.terms.kind).toBe('dsa');
+    expect(r.input.terms.agency).toBe('dcbs');
+    expect(r.input.terms.scope).toContain('foster_aging_out_roster');
+    expect(r.input.terms.individual_records_authorized).toBe(true);
+    expect(r.input.terms.population_focus).toBe('foster_aging_out');
+    expect(r.input.terms.data_destruction_due).toBe('on_termination');
+  });
+
+  it('rejects missing partnerOrgId', () => {
+    const r = parseDcbsDsaAgreementForm(makeDcbsFormData({ partnerOrgId: '' }));
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toMatch(/dcbs partner/i);
+  });
+
+  it('rejects missing agency_legal_name', () => {
+    const r = parseDcbsDsaAgreementForm(makeDcbsFormData({ agency_legal_name: '' }));
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toMatch(/agency legal name/i);
+  });
+
+  it('rejects missing state_contact_name', () => {
+    const r = parseDcbsDsaAgreementForm(makeDcbsFormData({ state_contact_name: '' }));
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toMatch(/contact name/i);
+  });
+
+  it('rejects missing state_contact_title', () => {
+    const r = parseDcbsDsaAgreementForm(makeDcbsFormData({ state_contact_title: '' }));
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toMatch(/contact title/i);
+  });
+
+  it('rejects state_contact_email without @', () => {
+    const r = parseDcbsDsaAgreementForm(makeDcbsFormData({ state_contact_email: 'not-an-email' }));
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toMatch(/valid email/i);
+  });
+
+  it('rejects no scope checkboxes selected', () => {
+    const r = parseDcbsDsaAgreementForm(makeDcbsFormData({ scope_foster_aging_out_roster: '' }));
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toMatch(/at least one data scope/i);
+  });
+
+  it('collects multiple scope checkboxes', () => {
+    const r = parseDcbsDsaAgreementForm(
+      makeDcbsFormData({
+        scope_placement_history: 'on',
+        scope_supports_in_place: 'on',
+        scope_teamky_eligibility: 'on',
+      }),
+    );
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.input.terms.scope.sort()).toEqual([
+      'foster_aging_out_roster',
+      'placement_history',
+      'supports_in_place',
+      'teamky_eligibility',
+    ]);
+  });
+
+  it('rejects unknown individual_records_authorized value', () => {
+    const r = parseDcbsDsaAgreementForm(
+      makeDcbsFormData({ individual_records_authorized: 'maybe' }),
+    );
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toMatch(/individual-records authorization/i);
+  });
+
+  it('parses individual_records_authorized=false correctly', () => {
+    const r = parseDcbsDsaAgreementForm(
+      makeDcbsFormData({ individual_records_authorized: 'false' }),
+    );
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.input.terms.individual_records_authorized).toBe(false);
+  });
+
+  it('rejects unknown data_destruction_due value', () => {
+    const r = parseDcbsDsaAgreementForm(
+      makeDcbsFormData({ data_destruction_due: 'never_required' }),
+    );
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toMatch(/data destruction policy/i);
+  });
+
+  it('accepts after_3_years and after_5_years destruction values', () => {
+    for (const val of ['after_3_years', 'after_5_years']) {
+      const r = parseDcbsDsaAgreementForm(makeDcbsFormData({ data_destruction_due: val }));
+      expect(r.ok).toBe(true);
+      if (!r.ok) return;
+      expect(r.input.terms.data_destruction_due).toBe(val);
+    }
+  });
+
+  it('rejects endDate before effectiveDate', () => {
+    const r = parseDcbsDsaAgreementForm(
+      makeDcbsFormData({ effectiveDate: '2026-09-01', endDate: '2026-08-01' }),
+    );
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toMatch(/end date must be on or after/i);
+  });
+
+  it('accepts open-ended agreement (no endDate)', () => {
+    const r = parseDcbsDsaAgreementForm(makeDcbsFormData({ endDate: '' }));
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.input.endDate).toBeNull();
+  });
+
+  it('includes optional state_contact_phone when provided', () => {
+    const r = parseDcbsDsaAgreementForm(
+      makeDcbsFormData({ state_contact_phone: '(502) 555-0100' }),
+    );
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.input.terms.state_contact.phone).toBe('(502) 555-0100');
+  });
+
+  it('rejects notes longer than 2000 chars', () => {
+    const r = parseDcbsDsaAgreementForm(makeDcbsFormData({ notes: 'x'.repeat(2001) }));
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toMatch(/2 000 characters/i);
   });
 });

--- a/src/app/actions/partner-agreements.ts
+++ b/src/app/actions/partner-agreements.ts
@@ -4,8 +4,8 @@ import * as Sentry from '@sentry/nextjs';
 import { revalidatePath } from 'next/cache';
 import { recordAgreement } from '@/db/queries/partner-agreements';
 import { requireRole } from '@/lib/auth';
-import type { FerpaTerms } from '@/lib/dtrs';
-import { parsePartnerAgreementForm } from './partner-agreements-parse';
+import type { DcbsDsaTerms, FerpaTerms } from '@/lib/dtrs';
+import { parseDcbsDsaAgreementForm, parsePartnerAgreementForm } from './partner-agreements-parse';
 
 /**
  * Known user-actionable error message prefixes from the domain / query layer.
@@ -15,8 +15,13 @@ import { parsePartnerAgreementForm } from './partner-agreements-parse';
 const KNOWN_DOMAIN_PREFIXES = [
   'FERPA terms',
   'MOU terms',
+  'DSA terms',
+  'DSA agency',
+  'DSA state_contact',
+  'DSA data_destruction_due',
   'partner_agreements insert',
   'Invalid FERPA scope',
+  'Invalid DCBS-DSA scope',
 ] as const;
 
 export type RecordFerpaAgreementResult =
@@ -66,6 +71,60 @@ export async function recordFerpaAgreementAction(
   } catch (err) {
     Sentry.captureException(err);
     console.error('[partner-agreements.recordFerpa] failed', err);
+    const raw = err instanceof Error ? err.message : '';
+    const isKnown = KNOWN_DOMAIN_PREFIXES.some((prefix) =>
+      raw.toLowerCase().startsWith(prefix.toLowerCase()),
+    );
+    const error = isKnown
+      ? raw
+      : 'Recording the agreement failed — please retry. The error has been logged.';
+    return { ok: false, error };
+  }
+}
+
+export type RecordDcbsDsaAgreementResult =
+  | { ok: true; agreementId: string }
+  | { ok: false; error: string };
+
+/**
+ * Admin-only server action: parse the DTRS-011 DCBS DSA intake FormData and
+ * persist via `recordAgreement` (terms validation + audit log happen inside
+ * that query function).
+ */
+export async function recordDcbsDsaAgreementAction(
+  formData: FormData,
+): Promise<RecordDcbsDsaAgreementResult> {
+  const user = await requireRole(['admin']);
+
+  const parsed = parseDcbsDsaAgreementForm(formData);
+  if (!parsed.ok) return { ok: false, error: parsed.error };
+
+  try {
+    const { effectiveDate, endDate, signedByPartner, notes, partnerOrgId, terms } = parsed.input;
+
+    const agreement = await recordAgreement({
+      partnerOrgId,
+      kind: 'dsa',
+      status: 'active',
+      effectiveDate: effectiveDate || null,
+      endDate: endDate || null,
+      signedByPartner: signedByPartner || null,
+      signedByCoalitionUserId: user.id,
+      templateVersion: 'dcbs-dsa-v1',
+      templateRendered: null,
+      // parseDcbsDsaAgreementForm validates scope values against the controlled vocab;
+      // the narrow cast to DcbsDsaTerms bridges string[] → DcbsDsaScopeValue[].
+      // recordAgreement re-validates via validateAgreementTerms before any insert.
+      terms: terms as DcbsDsaTerms,
+      notes: notes || null,
+      actorUserId: user.id,
+    });
+
+    revalidatePath('/app/admin/agreements/dcbs');
+    return { ok: true, agreementId: agreement.id };
+  } catch (err) {
+    Sentry.captureException(err);
+    console.error('[partner-agreements.recordDcbsDsa] failed', err);
     const raw = err instanceof Error ? err.message : '';
     const isKnown = KNOWN_DOMAIN_PREFIXES.some((prefix) =>
       raw.toLowerCase().startsWith(prefix.toLowerCase()),

--- a/src/app/agreements/dcbs/template/page.tsx
+++ b/src/app/agreements/dcbs/template/page.tsx
@@ -1,0 +1,331 @@
+/**
+ * Public DCBS Data-Sharing Agreement template page — no auth required.
+ * Template version: dcbs-dsa-v1
+ *
+ * Agencies review this page before signing. The signed copy is recorded
+ * in the coalition's partner-agreements registry per ADR 0004.
+ *
+ * NOT a legal instrument — this is a starting point that counsel and the
+ * Cabinet will review and may amend. Fields marked [TBD] require agency-
+ * specific detail to be attached before execution.
+ */
+
+export const dynamic = 'force-static';
+
+export default function DcbsDsaTemplatePage() {
+  return (
+    <div className="mx-auto max-w-3xl px-4 py-8 md:py-12 print:py-4">
+      {/* Header */}
+      <header className="mb-8 border-b pb-6">
+        <p className="text-xs font-medium uppercase tracking-widest text-muted-foreground">
+          Template Version: dcbs-dsa-v1 &bull; Daviess County Homeless Coalition
+        </p>
+        <h1 className="mt-2 font-serif text-3xl font-bold">
+          Data-Sharing Agreement
+          <br />
+          (Foster Aging-Out Pathway)
+        </h1>
+        <p className="mt-2 text-sm text-muted-foreground">
+          Between the Daviess County Homeless Coalition (&ldquo;Coalition&rdquo;) and the Kentucky
+          Cabinet for Health and Family Services, Department for Community Based Services
+          (&ldquo;DCBS&rdquo;)
+        </p>
+      </header>
+
+      <article className="prose prose-sm max-w-none dark:prose-invert space-y-6 text-sm leading-relaxed">
+        {/* Section 1 — Recitals */}
+        <section>
+          <h2 className="text-base font-semibold">1. Recitals</h2>
+          <p>
+            <strong>1.1 Coalition purpose.</strong> The Daviess County Homeless Coalition
+            (&ldquo;Coalition&rdquo;) is a county-level coordinating body working to prevent and end
+            homelessness in Daviess County, Kentucky.
+          </p>
+          <p>
+            <strong>1.2 DCBS responsibility.</strong> DCBS is the legal custodian of children and
+            youth in foster care under KRS Chapter 620 et seq. and bears continuing obligations
+            toward youth who age out of foster care, including coordination of independent-living
+            supports under the federal John H. Chafee Foster Care Program for Successful Transition
+            to Adulthood (42 U.S.C. § 677).
+          </p>
+          <p>
+            <strong>1.3 Aging-out crisis.</strong> Youth aging out of foster care at age 18 face
+            elevated risk of homelessness in the months immediately following discharge. The
+            Coalition coordinates housing-stability services, TEAMKY Former Foster Youth Medicaid
+            extension navigation, and wraparound supports to mitigate this risk.
+          </p>
+          <p>
+            <strong>1.4 Statutory basis.</strong> This Agreement is structured under the Family
+            First Prevention Services Act (Pub. L. 115-123) and Kentucky&apos;s Chafee program
+            implementation. DCBS, as legal guardian, may share individually identifying information
+            about youth in its custody with downstream service providers when the disclosure is
+            necessary to facilitate the youth&apos;s transition to stable adulthood.
+          </p>
+          <p>
+            <strong>1.5 Voluntary participation.</strong> This Agreement is voluntary. Either party
+            may withdraw with thirty (30) days written notice (see § 9). Withdrawal does not affect
+            services already initiated for an individual youth.
+          </p>
+        </section>
+
+        {/* Section 2 — Data scope */}
+        <section>
+          <h2 className="text-base font-semibold">2. Data Scope</h2>
+          <p>
+            DCBS may share with the Coalition the following categories of records, limited to youth
+            in DCBS custody who are within eighteen (18) months of their eighteenth birthday or who
+            have aged out within the prior twelve (12) months:
+          </p>
+          <ul className="list-disc pl-6 space-y-1">
+            <li>
+              <strong>Foster aging-out roster.</strong> Identifying information (legal name, date of
+              birth, DCBS case number) for youth approaching age-out, sufficient to enable Coalition
+              outreach in coordination with the assigned DCBS worker.
+            </li>
+            <li>
+              <strong>Placement history.</strong> Current placement type and a summary of placement
+              changes, sufficient to inform housing-stability planning.
+            </li>
+            <li>
+              <strong>Supports-in-place status.</strong> Whether each youth has documented housing
+              plans, Medicaid extension applications in progress, education plans (high-school
+              completion, post-secondary enrollment), and employment plans.
+            </li>
+            <li>
+              <strong>TEAMKY Medicaid extension eligibility.</strong> Eligibility flags and status
+              sufficient to support the Coalition in helping youth file the Former Foster Youth
+              Medicaid extension under 42 U.S.C. § 1396a(a)(10)(A)(i)(IX).
+            </li>
+          </ul>
+          <p>
+            The specific data classes covered by this Agreement are identified in the attached
+            Schedule A, which is incorporated by reference. [TBD — DCBS and Coalition complete
+            Schedule A before execution.]
+          </p>
+          <p>
+            DCBS shall <strong>not</strong> share substance-use treatment records (42 CFR Part 2),
+            mental-health diagnostic detail, or any data not explicitly listed in Schedule A without
+            a separate written amendment to this Agreement.
+          </p>
+        </section>
+
+        {/* Section 3 — Authority and population focus */}
+        <section>
+          <h2 className="text-base font-semibold">3. Authority and Population Focus</h2>
+          <p>
+            <strong>3.1 Population focus.</strong> Sprint 10 of this Agreement covers the{' '}
+            <strong>foster aging-out</strong> population only. Expansion to additional DCBS
+            populations (e.g. youth with active dependency cases under age 16, kinship placements)
+            requires a written amendment.
+          </p>
+          <p>
+            <strong>3.2 Individual records authorized.</strong> DCBS, as legal guardian under KRS
+            620.140, authorizes the Coalition to receive individually identifying records for the
+            population in § 3.1. The Coalition shall treat these records under the access controls
+            in § 4.
+          </p>
+          <p>
+            <strong>3.3 Coalition&apos;s role.</strong> The Coalition acts as a downstream service
+            coordinator on behalf of DCBS. The Coalition does not direct services for youth; the
+            assigned DCBS worker retains case-management authority. The Coalition shares observed
+            outcomes back to DCBS through scheduled coordination meetings.
+          </p>
+          <p>
+            <strong>3.4 No re-disclosure.</strong> The Coalition shall not re-disclose individually
+            identifiable youth records to any third party (including coalition partners not bound by
+            this Agreement) without separate written authorization from DCBS, except as required by
+            law or for emergency response under KRS 620.030.
+          </p>
+        </section>
+
+        {/* Section 4 — Data security */}
+        <section>
+          <h2 className="text-base font-semibold">4. Data Security and Access Controls</h2>
+          <p>
+            <strong>4.1 Access controls.</strong> The Coalition shall restrict access to youth
+            records to authorized Coalition staff on a need-to-know basis. A list of authorized
+            personnel shall be maintained and updated within ten (10) business days of any staffing
+            change, and shared with DCBS upon request.
+          </p>
+          <p>
+            <strong>4.2 Technical safeguards.</strong> The Coalition shall store shared records in a
+            password-protected, access-controlled system with audit logging. Records shall not be
+            stored on personal devices or unencrypted media. The system shall comply with the
+            Kentucky Cabinet for Health and Family Services data-handling standards as published
+            from time to time.
+          </p>
+          <p>
+            <strong>4.3 Breach notification.</strong> In the event of any unauthorized access,
+            disclosure, or loss of youth records, the Coalition shall notify the DCBS contact
+            identified in Schedule B within twenty-four (24) hours of discovery, with a written
+            incident report within seventy-two (72) hours.
+          </p>
+        </section>
+
+        {/* Section 5 — Data destruction */}
+        <section>
+          <h2 className="text-base font-semibold">5. Data Retention and Destruction</h2>
+          <p>
+            <strong>5.1 Retention limit.</strong> The Coalition shall retain youth records shared
+            under this Agreement only as long as necessary to fulfill the purposes described in §
+            3.3, with a default retention period defined in Schedule A.
+          </p>
+          <p>
+            <strong>5.2 Destruction on termination.</strong> Unless otherwise specified in Schedule
+            A, the Coalition shall securely destroy or return all youth records (including backup
+            copies) within the deadline elected at execution (&ldquo;Upon termination&rdquo;,
+            &ldquo;After 3 years&rdquo;, or &ldquo;After 5 years&rdquo;). &ldquo;Destruction&rdquo;
+            means irreversible deletion from all systems and media holding the records.
+          </p>
+          <p>
+            <strong>5.3 Certification.</strong> Upon request, the Coalition shall provide DCBS with
+            written certification that destruction has been completed.
+          </p>
+        </section>
+
+        {/* Section 6 — Coordination and reporting */}
+        <section>
+          <h2 className="text-base font-semibold">6. Coordination and Reporting</h2>
+          <p>
+            <strong>6.1 Joint case-coordination meetings.</strong> The Coalition and the assigned
+            DCBS worker shall coordinate at a cadence agreed upon in Schedule B (default: monthly).
+            The agenda shall include progress on supports-in-place for each youth and any emerging
+            risks.
+          </p>
+          <p>
+            <strong>6.2 Aggregate reporting.</strong> The Coalition shall provide DCBS with
+            quarterly aggregate reports on outcomes for the cohort: number of youth successfully
+            connected to housing, Medicaid extension filing rates, and connection-to-service times.
+            No individually identifying information shall be included in publicly published versions
+            of these reports.
+          </p>
+          <p>
+            <strong>6.3 Audit cooperation.</strong> The Coalition shall, upon reasonable notice,
+            provide DCBS with access to its audit logs and access-control records for the purpose of
+            verifying compliance with this Agreement.
+          </p>
+        </section>
+
+        {/* Section 7 — Term */}
+        <section>
+          <h2 className="text-base font-semibold">7. Term</h2>
+          <p>
+            This Agreement is effective on the date last signed below and continues until the
+            earlier of (a) the end date specified in Schedule A, (b) termination under § 9, or (c)
+            written mutual agreement to terminate.
+          </p>
+        </section>
+
+        {/* Section 8 — Amendments */}
+        <section>
+          <h2 className="text-base font-semibold">8. Amendments</h2>
+          <p>
+            Any amendment to this Agreement, including changes to Schedule A or expansions of the
+            population focus under § 3.1, must be in writing and signed by authorized
+            representatives of both parties. The Coalition will publish a new template version for
+            material amendments; the signed copy recorded in the Coalition&apos;s registry is the
+            authoritative instrument.
+          </p>
+        </section>
+
+        {/* Section 9 — Withdrawal */}
+        <section>
+          <h2 className="text-base font-semibold">9. Withdrawal</h2>
+          <p>
+            Either party may terminate this Agreement at any time by providing thirty (30) days
+            written notice to the other party. Notice may be delivered by email to the contacts
+            identified in Schedule B. Upon termination, the Coalition&apos;s data destruction
+            obligations under § 5 take effect.
+          </p>
+        </section>
+
+        {/* Section 10 — Governing law */}
+        <section>
+          <h2 className="text-base font-semibold">10. Governing Law</h2>
+          <p>
+            This Agreement is governed by federal law (Chafee program; Family First Prevention
+            Services Act) and the laws of the Commonwealth of Kentucky (KRS Chapter 620). Any
+            dispute arising under this Agreement shall be resolved through good-faith negotiation
+            between the Coalition and the appropriate DCBS Service Region Administrator before
+            seeking other remedies.
+          </p>
+        </section>
+
+        {/* Signatory blocks */}
+        <section className="mt-8">
+          <h2 className="text-base font-semibold">Signatories</h2>
+          <div className="mt-4 grid gap-8 sm:grid-cols-2">
+            <div className="space-y-4">
+              <p className="font-medium">Daviess County Homeless Coalition</p>
+              <div className="space-y-2">
+                <div className="border-b border-foreground/30 pb-0.5">
+                  <p className="mt-4 text-xs text-muted-foreground">Authorized signature</p>
+                </div>
+                <div className="border-b border-foreground/30 pb-0.5">
+                  <p className="mt-4 text-xs text-muted-foreground">Printed name &amp; title</p>
+                </div>
+                <div className="border-b border-foreground/30 pb-0.5">
+                  <p className="mt-4 text-xs text-muted-foreground">Date</p>
+                </div>
+              </div>
+            </div>
+            <div className="space-y-4">
+              <p className="font-medium">
+                Kentucky Cabinet for Health and Family Services
+                <br />
+                Department for Community Based Services
+              </p>
+              <div className="space-y-2">
+                <div className="border-b border-foreground/30 pb-0.5">
+                  <p className="mt-4 text-xs text-muted-foreground">Authorized signature</p>
+                </div>
+                <div className="border-b border-foreground/30 pb-0.5">
+                  <p className="mt-4 text-xs text-muted-foreground">Printed name &amp; title</p>
+                </div>
+                <div className="border-b border-foreground/30 pb-0.5">
+                  <p className="mt-4 text-xs text-muted-foreground">Date</p>
+                </div>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        {/* Schedule placeholders */}
+        <section className="mt-6">
+          <h2 className="text-base font-semibold">Schedule A — Data Classes</h2>
+          <p className="text-muted-foreground italic">
+            [TBD — to be completed by DCBS and Coalition before execution. Enumerate the specific
+            data elements, file format, transmission method, frequency, and retention period.]
+          </p>
+        </section>
+
+        <section className="mt-4">
+          <h2 className="text-base font-semibold">Schedule B — Contacts</h2>
+          <p className="text-muted-foreground italic">
+            [TBD — list Coalition data steward and DCBS Service Region Administrator names, emails,
+            and phone numbers. Include after-hours emergency contact for breach notification under §
+            4.3.]
+          </p>
+        </section>
+      </article>
+
+      {/* Footer note */}
+      <footer className="mt-10 border-t pt-6 text-xs text-muted-foreground">
+        <p>
+          This page is the public template (version <code className="font-mono">dcbs-dsa-v1</code>).
+          The signed copy is recorded in the coalition&apos;s partner-agreements registry per{' '}
+          <strong>ADR 0004</strong>; the privacy contract this agreement enforces is documented in{' '}
+          <strong>ADR 0006</strong>. This template is a starting point — DCBS and Coalition should
+          review it with counsel before execution. Fields marked [TBD] require agency-specific
+          detail.
+        </p>
+        <p className="mt-2">
+          References: John H. Chafee Foster Care Program for Successful Transition to Adulthood, 42
+          U.S.C. § 677. Family First Prevention Services Act, Pub. L. 115-123. KRS Chapter 620
+          (Kentucky dependency, neglect, and abuse). 42 U.S.C. § 1396a(a)(10)(A)(i)(IX) (Former
+          Foster Youth Medicaid extension to age 26).
+        </p>
+      </footer>
+    </div>
+  );
+}

--- a/src/app/app/admin/agreements/dcbs/page.tsx
+++ b/src/app/app/admin/agreements/dcbs/page.tsx
@@ -1,0 +1,136 @@
+import { eq } from 'drizzle-orm';
+import Link from 'next/link';
+import { DcbsDsaAgreementForm } from '@/components/dtrs/dcbs-dsa-agreement-form';
+import { db } from '@/db/client';
+import {
+  getActiveAgreementByKind,
+  listAgreementsForPartner,
+} from '@/db/queries/partner-agreements';
+import { partnerOrgs } from '@/db/schema/partner-orgs';
+import { requireRole } from '@/lib/auth';
+
+export const dynamic = 'force-dynamic';
+
+export default async function DcbsAgreementsPage() {
+  await requireRole(['admin']);
+
+  const agencies = await db
+    .select({ id: partnerOrgs.id, name: partnerOrgs.name })
+    .from(partnerOrgs)
+    .where(eq(partnerOrgs.type, 'government'))
+    .orderBy(partnerOrgs.name);
+
+  if (agencies.length === 0) {
+    return (
+      <div className="mx-auto max-w-2xl space-y-4 p-4 md:p-6">
+        <header>
+          <h1 className="font-serif text-3xl font-bold text-primary">
+            DCBS data-sharing agreements
+          </h1>
+          <p className="mt-1 text-sm text-muted-foreground">
+            Record DCBS DSAs for the foster aging-out pathway.
+          </p>
+        </header>
+        <div className="rounded-md border border-border bg-muted/20 p-6 text-sm">
+          <p className="font-semibold">No government-type partner orgs found.</p>
+          <p className="mt-2 text-muted-foreground">
+            Add a partner org with <code className="font-mono">type = &apos;government&apos;</code>{' '}
+            (e.g. &quot;DCBS — Region 2 (Owensboro)&quot;) before recording a DSA. Contact the
+            coalition data steward to add agencies.
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  const activeAgreements: Record<
+    string,
+    { id: string; effectiveDate: string | null; status: string } | undefined
+  > = {};
+
+  await Promise.all(
+    agencies.map(async (agency) => {
+      const active = await getActiveAgreementByKind(agency.id, 'dsa');
+      if (active) {
+        activeAgreements[agency.id] = {
+          id: active.id,
+          effectiveDate: active.effectiveDate,
+          status: active.status,
+        };
+      }
+    }),
+  );
+
+  const allAgreements = (
+    await Promise.all(agencies.map((a) => listAgreementsForPartner(a.id, { status: 'any' })))
+  ).flat();
+
+  const agencyIndex = Object.fromEntries(agencies.map((a) => [a.id, a.name]));
+
+  return (
+    <div className="mx-auto max-w-3xl space-y-8 p-4 md:p-6">
+      <header>
+        <h1 className="font-serif text-3xl font-bold text-primary">DCBS data-sharing agreements</h1>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Record and track DSAs with the Kentucky Cabinet for Health and Family Services. The agency
+          should review the{' '}
+          <Link
+            href="/agreements/dcbs/template"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="underline underline-offset-2 hover:text-foreground"
+          >
+            agreement template
+          </Link>{' '}
+          before signing. See <strong>ADR 0006</strong> for the privacy contract this agreement
+          enforces.
+        </p>
+      </header>
+
+      {allAgreements.length > 0 && (
+        <section className="space-y-3">
+          <h2 className="text-base font-semibold">Recorded agreements</h2>
+          <div className="overflow-x-auto rounded-md border border-border">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="border-b bg-muted/30 text-left">
+                  <th className="px-3 py-2 font-medium">Agency</th>
+                  <th className="px-3 py-2 font-medium">Kind</th>
+                  <th className="px-3 py-2 font-medium">Status</th>
+                  <th className="px-3 py-2 font-medium">Effective</th>
+                  <th className="px-3 py-2 font-medium">Ends</th>
+                </tr>
+              </thead>
+              <tbody>
+                {allAgreements.map((a) => (
+                  <tr key={a.id} className="border-b last:border-0">
+                    <td className="px-3 py-2">{agencyIndex[a.partnerOrgId] ?? a.partnerOrgId}</td>
+                    <td className="px-3 py-2 font-mono text-xs uppercase">{a.kind}</td>
+                    <td className="px-3 py-2">
+                      <span
+                        className={
+                          a.status === 'active'
+                            ? 'rounded bg-emerald-100 px-1.5 py-0.5 text-[10px] font-medium text-emerald-700 dark:bg-emerald-900/40 dark:text-emerald-400'
+                            : 'rounded bg-muted px-1.5 py-0.5 text-[10px] font-medium text-muted-foreground'
+                        }
+                      >
+                        {a.status}
+                      </span>
+                    </td>
+                    <td className="px-3 py-2 tabular-nums">{a.effectiveDate ?? '—'}</td>
+                    <td className="px-3 py-2 tabular-nums">{a.endDate ?? 'open'}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </section>
+      )}
+
+      <section className="space-y-4">
+        <h2 className="text-base font-semibold">Record a new DCBS DSA</h2>
+        <DcbsDsaAgreementForm agencies={agencies} activeAgreements={activeAgreements} />
+      </section>
+    </div>
+  );
+}

--- a/src/components/dtrs/dcbs-dsa-agreement-form.tsx
+++ b/src/components/dtrs/dcbs-dsa-agreement-form.tsx
@@ -1,0 +1,424 @@
+'use client';
+
+import Link from 'next/link';
+import { useId, useState, useTransition } from 'react';
+import { recordDcbsDsaAgreementAction } from '@/app/actions/partner-agreements';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+// Deep import: 'use client' files are exempt from the barrel rule (ADR 0001 / FND-040b).
+import { DCBS_DSA_SCOPE_OPTIONS } from '@/lib/dtrs/partner-agreements';
+
+type AgencyOption = {
+  id: string;
+  name: string;
+};
+
+type ActiveAgreement = {
+  id: string;
+  effectiveDate: string | null;
+  status: string;
+};
+
+type Props = {
+  agencies: AgencyOption[];
+  /** Map of partnerOrgId → active DSA agreement (if one exists). */
+  activeAgreements: Record<string, ActiveAgreement | undefined>;
+};
+
+const DESTRUCTION_OPTIONS = [
+  { value: 'on_termination', label: 'Upon agreement termination' },
+  { value: 'after_3_years', label: 'After 3 years of program completion' },
+  { value: 'after_5_years', label: 'After 5 years of program completion' },
+] as const;
+
+const DEFAULT_AGENCY_LEGAL_NAME =
+  'Kentucky Cabinet for Health and Family Services, Department for Community Based Services';
+
+export function DcbsDsaAgreementForm({ agencies, activeAgreements }: Props) {
+  const formId = useId();
+
+  const [selectedAgencyId, setSelectedAgencyId] = useState(agencies[0]?.id ?? '');
+  const [effectiveDate, setEffectiveDate] = useState('');
+  const [endDate, setEndDate] = useState('');
+  const [signedByPartner, setSignedByPartner] = useState('');
+  const [agencyLegalName, setAgencyLegalName] = useState(DEFAULT_AGENCY_LEGAL_NAME);
+  const [contactName, setContactName] = useState('');
+  const [contactTitle, setContactTitle] = useState('');
+  const [contactEmail, setContactEmail] = useState('');
+  const [contactPhone, setContactPhone] = useState('');
+  const [selectedScope, setSelectedScope] = useState<Set<string>>(new Set());
+  const [individualAuth, setIndividualAuth] = useState<'true' | 'false'>('true');
+  const [dataDestruction, setDataDestruction] = useState<string>('on_termination');
+  const [notes, setNotes] = useState('');
+
+  const [pending, startTransition] = useTransition();
+  const [result, setResult] = useState<
+    { ok: true; agreementId: string } | { ok: false; error: string } | null
+  >(null);
+
+  const existingAgreement = selectedAgencyId ? activeAgreements[selectedAgencyId] : undefined;
+
+  const toggleScope = (value: string) => {
+    setSelectedScope((prev) => {
+      const next = new Set(prev);
+      if (next.has(value)) {
+        next.delete(value);
+      } else {
+        next.add(value);
+      }
+      return next;
+    });
+  };
+
+  const resetForm = () => {
+    setEffectiveDate('');
+    setEndDate('');
+    setSignedByPartner('');
+    setContactName('');
+    setContactTitle('');
+    setContactEmail('');
+    setContactPhone('');
+    setSelectedScope(new Set());
+    setIndividualAuth('true');
+    setDataDestruction('on_termination');
+    setNotes('');
+    setResult(null);
+  };
+
+  const onSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    setResult(null);
+    const fd = new FormData(e.currentTarget);
+    startTransition(async () => {
+      const r = await recordDcbsDsaAgreementAction(fd);
+      setResult(r);
+      if (r.ok) resetForm();
+    });
+  };
+
+  if (result?.ok) {
+    return (
+      <div className="rounded-md border border-emerald-500/40 bg-emerald-500/5 p-4 text-sm">
+        <p className="font-semibold text-emerald-700 dark:text-emerald-400">DCBS DSA recorded.</p>
+        <p className="mt-1 text-muted-foreground">
+          Agreement ID: <code className="font-mono text-xs">{result.agreementId}</code>
+        </p>
+        <div className="mt-3 flex gap-2">
+          <Button type="button" variant="outline" onClick={() => setResult(null)}>
+            Record another
+          </Button>
+          <Link
+            href="/app/admin/agreements/dcbs"
+            className="inline-flex items-center rounded-md border border-input bg-background px-3 py-2 text-sm hover:bg-accent"
+          >
+            Back to list
+          </Link>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <form onSubmit={onSubmit} className="space-y-6">
+      {/* Agency selector */}
+      <div className="space-y-1">
+        <Label htmlFor={`${formId}-agency`}>DCBS office</Label>
+        <select
+          id={`${formId}-agency`}
+          name="partnerOrgId"
+          value={selectedAgencyId}
+          onChange={(e) => {
+            setSelectedAgencyId(e.target.value);
+            setResult(null);
+          }}
+          disabled={pending}
+          className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        >
+          {agencies.map((a) => (
+            <option key={a.id} value={a.id}>
+              {a.name}
+            </option>
+          ))}
+        </select>
+        {existingAgreement && (
+          <p className="text-xs text-amber-600 dark:text-amber-400">
+            This agency already has an active DSA (effective:{' '}
+            {existingAgreement.effectiveDate ?? 'open'}). Recording a new agreement will not
+            automatically supersede it — update the old agreement status separately.
+          </p>
+        )}
+      </div>
+
+      {/* Template preview link */}
+      <div className="rounded-md border border-border bg-muted/20 p-3 text-sm">
+        <p className="text-muted-foreground">
+          Before recording, the agency should review the{' '}
+          <Link
+            href="/agreements/dcbs/template"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="underline underline-offset-2 hover:text-foreground"
+          >
+            DCBS DSA template
+          </Link>
+          . The template version recorded here is{' '}
+          <code className="font-mono text-xs">dcbs-dsa-v1</code>.
+        </p>
+      </div>
+
+      {/* Dates */}
+      <div className="grid gap-4 sm:grid-cols-2">
+        <div className="space-y-1">
+          <Label htmlFor={`${formId}-effective`}>Effective date *</Label>
+          <Input
+            id={`${formId}-effective`}
+            name="effectiveDate"
+            type="date"
+            value={effectiveDate}
+            onChange={(e) => setEffectiveDate(e.target.value)}
+            required
+            disabled={pending}
+          />
+        </div>
+        <div className="space-y-1">
+          <Label htmlFor={`${formId}-end`}>
+            End date{' '}
+            <span className="font-normal text-muted-foreground text-xs">
+              (optional — open-ended if blank)
+            </span>
+          </Label>
+          <Input
+            id={`${formId}-end`}
+            name="endDate"
+            type="date"
+            value={endDate}
+            onChange={(e) => setEndDate(e.target.value)}
+            disabled={pending}
+          />
+        </div>
+      </div>
+
+      {/* Signed by partner */}
+      <div className="space-y-1">
+        <Label htmlFor={`${formId}-signed-by`}>
+          Signed by (DCBS){' '}
+          <span className="font-normal text-muted-foreground text-xs">(name + title)</span>
+        </Label>
+        <Input
+          id={`${formId}-signed-by`}
+          name="signedByPartner"
+          type="text"
+          value={signedByPartner}
+          onChange={(e) => setSignedByPartner(e.target.value)}
+          placeholder="e.g. Robin Davis, DCBS Service Region Administrator"
+          disabled={pending}
+        />
+      </div>
+
+      {/* Agency legal name */}
+      <div className="space-y-1">
+        <Label htmlFor={`${formId}-legal-name`}>Agency legal name *</Label>
+        <Input
+          id={`${formId}-legal-name`}
+          name="agency_legal_name"
+          type="text"
+          value={agencyLegalName}
+          onChange={(e) => setAgencyLegalName(e.target.value)}
+          required
+          disabled={pending}
+        />
+        <p className="text-xs text-muted-foreground">
+          Pre-filled with the standard CHFS / DCBS designation. Edit if a regional office signs.
+        </p>
+      </div>
+
+      {/* State contact */}
+      <fieldset className="space-y-3">
+        <legend className="text-sm font-medium">DCBS contact</legend>
+        <div className="grid gap-3 sm:grid-cols-2">
+          <div className="space-y-1">
+            <Label htmlFor={`${formId}-contact-name`}>Name *</Label>
+            <Input
+              id={`${formId}-contact-name`}
+              name="state_contact_name"
+              type="text"
+              value={contactName}
+              onChange={(e) => setContactName(e.target.value)}
+              required
+              disabled={pending}
+              placeholder="Full name"
+            />
+          </div>
+          <div className="space-y-1">
+            <Label htmlFor={`${formId}-contact-title`}>Title *</Label>
+            <Input
+              id={`${formId}-contact-title`}
+              name="state_contact_title"
+              type="text"
+              value={contactTitle}
+              onChange={(e) => setContactTitle(e.target.value)}
+              required
+              disabled={pending}
+              placeholder="e.g. Regional Program Administrator"
+            />
+          </div>
+          <div className="space-y-1">
+            <Label htmlFor={`${formId}-contact-email`}>Email *</Label>
+            <Input
+              id={`${formId}-contact-email`}
+              name="state_contact_email"
+              type="email"
+              value={contactEmail}
+              onChange={(e) => setContactEmail(e.target.value)}
+              required
+              disabled={pending}
+              placeholder="contact@ky.gov"
+            />
+          </div>
+          <div className="space-y-1">
+            <Label htmlFor={`${formId}-contact-phone`}>
+              Phone <span className="font-normal text-muted-foreground text-xs">(optional)</span>
+            </Label>
+            <Input
+              id={`${formId}-contact-phone`}
+              name="state_contact_phone"
+              type="tel"
+              value={contactPhone}
+              onChange={(e) => setContactPhone(e.target.value)}
+              disabled={pending}
+              placeholder="(502) 564-0000"
+            />
+          </div>
+        </div>
+      </fieldset>
+
+      {/* Scope checkboxes */}
+      <fieldset className="space-y-3">
+        <legend className="text-sm font-medium">
+          Data scope *{' '}
+          <span className="font-normal text-muted-foreground text-xs">
+            (select all that apply — at least one required)
+          </span>
+        </legend>
+        <div className="space-y-2">
+          {DCBS_DSA_SCOPE_OPTIONS.map((opt) => {
+            const inputId = `${formId}-scope-${opt.value}`;
+            return (
+              <label key={opt.value} className="flex items-start gap-2 text-sm">
+                <input
+                  type="checkbox"
+                  id={inputId}
+                  name={`scope_${opt.value}`}
+                  value="on"
+                  checked={selectedScope.has(opt.value)}
+                  onChange={() => toggleScope(opt.value)}
+                  disabled={pending}
+                  className="mt-0.5 h-4 w-4 rounded border-input"
+                />
+                <span>{opt.label}</span>
+              </label>
+            );
+          })}
+        </div>
+      </fieldset>
+
+      {/* Individual records authorization */}
+      <fieldset className="space-y-2">
+        <legend className="text-sm font-medium">Individual-record sharing authorized? *</legend>
+        <p className="text-xs text-muted-foreground">
+          Required <strong>Yes</strong> for the foster aging-out pathway (SUBP-001/002 read this
+          flag before enabling per-youth views). Select <strong>No</strong> only if the agreement is
+          informational/aggregate-only at this stage.
+        </p>
+        <div className="flex gap-4">
+          {(['true', 'false'] as const).map((val) => (
+            <label key={val} className="flex items-center gap-1.5 text-sm">
+              <input
+                type="radio"
+                name="individual_records_authorized"
+                value={val}
+                checked={individualAuth === val}
+                onChange={() => setIndividualAuth(val)}
+                disabled={pending}
+                className="h-4 w-4"
+              />
+              {val === 'true'
+                ? 'Yes — individual records authorized'
+                : 'No — aggregate / informational only'}
+            </label>
+          ))}
+        </div>
+      </fieldset>
+
+      {/* Population focus (locked) */}
+      <input type="hidden" name="population_focus" value="foster_aging_out" />
+      <div className="rounded-md border border-border bg-muted/20 p-3 text-sm">
+        <p className="text-muted-foreground">
+          Population focus: <strong>Foster aging-out</strong> (Sprint 10 scope; locked). Future
+          amendments may expand to additional DCBS populations.
+        </p>
+      </div>
+
+      {/* Data destruction policy */}
+      <fieldset className="space-y-2">
+        <legend className="text-sm font-medium">Data destruction policy *</legend>
+        <div className="space-y-2">
+          {DESTRUCTION_OPTIONS.map((opt) => (
+            <label key={opt.value} className="flex items-center gap-1.5 text-sm">
+              <input
+                type="radio"
+                name="data_destruction_due"
+                value={opt.value}
+                checked={dataDestruction === opt.value}
+                onChange={() => setDataDestruction(opt.value)}
+                disabled={pending}
+                className="h-4 w-4"
+              />
+              {opt.label}
+            </label>
+          ))}
+        </div>
+      </fieldset>
+
+      {/* Notes */}
+      <div className="space-y-1">
+        <Label htmlFor={`${formId}-notes`}>
+          Notes{' '}
+          <span className="font-normal text-muted-foreground text-xs">
+            (optional — no individual youth identifiers)
+          </span>
+        </Label>
+        <textarea
+          id={`${formId}-notes`}
+          name="notes"
+          rows={3}
+          value={notes}
+          onChange={(e) => setNotes(e.target.value)}
+          disabled={pending}
+          maxLength={2000}
+          className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50"
+          placeholder="Optional context about this agreement"
+        />
+      </div>
+
+      {result && !result.ok ? (
+        <p role="alert" className="text-sm text-destructive">
+          {result.error}
+        </p>
+      ) : null}
+
+      <div className="flex gap-2">
+        <Button type="submit" disabled={pending}>
+          {pending ? 'Recording…' : 'Record DCBS DSA'}
+        </Button>
+        <Link
+          href="/app/admin/agreements/dcbs"
+          className="inline-flex items-center rounded-md border border-input bg-background px-3 py-2 text-sm hover:bg-accent"
+        >
+          Cancel
+        </Link>
+      </div>
+    </form>
+  );
+}

--- a/src/lib/dtrs/partner-agreements.test.ts
+++ b/src/lib/dtrs/partner-agreements.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from 'vitest';
 import {
+  DCBS_DSA_SCOPE_OPTIONS,
   FERPA_SCOPE_OPTIONS,
   validateAgreementTerms,
+  validateDcbsDsaTerms,
   validateFerpaTerms,
   validateMouTerms,
 } from './partner-agreements';
@@ -189,6 +191,151 @@ describe('validateMouTerms', () => {
 });
 
 // ---------------------------------------------------------------------------
+// validateDcbsDsaTerms (DTRS-011)
+// ---------------------------------------------------------------------------
+
+const validDcbsDsa = {
+  kind: 'dsa',
+  agency: 'dcbs',
+  scope: ['foster_aging_out_roster', 'placement_history'],
+  agency_legal_name:
+    'Kentucky Cabinet for Health and Family Services, Department for Community Based Services',
+  state_contact: {
+    name: 'Robin Davis',
+    title: 'Service Region Administrator',
+    email: 'robin.davis@ky.gov',
+    phone: '(502) 564-0000',
+  },
+  population_focus: 'foster_aging_out',
+  individual_records_authorized: true,
+  data_destruction_due: 'on_termination',
+};
+
+describe('validateDcbsDsaTerms', () => {
+  it('accepts a valid DCBS DSA terms object', () => {
+    const result = validateDcbsDsaTerms(validDcbsDsa);
+    expect(result.kind).toBe('dsa');
+    expect(result.agency).toBe('dcbs');
+    expect(result.scope).toEqual(['foster_aging_out_roster', 'placement_history']);
+    expect(result.population_focus).toBe('foster_aging_out');
+    expect(result.individual_records_authorized).toBe(true);
+    expect(result.data_destruction_due).toBe('on_termination');
+  });
+
+  it('accepts all valid scope values', () => {
+    const allScopes = DCBS_DSA_SCOPE_OPTIONS.map((o) => o.value);
+    const result = validateDcbsDsaTerms({ ...validDcbsDsa, scope: allScopes });
+    expect(result.scope).toEqual(allScopes);
+  });
+
+  it('accepts all valid data_destruction_due values', () => {
+    for (const val of ['on_termination', 'after_3_years', 'after_5_years'] as const) {
+      const result = validateDcbsDsaTerms({ ...validDcbsDsa, data_destruction_due: val });
+      expect(result.data_destruction_due).toBe(val);
+    }
+  });
+
+  it('accepts terms without optional phone', () => {
+    const noPhone = {
+      ...validDcbsDsa,
+      state_contact: {
+        name: 'R',
+        title: 'T',
+        email: 'r@x.com',
+      },
+    };
+    const result = validateDcbsDsaTerms(noPhone);
+    expect(result.state_contact.phone).toBeUndefined();
+  });
+
+  it('rejects non-object input', () => {
+    expect(() => validateDcbsDsaTerms(null)).toThrow('must be an object');
+    expect(() => validateDcbsDsaTerms('dsa')).toThrow('must be an object');
+  });
+
+  it('rejects wrong kind', () => {
+    expect(() => validateDcbsDsaTerms({ ...validDcbsDsa, kind: 'mou' })).toThrow('kind: "dsa"');
+  });
+
+  it('rejects wrong agency', () => {
+    expect(() => validateDcbsDsaTerms({ ...validDcbsDsa, agency: 'ky_doc' })).toThrow(
+      'agency must be "dcbs"',
+    );
+  });
+
+  it('rejects empty scope array', () => {
+    expect(() => validateDcbsDsaTerms({ ...validDcbsDsa, scope: [] })).toThrow(
+      'at least one scope value',
+    );
+  });
+
+  it('rejects invalid scope value', () => {
+    expect(() =>
+      validateDcbsDsaTerms({ ...validDcbsDsa, scope: ['mental_health_records'] }),
+    ).toThrow('Invalid DCBS-DSA scope value: "mental_health_records"');
+  });
+
+  it('rejects empty agency_legal_name', () => {
+    expect(() => validateDcbsDsaTerms({ ...validDcbsDsa, agency_legal_name: '' })).toThrow(
+      'non-empty agency_legal_name',
+    );
+  });
+
+  it('rejects missing state_contact name', () => {
+    expect(() =>
+      validateDcbsDsaTerms({
+        ...validDcbsDsa,
+        state_contact: { name: '', title: 'T', email: 'r@x.com' },
+      }),
+    ).toThrow('non-empty name');
+  });
+
+  it('rejects missing state_contact title', () => {
+    expect(() =>
+      validateDcbsDsaTerms({
+        ...validDcbsDsa,
+        state_contact: { name: 'R', title: '', email: 'r@x.com' },
+      }),
+    ).toThrow('non-empty title');
+  });
+
+  it('rejects missing state_contact email', () => {
+    expect(() =>
+      validateDcbsDsaTerms({
+        ...validDcbsDsa,
+        state_contact: { name: 'R', title: 'T', email: '' },
+      }),
+    ).toThrow('non-empty email');
+  });
+
+  it('rejects expanded population_focus (Sprint 10 lock)', () => {
+    expect(() =>
+      validateDcbsDsaTerms({ ...validDcbsDsa, population_focus: 'all_open_cases' }),
+    ).toThrow('population_focus must be "foster_aging_out"');
+  });
+
+  it('rejects non-boolean individual_records_authorized', () => {
+    expect(() =>
+      validateDcbsDsaTerms({ ...validDcbsDsa, individual_records_authorized: 'yes' }),
+    ).toThrow('individual_records_authorized must be a boolean');
+  });
+
+  it('rejects invalid data_destruction_due', () => {
+    expect(() =>
+      validateDcbsDsaTerms({ ...validDcbsDsa, data_destruction_due: 'never_required' }),
+    ).toThrow('data_destruction_due must be one of');
+  });
+
+  it('strips extra/unexpected keys (does not pass through to JSONB)', () => {
+    const result = validateDcbsDsaTerms({
+      ...validDcbsDsa,
+      malicious_extra_field: 'should not survive',
+    });
+    expect(result).not.toHaveProperty('malicious_extra_field');
+  });
+});
+
+// ---------------------------------------------------------------------------
 // validateAgreementTerms dispatcher
 // ---------------------------------------------------------------------------
 
@@ -203,6 +350,28 @@ describe('validateAgreementTerms', () => {
     expect(result.kind).toBe('mou');
   });
 
+  it("dispatches dsa+agency='dcbs' to validateDcbsDsaTerms", () => {
+    const result = validateAgreementTerms('dsa', validDcbsDsa);
+    expect(result.kind).toBe('dsa');
+    if (result.kind === 'dsa') expect(result.agency).toBe('dcbs');
+  });
+
+  it('rejects dsa with missing agency discriminator', () => {
+    expect(() => validateAgreementTerms('dsa', { kind: 'dsa', scope: [] })).toThrow(
+      'agency is required',
+    );
+  });
+
+  it("rejects dsa with agency='ky_doc' (DTRS-012 not yet shipped)", () => {
+    expect(() =>
+      validateAgreementTerms('dsa', { kind: 'dsa', agency: 'ky_doc', scope: [] }),
+    ).toThrow("DSA agency 'ky_doc' not yet supported");
+  });
+
+  it('rejects dsa with non-object input', () => {
+    expect(() => validateAgreementTerms('dsa', null)).toThrow('must be an object');
+  });
+
   it('throws for placeholder kind baa (intake story not yet shipped)', () => {
     expect(() => validateAgreementTerms('baa', { kind: 'baa', foo: 'bar' })).toThrow(
       "agreement kind 'baa' not yet supported",
@@ -212,12 +381,6 @@ describe('validateAgreementTerms', () => {
   it('throws for placeholder kind qsoa (intake story not yet shipped)', () => {
     expect(() => validateAgreementTerms('qsoa', { kind: 'qsoa' })).toThrow(
       "agreement kind 'qsoa' not yet supported",
-    );
-  });
-
-  it('throws for placeholder kind dsa (intake story not yet shipped)', () => {
-    expect(() => validateAgreementTerms('dsa', { kind: 'dsa' })).toThrow(
-      "agreement kind 'dsa' not yet supported",
     );
   });
 

--- a/src/lib/dtrs/partner-agreements.ts
+++ b/src/lib/dtrs/partner-agreements.ts
@@ -1,14 +1,17 @@
 /**
- * Partner-agreements domain logic — DTRS-010.
+ * Partner-agreements domain logic — DTRS-010, DTRS-011.
  *
  * Discriminated-union types for the `terms` JSONB column in
- * `partner_agreements`. Each agreement kind owns its terms shape; only
- * `ferpa` and `mou` are fully specified for Sprint 9. The remaining kinds
- * carry a permissive placeholder until their stories ship.
+ * `partner_agreements`. Each agreement kind owns its terms shape. As of
+ * Sprint 10: `ferpa`, `mou`, and `dsa` (DCBS variant only) are fully
+ * specified. `baa`, `qsoa`, `memo_of_cooperation` carry a permissive
+ * placeholder until their stories ship; `dsa` with `agency='ky_doc'` is
+ * blocked until DTRS-012.
  *
- * Validators (`validateFerpaTerms`, `validateMouTerms`, `validateAgreementTerms`)
- * are pure functions — throw on invalid shape, return typed value on success.
- * They run BEFORE any DB insert so bad data never reaches storage.
+ * Validators (`validateFerpaTerms`, `validateMouTerms`, `validateDcbsDsaTerms`,
+ * `validateAgreementTerms`) are pure functions — throw on invalid shape,
+ * return typed value on success. They run BEFORE any DB insert so bad data
+ * never reaches storage.
  */
 
 import type { PartnerAgreementKind } from '@/db/schema/enums';
@@ -43,6 +46,37 @@ export const FERPA_SCOPE_OPTIONS = [
 ] as const;
 
 export type FerpaScopeValue = (typeof FERPA_SCOPE_OPTIONS)[number]['value'];
+
+/**
+ * DCBS-DSA data classes — the foster-aging-out cohort the coalition may
+ * receive from the Kentucky Cabinet for Health and Family Services,
+ * Department for Community Based Services. Foster youth are in state
+ * custody; the legal guardian executing the agreement is the Cabinet, not
+ * a parent (see ADR 0006).
+ *
+ * Single source of truth — the intake form renders checkboxes from this
+ * array.
+ */
+export const DCBS_DSA_SCOPE_OPTIONS = [
+  {
+    value: 'foster_aging_out_roster' as const,
+    label: 'Foster aging-out roster (youth turning 18 within 18 months)',
+  },
+  {
+    value: 'placement_history' as const,
+    label: 'Placement history and changes',
+  },
+  {
+    value: 'supports_in_place' as const,
+    label: 'Supports-in-place status (housing / Medicaid / education / employment plans)',
+  },
+  {
+    value: 'teamky_eligibility' as const,
+    label: 'TEAMKY Former Foster Youth Medicaid extension eligibility',
+  },
+] as const;
+
+export type DcbsDsaScopeValue = (typeof DCBS_DSA_SCOPE_OPTIONS)[number]['value'];
 
 // ---------------------------------------------------------------------------
 // Terms shapes
@@ -82,15 +116,66 @@ export type MouTerms = {
 };
 
 /**
+ * DCBS Data-Sharing Agreement terms (DTRS-011). Authorizes individual-record
+ * sharing for the foster aging-out pathway (SUBP-001/002).
+ *
+ * Distinguished from FERPA (ADR 0005, parental consent → first-initial only)
+ * and faith aggregate (ADR 0003, identification-impossible by structure):
+ * here the state is the legal guardian, so individual records flow under
+ * agency authority. See ADR 0006 for the full privacy contract.
+ *
+ * `individual_records_authorized` is the runtime gate that downstream
+ * SUBP-* features read before ingesting individual youth records.
+ */
+export type DcbsDsaTerms = {
+  kind: 'dsa';
+  agency: 'dcbs';
+  /** Which data classes are covered by this agreement. */
+  scope: DcbsDsaScopeValue[];
+  /** Full legal name of the executing agency office (e.g. regional DCBS office). */
+  agency_legal_name: string;
+  /** Single point of contact at the agency. */
+  state_contact: {
+    name: string;
+    title: string;
+    email: string;
+    phone?: string;
+  };
+  /**
+   * Population scope of this agreement. Sprint 10 ships `foster_aging_out`
+   * only; future amendments may expand.
+   */
+  population_focus: 'foster_aging_out';
+  /**
+   * MUST be true for any individual-record ingest. SUBP-001 reads this flag
+   * before enabling per-youth views; if false, the agreement is informational
+   * only and no individual records may be persisted.
+   */
+  individual_records_authorized: boolean;
+  /**
+   * Records-retention deadline. DCBS practice favors `on_termination` or
+   * `after_3_years` per the standard state DSA template.
+   */
+  data_destruction_due: 'on_termination' | 'after_3_years' | 'after_5_years';
+};
+
+/**
+ * Union of all DSA-kind terms shapes. Today only DCBS is specified; KY DOC
+ * (DTRS-012) will add a sibling type. The `agency` discriminator is the
+ * narrowing key.
+ */
+export type DsaTerms = DcbsDsaTerms;
+
+/**
  * Placeholder for agreement kinds whose intake stories haven't shipped yet
- * (BAA, QSOA, DSA, memo_of_cooperation). Tightened when those stories land.
+ * (BAA, QSOA, memo_of_cooperation). Tightened when those stories land.
  */
 export type GenericTerms = {
-  kind: 'baa' | 'qsoa' | 'dsa' | 'memo_of_cooperation';
+  kind: 'baa' | 'qsoa' | 'memo_of_cooperation';
   [k: string]: unknown;
 };
 
-export type PartnerAgreementTerms = FerpaTerms | MouTerms | GenericTerms;
+export type PartnerAgreementTerms = FerpaTerms | MouTerms | DsaTerms | GenericTerms;
 
 // ---------------------------------------------------------------------------
 // Validators
@@ -244,13 +329,130 @@ export function validateMouTerms(input: unknown): MouTerms {
   };
 }
 
+const DCBS_DSA_SCOPE_VALUES = DCBS_DSA_SCOPE_OPTIONS.map((o) => o.value);
+
+/**
+ * Validate DCBS-DSA terms (DTRS-011). Throws on invalid; returns typed value
+ * on success. See ADR 0006 for the privacy contract this validator enforces.
+ */
+export function validateDcbsDsaTerms(input: unknown): DcbsDsaTerms {
+  if (typeof input !== 'object' || input === null) {
+    throw new Error('DSA terms must be an object');
+  }
+
+  const {
+    kind,
+    agency,
+    scope,
+    agency_legal_name,
+    state_contact,
+    population_focus,
+    individual_records_authorized,
+    data_destruction_due,
+  } = input as {
+    kind?: unknown;
+    agency?: unknown;
+    scope?: unknown;
+    agency_legal_name?: unknown;
+    state_contact?: unknown;
+    population_focus?: unknown;
+    individual_records_authorized?: unknown;
+    data_destruction_due?: unknown;
+  };
+
+  if (kind !== 'dsa') {
+    throw new Error('DSA terms must have kind: "dsa"');
+  }
+  if (agency !== 'dcbs') {
+    throw new Error('DSA terms.agency must be "dcbs" for DCBS agreements');
+  }
+
+  // scope
+  if (!Array.isArray(scope) || scope.length === 0) {
+    throw new Error('DSA terms must include at least one scope value');
+  }
+  for (const s of scope as unknown[]) {
+    if (!DCBS_DSA_SCOPE_VALUES.includes(s as DcbsDsaScopeValue)) {
+      throw new Error(
+        `Invalid DCBS-DSA scope value: "${String(s)}" (allowed: ${DCBS_DSA_SCOPE_VALUES.join(', ')})`,
+      );
+    }
+  }
+
+  // agency_legal_name
+  if (typeof agency_legal_name !== 'string' || !agency_legal_name.trim()) {
+    throw new Error('DSA terms must include a non-empty agency_legal_name');
+  }
+
+  // state_contact
+  if (typeof state_contact !== 'object' || state_contact === null) {
+    throw new Error('DSA terms must include a state_contact object');
+  }
+  const {
+    name: scName,
+    title: scTitle,
+    email: scEmail,
+    phone: scPhone,
+  } = state_contact as {
+    name?: unknown;
+    title?: unknown;
+    email?: unknown;
+    phone?: unknown;
+  };
+  if (typeof scName !== 'string' || !scName.trim()) {
+    throw new Error('DSA state_contact must include a non-empty name');
+  }
+  if (typeof scTitle !== 'string' || !scTitle.trim()) {
+    throw new Error('DSA state_contact must include a non-empty title');
+  }
+  if (typeof scEmail !== 'string' || !scEmail.trim()) {
+    throw new Error('DSA state_contact must include a non-empty email');
+  }
+  if (scPhone !== undefined && typeof scPhone !== 'string') {
+    throw new Error('DSA state_contact.phone must be a string when provided');
+  }
+
+  // population_focus
+  if (population_focus !== 'foster_aging_out') {
+    throw new Error('DSA terms.population_focus must be "foster_aging_out" (Sprint 10 scope)');
+  }
+
+  // individual_records_authorized
+  if (typeof individual_records_authorized !== 'boolean') {
+    throw new Error('DSA terms.individual_records_authorized must be a boolean');
+  }
+
+  // data_destruction_due
+  const validDestruction = ['on_termination', 'after_3_years', 'after_5_years'] as const;
+  if (!validDestruction.includes(data_destruction_due as (typeof validDestruction)[number])) {
+    throw new Error(`DSA data_destruction_due must be one of: ${validDestruction.join(', ')}`);
+  }
+
+  return {
+    kind: 'dsa',
+    agency: 'dcbs',
+    scope: scope as DcbsDsaScopeValue[],
+    agency_legal_name,
+    state_contact: {
+      name: scName,
+      title: scTitle,
+      email: scEmail,
+      phone: scPhone as string | undefined,
+    },
+    population_focus: 'foster_aging_out',
+    individual_records_authorized,
+    data_destruction_due: data_destruction_due as DcbsDsaTerms['data_destruction_due'],
+  };
+}
+
 /**
  * Dispatcher — picks the right validator for the given agreement kind.
  *
- * Placeholder kinds (baa, qsoa, dsa, memo_of_cooperation) are intentionally
+ * Placeholder kinds (baa, qsoa, memo_of_cooperation) are intentionally
  * fail-closed: they throw until their intake stories ship and a real validator
- * is wired in. This prevents non-FERPA writes from silently accepting arbitrary
- * data before the intake forms are ready. See ADR 0004 for the registry plan.
+ * is wired in. `dsa` is dispatched on the `agency` discriminator: only
+ * `agency='dcbs'` (DTRS-011) is supported today; `ky_doc` is blocked until
+ * DTRS-012. See ADR 0004 for the registry plan.
  */
 export function validateAgreementTerms(
   kind: PartnerAgreementKind,
@@ -261,13 +463,26 @@ export function validateAgreementTerms(
       return validateFerpaTerms(input);
     case 'mou':
       return validateMouTerms(input);
+    case 'dsa': {
+      if (typeof input !== 'object' || input === null) {
+        throw new Error('DSA terms must be an object');
+      }
+      const agency = (input as { agency?: unknown }).agency;
+      if (agency === 'dcbs') return validateDcbsDsaTerms(input);
+      if (typeof agency !== 'string' || !agency) {
+        throw new Error("DSA terms.agency is required (e.g. 'dcbs')");
+      }
+      throw new Error(
+        `DSA agency '${agency}' not yet supported — its intake story has not shipped. ` +
+          'See ADR 0004 for the registry plan.',
+      );
+    }
     case 'baa':
     case 'qsoa':
-    case 'dsa':
     case 'memo_of_cooperation':
       throw new Error(
         `agreement kind '${kind}' not yet supported — its intake story has not shipped. ` +
-          `See ADR 0004 for the registry plan.`,
+          'See ADR 0004 for the registry plan.',
       );
     default: {
       // Exhaustiveness guard for future enum values added before validators are updated.


### PR DESCRIPTION
Closes #141.

Sprint 10's first story. Mirrors DTRS-010 (FERPA registry) using the [ADR 0004](docs/adr/0004-partner-agreements-registry.md) polymorphic partner-agreements registry — **no new table**, just a new `kind='dsa'` + `agency='dcbs'` discriminated-union variant.

## Why this shape

DTRS-010 already shipped the `partner_agreements` registry with `kind` enum including `dsa`. The right move was to extend the validator/parser/UI surface for the DCBS variant, not stand up parallel infrastructure. Avoids re-litigating ADR 0004.

## What changed

### Library (`src/lib/dtrs/partner-agreements.ts`)
- `DcbsDsaTerms` type with `agency='dcbs'` discriminator
- `DCBS_DSA_SCOPE_OPTIONS` controlled vocab (foster_aging_out_roster, placement_history, supports_in_place, teamky_eligibility)
- `validateDcbsDsaTerms` validator — strips extra keys, enforces `population_focus='foster_aging_out'` lock for Sprint 10
- Dispatcher routes `kind='dsa'` on the `agency` discriminator: only `dcbs` is supported today; `ky_doc` waits for DTRS-012
- Dropped `dsa` from `GenericTerms` placeholder

### Action layer (`src/app/actions/partner-agreements{,-parse}.ts`)
- Pure parser `parseDcbsDsaAgreementForm` (vitest-compatible, no `'use server'` per the STATE.md quirk pattern)
- Server action `recordDcbsDsaAgreementAction` (admin-gated, audit-logged via existing `recordAgreement`)

### UI
- Admin intake at `/app/admin/agreements/dcbs`:
  - Active-agreement warning when re-recording
  - Scope checkboxes from `DCBS_DSA_SCOPE_OPTIONS`
  - `individual_records_authorized` Yes/No toggle (the runtime feature flag SUBP-001/002 will read)
  - Locked `population_focus='foster_aging_out'` (hidden field)
  - Pre-filled CHFS/DCBS legal name
- Public template at `/agreements/dcbs/template` (force-static):
  - 10 sections grounded in 42 U.S.C. § 677 (Chafee), Family First Prevention Services Act, KRS Ch. 620, and 42 U.S.C. § 1396a(a)(10)(A)(i)(IX) (TEAMKY Medicaid extension)
  - Schedule A/B placeholders, signatory blocks
  - Footer references ADR 0004 + ADR 0006

### ADR 0006 — DCBS data-sharing privacy contract
Documents:
- Why state-as-guardian authorizes individual records (contrast ADR 0003 faith-aggregate "structurally impossible to identify" and ADR 0005 FERPA fork "first-initial only")
- Five-rule privacy contract (active-DSA gate, individual_records_authorized switch, no re-disclosure, audit every read, schema-locked population focus)
- Why we extended the registry instead of forking a third regime

## Test plan

- [x] 499 vitest tests pass (added 31 new: 17 `validateDcbsDsaTerms`, 4 dispatcher variants, 14 `parseDcbsDsaAgreementForm`)
- [x] `pnpm exec tsc --noEmit` clean
- [x] `pnpm exec biome check` clean (no `--write`)
- [x] `pnpm build` clean — both DCBS routes compile (force-static template + dynamic admin)
- [ ] Manual: visit `/agreements/dcbs/template` and confirm legal text renders + prints
- [ ] Manual: as admin, walk the intake form and confirm an active-agreement warning appears on re-record

## Followups (not in this PR)

- SUBP-001 (#130) reads `getActiveAgreementByKind(dcbsPartnerOrgId, 'dsa')` + `terms.individual_records_authorized` as a feature flag before persisting youth records
- DTRS-012 (KY DOC DSA, #142) — extend `DsaTerms` union with `KyDocDsaTerms` variant, wire into dispatcher

🤖 Generated with [Claude Code](https://claude.com/claude-code)