### PR TITLE
chore: pin pnpm to 9.15.9 via railpack.json (Railway deploy fix)

### DIFF
--- a/railpack.json
+++ b/railpack.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://schema.railpack.com",
+  "packages": {
+    "pnpm": "9.15.9"
+  }
+}


### PR DESCRIPTION
## Summary

Pin pnpm to **9.15.9** via a new `railpack.json` so Railway can resolve the package-manager version reliably.

## Context

- Railpack's version resolver started failing to resolve pnpm 9 around **2026-04-27 23:35 UTC**.
- **12+ deploys** since have failed with the same error.
- The build 1.5 h before that point succeeded — same lockfile, same code; the regression is in Railpack's resolver, not our app.
- Local development is unaffected by the pin (devs already run pnpm 9.x locally; lockfile is the same shape).

## What changed

- New file: `railpack.json` with a `packages.pnpm` pin to `9.15.9`.

## Test plan
- [ ] Merge to `main`; observe Railway redeploy succeed
- [ ] Confirm staging environment serves traffic on the new build
- [ ] (Optional) bump the pin in a follow-up once Railpack's resolver is fixed upstream

🤖 Generated with [Claude Code](https://claude.com/claude-code)