### PR TITLE
chore(nav): expose 8 orphaned routes + agreements hub

### DIFF
--- a/src/app/app/admin/agreements/page.tsx
+++ b/src/app/app/admin/agreements/page.tsx
@@ -1,0 +1,60 @@
+import Link from 'next/link';
+import { requireRole } from '@/lib/auth';
+
+export const dynamic = 'force-dynamic';
+
+const AGREEMENTS = [
+  {
+    label: 'OASIS DSA',
+    href: '/app/admin/agreements/oasis',
+    description:
+      'Data-sharing agreement with OASIS shelter for the DV survivor pathway (abuser-blind disclosure, § 40002 VAWA).',
+  },
+  {
+    label: 'DCBS DSA',
+    href: '/app/admin/agreements/dcbs',
+    description:
+      'Data-sharing agreement with the Cabinet for Health & Family Services for foster aging-out and TEAMKY referrals.',
+  },
+  {
+    label: 'School FERPA',
+    href: '/app/admin/agreements/ferpa',
+    description:
+      'Partner agreements with school districts under FERPA § 99.31 / McKinney-Vento for liaison referrals.',
+  },
+  {
+    label: 'MOU',
+    href: '/app/admin/agreements/mou',
+    description:
+      'General coalition memoranda of understanding (Steering Committee, faith-aggregate intake, ED super-utilizer pilot).',
+  },
+];
+
+export default async function AgreementsHubPage() {
+  await requireRole(['admin']);
+
+  return (
+    <div className="mx-auto max-w-3xl space-y-6 p-6">
+      <header>
+        <h1 className="font-serif text-3xl font-bold text-primary">Partner agreements</h1>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Record, renew, and monitor expiration of the four agreement kinds that gate cross-partner
+          data flow on the platform.
+        </p>
+      </header>
+      <ul className="space-y-3">
+        {AGREEMENTS.map((a) => (
+          <li
+            key={a.href}
+            className="rounded-md border border-border bg-card p-4 transition-colors hover:bg-muted/40"
+          >
+            <Link href={a.href} className="block">
+              <div className="font-semibold text-primary">{a.label} →</div>
+              <p className="mt-1 text-sm text-muted-foreground">{a.description}</p>
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/src/components/app-shell/nav-config.ts
+++ b/src/components/app-shell/nav-config.ts
@@ -26,6 +26,11 @@ export const NAV_ITEMS: NavItem[] = [
     roles: ['ed_coordinator', 'admin'],
   },
   {
+    label: 'First-time homeless',
+    href: '/app/care/first-time-homeless',
+    roles: ['ed_coordinator', 'admin'],
+  },
+  {
     label: 'Filings',
     href: '/app/cases/filings',
     roles: ['attorney', 'caseworker', 'admin'],
@@ -66,6 +71,21 @@ export const NAV_ITEMS: NavItem[] = [
     roles: ['caseworker', 'shelter_staff', 'admin'],
   },
   {
+    label: 'Families with children',
+    href: '/app/clients/families',
+    roles: ['caseworker', 'admin'],
+  },
+  {
+    label: 'Foster aging-out',
+    href: '/app/clients/foster-aging-out',
+    roles: ['caseworker', 'admin'],
+  },
+  {
+    label: 'DV survivors',
+    href: '/app/clients/dv-survivors',
+    roles: ['caseworker', 'admin'],
+  },
+  {
     label: 'Outcomes',
     href: '/app/metrics',
     roles: ['attorney', 'admin'],
@@ -90,6 +110,11 @@ export const NAV_ITEMS: NavItem[] = [
     label: 'Frontline Advisory Group',
     href: '/app/coalition/fag',
     roles: ['admin'],
+  },
+  {
+    label: 'Outreach priorities',
+    href: '/app/coalition/outreach-priorities',
+    roles: ['caseworker', 'admin'],
   },
   {
     label: 'Bed availability',
@@ -120,6 +145,13 @@ export const NAV_ITEMS: NavItem[] = [
   { label: 'Admin · Users', href: '/app/admin/users', roles: ['admin'] },
   { label: 'Admin · Audit log', href: '/app/admin/audit', roles: ['admin'] },
   { label: 'Admin · Triage overrides', href: '/app/admin/triage-overrides', roles: ['admin'] },
+  { label: 'Admin · Agreements', href: '/app/admin/agreements', roles: ['admin'] },
+  { label: 'Admin · Faith aggregate', href: '/app/admin/faith-aggregate', roles: ['admin'] },
+  {
+    label: 'Admin · Faith insights',
+    href: '/app/admin/faith-aggregate/insights',
+    roles: ['admin'],
+  },
 ];
 
 export function navItemsForRole(role: UserRole): NavItem[] {


### PR DESCRIPTION
## Summary

UI-coverage audit found 8 production pages shipped without a sidebar entry — most reachable only by typing the URL. This PR exposes them and adds an `/app/admin/agreements` hub to consolidate the four DSA workflows under one nav item.

### Pages newly linked from sidebar
- **First-time homeless** — `/app/care/first-time-homeless` (PRVN-001 #373)
- **Families with children** — `/app/clients/families` (SUBP-007 #372)
- **Foster aging-out** — `/app/clients/foster-aging-out` (SUBP-001 #366)
- **DV survivors** — `/app/clients/dv-survivors` (SUBP-004 #371)
- **Outreach priorities** — `/app/coalition/outreach-priorities` (PRVN-006 #374)
- **Admin · Agreements** (new hub) — `/app/admin/agreements` covering OASIS (DTRS-012), DCBS (DTRS-011), FERPA (DTRS-010), MOU (OPRT-002)
- **Admin · Faith aggregate** — `/app/admin/faith-aggregate` (DTRS-008)
- **Admin · Faith insights** — `/app/admin/faith-aggregate/insights` (DTRS-009)

Each entry's role gate matches the corresponding `requireRole()` call on the page.

### Intentionally NOT added
The three `/app/partner/school-referral/*` pages (PRVN-003 / PRVN-004 / COOR-014) remain out of the role-gated sidebar — they're token-gated for external school liaisons (membership in a `partner_org` of `type='school'`) and need a different distribution path (email/handout) rather than a staff sidebar entry.

## Test plan
- [ ] Verify each new sidebar entry appears for the right roles (caseworker / ed_coordinator / admin) and is hidden for other roles
- [ ] Click `Admin · Agreements` → hub renders with four cards linking to OASIS / DCBS / FERPA / MOU
- [ ] All 8 newly linked pages load without auth errors for the appropriate role

🤖 Generated with [Claude Code](https://claude.com/claude-code)