### PR TITLE
feat(PRVN-006): outreach pre-positioning priorities (ZIP-aggregate)

### DIFF
--- a/src/app/app/coalition/outreach-priorities/page.tsx
+++ b/src/app/app/coalition/outreach-priorities/page.tsx
@@ -1,0 +1,130 @@
+import Link from 'next/link';
+import { listOutreachPriorities } from '@/db/queries/outreach-priorities';
+import { requireRole } from '@/lib/auth';
+import { DEFAULT_OUTREACH_MIN_CELL_SIZE } from '@/lib/oprt';
+
+export const dynamic = 'force-dynamic';
+
+const WINDOW_DAYS = 30;
+
+export default async function OutreachPrioritiesPage() {
+  await requireRole(['admin', 'caseworker']);
+
+  const result = await listOutreachPriorities({ windowDays: WINDOW_DAYS });
+  const reportableTotal = result.priorities.reduce((s, p) => s + p.count, 0);
+
+  return (
+    <div className="mx-auto max-w-3xl space-y-6 p-4 md:p-6">
+      <div className="text-xs">
+        <Link href="/app/coalition" className="text-muted-foreground hover:underline">
+          ← Back to coalition
+        </Link>
+      </div>
+      <header>
+        <h1 className="font-serif text-3xl font-bold text-primary">
+          Outreach pre-positioning priorities
+        </h1>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Eviction-filing aggregate by ZIP for the last {WINDOW_DAYS} days. Mobile outreach teams
+          (Catholic Charities and other faith partners) use this to pre-position visits ahead of the
+          post-filing window. Aggregate-only — see{' '}
+          <Link
+            href="/agreements/faith-aggregate"
+            className="underline underline-offset-2 hover:text-foreground"
+          >
+            ADR 0003
+          </Link>
+          . Cell-size suppression at {DEFAULT_OUTREACH_MIN_CELL_SIZE} filings per ZIP.
+        </p>
+      </header>
+
+      <section className="grid gap-3 sm:grid-cols-3">
+        <div className="rounded-md border border-border bg-muted/10 p-3 text-sm">
+          <p className="text-xs text-muted-foreground">Filings considered</p>
+          <p className="text-2xl font-semibold tabular-nums">{result.totalFilings}</p>
+        </div>
+        <div className="rounded-md border border-border bg-muted/10 p-3 text-sm">
+          <p className="text-xs text-muted-foreground">Reportable</p>
+          <p className="text-2xl font-semibold tabular-nums">{reportableTotal}</p>
+          <p className="text-[10px] text-muted-foreground">
+            {result.priorities.length} ZIP{result.priorities.length === 1 ? '' : 's'} above
+            threshold
+          </p>
+        </div>
+        <div className="rounded-md border border-border bg-muted/10 p-3 text-sm">
+          <p className="text-xs text-muted-foreground">Suppressed</p>
+          <p className="text-2xl font-semibold tabular-nums">{result.suppressedCount}</p>
+          <p className="text-[10px] text-muted-foreground">
+            {result.suppressedRegions} ZIP{result.suppressedRegions === 1 ? '' : 's'} below
+            threshold
+          </p>
+        </div>
+      </section>
+
+      {result.priorities.length === 0 ? (
+        <div className="rounded-md border border-border bg-muted/20 p-6 text-sm">
+          <p className="font-semibold">No reportable ZIPs in the last {WINDOW_DAYS} days.</p>
+          <p className="mt-2 text-muted-foreground">
+            Either filing volume is below the cell-size threshold across the board, or the synthetic
+            seed hasn't loaded recent filings. Run{' '}
+            <code className="font-mono">pnpm tsx scripts/load-fixtures.ts</code> to refresh.
+          </p>
+        </div>
+      ) : (
+        <div className="overflow-x-auto rounded-md border border-border">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b bg-muted/30 text-left">
+                <th className="px-3 py-2 font-medium">Rank</th>
+                <th className="px-3 py-2 font-medium">ZIP</th>
+                <th className="px-3 py-2 font-medium">Filings</th>
+                <th className="px-3 py-2 font-medium">Share of reportable</th>
+              </tr>
+            </thead>
+            <tbody>
+              {result.priorities.map((p, idx) => {
+                const pct =
+                  reportableTotal === 0 ? 0 : Math.round((p.count / reportableTotal) * 100);
+                return (
+                  <tr key={p.zip} className="border-b last:border-0 hover:bg-muted/10">
+                    <td className="px-3 py-2 tabular-nums">#{idx + 1}</td>
+                    <td className="px-3 py-2 font-mono">{p.zip}</td>
+                    <td className="px-3 py-2 tabular-nums">{p.count}</td>
+                    <td className="px-3 py-2 tabular-nums text-muted-foreground">{pct}%</td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {result.unknownZipCount > 0 && (
+        <div className="rounded-md border border-amber-500/40 bg-amber-500/5 p-3 text-xs">
+          <p className="font-medium">Data quality note</p>
+          <p className="mt-1 text-muted-foreground">
+            {result.unknownZipCount} filing{result.unknownZipCount === 1 ? '' : 's'} could not be
+            resolved to a ZIP from the address text. These are not included in the priority ranking
+            but flag a parser gap worth investigating in the courtnet ingest pipeline.
+          </p>
+        </div>
+      )}
+
+      <div className="rounded-md border border-border bg-muted/10 p-3 text-xs">
+        <p className="font-medium">What this view is — and isn't</p>
+        <ul className="mt-1 list-disc pl-5 space-y-1 text-muted-foreground">
+          <li>Public eviction filings only. No ED, no school-referral, no SMS data.</li>
+          <li>Defendant names are not surfaced here; the query selects only address + filed-at.</li>
+          <li>
+            Cell-size suppression at {DEFAULT_OUTREACH_MIN_CELL_SIZE} mirrors the faith-aggregate
+            privacy contract (ADR 0003) — small ZIPs disappear so individuals can't be inferred.
+          </li>
+          <li>
+            Outreach decisions are downstream — this view ranks where to *consider* visiting, not
+            who.
+          </li>
+        </ul>
+      </div>
+    </div>
+  );
+}

--- a/src/db/queries/outreach-priorities.ts
+++ b/src/db/queries/outreach-priorities.ts
@@ -1,0 +1,49 @@
+/**
+ * PRVN-006 — outreach-priorities query.
+ *
+ * Reads eviction_filings (public court records — no PHI, no consent
+ * gate) over a window and feeds the pure aggregator in
+ * `src/lib/oprt/outreach-priorities.ts`. Returns only the address +
+ * filed-at fields needed for ZIP extraction; downstream consumers
+ * never see defendant names through this surface.
+ */
+
+import { gte } from 'drizzle-orm';
+import { db } from '@/db/client';
+import { evictionFilings } from '@/db/schema/eviction-filings';
+import {
+  type ComputeOutreachPrioritiesOpts,
+  computeOutreachPriorities,
+  type OutreachPrioritiesResult,
+} from '@/lib/oprt';
+
+export interface ListOutreachPrioritiesOpts extends ComputeOutreachPrioritiesOpts {
+  /** Lookback window in days. Default 30 — outreach acts on recent trends. */
+  windowDays?: number;
+}
+
+export async function listOutreachPriorities(
+  opts: ListOutreachPrioritiesOpts = {},
+): Promise<OutreachPrioritiesResult> {
+  const { windowDays = 30, ...aggOpts } = opts;
+  const since = new Date();
+  since.setDate(since.getDate() - windowDays);
+
+  // Defendant name is intentionally NOT selected — this surface is
+  // aggregate-only and the renderer must not have access to identifiers.
+  const rows = await db
+    .select({
+      defendantAddress: evictionFilings.defendantAddress,
+      filedAt: evictionFilings.filedAt,
+    })
+    .from(evictionFilings)
+    .where(gte(evictionFilings.filedAt, since));
+
+  return computeOutreachPriorities(
+    rows.map((r) => ({
+      defendantAddress: r.defendantAddress ?? null,
+      filedAt: r.filedAt instanceof Date ? r.filedAt : new Date(r.filedAt),
+    })),
+    aggOpts,
+  );
+}

--- a/src/lib/oprt/index.ts
+++ b/src/lib/oprt/index.ts
@@ -3,4 +3,5 @@
 // not from '@/lib/oprt/<internal>'. Enforced by
 // scripts/check-domain-boundaries.mts (FND-040b, ADR 0001).
 
+export * from './outreach-priorities';
 export * from './quarterly-narrative';

--- a/src/lib/oprt/outreach-priorities.test.ts
+++ b/src/lib/oprt/outreach-priorities.test.ts
@@ -1,0 +1,120 @@
+/**
+ * PRVN-006 — outreach-priorities tests.
+ *
+ * Pure function. No DB, no clocks. Verifies zip extraction, cell-size
+ * suppression, and ranking deterministically.
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  computeOutreachPriorities,
+  DEFAULT_OUTREACH_MIN_CELL_SIZE,
+  extractZip,
+  type FilingForPriorities,
+} from './outreach-priorities';
+
+describe('extractZip', () => {
+  it('extracts a 5-digit zip from a "Owensboro, KY 42301" address', () => {
+    expect(extractZip('123 Main St, Owensboro, KY 42301')).toBe('42301');
+  });
+
+  it('extracts a 5-digit zip from a ZIP+4', () => {
+    expect(extractZip('123 Main St, Owensboro, KY 42301-1234')).toBe('42301');
+  });
+
+  it('returns null when no zip is present', () => {
+    expect(extractZip('123 Main St, Owensboro, KY')).toBeNull();
+  });
+
+  it('returns null on empty / null-ish input', () => {
+    expect(extractZip('')).toBeNull();
+    expect(extractZip(null)).toBeNull();
+    expect(extractZip(undefined)).toBeNull();
+  });
+
+  it('does not match phone numbers or other 5-digit sequences', () => {
+    // No comma + state pattern → not a zip context. We're conservative:
+    // only match 5-digit sequences at end-of-string or end-of-line.
+    expect(extractZip('Phone 12345 some other address')).toBeNull();
+  });
+
+  it('matches the LAST 5-digit zip when multiple are present', () => {
+    // Some addresses include both a unit number and zip; we want the zip.
+    expect(extractZip('Apt 12345, Owensboro, KY 42303')).toBe('42303');
+  });
+});
+
+const filing = (zip: string | null, daysAgo: number): FilingForPriorities => ({
+  defendantAddress:
+    zip === null ? '123 Main St, Owensboro, KY' : `123 Main St, Owensboro, KY ${zip}`,
+  filedAt: new Date(Date.now() - daysAgo * 86_400_000),
+});
+
+describe('computeOutreachPriorities', () => {
+  it('ranks zips by filing count descending', () => {
+    const filings: FilingForPriorities[] = [
+      ...Array(8).fill(filing('42301', 1)),
+      ...Array(12).fill(filing('42303', 2)),
+    ];
+    const r = computeOutreachPriorities(filings, { minCellSize: 5 });
+    expect(r.priorities[0].zip).toBe('42303');
+    expect(r.priorities[0].count).toBe(12);
+    expect(r.priorities[1].zip).toBe('42301');
+    expect(r.priorities[1].count).toBe(8);
+  });
+
+  it('suppresses zips below the cell-size threshold', () => {
+    const filings: FilingForPriorities[] = [
+      ...Array(2).fill(filing('42301', 1)), // below threshold
+      ...Array(7).fill(filing('42303', 2)),
+    ];
+    const r = computeOutreachPriorities(filings, { minCellSize: 5 });
+    // 42301 dropped; 42303 reported.
+    expect(r.priorities.map((p) => p.zip)).toEqual(['42303']);
+    expect(r.suppressedRegions).toBe(1);
+    expect(r.suppressedCount).toBe(2);
+  });
+
+  it('groups null-zip filings into "unknown" and suppresses if below threshold', () => {
+    const filings: FilingForPriorities[] = [
+      ...Array(10).fill(filing('42301', 1)),
+      ...Array(3).fill(filing(null, 5)),
+    ];
+    const r = computeOutreachPriorities(filings, { minCellSize: 5 });
+    expect(r.priorities.map((p) => p.zip)).toEqual(['42301']);
+    expect(r.unknownZipCount).toBe(3);
+  });
+
+  it('uses default min cell size = 5', () => {
+    expect(DEFAULT_OUTREACH_MIN_CELL_SIZE).toBe(5);
+    const filings: FilingForPriorities[] = Array(4).fill(filing('42301', 1));
+    const r = computeOutreachPriorities(filings);
+    expect(r.priorities).toEqual([]);
+    expect(r.suppressedRegions).toBe(1);
+  });
+
+  it('returns empty priorities + zero counts on empty input', () => {
+    const r = computeOutreachPriorities([]);
+    expect(r.priorities).toEqual([]);
+    expect(r.totalFilings).toBe(0);
+  });
+
+  it('exposes total filings (across all zips, including suppressed)', () => {
+    const filings: FilingForPriorities[] = [
+      ...Array(7).fill(filing('42301', 1)),
+      ...Array(2).fill(filing('42303', 2)),
+    ];
+    const r = computeOutreachPriorities(filings, { minCellSize: 5 });
+    expect(r.totalFilings).toBe(9);
+  });
+
+  it('breaks ties on count by zip ascending (deterministic)', () => {
+    const filings: FilingForPriorities[] = [
+      ...Array(7).fill(filing('42303', 1)),
+      ...Array(7).fill(filing('42301', 2)),
+    ];
+    const r = computeOutreachPriorities(filings, { minCellSize: 5 });
+    // Same count → smaller zip wins the tie-break.
+    expect(r.priorities.map((p) => p.zip)).toEqual(['42301', '42303']);
+  });
+});

--- a/src/lib/oprt/outreach-priorities.ts
+++ b/src/lib/oprt/outreach-priorities.ts
@@ -1,0 +1,119 @@
+/**
+ * PRVN-006 — outreach-priorities aggregation engine.
+ *
+ * Pure function. Aggregates eviction filings by ZIP code over a time
+ * window, applies cell-size suppression (per ADR 0003 — "aggregate-only,
+ * never identifying"), and returns a ranked list mobile-outreach teams
+ * (Catholic Charities and other faith partners) can pre-position
+ * against.
+ *
+ * Why eviction filings (only) for v1: filings are public court records
+ * — no PHI, no consent dependency. Adding ED super-utilizer or school-
+ * referral signals to the rollup is a future story (each carries its
+ * own privacy regime).
+ *
+ * Why ZIP and not a finer geography: at county-level pilot scale,
+ * ZIP gives a usable signal without naming individuals. Block-level or
+ * street-level grouping would risk re-identification. Cell-size
+ * suppression at the ZIP level is the safety net.
+ */
+
+const ZIP_REGEX = /(\d{5})(?:-\d{4})?\s*$/;
+
+/**
+ * Extract a 5-digit ZIP from the LAST trailing zip-shaped sequence on
+ * the input. Returns null if no zip is present. Conservative: matches
+ * only at end-of-string (after possibly-stripping ZIP+4) so 5-digit
+ * apartment numbers, phone numbers, etc. don't accidentally match.
+ */
+export function extractZip(address: string | null | undefined): string | null {
+  if (!address) return null;
+  const trimmed = address.trim();
+  if (!trimmed) return null;
+  const m = trimmed.match(ZIP_REGEX);
+  return m ? m[1] : null;
+}
+
+export type FilingForPriorities = {
+  defendantAddress: string | null;
+  filedAt: Date;
+};
+
+export type OutreachPriority = {
+  zip: string;
+  count: number;
+};
+
+export type OutreachPrioritiesResult = {
+  priorities: OutreachPriority[];
+  /** Total filings considered (including those that landed in suppressed regions and unknown). */
+  totalFilings: number;
+  /** How many distinct zips were below the cell-size threshold and dropped from the report. */
+  suppressedRegions: number;
+  /** Sum of filings inside suppressed regions (audit trail for the suppression). */
+  suppressedCount: number;
+  /** Filings whose ZIP could not be extracted from the address (always grouped as "unknown"). */
+  unknownZipCount: number;
+};
+
+export const DEFAULT_OUTREACH_MIN_CELL_SIZE = 5;
+
+export type ComputeOutreachPrioritiesOpts = {
+  minCellSize?: number;
+};
+
+/**
+ * Compute outreach priorities. Pure: no DB, no clocks. Caller picks
+ * the time window upstream by filtering `filings` before passing in.
+ *
+ * Cell-size suppression: any zip with raw count below `minCellSize`
+ * is dropped from `priorities` and counted toward `suppressedRegions`
+ * + `suppressedCount`. Filings without a parseable zip are tracked
+ * as `unknownZipCount` and are never reported as a priority (they're
+ * a data-quality signal, not an actionable ZIP).
+ */
+export function computeOutreachPriorities(
+  filings: ReadonlyArray<FilingForPriorities>,
+  opts: ComputeOutreachPrioritiesOpts = {},
+): OutreachPrioritiesResult {
+  const minCellSize = opts.minCellSize ?? DEFAULT_OUTREACH_MIN_CELL_SIZE;
+
+  let unknownZipCount = 0;
+  const counts = new Map<string, number>();
+
+  for (const f of filings) {
+    const zip = extractZip(f.defendantAddress);
+    if (zip === null) {
+      unknownZipCount += 1;
+      continue;
+    }
+    counts.set(zip, (counts.get(zip) ?? 0) + 1);
+  }
+
+  let suppressedRegions = 0;
+  let suppressedCount = 0;
+  const reported: OutreachPriority[] = [];
+
+  for (const [zip, count] of counts) {
+    if (count < minCellSize) {
+      suppressedRegions += 1;
+      suppressedCount += count;
+      continue;
+    }
+    reported.push({ zip, count });
+  }
+
+  // Rank: count DESC, then zip ASC for deterministic tie-break.
+  reported.sort((a, b) => {
+    if (a.count !== b.count) return b.count - a.count;
+    return a.zip.localeCompare(b.zip);
+  });
+
+  return {
+    priorities: reported,
+    totalFilings: filings.length,
+    suppressedRegions,
+    suppressedCount,
+    unknownZipCount,
+  };
+}


### PR DESCRIPTION
Closes #128.

Sprint 12. Pure-function ZIP aggregation over public eviction filings, with cell-size suppression mirroring the faith-aggregate privacy contract ([ADR 0003](docs/adr/0003-faith-aggregate-privacy-contract.md)). Mobile outreach teams (Catholic Charities and other faith partners) use this to pre-position visits ahead of the post-filing window.

## Why this shape

Public court records, no PHI, no consent dependency. Aggregating-by-ZIP with cell-size suppression at 5 mirrors the existing faith-aggregate discipline. No schema change — just a pure aggregator + a small query + a single read-only route.

## Lib

`src/lib/oprt/outreach-priorities.ts`:
- `extractZip(address)` — conservative regex on the trailing 5-digit (or ZIP+4) sequence. Won't match phone numbers or apartment numbers in body text.
- `computeOutreachPriorities(filings, opts)` — returns ranked priorities, total filings considered, suppressed regions/count, and unknown-zip count (the data-quality signal). Deterministic: tie-breaks on ZIP ascending.
- 13 vitest cases including the load-bearing suppression boundary, unknown-zip behavior, and the "phone numbers don't match as ZIPs" defensive case.

## Query

`src/db/queries/outreach-priorities.ts` — selects ONLY `defendantAddress + filedAt`. Defendant names are not surfaced through this path; the renderer can't accidentally leak them.

## Surface

`/app/coalition/outreach-priorities` — admin + caseworker gated. Three KPI cards (filings considered / reportable / suppressed) plus the ranked ZIP table with share-of-reportable %. Data-quality banner when `unknown-zip` count > 0. Closes with a "what this view is — and isn't" disclaimer.

## Test plan

- [x] 629 vitest tests pass (13 new for the aggregator)
- [x] `pnpm exec tsc --noEmit` clean
- [x] `pnpm exec biome check` clean (no `--write`)
- [x] `pnpm exec tsx scripts/check-domain-boundaries.mts` clean
- [x] `pnpm build` clean — `/app/coalition/outreach-priorities` compiles
- [ ] Manual: with the existing synthetic eviction-filings fixture, walk the page; confirm the suppressed count matches the small-ZIP rows in the source

## Followups

- Fold ED super-utilizer and school-referral signals into the rollup (each carries its own privacy regime — separate stories).
- Per-faith-partner customization (different partners may want different thresholds).
- Geo finer than ZIP (block / street) is **explicitly out of scope** to preserve the privacy contract.

No schema change → no migration conflict with the in-review PRs (#371, #372). No PHI; public-records-aggregate only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)