### PR TITLE
feat(DTRS-012): OASIS data-sharing agreement workflow + ADR 0007

### DIFF
--- a/docs/adr/0007-oasis-dv-survivor-privacy-contract.md
+++ b/docs/adr/0007-oasis-dv-survivor-privacy-contract.md
@@ -1,0 +1,89 @@
+# ADR 0007 — OASIS / DV survivor privacy contract (abuser-blind by contract, not by convention)
+
+**Status:** Accepted — 2026-04-28
+**Driver:** Sprint 11. DTRS-012 ([#360](https://github.com/DobbsBoldry/homeless/issues/360)) introduces the inbound flow for OASIS (Owensboro Area Shelter and Information Services) DV-survivor coordination. SUBP-004 ([#133](https://github.com/DobbsBoldry/homeless/issues/133)) builds on top — but no per-record survivor data may flow until the privacy contract for this relationship is specified. DV survivors are the first cohort where the threat model centers on a third party (the abuser) actively trying to obtain location through any data leak. The contract must encode that threat model directly.
+
+## Context
+
+Sprint 9 closed the schools entry under ADR 0005 (FERPA fork). Sprint 10 closed the foster-aging-out entry under ADR 0006 (DCBS state-as-guardian). Sprint 11 starts the DV survivor entry, which is structurally different from both:
+
+| | FERPA (ADR 0005) | DCBS DSA (ADR 0006) | OASIS DSA (this ADR) |
+|---|---|---|---|
+| Consenter | Parent / eligible student (18+) | The state, as legal guardian (KRS 620.140) | The survivor, voluntarily, via OASIS ROI |
+| Threat model | Identity exposure → stigma, services denial | State-custody data leakage → trust loss | Abuser obtaining survivor location → physical harm or death |
+| Default rule | Forbidden without consent | Authorized to share with service providers | Suppress location-identifying fields by default; share only with explicit redaction-policy authorization |
+| Cohort scale | Hundreds of students | Tens of youth | Tens of survivors |
+| Statutory regime | 20 U.S.C. § 1232g; 34 CFR § 99 | KRS 620, 42 U.S.C. § 677, Family First | **KRS 209A**, VAWA (34 U.S.C. § 12291 et seq.) |
+| Re-disclosure | Forbidden without § 99.31 exception | Forbidden without DCBS authorization or KRS 620.030 emergency | Forbidden without OASIS authorization, with mandatory notification when compelled |
+| Audit obligation | District-side § 99.32 disclosure log | Coalition-side audit log; DCBS audit cooperation | **Coalition-side audit log on every read**, OASIS audit cooperation, breach → mandatory data-flow suspension |
+
+The structural difference: in FERPA / DCBS, the threat is misuse by the receiving party; the contract constrains the Coalition's downstream behavior. In OASIS / DV, the threat is misuse by an external party (the abuser) who may obtain data through any link in the chain — including via the survivor's own coerced cooperation. The contract must therefore make abuser-blind discipline a *structural property of the data flow*, not a downstream policy that downstream code may or may not honor correctly.
+
+The platform has built one prior abuser-blind primitive ([`src/lib/dtrs/dv-blind.ts`](../../src/lib/dtrs/dv-blind.ts)): a role-based address-redaction helper sitting on a `dv_flagged_persons` table that flags eviction defendants and ED encounters where a DV concern is noted. That primitive is sound but narrow — it operates inside individual domains (eviction, ED) and is invoked at render time. SUBP-004's middleware will *also* be invoked at every survivor-record read. The question this ADR answers is: where does the redaction policy live, and what is the source of truth?
+
+## Decision
+
+**Use the existing `partner_agreements` registry (ADR 0004) with `kind='dsa'` and `agency='oasis'`. Encode the abuser-blind redaction policy as a structured field on the JSONB `terms`. Treat the agreement's stored policy as the contract-of-record for SUBP-004's middleware.** Persist survivor records under the gate of an active OASIS DSA whose `abuser_blind_attestation` flag is `true` and whose `redaction_policy` covers every field in the controlled vocabulary.
+
+### Privacy contract — five rules
+
+1. **No survivor record may be persisted without an active OASIS DSA.** SUBP-004's ingest path reads `getActiveOasisDsa(oasisPartnerOrgId)` before every write batch and fails closed if no active agreement exists. Same gate applies on every read for reporting. Per ADR 0004 § 3.1.
+
+2. **`abuser_blind_attestation` is non-optional.** The validator (`validateOasisDsaTerms`) refuses to accept a terms object without `abuser_blind_attestation === true`. The intake form's submit button is disabled until the attestation checkbox is checked. There is no draft path that bypasses attestation. If a future use case requires drafting an OASIS DSA without attestation, revisit this ADR — do not weaken the validator.
+
+3. **The redaction policy is the contract-of-record.** SUBP-004's middleware reads `terms.redaction_policy` per request and applies the per-field treatment (`suppress` / `aggregate_only` / `share`). Adding a redactable field is a contract amendment (signed-by-both-parties), not a code change in isolation. The default policy (`OASIS_DEFAULT_REDACTION_POLICY` in `src/lib/dtrs/partner-agreements.ts`) suppresses every field that could leak survivor location. Relaxing a field requires explicit selection in the intake form and is recorded in the agreement's terms JSONB.
+
+4. **Audit every read, not just every write.** Per § 4.3 of the template: every individual-record read of a survivor goes through `logAuditEvent` via the `read_survivor_record` action. The audit table is the source of truth for the cooperation obligation in § 6.3 of the template. SUBP-004's middleware enforces this — direct queries against `dv_survivors` outside the middleware are blocked by `scripts/check-domain-boundaries.mts`.
+
+5. **No enumeration.** Coalition surfaces shall not disclose, even to authorized readers, the existence of a survivor record by name-based or identifier-guess query. Survivor records are accessible only via authenticated, role-authorized routes; cross-domain joins that would correlate survivor identity with non-survivor records are blocked at the `dtrs/data-access.ts` policy gate. A "does this person have an OASIS referral?" lookup is a P0 abuser-attack vector, not a feature request.
+
+### What does NOT change
+
+- ADR 0003 (faith-aggregate privacy contract) is unchanged. Faith partners remain aggregate-only with structural impossibility of identification.
+- ADR 0005 (FERPA fork) is unchanged. Schools remain on the McKinney-Vento exception with `student_first_initial` only.
+- ADR 0006 (DCBS state-as-guardian) is unchanged. Foster youth records flow under the state's custodial authority, distinct from a survivor's voluntary, abuser-blind opt-in.
+- The existing `dv-blind.ts` primitive (role-based address redaction in eviction / ED contexts) is not deprecated. It continues to handle non-OASIS-sourced DV flags (e.g., a defendant in eviction court with a DV concern). SUBP-004's middleware is additive — it adds OASIS-sourced flow to the existing surfaces.
+
+### Why this design and not alternatives
+
+**Alternative A — separate `oasis_survivor_records` table and a parallel agreement-tracking table.** Rejected: re-litigates ADR 0004's "one agreement registry" decision, and worse, separates the policy from the agreement that authorizes it. If the registry and the table drift, the policy enforcement drifts with them.
+
+**Alternative B — encode the redaction policy in `src/lib/dtrs/data-access.ts` as code, with the DSA being purely informational.** Rejected: the redaction policy is a *contractual* commitment OASIS makes about what the Coalition's software will do. Encoding it solely in code means OASIS and the Coalition negotiate a contract orally and then the engineer translates it; the translation step is where abuser-blind discipline gets lost. Encoding it in the agreement's `terms` JSONB makes the contract and the enforcement point be the same artifact. Code reads the contract, not vice versa.
+
+**Alternative C — fork a third privacy regime like ADR 0005 did for FERPA.** Considered. The FERPA fork was structurally necessary because the consent surface (one consent record per subject) doesn't model FERPA's "parent consents on behalf of minor" + McKinney-Vento exception layering. OASIS doesn't need a fork: the consent surface is OASIS's own ROI process, which is upstream of the Coalition. The Coalition only sees the result (survivor opted in via OASIS) and applies the redaction policy. The agreement registry already accommodates this.
+
+**Alternative D — make `validateOasisDsaTerms` accept `abuser_blind_attestation: false` for draft agreements.** Rejected: there is no legitimate use case for an OASIS DSA without abuser-blind discipline. If a draft path is ever needed (e.g., negotiating an early version), the agreement should be drafted outside this system and only entered into the registry once attested. Strict validation here is a feature, not a limitation.
+
+## Consequences
+
+**What we get:**
+
+- DTRS-012 ships a working OASIS DSA workflow in 5 points: registry-extension, redaction-policy encoded in terms, attestation enforcement at the validator. Same shape as DTRS-011 / OPRT-002 pivots — minimal new surface area.
+- SUBP-004's middleware reads `terms.redaction_policy` as its single source of truth. Changing the policy is a contract amendment with a new agreement row; the rendered template (`template_rendered`) preserves the legal artifact (ADR 0004 immutability).
+- Cross-cutting: `getActiveOasisDsa(partnerOrgId)` is exposed via the dtrs barrel for any future SUBP-* survivor-adjacent stories (LGBTQ+ youth fleeing, families fleeing) to reuse the gate.
+- Audit-on-read is the default, not an opt-in. The middleware is the only path to survivor records, and the middleware always logs.
+
+**What we don't get:**
+
+- Per-survivor consent variation. The OASIS DSA covers all survivors who have given OASIS-side ROI consent. Survivor-specific opt-outs (e.g., a survivor who consents to housing referrals but not legal referrals) are managed at OASIS, not in the Coalition's database. If the Coalition ever needs to model per-survivor consent, that's a separate ADR.
+- Real-time notification of redaction-policy changes. Amendments take effect when the new agreement row is recorded as `active` and the prior one is `superseded`. Between those events, there's a brief window where SUBP-004 is reading the old policy. This is acceptable for the Sprint 11 scope; if it becomes a problem (e.g., an emergency policy tightening), we add a "policy version pin" check to the middleware.
+- Automatic enforcement of "no enumeration." Rule 5 is implemented as code review + boundary lint, not as a runtime check. A future sprint may add fuzzing or property-based tests to verify enumeration-resistance.
+
+**What we should watch for:**
+
+1. **Drift between `terms.redaction_policy` and SUBP-004's middleware behavior.** This is the contract's most fragile point. Mitigations: (a) the middleware reads policy per-request, never caches; (b) add a contract test that exercises every field × every treatment combination; (c) any code change to the middleware that touches a redactable field requires reviewing the policy schema in this ADR.
+2. **Templates becoming living documents.** Same concern as ADR 0004: `template_rendered` is set once at signing and treated as immutable. The form does not expose an edit path on rows with `status='active'`. Editing the template-version goes through a new agreement row.
+3. **Multiple active OASIS DSAs for the same partner.** Pathological — only one should be active at a time. Don't enforce uniqueness at the DB (consistent with ADR 0004); let the form's "active-agreement warning" banner surface the conflict and let the admin supersede explicitly.
+4. **Notification of breach to OASIS.** § 4.4 of the template requires breach notification within 24 hours. There's no automated piping for this today (Sentry-only); a follow-up story should add a notification path that pages OASIS-side contacts when a breach event lands. Until then, ops must monitor Sentry for `dtrs.oasis.*` errors and notify manually.
+
+## Implementation checklist (DTRS-012 picks this up)
+
+- [x] Lib: extend `src/lib/dtrs/partner-agreements.ts` with `OasisDsaTerms`, `OASIS_DSA_SCOPE_OPTIONS`, `OASIS_REDACTABLE_FIELDS`, `OASIS_DEFAULT_REDACTION_POLICY`, `validateOasisDsaTerms`. Update `validateAgreementTerms` dispatcher to handle `agency==='oasis'`.
+- [x] Parser: add `parseOasisDsaAgreementForm` in `src/app/actions/partner-agreements-parse.ts` (sibling pure module per the `'use server'` × vitest quirk).
+- [x] Action: add `recordOasisDsaAgreementAction` in `src/app/actions/partner-agreements.ts`.
+- [x] Query: add `getActiveOasisDsa(partnerOrgId)` in `src/db/queries/partner-agreements.ts` using JSONB `terms->>'agency' = 'oasis'` filter.
+- [x] Form component: `src/components/dtrs/oasis-dsa-agreement-form.tsx` with redaction policy fieldset + abuser-blind attestation checkbox.
+- [x] Admin page: `src/app/app/admin/agreements/oasis/page.tsx`.
+- [x] Public template: `src/app/agreements/oasis/template/page.tsx` (template version `oasis-dsa-v1`).
+- [x] Tests: validator tests in `src/lib/dtrs/partner-agreements.test.ts`; parser tests in `src/app/actions/partner-agreements.test.ts`.
+- [ ] SUBP-004 picks this up in a follow-up PR — its middleware reads `getActiveOasisDsa()` and `terms.redaction_policy`.

--- a/src/app/actions/partner-agreements-parse.ts
+++ b/src/app/actions/partner-agreements-parse.ts
@@ -8,10 +8,24 @@
  * See STATE.md known quirk: Next.js 'use server' × vitest incompatibility.
  */
 
-import { DCBS_DSA_SCOPE_OPTIONS, FERPA_SCOPE_OPTIONS } from '@/lib/dtrs';
+import {
+  DCBS_DSA_SCOPE_OPTIONS,
+  FERPA_SCOPE_OPTIONS,
+  OASIS_DEFAULT_REDACTION_POLICY,
+  OASIS_DSA_SCOPE_OPTIONS,
+  OASIS_REDACTABLE_FIELDS,
+  type OasisRedactionPolicy,
+  type OasisRedactionTreatment,
+} from '@/lib/dtrs';
 
 const FERPA_SCOPE_VALUES = FERPA_SCOPE_OPTIONS.map((o) => o.value);
 const DCBS_DSA_SCOPE_VALUES = DCBS_DSA_SCOPE_OPTIONS.map((o) => o.value);
+const OASIS_DSA_SCOPE_VALUES = OASIS_DSA_SCOPE_OPTIONS.map((o) => o.value);
+const OASIS_REDACTION_TREATMENTS: readonly OasisRedactionTreatment[] = [
+  'share',
+  'suppress',
+  'aggregate_only',
+];
 
 export type ParsedFerpaAgreementInput = {
   partnerOrgId: string;
@@ -294,6 +308,172 @@ export function parseDcbsDsaAgreementForm(
         },
         population_focus: 'foster_aging_out',
         individual_records_authorized,
+        data_destruction_due,
+      },
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// DTRS-012 — OASIS DSA parser
+// ---------------------------------------------------------------------------
+
+export type ParsedOasisDsaAgreementInput = {
+  partnerOrgId: string;
+  effectiveDate: string;
+  endDate: string | null;
+  signedByPartner: string | null;
+  notes: string | null;
+  terms: {
+    kind: 'dsa';
+    agency: 'oasis';
+    scope: string[];
+    agency_legal_name: string;
+    agency_contact: { name: string; title: string; email: string; phone?: string };
+    redaction_policy: OasisRedactionPolicy;
+    abuser_blind_attestation: true;
+    data_destruction_due: 'on_termination' | 'after_3_years' | 'after_5_years';
+  };
+};
+
+/**
+ * Parse + validate FormData from the OASIS DSA agreement intake form.
+ *
+ * Per ADR 0007, the abuser-blind attestation is required (the form's submit
+ * button is disabled until checked, and this parser fails closed if the box
+ * was bypassed). Redaction policy defaults from `OASIS_DEFAULT_REDACTION_POLICY`
+ * are applied when a per-field treatment is missing — but every field in
+ * `OASIS_REDACTABLE_FIELDS` is then validated against the controlled
+ * vocabulary. Bad-shape input is rejected with a user-facing error.
+ *
+ * FormData shape:
+ *   partnerOrgId                       — uuid of the OASIS partner_org
+ *   effectiveDate                      — YYYY-MM-DD (required)
+ *   endDate                            — YYYY-MM-DD (optional)
+ *   signedByPartner                    — text (optional)
+ *   notes                              — text (optional)
+ *   agency_legal_name                  — text (required)
+ *   agency_contact_name                — text (required)
+ *   agency_contact_title               — text (required)
+ *   agency_contact_email               — text (required, basic format check)
+ *   agency_contact_phone               — text (optional)
+ *   scope_{value}                      — checkbox "on" when checked
+ *   redaction_{field}                  — 'share' | 'suppress' | 'aggregate_only'
+ *   abuser_blind_attestation           — "true" required (any other value rejected)
+ *   data_destruction_due               — 'on_termination' | 'after_3_years' | 'after_5_years'
+ */
+export function parseOasisDsaAgreementForm(
+  formData: FormData,
+): { ok: true; input: ParsedOasisDsaAgreementInput } | { ok: false; error: string } {
+  const str = (key: string) => (formData.get(key) ?? '').toString().trim();
+
+  const partnerOrgId = str('partnerOrgId');
+  if (!partnerOrgId) return { ok: false, error: 'OASIS partner is required.' };
+
+  const effectiveDateRaw = str('effectiveDate');
+  if (!effectiveDateRaw) return { ok: false, error: 'Effective date is required.' };
+  if (Number.isNaN(Date.parse(effectiveDateRaw))) {
+    return { ok: false, error: 'Effective date is not a valid date.' };
+  }
+
+  const endDateRaw = str('endDate');
+  let endDate: string | null = null;
+  if (endDateRaw) {
+    if (Number.isNaN(Date.parse(endDateRaw))) {
+      return { ok: false, error: 'End date is not a valid date.' };
+    }
+    if (endDateRaw < effectiveDateRaw) {
+      return { ok: false, error: 'End date must be on or after effective date.' };
+    }
+    endDate = endDateRaw;
+  }
+
+  const signedByPartner = str('signedByPartner') || null;
+
+  const notes = str('notes') || null;
+  if (notes && notes.length > 2000) {
+    return { ok: false, error: 'Notes must be 2 000 characters or fewer.' };
+  }
+
+  const agency_legal_name = str('agency_legal_name');
+  if (!agency_legal_name) return { ok: false, error: 'Agency legal name is required.' };
+
+  const ac_name = str('agency_contact_name');
+  if (!ac_name) return { ok: false, error: 'OASIS contact name is required.' };
+
+  const ac_title = str('agency_contact_title');
+  if (!ac_title) return { ok: false, error: 'OASIS contact title is required.' };
+
+  const ac_email = str('agency_contact_email');
+  if (!ac_email) return { ok: false, error: 'OASIS contact email is required.' };
+  if (!ac_email.includes('@')) {
+    return { ok: false, error: 'OASIS contact email must be a valid email address.' };
+  }
+
+  const ac_phone = str('agency_contact_phone') || undefined;
+
+  const scope: string[] = [];
+  for (const opt of OASIS_DSA_SCOPE_VALUES) {
+    const val = formData.get(`scope_${opt}`);
+    if (val === 'on' || val === 'true' || val === opt) {
+      scope.push(opt);
+    }
+  }
+  if (scope.length === 0) {
+    return { ok: false, error: 'At least one data scope must be selected.' };
+  }
+
+  const redaction_policy: Partial<OasisRedactionPolicy> = {};
+  for (const field of OASIS_REDACTABLE_FIELDS) {
+    const raw = str(`redaction_${field}`);
+    const treatment = raw || OASIS_DEFAULT_REDACTION_POLICY[field];
+    if (!OASIS_REDACTION_TREATMENTS.includes(treatment as OasisRedactionTreatment)) {
+      return {
+        ok: false,
+        error: `Redaction treatment for "${field}" must be one of: ${OASIS_REDACTION_TREATMENTS.join(', ')}.`,
+      };
+    }
+    redaction_policy[field] = treatment as OasisRedactionTreatment;
+  }
+
+  const attestationRaw = str('abuser_blind_attestation');
+  if (attestationRaw !== 'true') {
+    return {
+      ok: false,
+      error:
+        'The abuser-blind attestation must be checked. Recording an OASIS DSA without it is not permitted (ADR 0007).',
+    };
+  }
+
+  const VALID_DESTRUCTION = ['on_termination', 'after_3_years', 'after_5_years'] as const;
+  type DestructionValue = (typeof VALID_DESTRUCTION)[number];
+  const destructionRaw = str('data_destruction_due');
+  if (!VALID_DESTRUCTION.includes(destructionRaw as DestructionValue)) {
+    return { ok: false, error: 'Data destruction policy selection is required.' };
+  }
+  const data_destruction_due = destructionRaw as DestructionValue;
+
+  return {
+    ok: true,
+    input: {
+      partnerOrgId,
+      effectiveDate: effectiveDateRaw,
+      endDate,
+      signedByPartner,
+      notes,
+      terms: {
+        kind: 'dsa',
+        agency: 'oasis',
+        scope,
+        agency_legal_name,
+        agency_contact: {
+          name: ac_name,
+          title: ac_title,
+          email: ac_email,
+          phone: ac_phone,
+        },
+        redaction_policy: redaction_policy as OasisRedactionPolicy,
+        abuser_blind_attestation: true,
         data_destruction_due,
       },
     },

--- a/src/app/actions/partner-agreements.test.ts
+++ b/src/app/actions/partner-agreements.test.ts
@@ -9,6 +9,7 @@ import { describe, expect, it } from 'vitest';
 import {
   parseDcbsDsaAgreementForm,
   parseMouAgreementForm,
+  parseOasisDsaAgreementForm,
   parsePartnerAgreementForm,
 } from './partner-agreements-parse';
 
@@ -454,5 +455,168 @@ describe('parseMouAgreementForm', () => {
     expect(r.ok).toBe(true);
     if (!r.ok) return;
     expect(r.input.endDate).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseOasisDsaAgreementForm (DTRS-012)
+// ---------------------------------------------------------------------------
+
+function makeOasisFormData(overrides: Record<string, string> = {}): FormData {
+  const fd = new FormData();
+  fd.set('partnerOrgId', 'oasis-uuid-001');
+  fd.set('effectiveDate', '2026-10-01');
+  fd.set('agency_legal_name', 'Owensboro Area Shelter and Information Services, Inc.');
+  fd.set('agency_contact_name', 'Avery Hart');
+  fd.set('agency_contact_title', 'Executive Director');
+  fd.set('agency_contact_email', 'avery.hart@oasisshelter.org');
+  fd.set('scope_survivor_intake_roster', 'on');
+  fd.set('abuser_blind_attestation', 'true');
+  fd.set('data_destruction_due', 'on_termination');
+  // Redaction policy: form omits = parser falls back to default. Tests
+  // explicitly override per case to exercise the controlled vocabulary.
+  for (const [k, v] of Object.entries(overrides)) {
+    if (v === '__DELETE__') {
+      fd.delete(k);
+    } else {
+      fd.set(k, v);
+    }
+  }
+  return fd;
+}
+
+describe('parseOasisDsaAgreementForm', () => {
+  it('returns ok:true for a valid form (defaults to abuser-blind redaction policy)', () => {
+    const r = parseOasisDsaAgreementForm(makeOasisFormData());
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.input.partnerOrgId).toBe('oasis-uuid-001');
+    expect(r.input.terms.kind).toBe('dsa');
+    expect(r.input.terms.agency).toBe('oasis');
+    expect(r.input.terms.scope).toContain('survivor_intake_roster');
+    expect(r.input.terms.abuser_blind_attestation).toBe(true);
+    // Defaults applied when fields are omitted from FormData.
+    expect(r.input.terms.redaction_policy.current_address).toBe('suppress');
+    expect(r.input.terms.redaction_policy.current_employer).toBe('suppress');
+    expect(r.input.terms.redaction_policy.risk_tier).toBe('share');
+  });
+
+  it('rejects missing partnerOrgId', () => {
+    const r = parseOasisDsaAgreementForm(makeOasisFormData({ partnerOrgId: '' }));
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toMatch(/oasis partner/i);
+  });
+
+  it('rejects missing agency_legal_name', () => {
+    const r = parseOasisDsaAgreementForm(makeOasisFormData({ agency_legal_name: '' }));
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toMatch(/agency legal name/i);
+  });
+
+  it('rejects missing agency_contact_name', () => {
+    const r = parseOasisDsaAgreementForm(makeOasisFormData({ agency_contact_name: '' }));
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toMatch(/contact name/i);
+  });
+
+  it('rejects agency_contact_email without @', () => {
+    const r = parseOasisDsaAgreementForm(
+      makeOasisFormData({ agency_contact_email: 'not-an-email' }),
+    );
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toMatch(/valid email/i);
+  });
+
+  it('rejects no scope checkboxes selected', () => {
+    const r = parseOasisDsaAgreementForm(makeOasisFormData({ scope_survivor_intake_roster: '' }));
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toMatch(/at least one data scope/i);
+  });
+
+  it('collects multiple scope checkboxes', () => {
+    const r = parseOasisDsaAgreementForm(
+      makeOasisFormData({
+        scope_safety_plan_status: 'on',
+        scope_service_referral_history: 'on',
+        scope_risk_tier_only: 'on',
+      }),
+    );
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.input.terms.scope.sort()).toEqual([
+      'risk_tier_only',
+      'safety_plan_status',
+      'service_referral_history',
+      'survivor_intake_roster',
+    ]);
+  });
+
+  it('rejects abuser_blind_attestation missing', () => {
+    const r = parseOasisDsaAgreementForm(makeOasisFormData({ abuser_blind_attestation: '' }));
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toMatch(/abuser-blind attestation/i);
+  });
+
+  it('rejects abuser_blind_attestation set to anything other than "true"', () => {
+    const r = parseOasisDsaAgreementForm(makeOasisFormData({ abuser_blind_attestation: 'false' }));
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toMatch(/abuser-blind attestation/i);
+  });
+
+  it('honors per-field redaction_policy override', () => {
+    const r = parseOasisDsaAgreementForm(
+      makeOasisFormData({ redaction_risk_tier: 'aggregate_only' }),
+    );
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.input.terms.redaction_policy.risk_tier).toBe('aggregate_only');
+    // Other fields unchanged from default.
+    expect(r.input.terms.redaction_policy.current_address).toBe('suppress');
+  });
+
+  it('rejects an invalid redaction treatment', () => {
+    const r = parseOasisDsaAgreementForm(
+      makeOasisFormData({ redaction_current_address: 'show_to_all' }),
+    );
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toMatch(/redaction treatment.*current_address/i);
+  });
+
+  it('rejects unknown data_destruction_due value', () => {
+    const r = parseOasisDsaAgreementForm(
+      makeOasisFormData({ data_destruction_due: 'never_required' }),
+    );
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toMatch(/data destruction policy/i);
+  });
+
+  it('accepts open-ended agreement (no endDate)', () => {
+    const r = parseOasisDsaAgreementForm(makeOasisFormData({ endDate: '' }));
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.input.endDate).toBeNull();
+  });
+
+  it('rejects endDate before effectiveDate', () => {
+    const r = parseOasisDsaAgreementForm(
+      makeOasisFormData({ effectiveDate: '2026-10-01', endDate: '2026-09-01' }),
+    );
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toMatch(/end date must be on or after/i);
+  });
+
+  it('includes optional agency_contact_phone when provided', () => {
+    const r = parseOasisDsaAgreementForm(
+      makeOasisFormData({ agency_contact_phone: '(270) 685-0260' }),
+    );
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.input.terms.agency_contact.phone).toBe('(270) 685-0260');
+  });
+
+  it('rejects notes longer than 2000 chars', () => {
+    const r = parseOasisDsaAgreementForm(makeOasisFormData({ notes: 'x'.repeat(2001) }));
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toMatch(/2 000 characters/i);
   });
 });

--- a/src/app/actions/partner-agreements.ts
+++ b/src/app/actions/partner-agreements.ts
@@ -4,10 +4,11 @@ import * as Sentry from '@sentry/nextjs';
 import { revalidatePath } from 'next/cache';
 import { recordAgreement, updateAgreementStatus } from '@/db/queries/partner-agreements';
 import { requireRole } from '@/lib/auth';
-import type { DcbsDsaTerms, FerpaTerms, MouTerms } from '@/lib/dtrs';
+import type { DcbsDsaTerms, FerpaTerms, MouTerms, OasisDsaTerms } from '@/lib/dtrs';
 import {
   parseDcbsDsaAgreementForm,
   parseMouAgreementForm,
+  parseOasisDsaAgreementForm,
   parsePartnerAgreementForm,
 } from './partner-agreements-parse';
 
@@ -22,10 +23,13 @@ const KNOWN_DOMAIN_PREFIXES = [
   'DSA terms',
   'DSA agency',
   'DSA state_contact',
+  'DSA agency_contact',
   'DSA data_destruction_due',
   'partner_agreements insert',
   'Invalid FERPA scope',
   'Invalid DCBS-DSA scope',
+  'Invalid OASIS-DSA scope',
+  'Invalid OASIS-DSA redaction_policy',
 ] as const;
 
 export type RecordFerpaAgreementResult =
@@ -140,6 +144,62 @@ export async function recordDcbsDsaAgreementAction(
   }
 }
 
+export type RecordOasisDsaAgreementResult =
+  | { ok: true; agreementId: string }
+  | { ok: false; error: string };
+
+/**
+ * Admin-only server action: parse the DTRS-012 OASIS DSA intake FormData and
+ * persist via `recordAgreement` (terms validation + audit log happen inside
+ * that query function). The validator strictly enforces
+ * `abuser_blind_attestation === true` (ADR 0007); the parser also fails
+ * closed if the attestation checkbox is missing from the form.
+ */
+export async function recordOasisDsaAgreementAction(
+  formData: FormData,
+): Promise<RecordOasisDsaAgreementResult> {
+  const user = await requireRole(['admin']);
+
+  const parsed = parseOasisDsaAgreementForm(formData);
+  if (!parsed.ok) return { ok: false, error: parsed.error };
+
+  try {
+    const { effectiveDate, endDate, signedByPartner, notes, partnerOrgId, terms } = parsed.input;
+
+    const agreement = await recordAgreement({
+      partnerOrgId,
+      kind: 'dsa',
+      status: 'active',
+      effectiveDate: effectiveDate || null,
+      endDate: endDate || null,
+      signedByPartner: signedByPartner || null,
+      signedByCoalitionUserId: user.id,
+      templateVersion: 'oasis-dsa-v1',
+      templateRendered: null,
+      // parseOasisDsaAgreementForm validates scope + redaction_policy + attestation;
+      // the narrow cast bridges the parser's structural type to the domain type.
+      // recordAgreement re-validates via validateAgreementTerms before any insert.
+      terms: terms as OasisDsaTerms,
+      notes: notes || null,
+      actorUserId: user.id,
+    });
+
+    revalidatePath('/app/admin/agreements/oasis');
+    return { ok: true, agreementId: agreement.id };
+  } catch (err) {
+    Sentry.captureException(err);
+    console.error('[partner-agreements.recordOasisDsa] failed', err);
+    const raw = err instanceof Error ? err.message : '';
+    const isKnown = KNOWN_DOMAIN_PREFIXES.some((prefix) =>
+      raw.toLowerCase().startsWith(prefix.toLowerCase()),
+    );
+    const error = isKnown
+      ? raw
+      : 'Recording the agreement failed — please retry. The error has been logged.';
+    return { ok: false, error };
+  }
+}
+
 export type RecordMouAgreementResult =
   | { ok: true; agreementId: string }
   | { ok: false; error: string };
@@ -205,6 +265,7 @@ export async function updateAgreementStatusAction(
     revalidatePath('/app/admin/agreements/mou');
     revalidatePath('/app/admin/agreements/ferpa');
     revalidatePath('/app/admin/agreements/dcbs');
+    revalidatePath('/app/admin/agreements/oasis');
     return { ok: true };
   } catch (err) {
     Sentry.captureException(err);

--- a/src/app/agreements/oasis/template/page.tsx
+++ b/src/app/agreements/oasis/template/page.tsx
@@ -1,0 +1,359 @@
+/**
+ * Public OASIS Data-Sharing Agreement template page — no auth required.
+ * Template version: oasis-dsa-v1
+ *
+ * OASIS reviews this page before signing. The signed copy is recorded
+ * in the coalition's partner-agreements registry per ADR 0004; the
+ * privacy contract enforced is documented in ADR 0007.
+ *
+ * NOT a legal instrument — this is a starting point that counsel and
+ * OASIS will review and may amend. Fields marked [TBD] require partner-
+ * specific detail before execution.
+ */
+
+export const dynamic = 'force-static';
+
+export default function OasisDsaTemplatePage() {
+  return (
+    <div className="mx-auto max-w-3xl px-4 py-8 md:py-12 print:py-4">
+      {/* Header */}
+      <header className="mb-8 border-b pb-6">
+        <p className="text-xs font-medium uppercase tracking-widest text-muted-foreground">
+          Template Version: oasis-dsa-v1 &bull; Daviess County Homeless Coalition
+        </p>
+        <h1 className="mt-2 font-serif text-3xl font-bold">
+          Data-Sharing Agreement
+          <br />
+          (DV Survivor Pathway)
+        </h1>
+        <p className="mt-2 text-sm text-muted-foreground">
+          Between the Daviess County Homeless Coalition (&ldquo;Coalition&rdquo;) and Owensboro Area
+          Shelter and Information Services, Inc. (&ldquo;OASIS&rdquo;)
+        </p>
+      </header>
+
+      <article className="prose prose-sm max-w-none dark:prose-invert space-y-6 text-sm leading-relaxed">
+        {/* Section 1 — Recitals */}
+        <section>
+          <h2 className="text-base font-semibold">1. Recitals</h2>
+          <p>
+            <strong>1.1 Coalition purpose.</strong> The Daviess County Homeless Coalition
+            (&ldquo;Coalition&rdquo;) is a county-level coordinating body working to prevent and end
+            homelessness in Daviess County, Kentucky.
+          </p>
+          <p>
+            <strong>1.2 OASIS mission.</strong> OASIS provides confidential shelter, advocacy, and
+            support services to victims of domestic violence and sexual assault throughout western
+            Kentucky. OASIS&apos;s services and survivor records are protected under{' '}
+            <strong>KRS 209A</strong> (Kentucky&apos;s domestic-violence-victims-services
+            confidentiality statute) and the federal Violence Against Women Act.
+          </p>
+          <p>
+            <strong>1.3 Pathway purpose.</strong> Survivors of domestic violence face elevated risk
+            of homelessness when fleeing abusers, especially when the abuser controls housing,
+            finances, or transportation. The Coalition coordinates housing-stability services and
+            downstream legal / employment / childcare referrals; OASIS coordinates shelter, safety
+            planning, and advocacy. This Agreement structures the limited data flow necessary to
+            coordinate those services without compromising survivor safety.
+          </p>
+          <p>
+            <strong>1.4 Abuser-blind discipline.</strong> Both parties acknowledge that the single
+            most consequential threat to a survivor&apos;s safety is an abuser obtaining the
+            survivor&apos;s current location through any data leak — direct, indirect, or
+            inferential. This Agreement encodes abuser-blind discipline at the contract layer: the
+            redaction policy in § 3 binds the Coalition&apos;s software to suppress any field that
+            could leak survivor location, and the Coalition&apos;s middleware reads this policy as
+            the contract-of-record. This is non-negotiable and is the cornerstone of the Agreement.
+          </p>
+          <p>
+            <strong>1.5 Voluntary participation.</strong> This Agreement is voluntary. Either party
+            may withdraw with thirty (30) days written notice (see § 9). Withdrawal does not affect
+            services already initiated for an individual survivor and does not relieve the Coalition
+            of its data destruction obligations under § 5.
+          </p>
+        </section>
+
+        {/* Section 2 — Data scope */}
+        <section>
+          <h2 className="text-base font-semibold">2. Data Scope</h2>
+          <p>
+            OASIS may share with the Coalition the following categories of records, limited to
+            survivors who have given express, informed, signed consent for cross-agency coordination
+            per OASIS&apos;s standard release-of-information process:
+          </p>
+          <ul className="list-disc pl-6 space-y-1">
+            <li>
+              <strong>Survivor intake roster.</strong> The fact of a survivor&apos;s active
+              enrollment with OASIS plus a non-locating risk-tier band (Campbell DA-scale or
+              equivalent), sufficient to enable Coalition prioritization without conveying any
+              location-identifying detail.
+            </li>
+            <li>
+              <strong>Safety-plan status.</strong> Whether a written safety plan is on file and when
+              it was last updated. <strong>The contents of safety plans are never shared.</strong>
+            </li>
+            <li>
+              <strong>Service-referral history.</strong> Categories of referrals OASIS has issued
+              (legal, housing, childcare, employment, mental-health) and their date-bands.
+              Identifying details of receiving providers may be redacted per § 3.
+            </li>
+            <li>
+              <strong>Risk-tier-only fallback.</strong> When abuser-blind discipline cannot be
+              guaranteed for full per-record sharing, OASIS may share only an aggregate count and
+              the highest-tier band present in the cohort.
+            </li>
+          </ul>
+          <p>
+            The specific data classes covered by this Agreement are identified in the attached
+            Schedule A, which is incorporated by reference. [TBD — OASIS and Coalition complete
+            Schedule A before execution.]
+          </p>
+          <p>
+            OASIS shall <strong>not</strong> share substance-use treatment records (42 CFR Part 2),
+            mental-health diagnostic detail, communications-with-counsel records, the contents of
+            safety plans, or any data not explicitly listed in Schedule A without a separate written
+            amendment to this Agreement.
+          </p>
+        </section>
+
+        {/* Section 3 — Abuser-blind redaction policy */}
+        <section>
+          <h2 className="text-base font-semibold">3. Abuser-Blind Redaction Policy</h2>
+          <p>
+            <strong>3.1 Policy as contract.</strong> The redaction policy executed alongside this
+            Agreement is itself a contractual instrument. Each enumerated field is classified as one
+            of:
+          </p>
+          <ul className="list-disc pl-6 space-y-1">
+            <li>
+              <strong>Suppress</strong> — never transmitted to the Coalition under any circumstance.
+            </li>
+            <li>
+              <strong>Aggregate only</strong> — included in cohort counts; never shared
+              per-survivor.
+            </li>
+            <li>
+              <strong>Share</strong> — transmitted to authorized Coalition readers per § 4.
+            </li>
+          </ul>
+          <p>
+            <strong>3.2 Default policy (abuser-blind by default).</strong> Unless modified in
+            writing, the following fields are <strong>suppressed</strong>: current address, current
+            employer, child school enrollment. The following are <strong>shareable</strong> as
+            identifiers of records (not identifiers of locations): risk-tier band, enrollment
+            timestamp, assigned-advocate identifier (id only — never name).
+          </p>
+          <p>
+            <strong>3.3 Amendments to the policy.</strong> Any change to a field&apos;s treatment
+            requires a written amendment signed by both parties. Adding a new redactable field also
+            requires written amendment. The Coalition&apos;s software reads the policy as the source
+            of truth; misalignment between the signed policy and the software&apos;s behavior is a
+            contractual breach.
+          </p>
+          <p>
+            <strong>3.4 Re-disclosure.</strong> The Coalition shall not re-disclose individually
+            identifiable survivor records to any third party without separate written authorization
+            from OASIS, except as required by law. In any disclosure compelled by law, the Coalition
+            shall notify OASIS within twenty-four (24) hours unless the notification itself is
+            prohibited.
+          </p>
+        </section>
+
+        {/* Section 4 — Data security */}
+        <section>
+          <h2 className="text-base font-semibold">4. Data Security and Access Controls</h2>
+          <p>
+            <strong>4.1 Authorized readers.</strong> The Coalition shall restrict access to survivor
+            records to assigned advocates, supervising advocates, and admins on a strict
+            need-to-know basis. The list of authorized readers is maintained by the Coalition&apos;s
+            data steward and provided to OASIS upon request.
+          </p>
+          <p>
+            <strong>4.2 No enumeration.</strong> The Coalition&apos;s surfaces shall not disclose,
+            even to authorized readers, the existence of a survivor record by name-based or
+            identifier-guess query (no &ldquo;does this person have an OASIS referral?&rdquo;
+            lookups). Records are accessible only via authenticated, role- authorized routes;
+            cross-domain joins that would correlate survivor identity with non-survivor records are
+            blocked at the policy gate (`src/lib/dtrs/data-access.ts`).
+          </p>
+          <p>
+            <strong>4.3 Audit logging.</strong> Every read of a survivor record is audit-logged. The
+            audit table is the source of truth for the cooperation obligation in § 6.3.
+          </p>
+          <p>
+            <strong>4.4 Breach notification.</strong> Any unauthorized access, disclosure, or loss
+            of survivor records — including any incident in which an abuser is reasonably suspected
+            to have obtained survivor information through Coalition systems — must be reported to
+            OASIS within twenty-four (24) hours of discovery, with a written incident report within
+            seventy-two (72) hours and immediate suspension of the data flow pending review.
+          </p>
+        </section>
+
+        {/* Section 5 — Data destruction */}
+        <section>
+          <h2 className="text-base font-semibold">5. Data Retention and Destruction</h2>
+          <p>
+            <strong>5.1 Default retention.</strong> Per KRS 209A best practice, the default
+            retention is <strong>destruction upon agreement termination</strong>. Longer retention
+            windows (3 years, 5 years) are available only with explicit written justification and
+            OASIS approval.
+          </p>
+          <p>
+            <strong>5.2 Destruction on termination.</strong> Upon termination, the Coalition shall
+            securely destroy or return all survivor records (including backup copies) within thirty
+            (30) days. &ldquo;Destruction&rdquo; means irreversible deletion from all systems and
+            media holding the records.
+          </p>
+          <p>
+            <strong>5.3 Certification.</strong> The Coalition shall provide OASIS with written
+            certification of destruction. OASIS may inspect destruction logs upon reasonable notice.
+          </p>
+        </section>
+
+        {/* Section 6 — Coordination and reporting */}
+        <section>
+          <h2 className="text-base font-semibold">6. Coordination and Reporting</h2>
+          <p>
+            <strong>6.1 Joint case-coordination.</strong> The Coalition and OASIS shall coordinate
+            at a cadence agreed upon in Schedule B (default: every two weeks). The agenda shall
+            include progress on referrals, emerging risks, and any redaction-policy questions.
+            Coordination meetings shall not include any survivor identifying detail beyond what § 3
+            permits.
+          </p>
+          <p>
+            <strong>6.2 Aggregate reporting.</strong> The Coalition shall provide OASIS with
+            quarterly aggregate reports on outcomes for the cohort: number of survivors successfully
+            connected to housing, referral-to-service times, and aggregate risk-tier movement. No
+            individually identifying information shall be included in publicly published versions.
+          </p>
+          <p>
+            <strong>6.3 Audit cooperation.</strong> The Coalition shall, upon reasonable notice,
+            provide OASIS with access to audit logs and access-control records for the purpose of
+            verifying compliance with this Agreement.
+          </p>
+        </section>
+
+        {/* Section 7 — Term */}
+        <section>
+          <h2 className="text-base font-semibold">7. Term</h2>
+          <p>
+            This Agreement is effective on the date last signed below and continues until the
+            earlier of (a) the end date specified in Schedule A, (b) termination under § 9, or (c)
+            written mutual agreement to terminate.
+          </p>
+        </section>
+
+        {/* Section 8 — Amendments */}
+        <section>
+          <h2 className="text-base font-semibold">8. Amendments</h2>
+          <p>
+            Any amendment to this Agreement, including changes to Schedule A or to the redaction
+            policy under § 3, must be in writing and signed by authorized representatives of both
+            parties. The Coalition will publish a new template version for material amendments; the
+            signed copy recorded in the Coalition&apos;s registry is the authoritative instrument.
+          </p>
+        </section>
+
+        {/* Section 9 — Withdrawal */}
+        <section>
+          <h2 className="text-base font-semibold">9. Withdrawal</h2>
+          <p>
+            Either party may terminate this Agreement at any time by providing thirty (30) days
+            written notice to the other party. Notice may be delivered by email to the contacts
+            identified in Schedule B. Upon termination, the Coalition&apos;s data destruction
+            obligations under § 5 take effect immediately. OASIS may suspend data flow at any time
+            without notice if abuser-blind compliance is in question; suspension is not termination.
+          </p>
+        </section>
+
+        {/* Section 10 — Governing law */}
+        <section>
+          <h2 className="text-base font-semibold">10. Governing Law</h2>
+          <p>
+            This Agreement is governed by the laws of the Commonwealth of Kentucky, including{' '}
+            <strong>KRS 209A</strong> (DV-victims-services confidentiality), and applicable federal
+            law (Violence Against Women Act, 34 U.S.C. § 12291 et seq.). Any dispute arising under
+            this Agreement shall be resolved through good-faith negotiation between the
+            Coalition&apos;s data steward and OASIS&apos;s Executive Director before seeking other
+            remedies.
+          </p>
+        </section>
+
+        {/* Signatory blocks */}
+        <section className="mt-8">
+          <h2 className="text-base font-semibold">Signatories</h2>
+          <div className="mt-4 grid gap-8 sm:grid-cols-2">
+            <div className="space-y-4">
+              <p className="font-medium">Daviess County Homeless Coalition</p>
+              <div className="space-y-2">
+                <div className="border-b border-foreground/30 pb-0.5">
+                  <p className="mt-4 text-xs text-muted-foreground">Authorized signature</p>
+                </div>
+                <div className="border-b border-foreground/30 pb-0.5">
+                  <p className="mt-4 text-xs text-muted-foreground">Printed name &amp; title</p>
+                </div>
+                <div className="border-b border-foreground/30 pb-0.5">
+                  <p className="mt-4 text-xs text-muted-foreground">Date</p>
+                </div>
+              </div>
+            </div>
+            <div className="space-y-4">
+              <p className="font-medium">
+                Owensboro Area Shelter and
+                <br />
+                Information Services, Inc. (OASIS)
+              </p>
+              <div className="space-y-2">
+                <div className="border-b border-foreground/30 pb-0.5">
+                  <p className="mt-4 text-xs text-muted-foreground">Authorized signature</p>
+                </div>
+                <div className="border-b border-foreground/30 pb-0.5">
+                  <p className="mt-4 text-xs text-muted-foreground">Printed name &amp; title</p>
+                </div>
+                <div className="border-b border-foreground/30 pb-0.5">
+                  <p className="mt-4 text-xs text-muted-foreground">Date</p>
+                </div>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        {/* Schedule placeholders */}
+        <section className="mt-6">
+          <h2 className="text-base font-semibold">Schedule A — Data Classes</h2>
+          <p className="text-muted-foreground italic">
+            [TBD — to be completed by OASIS and Coalition before execution. Enumerate the specific
+            data elements, file format, transmission method, frequency, retention period, and the
+            executed redaction policy per § 3.]
+          </p>
+        </section>
+
+        <section className="mt-4">
+          <h2 className="text-base font-semibold">Schedule B — Contacts</h2>
+          <p className="text-muted-foreground italic">
+            [TBD — list Coalition data steward and OASIS Executive Director (or designee) names,
+            emails, and phone numbers. Include after-hours emergency contact for breach notification
+            under § 4.4.]
+          </p>
+        </section>
+      </article>
+
+      {/* Footer note */}
+      <footer className="mt-10 border-t pt-6 text-xs text-muted-foreground">
+        <p>
+          This page is the public template (version <code className="font-mono">oasis-dsa-v1</code>
+          ). The signed copy is recorded in the coalition&apos;s partner-agreements registry per{' '}
+          <strong>ADR 0004</strong>; the privacy contract this agreement enforces is documented in{' '}
+          <strong>ADR 0007</strong>. This template is a starting point — OASIS and Coalition should
+          review it with counsel before execution. Fields marked [TBD] require partner-specific
+          detail.
+        </p>
+        <p className="mt-2">
+          References: KRS 209A (Kentucky Domestic Violence Victims Services confidentiality);
+          Violence Against Women Act, 34 U.S.C. § 12291 et seq.; Campbell, J.C. (2003) Danger
+          Assessment, Johns Hopkins School of Nursing (risk-tier framework).
+        </p>
+      </footer>
+    </div>
+  );
+}

--- a/src/app/app/admin/agreements/oasis/page.tsx
+++ b/src/app/app/admin/agreements/oasis/page.tsx
@@ -1,0 +1,144 @@
+import { eq } from 'drizzle-orm';
+import Link from 'next/link';
+import { OasisDsaAgreementForm } from '@/components/dtrs/oasis-dsa-agreement-form';
+import { db } from '@/db/client';
+import { getActiveOasisDsa, listAgreementsForPartner } from '@/db/queries/partner-agreements';
+import { partnerOrgs } from '@/db/schema/partner-orgs';
+import { requireRole } from '@/lib/auth';
+
+export const dynamic = 'force-dynamic';
+
+export default async function OasisAgreementsPage() {
+  await requireRole(['admin']);
+
+  // OASIS is type='shelter' in the seeded directory. The admin picks the
+  // OASIS partner from the list — other shelters won't typically execute a
+  // DV-survivor DSA (they'd use a different agreement kind).
+  const shelters = await db
+    .select({ id: partnerOrgs.id, name: partnerOrgs.name })
+    .from(partnerOrgs)
+    .where(eq(partnerOrgs.type, 'shelter'))
+    .orderBy(partnerOrgs.name);
+
+  if (shelters.length === 0) {
+    return (
+      <div className="mx-auto max-w-2xl space-y-4 p-4 md:p-6">
+        <header>
+          <h1 className="font-serif text-3xl font-bold text-primary">
+            OASIS data-sharing agreements
+          </h1>
+          <p className="mt-1 text-sm text-muted-foreground">
+            Record OASIS DSAs for the DV survivor pathway.
+          </p>
+        </header>
+        <div className="rounded-md border border-border bg-muted/20 p-6 text-sm">
+          <p className="font-semibold">No shelter-type partner orgs found.</p>
+          <p className="mt-2 text-muted-foreground">
+            Add a partner org with <code className="font-mono">type = &apos;shelter&apos;</code>{' '}
+            (e.g. &quot;OASIS Shelter (DV / SUD)&quot;) before recording a DSA. Contact the
+            coalition data steward to add partners.
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  const activeAgreements: Record<
+    string,
+    { id: string; effectiveDate: string | null; status: string } | undefined
+  > = {};
+
+  await Promise.all(
+    shelters.map(async (s) => {
+      const active = await getActiveOasisDsa(s.id);
+      if (active) {
+        activeAgreements[s.id] = {
+          id: active.id,
+          effectiveDate: active.effectiveDate,
+          status: active.status,
+        };
+      }
+    }),
+  );
+
+  // List all DSA agreements (any status, any agency) for these shelters; we
+  // surface them in the recorded-agreements table to give admins an audit
+  // trail. Most rows here will be OASIS, but a non-OASIS DSA on a shelter
+  // (e.g. future amendments) would also appear with its kind/agency clearly
+  // tagged.
+  const allAgreements = (
+    await Promise.all(shelters.map((s) => listAgreementsForPartner(s.id, { status: 'any' })))
+  ).flat();
+
+  const shelterIndex = Object.fromEntries(shelters.map((s) => [s.id, s.name]));
+
+  return (
+    <div className="mx-auto max-w-3xl space-y-8 p-4 md:p-6">
+      <header>
+        <h1 className="font-serif text-3xl font-bold text-primary">
+          OASIS data-sharing agreements
+        </h1>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Record and track DSAs with OASIS (Owensboro Area Shelter and Information Services) for the
+          DV survivor pathway. Survivors are not in state custody — abuser-blind discipline at the
+          contract layer is the cornerstone. OASIS should review the{' '}
+          <Link
+            href="/agreements/oasis/template"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="underline underline-offset-2 hover:text-foreground"
+          >
+            agreement template
+          </Link>{' '}
+          before signing. See <strong>ADR 0007</strong> for the privacy contract this agreement
+          enforces.
+        </p>
+      </header>
+
+      {allAgreements.length > 0 && (
+        <section className="space-y-3">
+          <h2 className="text-base font-semibold">Recorded agreements</h2>
+          <div className="overflow-x-auto rounded-md border border-border">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="border-b bg-muted/30 text-left">
+                  <th className="px-3 py-2 font-medium">Partner</th>
+                  <th className="px-3 py-2 font-medium">Kind</th>
+                  <th className="px-3 py-2 font-medium">Status</th>
+                  <th className="px-3 py-2 font-medium">Effective</th>
+                  <th className="px-3 py-2 font-medium">Ends</th>
+                </tr>
+              </thead>
+              <tbody>
+                {allAgreements.map((a) => (
+                  <tr key={a.id} className="border-b last:border-0">
+                    <td className="px-3 py-2">{shelterIndex[a.partnerOrgId] ?? a.partnerOrgId}</td>
+                    <td className="px-3 py-2 font-mono text-xs uppercase">{a.kind}</td>
+                    <td className="px-3 py-2">
+                      <span
+                        className={
+                          a.status === 'active'
+                            ? 'rounded bg-emerald-100 px-1.5 py-0.5 text-[10px] font-medium text-emerald-700 dark:bg-emerald-900/40 dark:text-emerald-400'
+                            : 'rounded bg-muted px-1.5 py-0.5 text-[10px] font-medium text-muted-foreground'
+                        }
+                      >
+                        {a.status}
+                      </span>
+                    </td>
+                    <td className="px-3 py-2 tabular-nums">{a.effectiveDate ?? '—'}</td>
+                    <td className="px-3 py-2 tabular-nums">{a.endDate ?? 'open'}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </section>
+      )}
+
+      <section className="space-y-4">
+        <h2 className="text-base font-semibold">Record a new OASIS DSA</h2>
+        <OasisDsaAgreementForm shelters={shelters} activeAgreements={activeAgreements} />
+      </section>
+    </div>
+  );
+}

--- a/src/components/dtrs/oasis-dsa-agreement-form.tsx
+++ b/src/components/dtrs/oasis-dsa-agreement-form.tsx
@@ -1,0 +1,483 @@
+'use client';
+
+import Link from 'next/link';
+import { useId, useState, useTransition } from 'react';
+import { recordOasisDsaAgreementAction } from '@/app/actions/partner-agreements';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+// Deep imports: 'use client' files are exempt from the barrel rule (ADR 0001 / FND-040b).
+import {
+  OASIS_DEFAULT_REDACTION_POLICY,
+  OASIS_DSA_SCOPE_OPTIONS,
+  OASIS_REDACTABLE_FIELDS,
+  type OasisRedactableField,
+  type OasisRedactionPolicy,
+  type OasisRedactionTreatment,
+} from '@/lib/dtrs/partner-agreements';
+
+type ShelterOption = {
+  id: string;
+  name: string;
+};
+
+type ActiveAgreement = {
+  id: string;
+  effectiveDate: string | null;
+  status: string;
+};
+
+type Props = {
+  shelters: ShelterOption[];
+  /** Map of partnerOrgId → active OASIS DSA agreement (if one exists). */
+  activeAgreements: Record<string, ActiveAgreement | undefined>;
+};
+
+const DESTRUCTION_OPTIONS = [
+  { value: 'on_termination', label: 'Upon agreement termination (recommended for DV data)' },
+  { value: 'after_3_years', label: 'After 3 years of program completion' },
+  { value: 'after_5_years', label: 'After 5 years of program completion' },
+] as const;
+
+const REDACTION_OPTIONS: ReadonlyArray<{ value: OasisRedactionTreatment; label: string }> = [
+  { value: 'suppress', label: 'Suppress (never transmit)' },
+  { value: 'aggregate_only', label: 'Aggregate only (counts, never per-record)' },
+  { value: 'share', label: 'Share (transmit to authorized readers)' },
+];
+
+const REDACTION_FIELD_LABELS: Record<OasisRedactableField, string> = {
+  current_address: 'Current address',
+  current_employer: 'Current employer',
+  child_school_id: 'Child school enrollment',
+  risk_tier: 'Risk tier (Campbell DA-scale band)',
+  enrolled_at: 'Enrollment timestamp',
+  assigned_advocate_id: 'Assigned advocate (id only, never name)',
+};
+
+const DEFAULT_AGENCY_LEGAL_NAME = 'Owensboro Area Shelter and Information Services, Inc.';
+
+export function OasisDsaAgreementForm({ shelters, activeAgreements }: Props) {
+  const formId = useId();
+
+  const [selectedShelterId, setSelectedShelterId] = useState(shelters[0]?.id ?? '');
+  const [effectiveDate, setEffectiveDate] = useState('');
+  const [endDate, setEndDate] = useState('');
+  const [signedByPartner, setSignedByPartner] = useState('');
+  const [agencyLegalName, setAgencyLegalName] = useState(DEFAULT_AGENCY_LEGAL_NAME);
+  const [contactName, setContactName] = useState('');
+  const [contactTitle, setContactTitle] = useState('');
+  const [contactEmail, setContactEmail] = useState('');
+  const [contactPhone, setContactPhone] = useState('');
+  const [selectedScope, setSelectedScope] = useState<Set<string>>(new Set());
+  const [redactionPolicy, setRedactionPolicy] = useState<OasisRedactionPolicy>(
+    OASIS_DEFAULT_REDACTION_POLICY,
+  );
+  const [attested, setAttested] = useState(false);
+  const [dataDestruction, setDataDestruction] = useState<string>('on_termination');
+  const [notes, setNotes] = useState('');
+
+  const [pending, startTransition] = useTransition();
+  const [result, setResult] = useState<
+    { ok: true; agreementId: string } | { ok: false; error: string } | null
+  >(null);
+
+  const existingAgreement = selectedShelterId ? activeAgreements[selectedShelterId] : undefined;
+
+  const toggleScope = (value: string) => {
+    setSelectedScope((prev) => {
+      const next = new Set(prev);
+      if (next.has(value)) {
+        next.delete(value);
+      } else {
+        next.add(value);
+      }
+      return next;
+    });
+  };
+
+  const setRedaction = (field: OasisRedactableField, treatment: OasisRedactionTreatment) => {
+    setRedactionPolicy((prev) => ({ ...prev, [field]: treatment }));
+  };
+
+  const resetForm = () => {
+    setEffectiveDate('');
+    setEndDate('');
+    setSignedByPartner('');
+    setContactName('');
+    setContactTitle('');
+    setContactEmail('');
+    setContactPhone('');
+    setSelectedScope(new Set());
+    setRedactionPolicy(OASIS_DEFAULT_REDACTION_POLICY);
+    setAttested(false);
+    setDataDestruction('on_termination');
+    setNotes('');
+    setResult(null);
+  };
+
+  const onSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    setResult(null);
+    const fd = new FormData(e.currentTarget);
+    startTransition(async () => {
+      const r = await recordOasisDsaAgreementAction(fd);
+      setResult(r);
+      if (r.ok) resetForm();
+    });
+  };
+
+  if (result?.ok) {
+    return (
+      <div className="rounded-md border border-emerald-500/40 bg-emerald-500/5 p-4 text-sm">
+        <p className="font-semibold text-emerald-700 dark:text-emerald-400">OASIS DSA recorded.</p>
+        <p className="mt-1 text-muted-foreground">
+          Agreement ID: <code className="font-mono text-xs">{result.agreementId}</code>
+        </p>
+        <div className="mt-3 flex gap-2">
+          <Button type="button" variant="outline" onClick={() => setResult(null)}>
+            Record another
+          </Button>
+          <Link
+            href="/app/admin/agreements/oasis"
+            className="inline-flex items-center rounded-md border border-input bg-background px-3 py-2 text-sm hover:bg-accent"
+          >
+            Back to list
+          </Link>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <form onSubmit={onSubmit} className="space-y-6">
+      {/* Shelter selector */}
+      <div className="space-y-1">
+        <Label htmlFor={`${formId}-shelter`}>OASIS partner</Label>
+        <select
+          id={`${formId}-shelter`}
+          name="partnerOrgId"
+          value={selectedShelterId}
+          onChange={(e) => {
+            setSelectedShelterId(e.target.value);
+            setResult(null);
+          }}
+          disabled={pending}
+          className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        >
+          {shelters.map((s) => (
+            <option key={s.id} value={s.id}>
+              {s.name}
+            </option>
+          ))}
+        </select>
+        {existingAgreement && (
+          <p className="text-xs text-amber-600 dark:text-amber-400">
+            This partner already has an active DSA (effective:{' '}
+            {existingAgreement.effectiveDate ?? 'open'}). Recording a new agreement will not
+            automatically supersede it — update the old agreement status separately.
+          </p>
+        )}
+      </div>
+
+      {/* Template preview link */}
+      <div className="rounded-md border border-border bg-muted/20 p-3 text-sm">
+        <p className="text-muted-foreground">
+          Before recording, OASIS should review the{' '}
+          <Link
+            href="/agreements/oasis/template"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="underline underline-offset-2 hover:text-foreground"
+          >
+            OASIS DSA template
+          </Link>
+          . The template version recorded here is{' '}
+          <code className="font-mono text-xs">oasis-dsa-v1</code>.
+        </p>
+      </div>
+
+      {/* Dates */}
+      <div className="grid gap-4 sm:grid-cols-2">
+        <div className="space-y-1">
+          <Label htmlFor={`${formId}-effective`}>Effective date *</Label>
+          <Input
+            id={`${formId}-effective`}
+            name="effectiveDate"
+            type="date"
+            value={effectiveDate}
+            onChange={(e) => setEffectiveDate(e.target.value)}
+            required
+            disabled={pending}
+          />
+        </div>
+        <div className="space-y-1">
+          <Label htmlFor={`${formId}-end`}>
+            End date{' '}
+            <span className="font-normal text-muted-foreground text-xs">
+              (optional — open-ended if blank)
+            </span>
+          </Label>
+          <Input
+            id={`${formId}-end`}
+            name="endDate"
+            type="date"
+            value={endDate}
+            onChange={(e) => setEndDate(e.target.value)}
+            disabled={pending}
+          />
+        </div>
+      </div>
+
+      {/* Signed by partner */}
+      <div className="space-y-1">
+        <Label htmlFor={`${formId}-signed-by`}>
+          Signed by (OASIS){' '}
+          <span className="font-normal text-muted-foreground text-xs">(name + title)</span>
+        </Label>
+        <Input
+          id={`${formId}-signed-by`}
+          name="signedByPartner"
+          type="text"
+          value={signedByPartner}
+          onChange={(e) => setSignedByPartner(e.target.value)}
+          placeholder="e.g. Avery Hart, OASIS Executive Director"
+          disabled={pending}
+        />
+      </div>
+
+      {/* Agency legal name */}
+      <div className="space-y-1">
+        <Label htmlFor={`${formId}-legal-name`}>Agency legal name *</Label>
+        <Input
+          id={`${formId}-legal-name`}
+          name="agency_legal_name"
+          type="text"
+          value={agencyLegalName}
+          onChange={(e) => setAgencyLegalName(e.target.value)}
+          required
+          disabled={pending}
+        />
+      </div>
+
+      {/* Agency contact */}
+      <fieldset className="space-y-3">
+        <legend className="text-sm font-medium">OASIS contact</legend>
+        <div className="grid gap-3 sm:grid-cols-2">
+          <div className="space-y-1">
+            <Label htmlFor={`${formId}-contact-name`}>Name *</Label>
+            <Input
+              id={`${formId}-contact-name`}
+              name="agency_contact_name"
+              type="text"
+              value={contactName}
+              onChange={(e) => setContactName(e.target.value)}
+              required
+              disabled={pending}
+              placeholder="Full name"
+            />
+          </div>
+          <div className="space-y-1">
+            <Label htmlFor={`${formId}-contact-title`}>Title *</Label>
+            <Input
+              id={`${formId}-contact-title`}
+              name="agency_contact_title"
+              type="text"
+              value={contactTitle}
+              onChange={(e) => setContactTitle(e.target.value)}
+              required
+              disabled={pending}
+              placeholder="e.g. Executive Director"
+            />
+          </div>
+          <div className="space-y-1">
+            <Label htmlFor={`${formId}-contact-email`}>Email *</Label>
+            <Input
+              id={`${formId}-contact-email`}
+              name="agency_contact_email"
+              type="email"
+              value={contactEmail}
+              onChange={(e) => setContactEmail(e.target.value)}
+              required
+              disabled={pending}
+              placeholder="contact@oasisshelter.org"
+            />
+          </div>
+          <div className="space-y-1">
+            <Label htmlFor={`${formId}-contact-phone`}>
+              Phone <span className="font-normal text-muted-foreground text-xs">(optional)</span>
+            </Label>
+            <Input
+              id={`${formId}-contact-phone`}
+              name="agency_contact_phone"
+              type="tel"
+              value={contactPhone}
+              onChange={(e) => setContactPhone(e.target.value)}
+              disabled={pending}
+              placeholder="(270) 685-0260"
+            />
+          </div>
+        </div>
+      </fieldset>
+
+      {/* Scope checkboxes */}
+      <fieldset className="space-y-3">
+        <legend className="text-sm font-medium">
+          Data scope *{' '}
+          <span className="font-normal text-muted-foreground text-xs">
+            (select all that apply — at least one required)
+          </span>
+        </legend>
+        <div className="space-y-2">
+          {OASIS_DSA_SCOPE_OPTIONS.map((opt) => {
+            const inputId = `${formId}-scope-${opt.value}`;
+            return (
+              <label key={opt.value} className="flex items-start gap-2 text-sm">
+                <input
+                  type="checkbox"
+                  id={inputId}
+                  name={`scope_${opt.value}`}
+                  value="on"
+                  checked={selectedScope.has(opt.value)}
+                  onChange={() => toggleScope(opt.value)}
+                  disabled={pending}
+                  className="mt-0.5 h-4 w-4 rounded border-input"
+                />
+                <span>{opt.label}</span>
+              </label>
+            );
+          })}
+        </div>
+      </fieldset>
+
+      {/* Abuser-blind redaction policy */}
+      <fieldset className="space-y-3 rounded-md border border-border bg-muted/10 p-4">
+        <legend className="px-1 text-sm font-semibold text-foreground">
+          Abuser-blind redaction policy
+        </legend>
+        <p className="text-xs text-muted-foreground">
+          For each field, choose how OASIS will share it with the coalition. The defaults are
+          abuser-blind — any field that could leak survivor location is suppressed. Relax a field
+          only with explicit OASIS authorization. SUBP-004 reads this policy as the contract-of-
+          record (ADR 0007 § 3.2).
+        </p>
+        <div className="space-y-3">
+          {OASIS_REDACTABLE_FIELDS.map((field) => {
+            const groupId = `${formId}-redaction-${field}`;
+            return (
+              <div key={field} className="space-y-1">
+                <p className="text-sm font-medium">{REDACTION_FIELD_LABELS[field]}</p>
+                <div className="flex flex-wrap gap-3">
+                  {REDACTION_OPTIONS.map((opt) => {
+                    const inputId = `${groupId}-${opt.value}`;
+                    return (
+                      <label
+                        key={opt.value}
+                        htmlFor={inputId}
+                        className="flex items-center gap-1.5 text-xs"
+                      >
+                        <input
+                          type="radio"
+                          id={inputId}
+                          name={`redaction_${field}`}
+                          value={opt.value}
+                          checked={redactionPolicy[field] === opt.value}
+                          onChange={() => setRedaction(field, opt.value)}
+                          disabled={pending}
+                          className="h-3.5 w-3.5"
+                        />
+                        {opt.label}
+                      </label>
+                    );
+                  })}
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      </fieldset>
+
+      {/* Abuser-blind attestation */}
+      <fieldset className="space-y-2 rounded-md border border-amber-500/40 bg-amber-500/5 p-4">
+        <legend className="px-1 text-sm font-semibold text-amber-700 dark:text-amber-400">
+          Required attestation
+        </legend>
+        <label className="flex items-start gap-2 text-sm">
+          <input
+            type="checkbox"
+            name="abuser_blind_attestation"
+            value="true"
+            checked={attested}
+            onChange={(e) => setAttested(e.target.checked)}
+            disabled={pending}
+            className="mt-0.5 h-4 w-4"
+            required
+          />
+          <span>
+            I attest that this redaction policy enforces abuser-blind discipline as required by ADR
+            0007 and KRS 209A. I have authority to record this OASIS DSA on behalf of the coalition.
+          </span>
+        </label>
+      </fieldset>
+
+      {/* Data destruction policy */}
+      <fieldset className="space-y-2">
+        <legend className="text-sm font-medium">Data destruction policy *</legend>
+        <div className="space-y-2">
+          {DESTRUCTION_OPTIONS.map((opt) => (
+            <label key={opt.value} className="flex items-center gap-1.5 text-sm">
+              <input
+                type="radio"
+                name="data_destruction_due"
+                value={opt.value}
+                checked={dataDestruction === opt.value}
+                onChange={() => setDataDestruction(opt.value)}
+                disabled={pending}
+                className="h-4 w-4"
+              />
+              {opt.label}
+            </label>
+          ))}
+        </div>
+      </fieldset>
+
+      {/* Notes */}
+      <div className="space-y-1">
+        <Label htmlFor={`${formId}-notes`}>
+          Notes{' '}
+          <span className="font-normal text-muted-foreground text-xs">
+            (optional — no survivor identifiers)
+          </span>
+        </Label>
+        <textarea
+          id={`${formId}-notes`}
+          name="notes"
+          rows={3}
+          value={notes}
+          onChange={(e) => setNotes(e.target.value)}
+          disabled={pending}
+          maxLength={2000}
+          className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50"
+          placeholder="Optional context about this agreement"
+        />
+      </div>
+
+      {result && !result.ok ? (
+        <p role="alert" className="text-sm text-destructive">
+          {result.error}
+        </p>
+      ) : null}
+
+      <div className="flex gap-2">
+        <Button type="submit" disabled={pending || !attested}>
+          {pending ? 'Recording…' : 'Record OASIS DSA'}
+        </Button>
+        <Link
+          href="/app/admin/agreements/oasis"
+          className="inline-flex items-center rounded-md border border-input bg-background px-3 py-2 text-sm hover:bg-accent"
+        >
+          Cancel
+        </Link>
+      </div>
+    </form>
+  );
+}

--- a/src/db/queries/partner-agreements.ts
+++ b/src/db/queries/partner-agreements.ts
@@ -1,4 +1,4 @@
-import { and, eq, gte, isNotNull, lt, lte } from 'drizzle-orm';
+import { and, eq, gte, isNotNull, lt, lte, sql } from 'drizzle-orm';
 import { db } from '@/db/client';
 import { type NewPartnerAgreement, type PartnerAgreement, partnerAgreements } from '@/db/schema';
 import type { PartnerAgreementKind, PartnerAgreementStatus } from '@/db/schema/enums';
@@ -51,6 +51,33 @@ export async function getActiveAgreementByKind(
         eq(partnerAgreements.partnerOrgId, partnerOrgId),
         eq(partnerAgreements.kind, kind),
         eq(partnerAgreements.status, 'active'),
+      ),
+    )
+    .limit(1);
+  return rows[0] ?? null;
+}
+
+/**
+ * Return the active OASIS Data-Sharing Agreement for a partner, or null.
+ *
+ * SUBP-004's abuser-blind middleware reads the active agreement before every
+ * survivor-record write and exposes the redaction policy as the contract-of-
+ * record. The JSONB filter `terms->>'agency' = 'oasis'` discriminates OASIS
+ * agreements from DCBS / future KY DOC under the shared `dsa` kind (ADR 0004).
+ *
+ * Returns `null` when no active OASIS DSA exists; SUBP-004 must fail closed
+ * in that case (ADR 0007 § 3.1).
+ */
+export async function getActiveOasisDsa(partnerOrgId: string): Promise<PartnerAgreement | null> {
+  const rows = await db
+    .select()
+    .from(partnerAgreements)
+    .where(
+      and(
+        eq(partnerAgreements.partnerOrgId, partnerOrgId),
+        eq(partnerAgreements.kind, 'dsa'),
+        eq(partnerAgreements.status, 'active'),
+        sql`(${partnerAgreements.terms}->>'agency') = 'oasis'`,
       ),
     )
     .limit(1);

--- a/src/lib/dtrs/partner-agreements.test.ts
+++ b/src/lib/dtrs/partner-agreements.test.ts
@@ -2,10 +2,13 @@ import { describe, expect, it } from 'vitest';
 import {
   DCBS_DSA_SCOPE_OPTIONS,
   FERPA_SCOPE_OPTIONS,
+  OASIS_DEFAULT_REDACTION_POLICY,
+  OASIS_DSA_SCOPE_OPTIONS,
   validateAgreementTerms,
   validateDcbsDsaTerms,
   validateFerpaTerms,
   validateMouTerms,
+  validateOasisDsaTerms,
 } from './partner-agreements';
 
 // ---------------------------------------------------------------------------
@@ -388,5 +391,163 @@ describe('validateAgreementTerms', () => {
     expect(() => validateAgreementTerms('memo_of_cooperation', {})).toThrow(
       "agreement kind 'memo_of_cooperation' not yet supported",
     );
+  });
+
+  it("dispatches dsa+agency='oasis' to validateOasisDsaTerms", () => {
+    const result = validateAgreementTerms('dsa', validOasisDsa);
+    expect(result.kind).toBe('dsa');
+    if (result.kind === 'dsa') expect(result.agency).toBe('oasis');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// validateOasisDsaTerms (DTRS-012)
+// ---------------------------------------------------------------------------
+
+const validOasisDsa = {
+  kind: 'dsa',
+  agency: 'oasis',
+  scope: ['survivor_intake_roster', 'safety_plan_status'],
+  agency_legal_name: 'Owensboro Area Shelter and Information Services, Inc.',
+  agency_contact: {
+    name: 'Avery Hart',
+    title: 'Executive Director',
+    email: 'avery.hart@oasisshelter.org',
+    phone: '(270) 685-0260',
+  },
+  redaction_policy: OASIS_DEFAULT_REDACTION_POLICY,
+  abuser_blind_attestation: true,
+  data_destruction_due: 'on_termination',
+};
+
+describe('validateOasisDsaTerms', () => {
+  it('accepts a valid OASIS DSA terms object', () => {
+    const result = validateOasisDsaTerms(validOasisDsa);
+    expect(result.kind).toBe('dsa');
+    expect(result.agency).toBe('oasis');
+    expect(result.scope).toEqual(['survivor_intake_roster', 'safety_plan_status']);
+    expect(result.abuser_blind_attestation).toBe(true);
+    expect(result.redaction_policy.current_address).toBe('suppress');
+  });
+
+  it('accepts all valid scope values', () => {
+    const allScopes = OASIS_DSA_SCOPE_OPTIONS.map((o) => o.value);
+    const result = validateOasisDsaTerms({ ...validOasisDsa, scope: allScopes });
+    expect(result.scope).toEqual(allScopes);
+  });
+
+  it('accepts all valid data_destruction_due values', () => {
+    for (const val of ['on_termination', 'after_3_years', 'after_5_years'] as const) {
+      const result = validateOasisDsaTerms({ ...validOasisDsa, data_destruction_due: val });
+      expect(result.data_destruction_due).toBe(val);
+    }
+  });
+
+  it('accepts a relaxed redaction policy when admin opts in (still abuser-blind via attestation)', () => {
+    const relaxed = {
+      ...validOasisDsa,
+      redaction_policy: {
+        ...OASIS_DEFAULT_REDACTION_POLICY,
+        risk_tier: 'aggregate_only' as const,
+      },
+    };
+    const result = validateOasisDsaTerms(relaxed);
+    expect(result.redaction_policy.risk_tier).toBe('aggregate_only');
+  });
+
+  it('accepts terms without optional phone', () => {
+    const noPhone = {
+      ...validOasisDsa,
+      agency_contact: { name: 'A', title: 'T', email: 'a@x.com' },
+    };
+    const result = validateOasisDsaTerms(noPhone);
+    expect(result.agency_contact.phone).toBeUndefined();
+  });
+
+  it('rejects non-object input', () => {
+    expect(() => validateOasisDsaTerms(null)).toThrow('must be an object');
+    expect(() => validateOasisDsaTerms('dsa')).toThrow('must be an object');
+  });
+
+  it('rejects wrong kind', () => {
+    expect(() => validateOasisDsaTerms({ ...validOasisDsa, kind: 'mou' })).toThrow('kind: "dsa"');
+  });
+
+  it('rejects wrong agency', () => {
+    expect(() => validateOasisDsaTerms({ ...validOasisDsa, agency: 'dcbs' })).toThrow(
+      'agency must be "oasis"',
+    );
+  });
+
+  it('rejects empty scope array', () => {
+    expect(() => validateOasisDsaTerms({ ...validOasisDsa, scope: [] })).toThrow(
+      'at least one scope value',
+    );
+  });
+
+  it('rejects invalid scope value', () => {
+    expect(() => validateOasisDsaTerms({ ...validOasisDsa, scope: ['gps_pings'] })).toThrow(
+      'Invalid OASIS-DSA scope value: "gps_pings"',
+    );
+  });
+
+  it('rejects empty agency_legal_name', () => {
+    expect(() => validateOasisDsaTerms({ ...validOasisDsa, agency_legal_name: '' })).toThrow(
+      'non-empty agency_legal_name',
+    );
+  });
+
+  it('rejects missing agency_contact name', () => {
+    expect(() =>
+      validateOasisDsaTerms({
+        ...validOasisDsa,
+        agency_contact: { name: '', title: 'T', email: 'a@x.com' },
+      }),
+    ).toThrow('non-empty name');
+  });
+
+  it('rejects abuser_blind_attestation = false (the cornerstone of the contract)', () => {
+    expect(() =>
+      validateOasisDsaTerms({ ...validOasisDsa, abuser_blind_attestation: false }),
+    ).toThrow('abuser_blind_attestation must be true');
+  });
+
+  it('rejects abuser_blind_attestation missing entirely', () => {
+    const { abuser_blind_attestation: _omit, ...withoutAttestation } = validOasisDsa;
+    void _omit;
+    expect(() => validateOasisDsaTerms(withoutAttestation)).toThrow(
+      'abuser_blind_attestation must be true',
+    );
+  });
+
+  it('rejects redaction_policy missing a required field', () => {
+    const { current_address: _drop, ...partialPolicy } = OASIS_DEFAULT_REDACTION_POLICY;
+    void _drop;
+    expect(() =>
+      validateOasisDsaTerms({ ...validOasisDsa, redaction_policy: partialPolicy }),
+    ).toThrow('redaction_policy["current_address"]');
+  });
+
+  it('rejects redaction_policy with an invalid treatment value', () => {
+    expect(() =>
+      validateOasisDsaTerms({
+        ...validOasisDsa,
+        redaction_policy: { ...OASIS_DEFAULT_REDACTION_POLICY, current_address: 'show_to_all' },
+      }),
+    ).toThrow('redaction_policy["current_address"]');
+  });
+
+  it('rejects invalid data_destruction_due', () => {
+    expect(() =>
+      validateOasisDsaTerms({ ...validOasisDsa, data_destruction_due: 'never_required' }),
+    ).toThrow('data_destruction_due must be one of');
+  });
+
+  it('strips extra/unexpected keys (does not pass through to JSONB)', () => {
+    const result = validateOasisDsaTerms({
+      ...validOasisDsa,
+      survivor_home_address: '123 Real St',
+    });
+    expect(result).not.toHaveProperty('survivor_home_address');
   });
 });

--- a/src/lib/dtrs/partner-agreements.ts
+++ b/src/lib/dtrs/partner-agreements.ts
@@ -78,6 +78,75 @@ export const DCBS_DSA_SCOPE_OPTIONS = [
 
 export type DcbsDsaScopeValue = (typeof DCBS_DSA_SCOPE_OPTIONS)[number]['value'];
 
+/**
+ * OASIS-DSA data classes — the DV-survivor cohort the coalition may receive
+ * from OASIS (Owensboro Area Shelter and Information Services). Survivors
+ * are not in state custody — abuser-blind redaction at the contract layer
+ * is the cornerstone (see ADR 0007).
+ *
+ * Single source of truth — the intake form renders checkboxes from this
+ * array.
+ */
+export const OASIS_DSA_SCOPE_OPTIONS = [
+  {
+    value: 'survivor_intake_roster' as const,
+    label: 'Survivor intake roster (active enrollments + risk tier)',
+  },
+  {
+    value: 'safety_plan_status' as const,
+    label: 'Safety-plan status (on-file flag, last-updated date — never plan content)',
+  },
+  {
+    value: 'service_referral_history' as const,
+    label: 'Service-referral history (legal / housing / childcare / employment)',
+  },
+  {
+    value: 'risk_tier_only' as const,
+    label: 'Risk tier only (Campbell DA-scale band; aggregate fallback)',
+  },
+] as const;
+
+export type OasisDsaScopeValue = (typeof OASIS_DSA_SCOPE_OPTIONS)[number]['value'];
+
+/**
+ * Abuser-blind redaction-policy fields. Each field is classified as:
+ *   - 'share': transmitted as-is to authorized readers
+ *   - 'suppress': never transmitted (or transmitted as null) — risk of
+ *     abuser obtaining survivor location through a coalition data leak
+ *   - 'aggregate_only': only included in aggregate counts, never per-record
+ *
+ * The set of fields below is the v1 minimum-locked policy. Adding a field
+ * later is a contract amendment (ADR 0007 § 3.3).
+ */
+export const OASIS_REDACTABLE_FIELDS = [
+  'current_address',
+  'current_employer',
+  'child_school_id',
+  'risk_tier',
+  'enrolled_at',
+  'assigned_advocate_id',
+] as const;
+
+export type OasisRedactableField = (typeof OASIS_REDACTABLE_FIELDS)[number];
+export type OasisRedactionTreatment = 'share' | 'suppress' | 'aggregate_only';
+export type OasisRedactionPolicy = Record<OasisRedactableField, OasisRedactionTreatment>;
+
+/**
+ * Default redaction policy — abuser-blind by default. Locations and
+ * identifying details suppressed; risk tier and enrollment date shareable.
+ * The intake form starts here; admin may relax fields with explicit
+ * justification, but `abuser_blind_attestation` must remain true to record
+ * the agreement as `active`.
+ */
+export const OASIS_DEFAULT_REDACTION_POLICY: OasisRedactionPolicy = {
+  current_address: 'suppress',
+  current_employer: 'suppress',
+  child_school_id: 'suppress',
+  risk_tier: 'share',
+  enrolled_at: 'share',
+  assigned_advocate_id: 'share',
+};
+
 // ---------------------------------------------------------------------------
 // Terms shapes
 // ---------------------------------------------------------------------------
@@ -160,11 +229,62 @@ export type DcbsDsaTerms = {
 };
 
 /**
- * Union of all DSA-kind terms shapes. Today only DCBS is specified; KY DOC
- * (DTRS-012) will add a sibling type. The `agency` discriminator is the
- * narrowing key.
+ * OASIS Data-Sharing Agreement terms (DTRS-012). Authorizes individual-record
+ * sharing for the DV survivor pathway (SUBP-004).
+ *
+ * Distinguished from DCBS (ADR 0006, state-as-guardian custodial authority):
+ * OASIS survivors are not in state custody. The contract's privacy guarantee
+ * is the abuser-blind redaction policy itself — encoded in the `terms` so
+ * SUBP-004's middleware reads it as the single source of truth, not a
+ * downstream re-derivation. See ADR 0007 for the full contract.
+ *
+ * `abuser_blind_attestation` must be true when status='active'. The
+ * validator enforces this; `validateAgreementTerms` re-runs it on every
+ * insert.
  */
-export type DsaTerms = DcbsDsaTerms;
+export type OasisDsaTerms = {
+  kind: 'dsa';
+  agency: 'oasis';
+  /** Which data classes are covered by this agreement. */
+  scope: OasisDsaScopeValue[];
+  /** Full legal name of the executing OASIS entity. */
+  agency_legal_name: string;
+  /** Single point of contact at OASIS (advocate or program director). */
+  agency_contact: {
+    name: string;
+    title: string;
+    email: string;
+    phone?: string;
+  };
+  /**
+   * Per-field abuser-blind redaction treatment. Reads:
+   *   - `suppress`: SUBP-004 never persists or surfaces this field
+   *   - `aggregate_only`: SUBP-004 may include in counts; never per-record
+   *   - `share`: transmitted to authorized readers per `data-access.ts`
+   *
+   * The default policy (`OASIS_DEFAULT_REDACTION_POLICY`) suppresses every
+   * field that could leak survivor location.
+   */
+  redaction_policy: OasisRedactionPolicy;
+  /**
+   * MUST be true to record this agreement as `status='active'`. The admin
+   * checks this box in the intake form after reviewing the redaction
+   * policy. Validator throws if the policy is `active` and this flag is
+   * not true.
+   */
+  abuser_blind_attestation: boolean;
+  /**
+   * Records-retention deadline. KRS 209A confidentiality and DV best
+   * practice favor `on_termination` for victim-services data.
+   */
+  data_destruction_due: 'on_termination' | 'after_3_years' | 'after_5_years';
+};
+
+/**
+ * Union of all DSA-kind terms shapes. The `agency` discriminator is the
+ * narrowing key. KY DOC reentry (SUBP-005) will add a third sibling.
+ */
+export type DsaTerms = DcbsDsaTerms | OasisDsaTerms;
 
 /**
  * Placeholder for agreement kinds whose intake stories haven't shipped yet
@@ -445,14 +565,158 @@ export function validateDcbsDsaTerms(input: unknown): DcbsDsaTerms {
   };
 }
 
+const OASIS_DSA_SCOPE_VALUES = OASIS_DSA_SCOPE_OPTIONS.map((o) => o.value);
+const OASIS_REDACTION_TREATMENTS: readonly OasisRedactionTreatment[] = [
+  'share',
+  'suppress',
+  'aggregate_only',
+];
+
+/**
+ * Validate OASIS-DSA terms (DTRS-012). Throws on invalid; returns typed value
+ * on success. See ADR 0007 for the privacy contract this validator enforces.
+ *
+ * **Strict abuser-blind enforcement:** `abuser_blind_attestation` MUST be
+ * `true`. Recording an OASIS-DSA without attestation is an architectural
+ * bug — the abuser-blind discipline is the contract, not an option. If a
+ * draft path is ever needed, revisit with an explicit `status` parameter
+ * here rather than weakening the validator (ADR 0007 § 3.3).
+ *
+ * The redaction policy must cover every field in `OASIS_REDACTABLE_FIELDS` —
+ * partial policies are rejected, since SUBP-004's middleware reads this as
+ * its single source of truth and a missing field would silently fall through
+ * to "share." Adding a field to the policy is a contract amendment.
+ */
+export function validateOasisDsaTerms(input: unknown): OasisDsaTerms {
+  if (typeof input !== 'object' || input === null) {
+    throw new Error('DSA terms must be an object');
+  }
+
+  const {
+    kind,
+    agency,
+    scope,
+    agency_legal_name,
+    agency_contact,
+    redaction_policy,
+    abuser_blind_attestation,
+    data_destruction_due,
+  } = input as {
+    kind?: unknown;
+    agency?: unknown;
+    scope?: unknown;
+    agency_legal_name?: unknown;
+    agency_contact?: unknown;
+    redaction_policy?: unknown;
+    abuser_blind_attestation?: unknown;
+    data_destruction_due?: unknown;
+  };
+
+  if (kind !== 'dsa') {
+    throw new Error('DSA terms must have kind: "dsa"');
+  }
+  if (agency !== 'oasis') {
+    throw new Error('DSA terms.agency must be "oasis" for OASIS agreements');
+  }
+
+  if (!Array.isArray(scope) || scope.length === 0) {
+    throw new Error('DSA terms must include at least one scope value');
+  }
+  for (const s of scope as unknown[]) {
+    if (!OASIS_DSA_SCOPE_VALUES.includes(s as OasisDsaScopeValue)) {
+      throw new Error(
+        `Invalid OASIS-DSA scope value: "${String(s)}" (allowed: ${OASIS_DSA_SCOPE_VALUES.join(', ')})`,
+      );
+    }
+  }
+
+  if (typeof agency_legal_name !== 'string' || !agency_legal_name.trim()) {
+    throw new Error('DSA terms must include a non-empty agency_legal_name');
+  }
+
+  if (typeof agency_contact !== 'object' || agency_contact === null) {
+    throw new Error('DSA terms must include an agency_contact object');
+  }
+  const {
+    name: acName,
+    title: acTitle,
+    email: acEmail,
+    phone: acPhone,
+  } = agency_contact as {
+    name?: unknown;
+    title?: unknown;
+    email?: unknown;
+    phone?: unknown;
+  };
+  if (typeof acName !== 'string' || !acName.trim()) {
+    throw new Error('DSA agency_contact must include a non-empty name');
+  }
+  if (typeof acTitle !== 'string' || !acTitle.trim()) {
+    throw new Error('DSA agency_contact must include a non-empty title');
+  }
+  if (typeof acEmail !== 'string' || !acEmail.trim()) {
+    throw new Error('DSA agency_contact must include a non-empty email');
+  }
+  if (acPhone !== undefined && typeof acPhone !== 'string') {
+    throw new Error('DSA agency_contact.phone must be a string when provided');
+  }
+
+  if (typeof redaction_policy !== 'object' || redaction_policy === null) {
+    throw new Error('DSA terms must include a redaction_policy object');
+  }
+  const policyEntries = redaction_policy as Record<string, unknown>;
+  const validatedPolicy: Partial<OasisRedactionPolicy> = {};
+  for (const field of OASIS_REDACTABLE_FIELDS) {
+    const treatment = policyEntries[field];
+    if (
+      typeof treatment !== 'string' ||
+      !OASIS_REDACTION_TREATMENTS.includes(treatment as OasisRedactionTreatment)
+    ) {
+      throw new Error(
+        `Invalid OASIS-DSA redaction_policy["${field}"]: must be one of ${OASIS_REDACTION_TREATMENTS.join(', ')}`,
+      );
+    }
+    validatedPolicy[field] = treatment as OasisRedactionTreatment;
+  }
+
+  if (abuser_blind_attestation !== true) {
+    throw new Error(
+      'DSA terms.abuser_blind_attestation must be true — abuser-blind discipline is the OASIS contract (ADR 0007). ' +
+        'Recording without attestation is not permitted.',
+    );
+  }
+
+  const validDestruction = ['on_termination', 'after_3_years', 'after_5_years'] as const;
+  if (!validDestruction.includes(data_destruction_due as (typeof validDestruction)[number])) {
+    throw new Error(`DSA data_destruction_due must be one of: ${validDestruction.join(', ')}`);
+  }
+
+  return {
+    kind: 'dsa',
+    agency: 'oasis',
+    scope: scope as OasisDsaScopeValue[],
+    agency_legal_name,
+    agency_contact: {
+      name: acName,
+      title: acTitle,
+      email: acEmail,
+      phone: acPhone as string | undefined,
+    },
+    redaction_policy: validatedPolicy as OasisRedactionPolicy,
+    abuser_blind_attestation: true,
+    data_destruction_due: data_destruction_due as OasisDsaTerms['data_destruction_due'],
+  };
+}
+
 /**
  * Dispatcher — picks the right validator for the given agreement kind.
  *
  * Placeholder kinds (baa, qsoa, memo_of_cooperation) are intentionally
  * fail-closed: they throw until their intake stories ship and a real validator
- * is wired in. `dsa` is dispatched on the `agency` discriminator: only
- * `agency='dcbs'` (DTRS-011) is supported today; `ky_doc` is blocked until
- * DTRS-012. See ADR 0004 for the registry plan.
+ * is wired in. `dsa` is dispatched on the `agency` discriminator: `dcbs`
+ * (DTRS-011) and `oasis` (DTRS-012) are supported; `ky_doc` reentry is
+ * blocked until SUBP-005's prerequisite DTRS story lands. See ADR 0004 for
+ * the registry plan.
  */
 export function validateAgreementTerms(
   kind: PartnerAgreementKind,
@@ -469,8 +733,9 @@ export function validateAgreementTerms(
       }
       const agency = (input as { agency?: unknown }).agency;
       if (agency === 'dcbs') return validateDcbsDsaTerms(input);
+      if (agency === 'oasis') return validateOasisDsaTerms(input);
       if (typeof agency !== 'string' || !agency) {
-        throw new Error("DSA terms.agency is required (e.g. 'dcbs')");
+        throw new Error("DSA terms.agency is required (e.g. 'dcbs', 'oasis')");
       }
       throw new Error(
         `DSA agency '${agency}' not yet supported — its intake story has not shipped. ` +


### PR DESCRIPTION
Closes #360.

Sprint 11 receiving infrastructure for the DV survivor pathway (SUBP-004). Same registry pivot as DTRS-011 / OPRT-002 (#368): not a new table — extends the polymorphic [`partner_agreements`](docs/adr/0004-partner-agreements-registry.md) registry with `kind='dsa'` and `agency='oasis'` on the JSONB `terms`.

## Why this shape, not a new table

The OPRT-002 PR walked the same path: ADR 0004 explicitly enumerated `dsa` for state/agency agreements; building a parallel `oasis_data_sharing_agreements` table would have duplicated agreement-tracking surface and split the policy from the registry that authorizes it. **This story closes the loop:** the OASIS-specific shape sits on the existing registry as a discriminated `OasisDsaTerms` variant.

The unique-to-OASIS constraint is the cornerstone:

> Survivors are **not** in state custody (unlike DCBS / ADR 0006). The threat model centers on a third party (the abuser) actively trying to obtain location through any data leak. Abuser-blind discipline must be a *structural property of the data flow*, not a downstream policy that downstream code may or may not honor correctly.

So the contract encodes the redaction policy itself — `terms.redaction_policy` is the contract-of-record that SUBP-004's middleware reads (ADR 0007 § 3.2).

## What changed

### Lib (`src/lib/dtrs/partner-agreements.ts`)
- `OasisDsaTerms` discriminated-union variant on the existing `DsaTerms` union (alongside `DcbsDsaTerms`).
- `OASIS_DSA_SCOPE_OPTIONS` controlled vocabulary: `survivor_intake_roster`, `safety_plan_status`, `service_referral_history`, `risk_tier_only`.
- `OASIS_REDACTABLE_FIELDS` + `OASIS_DEFAULT_REDACTION_POLICY` — abuser-blind by default (location-identifying fields suppressed; risk-tier band, enrollment timestamp, advocate-id-only shareable).
- `validateOasisDsaTerms` — strict: `abuser_blind_attestation === true` is non-optional; redaction policy must cover every field in the controlled vocabulary (partial policies rejected to prevent silent fall-through).
- `validateAgreementTerms` dispatcher updated to handle `agency='oasis'`.

### Parser (`src/app/actions/partner-agreements-parse.ts`)
- `parseOasisDsaAgreementForm` (sibling pure module per the `'use server'` × vitest quirk in STATE.md).
- Defaults missing per-field redaction treatments from `OASIS_DEFAULT_REDACTION_POLICY`; rejects invalid treatments; rejects attestation absence.

### Action (`src/app/actions/partner-agreements.ts`)
- `recordOasisDsaAgreementAction` (admin-gated, audit-logged via existing `recordAgreement`).
- `updateAgreementStatusAction` now also revalidates `/app/admin/agreements/oasis`.

### Query (`src/db/queries/partner-agreements.ts`)
- `getActiveOasisDsa(partnerOrgId)` — JSONB filter `terms->>'agency' = 'oasis'`, exposed via the dtrs barrel for SUBP-004 to gate ingestion. Returns `null` when no active OASIS DSA exists; SUBP-004 must fail closed in that case (ADR 0007 § 3.1).

### Admin UI
- `/app/admin/agreements/oasis/page.tsx` — partner picker (filtered to `type='shelter'`), active-agreement warning, recorded-agreements summary.
- `OasisDsaAgreementForm` — redaction-policy fieldset (per-field radio: suppress / aggregate_only / share), attestation checkbox (submit button disabled until checked).

### Public template
- `/agreements/oasis/template/page.tsx` — template version `oasis-dsa-v1`. Recitals cover KRS 209A confidentiality, VAWA, abuser-blind discipline as a structural property, breach → mandatory data-flow suspension, and the redaction-policy-as-contractual-instrument framing.

### ADR 0007 — OASIS / DV survivor privacy contract
Five-rule contract, contrast table vs. ADR 0005 (FERPA fork) / ADR 0006 (DCBS state-as-guardian). Documents rejected alternatives: separate table, code-only policy, third privacy regime fork, draft path weakening. Explicit on what doesn't change (existing `dv-blind.ts` primitive remains; ADR 0003 / 0005 / 0006 unchanged).

## Test plan

- [x] 616 vitest tests pass (33 new: 17 validator cases + 16 parser cases — including attestation enforcement, redaction-policy completeness, treatment-vocabulary, default-policy fallback, no-enumeration-of-extra-keys)
- [x] `pnpm exec tsc --noEmit` clean
- [x] `pnpm exec biome check` clean (no `--write`)
- [x] `pnpm exec tsx scripts/check-domain-boundaries.mts` clean
- [x] `pnpm build` clean — both `/agreements/oasis/template` (static) and `/app/admin/agreements/oasis` (dynamic) routes compile
- [ ] Manual: walk the form, confirm submit button is disabled until attestation checked, confirm active-agreement warning fires when re-recording for the same shelter
- [ ] Manual: relax one redaction field (e.g. `risk_tier` → `aggregate_only`) and confirm it round-trips through the validator → JSONB → read

## Followups (out of scope for this PR)

- **SUBP-004** picks this up next: its middleware reads `getActiveOasisDsa()` and `terms.redaction_policy` as the contract-of-record. New PR.
- Breach notification piping (template § 4.4 — currently Sentry-only; OASIS-side paging is a follow-up).
- A redaction-policy contract test that exercises every field × every treatment combination end-to-end (mentioned in ADR 0007 § Consequences — defer to SUBP-004 where the middleware lives).

Synthetic-only across the board — PHI fence still in effect ([CLAUDE.md](CLAUDE.md)).

🤖 Generated with [Claude Code](https://claude.com/claude-code)