### PR TITLE
feat(PRVN-001): ED first-time-homeless flag + alert view

### DIFF
--- a/src/app/app/care/first-time-homeless/page.tsx
+++ b/src/app/app/care/first-time-homeless/page.tsx
@@ -1,0 +1,109 @@
+import Link from 'next/link';
+import { listFirstTimeHomelessAlerts } from '@/db/queries/ed-encounters';
+import { requireRole } from '@/lib/auth';
+
+export const dynamic = 'force-dynamic';
+
+const HOURS_RECENT_THRESHOLD = 48;
+
+export default async function FirstTimeHomelessAlertsPage() {
+  await requireRole(['ed_coordinator', 'admin']);
+
+  const alerts = await listFirstTimeHomelessAlerts({ windowDays: 90 });
+  const now = Date.now();
+
+  return (
+    <div className="mx-auto max-w-5xl space-y-6 p-4 md:p-6">
+      <div className="text-xs">
+        <Link href="/app/care/queue" className="text-muted-foreground hover:underline">
+          ← Back to care queue
+        </Link>
+      </div>
+      <header>
+        <h1 className="font-serif text-3xl font-bold text-primary">First-time-homeless alerts</h1>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Patients whose most recent ED encounter is their first transition to{' '}
+          <code className="font-mono text-xs">shelter</code> or{' '}
+          <code className="font-mono text-xs">unsheltered</code> housing on coalition record. The
+          alert window is the discharge moment — coordinate outreach before the patient leaves the
+          ED. Patients with a single homeless encounter (no prior history) are excluded; chronic
+          super-utilizers belong on the{' '}
+          <Link
+            href="/app/care/queue"
+            className="underline underline-offset-2 hover:text-foreground"
+          >
+            super-utilizer queue
+          </Link>
+          .
+        </p>
+      </header>
+
+      {alerts.length === 0 ? (
+        <div className="rounded-md border border-border bg-muted/20 p-6 text-sm">
+          <p className="font-semibold">No first-time-homeless alerts in the last 90 days.</p>
+          <p className="mt-2 text-muted-foreground">
+            This is the synthetic-default state for a freshly-seeded fixture without a transition
+            pattern. Run{' '}
+            <code className="font-mono">pnpm tsx scripts/gen-synthetic-ed-encounters.ts</code> to
+            seed a richer signal.
+          </p>
+        </div>
+      ) : (
+        <div className="overflow-x-auto rounded-md border border-border">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b bg-muted/30 text-left">
+                <th className="px-3 py-2 font-medium">Patient</th>
+                <th className="px-3 py-2 font-medium">Transition</th>
+                <th className="px-3 py-2 font-medium">Prior visits</th>
+                <th className="px-3 py-2 font-medium">Disposition</th>
+                <th className="px-3 py-2 font-medium">Chief complaint</th>
+              </tr>
+            </thead>
+            <tbody>
+              {alerts.map((a) => {
+                const transitionAt = a.classification.transitionAt;
+                const ageHours = transitionAt
+                  ? (now - transitionAt.getTime()) / (1000 * 60 * 60)
+                  : null;
+                const isRecent = ageHours !== null && ageHours < HOURS_RECENT_THRESHOLD;
+                return (
+                  <tr key={a.patientId} className="border-b last:border-0 hover:bg-muted/10">
+                    <td className="px-3 py-2 font-mono text-xs">
+                      <Link href={`/app/care/patients/${a.patientId}`} className="hover:underline">
+                        {a.patientId}
+                      </Link>
+                    </td>
+                    <td className="px-3 py-2 tabular-nums">
+                      {transitionAt ? transitionAt.toISOString().slice(0, 10) : '—'}
+                      {isRecent && (
+                        <span className="ml-2 rounded bg-red-100 px-1.5 py-0.5 text-[10px] font-medium text-red-700 dark:bg-red-900/40 dark:text-red-400">
+                          ≤{HOURS_RECENT_THRESHOLD}h
+                        </span>
+                      )}
+                    </td>
+                    <td className="px-3 py-2 tabular-nums">{a.classification.encountersBefore}</td>
+                    <td className="px-3 py-2 capitalize">{a.lastDisposition}</td>
+                    <td className="px-3 py-2 max-w-md truncate" title={a.lastChiefComplaint}>
+                      {a.lastChiefComplaint}
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      <div className="rounded-md border border-amber-500/40 bg-amber-500/5 p-3 text-xs">
+        <p className="font-medium">PHI fence still in effect.</p>
+        <p className="mt-1 text-muted-foreground">
+          Patient identifiers are opaque (synthetic <code className="font-mono">SYN-PAT-…</code>{' '}
+          prefix today, hashed Epic ids post-BAA). The alert engine reads housing-status transitions
+          only — no clinical free-text. Real-time discharge alerting to OH social workers is a
+          follow-up; today this is a read-only triage view for the coalition's ED coordinator.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/db/queries/ed-encounters.ts
+++ b/src/db/queries/ed-encounters.ts
@@ -5,10 +5,15 @@
 // that point migrate to DISTINCT ON (patient_id) CTE for "latest
 // row per patient" + a separate count CTE, joined. A composite
 // index (patient_id, arrived_at DESC) helps either way.
-import { count, desc, eq, gte, max, sql } from 'drizzle-orm';
+import { asc, count, desc, eq, gte, max, sql } from 'drizzle-orm';
 import { db } from '@/db/client';
 import { edEncounters } from '@/db/schema/ed-encounters';
-import { HOUSING_INSTABILITY_FLAGS, type SuperUtilizerRow } from '@/lib/esuc';
+import {
+  classifyFirstTimeHomeless,
+  type FirstTimeHomelessClassification,
+  HOUSING_INSTABILITY_FLAGS,
+  type SuperUtilizerRow,
+} from '@/lib/esuc';
 
 export interface ListSuperUtilizersOpts {
   /** Minimum number of ED visits in the window to qualify. Default 3. */
@@ -100,4 +105,94 @@ export async function listEncountersForPatient(patientId: string) {
     .from(edEncounters)
     .where(eq(edEncounters.patientId, patientId))
     .orderBy(desc(edEncounters.arrivedAt));
+}
+
+// ---------------------------------------------------------------------------
+// PRVN-001 — first-time-homeless alerts
+// ---------------------------------------------------------------------------
+
+export interface FirstTimeHomelessAlertRow {
+  patientId: string;
+  classification: FirstTimeHomelessClassification;
+  /** Most recent chief complaint (lightweight context for the alert list). */
+  lastChiefComplaint: string;
+  /** Most recent disposition — caseworkers triage discharged-home faster. */
+  lastDisposition: string;
+}
+
+export interface ListFirstTimeHomelessAlertsOpts {
+  /** Lookback window in days. Default 90 — caseworkers don't act on stale signals. */
+  windowDays?: number;
+  /** Cap on rows returned. Default 50. */
+  limit?: number;
+}
+
+/**
+ * List patients whose most recent ED encounter is their first-time-homeless
+ * transition — i.e. they are being discharged into homelessness for the
+ * first time on coalition record. Composes the pure classifier in
+ * `src/lib/esuc/first-time-homeless.ts` over each patient's encounter
+ * history.
+ *
+ * Patients with only a single encounter that is homeless are excluded
+ * (no prior history to confirm "first time"). See classifier docs.
+ *
+ * Sorted by transition timestamp descending — most-recent alerts first.
+ */
+export async function listFirstTimeHomelessAlerts(
+  opts: ListFirstTimeHomelessAlertsOpts = {},
+): Promise<FirstTimeHomelessAlertRow[]> {
+  const { windowDays = 90, limit = 50 } = opts;
+  const since = new Date();
+  since.setDate(since.getDate() - windowDays);
+
+  // Pull all encounters in the window. Cheaper than per-patient round-trips
+  // for Phase-1-scale data; if this gets large, push the classification
+  // into a SQL CTE.
+  const rows = await db
+    .select({
+      id: edEncounters.id,
+      patientId: edEncounters.patientId,
+      arrivedAt: edEncounters.arrivedAt,
+      housingStatus: edEncounters.housingStatus,
+      chiefComplaint: edEncounters.chiefComplaint,
+      disposition: edEncounters.disposition,
+    })
+    .from(edEncounters)
+    .where(gte(edEncounters.arrivedAt, since))
+    .orderBy(asc(edEncounters.patientId), asc(edEncounters.arrivedAt));
+
+  // Group by patient.
+  const byPatient = new Map<string, typeof rows>();
+  for (const r of rows) {
+    const list = byPatient.get(r.patientId);
+    if (list) list.push(r);
+    else byPatient.set(r.patientId, [r]);
+  }
+
+  const alerts: FirstTimeHomelessAlertRow[] = [];
+  for (const [patientId, encounters] of byPatient) {
+    const classification = classifyFirstTimeHomeless(
+      encounters.map((e) => ({
+        id: e.id,
+        arrivedAt: e.arrivedAt instanceof Date ? e.arrivedAt : new Date(e.arrivedAt),
+        housingStatus: e.housingStatus,
+      })),
+    );
+    if (!classification.isAlertCandidate) continue;
+    const last = encounters[encounters.length - 1];
+    alerts.push({
+      patientId,
+      classification,
+      lastChiefComplaint: last.chiefComplaint,
+      lastDisposition: last.disposition,
+    });
+  }
+
+  alerts.sort((a, b) => {
+    const at = a.classification.transitionAt?.getTime() ?? 0;
+    const bt = b.classification.transitionAt?.getTime() ?? 0;
+    return bt - at;
+  });
+  return alerts.slice(0, limit);
 }

--- a/src/lib/esuc/first-time-homeless.test.ts
+++ b/src/lib/esuc/first-time-homeless.test.ts
@@ -1,0 +1,123 @@
+/**
+ * PRVN-001 — first-time-homeless classifier tests.
+ *
+ * Pure function. The classifier reads a chronological encounter
+ * sequence for one patient and identifies the transition point — the
+ * earliest encounter where housing flipped from "housed / unknown" to
+ * "shelter / unsheltered". The alert use case (caseworker outreach
+ * before discharge) fires when that transition is the most recent
+ * encounter — i.e. the patient is being discharged into homelessness
+ * for the first time on coalition record.
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  classifyFirstTimeHomeless,
+  type EncounterForClassification,
+  HOMELESS_HOUSING_STATUSES,
+} from './first-time-homeless';
+
+const enc = (
+  id: string,
+  arrivedAt: string,
+  housingStatus: EncounterForClassification['housingStatus'],
+): EncounterForClassification => ({ id, arrivedAt: new Date(arrivedAt), housingStatus });
+
+describe('classifyFirstTimeHomeless', () => {
+  it('returns null transition when patient was never housing-flagged', () => {
+    const r = classifyFirstTimeHomeless([
+      enc('e1', '2026-01-01', 'housed'),
+      enc('e2', '2026-02-01', 'housed'),
+      enc('e3', '2026-03-01', 'unknown'),
+    ]);
+    expect(r.transitionEncounterId).toBeNull();
+    expect(r.isAlertCandidate).toBe(false);
+  });
+
+  it('flags first-time-homeless when transition is the most recent encounter', () => {
+    const r = classifyFirstTimeHomeless([
+      enc('e1', '2026-01-01', 'housed'),
+      enc('e2', '2026-02-01', 'housed'),
+      enc('e3', '2026-03-01', 'unsheltered'),
+    ]);
+    expect(r.transitionEncounterId).toBe('e3');
+    expect(r.encountersBefore).toBe(2);
+    expect(r.isAlertCandidate).toBe(true);
+  });
+
+  it('does NOT flag alert when transition is an OLDER encounter (no longer first-time)', () => {
+    const r = classifyFirstTimeHomeless([
+      enc('e1', '2026-01-01', 'housed'),
+      enc('e2', '2026-02-01', 'unsheltered'),
+      enc('e3', '2026-03-01', 'shelter'),
+    ]);
+    // Transition was e2; e3 is also homeless but no longer the FIRST time.
+    expect(r.transitionEncounterId).toBe('e2');
+    expect(r.isAlertCandidate).toBe(false);
+  });
+
+  it('treats shelter and unsheltered both as homeless', () => {
+    const r = classifyFirstTimeHomeless([
+      enc('e1', '2026-01-01', 'doubled_up'),
+      enc('e2', '2026-02-01', 'shelter'),
+    ]);
+    expect(r.transitionEncounterId).toBe('e2');
+    expect(r.isAlertCandidate).toBe(true);
+  });
+
+  it('treats doubled_up as NOT homeless (first-time-homeless is the unsheltered/shelter step)', () => {
+    const r = classifyFirstTimeHomeless([
+      enc('e1', '2026-01-01', 'housed'),
+      enc('e2', '2026-02-01', 'doubled_up'),
+      enc('e3', '2026-03-01', 'doubled_up'),
+    ]);
+    expect(r.transitionEncounterId).toBeNull();
+    expect(r.isAlertCandidate).toBe(false);
+  });
+
+  it('first encounter unsheltered → already-homeless on first visit; no alert (no prior history)', () => {
+    // Without prior history, we can't know if this is truly first-time.
+    // The conservative call: do not alert — the patient may be chronically
+    // homeless. A dedicated story can refine if needed.
+    const r = classifyFirstTimeHomeless([enc('e1', '2026-01-01', 'unsheltered')]);
+    expect(r.transitionEncounterId).toBe('e1');
+    expect(r.encountersBefore).toBe(0);
+    expect(r.isAlertCandidate).toBe(false);
+  });
+
+  it('handles unsorted input by sorting chronologically', () => {
+    const r = classifyFirstTimeHomeless([
+      enc('e3', '2026-03-01', 'unsheltered'),
+      enc('e1', '2026-01-01', 'housed'),
+      enc('e2', '2026-02-01', 'housed'),
+    ]);
+    expect(r.transitionEncounterId).toBe('e3');
+    expect(r.isAlertCandidate).toBe(true);
+  });
+
+  it('returns null on empty input (defensive)', () => {
+    const r = classifyFirstTimeHomeless([]);
+    expect(r.transitionEncounterId).toBeNull();
+    expect(r.encountersBefore).toBe(0);
+    expect(r.isAlertCandidate).toBe(false);
+  });
+
+  it('handles patient bouncing back to housed and then homeless again', () => {
+    // First time was e2; e4 is a re-entry, not first-time.
+    const r = classifyFirstTimeHomeless([
+      enc('e1', '2026-01-01', 'housed'),
+      enc('e2', '2026-02-01', 'shelter'),
+      enc('e3', '2026-03-01', 'housed'),
+      enc('e4', '2026-04-01', 'unsheltered'),
+    ]);
+    expect(r.transitionEncounterId).toBe('e2');
+    expect(r.isAlertCandidate).toBe(false);
+  });
+
+  it('exposes HOMELESS_HOUSING_STATUSES as a stable controlled vocab', () => {
+    expect(HOMELESS_HOUSING_STATUSES).toContain('shelter');
+    expect(HOMELESS_HOUSING_STATUSES).toContain('unsheltered');
+    expect(HOMELESS_HOUSING_STATUSES).not.toContain('doubled_up');
+    expect(HOMELESS_HOUSING_STATUSES).not.toContain('housed');
+  });
+});

--- a/src/lib/esuc/first-time-homeless.ts
+++ b/src/lib/esuc/first-time-homeless.ts
@@ -1,0 +1,95 @@
+/**
+ * PRVN-001 — first-time-homeless classifier.
+ *
+ * Pure function. Given a chronological sequence of one patient's ED
+ * encounters, identifies whether the patient is transitioning to
+ * homelessness for the first time on coalition record. The "alert"
+ * use case (caseworker outreach before discharge) fires only when:
+ *
+ *   1. There is a transition encounter (a prior non-homeless encounter
+ *      followed by a homeless one), AND
+ *   2. The transition encounter is the most recent encounter (the
+ *      patient is being discharged into homelessness right now).
+ *
+ * "Homeless" for this classifier = `housing_status ∈ {shelter, unsheltered}`.
+ * `doubled_up` is intentionally excluded — that's housing instability but
+ * not the discharge-into-homelessness signal this engine is built to
+ * catch. A later story can refine if the alert population needs widening.
+ *
+ * No DB, no clocks. Tested in isolation; the query layer composes this
+ * over patient-by-patient encounter histories.
+ */
+
+import type { HousingStatus } from '@/db/schema/enums';
+
+/**
+ * Housing statuses that count as "homeless" for the first-time-homeless
+ * alert. Stable controlled vocab — change with intent and update tests.
+ */
+export const HOMELESS_HOUSING_STATUSES: ReadonlyArray<HousingStatus> = ['shelter', 'unsheltered'];
+
+export type EncounterForClassification = {
+  id: string;
+  arrivedAt: Date;
+  housingStatus: HousingStatus;
+};
+
+export type FirstTimeHomelessClassification = {
+  /** Earliest encounter where housing flipped to homeless. Null if never. */
+  transitionEncounterId: string | null;
+  /** Timestamp of the transition encounter, or null. */
+  transitionAt: Date | null;
+  /** Encounters preceding the transition (used to gauge confidence). */
+  encountersBefore: number;
+  /**
+   * True only when the transition encounter is the patient's MOST recent
+   * encounter — i.e. they are being discharged into homelessness right
+   * now. This is the caseworker-alert trigger.
+   */
+  isAlertCandidate: boolean;
+};
+
+function isHomeless(status: HousingStatus): boolean {
+  return HOMELESS_HOUSING_STATUSES.includes(status);
+}
+
+export function classifyFirstTimeHomeless(
+  encounters: ReadonlyArray<EncounterForClassification>,
+): FirstTimeHomelessClassification {
+  if (encounters.length === 0) {
+    return {
+      transitionEncounterId: null,
+      transitionAt: null,
+      encountersBefore: 0,
+      isAlertCandidate: false,
+    };
+  }
+
+  // Sort chronologically (defensive — callers may pass unsorted).
+  const sorted = [...encounters].sort((a, b) => a.arrivedAt.getTime() - b.arrivedAt.getTime());
+
+  // Find the earliest encounter whose housing is homeless.
+  const transitionIdx = sorted.findIndex((e) => isHomeless(e.housingStatus));
+  if (transitionIdx === -1) {
+    return {
+      transitionEncounterId: null,
+      transitionAt: null,
+      encountersBefore: 0,
+      isAlertCandidate: false,
+    };
+  }
+
+  const transitionEncounter = sorted[transitionIdx];
+  const isMostRecent = transitionIdx === sorted.length - 1;
+  // Alert only when the transition is the MOST recent encounter AND there
+  // is at least one prior non-homeless encounter (so we know it's truly a
+  // transition, not a chronic state we lack history for).
+  const isAlertCandidate = isMostRecent && transitionIdx > 0;
+
+  return {
+    transitionEncounterId: transitionEncounter.id,
+    transitionAt: transitionEncounter.arrivedAt,
+    encountersBefore: transitionIdx,
+    isAlertCandidate,
+  };
+}

--- a/src/lib/esuc/index.ts
+++ b/src/lib/esuc/index.ts
@@ -5,6 +5,7 @@
 
 export * from './care-plan';
 export * from './ed-triage';
+export * from './first-time-homeless';
 export * from './patient-qa';
 export * from './scrub';
 export * from './super-utilizer-ranking';


### PR DESCRIPTION
Closes #123.

Sprint 12 early start (Sprint 11's three PRs are all in flight). Pure-function classifier on top of the existing `ed_encounters` table — **no schema change**, no new domain. Identifies patients whose most recent encounter is their first transition to shelter/unsheltered housing on coalition record (the discharge-into-homelessness moment caseworkers want to catch).

## Why this shape

ESUC already owns the ED-encounter signals; PRVN-001's value is a derivation, not new data. So the classifier lives in `src/lib/esuc/`, the query is on `src/db/queries/ed-encounters.ts`, and the route is at `/app/care/first-time-homeless/`. No new schema, no new boundary, minimal new surface.

## Lib

`classifyFirstTimeHomeless(encounters)` — pure, vitest-covered. Returns:
- `transitionEncounterId` — earliest encounter where housing flipped to homeless
- `transitionAt` — timestamp of that transition
- `encountersBefore` — confidence signal (more prior encounters → more confident this is truly "first time")
- `isAlertCandidate` — true only when the transition is the patient's MOST recent encounter AND there is at least one prior non-homeless encounter

`HOMELESS_HOUSING_STATUSES` controlled vocab: `shelter` + `unsheltered`. `doubled_up` intentionally excluded — that's housing instability but not the discharge-into-homelessness signal.

## Test coverage

10 cases, covering the load-bearing edges:
- Transition-is-most-recent → alert ✓
- Transition-is-older → no alert (no longer first-time)
- First encounter homeless → no alert (no prior history to confirm)
- Bounce-back pattern (housed → shelter → housed → unsheltered): only the first transition is the alert moment
- `doubled_up` doesn't count
- Unsorted input → sorted defensively
- Empty input → safe

## Surface

`/app/care/first-time-homeless` — ED-coordinator + admin gated. Mirrors existing `/app/care/triage` pattern. Patient identifiers stay opaque (synthetic `SYN-PAT-...` today; hashed Epic IDs post-BAA). Recent-transition badge fires for transitions in the last 48 hours.

## Test plan

- [x] 626 vitest tests pass (10 new)
- [x] `pnpm exec tsc --noEmit` clean
- [x] `pnpm exec biome check` clean (no `--write`)
- [x] `pnpm exec tsx scripts/check-domain-boundaries.mts` clean
- [x] `pnpm build` clean — `/app/care/first-time-homeless` route compiles
- [ ] Manual: walk the synthetic ED encounter dataset for a patient with the housed → unsheltered transition pattern; confirm they appear with the recent badge

## Followups

- **Real-time discharge alerting** to OH social workers. Today is read-only — the route is for the coalition's ED coordinator. Real-time OH integration requires the BAA (currently unresolved).
- Cross-link to / from the super-utilizer queue (a chronic super-utilizer is a different cohort than a first-time-homeless patient; the link helps caseworkers triage).
- Inngest job that dispatches the alert list to the day's on-call ED coordinator (Sentry today, email/dashboard later).

Synthetic-only — PHI fence still in effect ([CLAUDE.md](CLAUDE.md)). No schema change → no migration conflict with the in-review #371 / #372.

🤖 Generated with [Claude Code](https://claude.com/claude-code)