### PR TITLE
feat(DTRS-013): KY DOC reentry data-sharing workflow + ADR 0009

### DIFF
--- a/docs/adr/0009-ky-doc-reentry-data-sharing-privacy-contract.md
+++ b/docs/adr/0009-ky-doc-reentry-data-sharing-privacy-contract.md
@@ -1,0 +1,98 @@
+# ADR 0009 — KY DOC reentry data-sharing privacy contract (state-as-custodian, narrow window, no recidivism prediction)
+
+**Status:** Accepted — 2026-04-28
+**Driver:** Sprint 12. DTRS-013 ([#142](https://github.com/DobbsBoldry/homeless/issues/142)) introduces the inbound flow for the Kentucky Department of Corrections (KY DOC) to support SUBP-005 (Reentry pathway, [#134](https://github.com/DobbsBoldry/homeless/issues/134)). The reentry use case is the third state-authorized data-sharing relationship after DCBS (ADR 0006) and OASIS (ADR 0007). It needs its own privacy contract because the cohort, the threat model, and the statutory regime differ from both.
+
+## Context
+
+Sprint 10 closed the foster-aging-out entry under ADR 0006 (DCBS state-as-guardian — the state holds custodial authority and authorizes downstream sharing). Sprint 11 closed the DV-survivor entry under ADR 0007 (OASIS abuser-blind, where the threat model centers on a third-party adversary). Sprint 12 starts the reentry entry, which is structurally distinct from both:
+
+| | DCBS (ADR 0006) | OASIS (ADR 0007) | KY DOC (this ADR) |
+|---|---|---|---|
+| Cohort | Foster youth in state custody | DV survivors voluntarily enrolled with OASIS | Incarcerated people approaching release |
+| Custodial authority | The state, as legal guardian (KRS 620.140) | The survivor herself (voluntary OASIS ROI) | The state, as custodian during incarceration (KRS Chapter 197) |
+| Threat model | State-custody data leakage → trust loss + potential placement disruption | Abuser obtaining survivor location → physical harm or death | (a) stigma-driven housing/employment denial; (b) misuse for recidivism prediction; (c) re-identification by parole / law-enforcement secondary use |
+| Default rule | Authorized to share with service providers per state DSA | Suppress location-identifying fields by default; share only with explicit redaction | Authorized to share narrow pre-release fields under DOC DSA; **no recidivism inference, no parole-supervision data flow without separate authorization** |
+| Cohort scale | Tens of youth | Tens of survivors | Tens to low hundreds of pre-release individuals (Daviess Co. residents in KY DOC custody approaching release) |
+| Statutory regime | KRS 620, 42 U.S.C. § 677, Family First | KRS 209A, VAWA (34 U.S.C. § 12291 et seq.) | **KRS Chapter 197** (Department of Corrections), **KRS Chapter 439** (probation and parole), the federal Second Chance Act (42 U.S.C. § 17501 et seq.), and the Kentucky Reentry Council mandate |
+| Re-disclosure | Forbidden without DCBS authorization or KRS 620.030 emergency | Forbidden without OASIS authorization, with mandatory notification when compelled | Forbidden without KY DOC authorization; **explicit prohibition on disclosure to law enforcement, parole, or probation absent court order** |
+| Window of receipt | Continuous while youth is in state custody, plus a tail under TEAMKY | Continuous while survivor enrolled with OASIS | **Bounded** — a configurable pre-release window (default 60 days) before projected release, plus a short tail post-release for warm-handoff coordination only |
+| Audit obligation | Coalition-side audit log + DCBS audit cooperation | Coalition-side audit log on every read + OASIS audit cooperation + breach → mandatory data-flow suspension | **Coalition-side audit log on every read**, KY DOC audit cooperation, breach → mandatory KY DOC notification within 72 hours |
+
+**Why a window matters.** The reentry use case is fundamentally a coordination problem on a clock: roughly 60 days before projected release is when housing, healthcare, and employment supports must be lined up so the released individual does not return to homelessness. Data older than that window adds nothing operationally and adds risk (stale records, drift between custody status and actual release date, increased blast radius if breached). The contract therefore makes the window a structural property of the data flow — KY DOC sends only records inside the window, the Coalition deletes records that age out of the window, and the runtime gate enforces both directions.
+
+**Why "no recidivism prediction" is in the contract.** Reentry support is fundamentally different from probation supervision. The Coalition's purpose is to help a person succeed at re-entry by lining up housing, healthcare, employment, and family connection. It is *not* to predict whether the person will reoffend. The contract makes this explicit because the same data (release date, supports-in-place, prior-incarceration history) could in principle be repurposed for actuarial recidivism scoring — and there is a documented record of well-intentioned reentry tools drifting in that direction once the data is in hand. Encoding the prohibition in the agreement, not just the policy, makes drift a contractual breach rather than a code review failure.
+
+The platform already has the registry infrastructure ([ADR 0004 modular monolith / partner_agreements](./0004-modular-monolith.md)), the per-partner-org agreement-recording pattern ([DTRS-010 FERPA #359](https://github.com/DobbsBoldry/homeless/pull/359), [DTRS-011 DCBS #364](https://github.com/DobbsBoldry/homeless/pull/364), [DTRS-012 OASIS #370](https://github.com/DobbsBoldry/homeless/pull/370)), and the generic expiration watcher ([OPRT-002 #368](https://github.com/DobbsBoldry/homeless/pull/368)). The question this ADR answers is: where does the reentry-specific privacy contract live, and what is the source of truth for SUBP-005's runtime gates?
+
+## Decision
+
+**Use the existing `partner_agreements` registry (ADR 0004) with `kind='dsa'` and `agency='ky_doc'`. Encode the reentry-specific contract — pre-release window length, individual-records authorization, no-recidivism-prediction acknowledgement, and population focus — as structured fields on the JSONB `terms`. Treat the agreement's stored terms as the contract-of-record for SUBP-005's pre-release gates.** Persist any pre-release roster record under the gate of an active KY DOC DSA whose `individual_records_authorized` flag is `true` and whose `pre_release_window_days` covers the record's projected-release horizon.
+
+### Privacy contract — six rules
+
+1. **No pre-release record may be persisted without an active KY DOC DSA.** SUBP-005's ingest path reads `getActiveKyDocDsa(kyDocPartnerOrgId)` before every write batch and fails closed if no active agreement exists. Same gate applies on every read for reporting. Per ADR 0004 § 3.1.
+
+2. **`individual_records_authorized` is the runtime authorization gate.** Mirrors DCBS. SUBP-005 reads this flag before enabling per-individual views; if `false`, the agreement is informational only and no individual records may be persisted. The intake form requires a default `true` only if the admin can attest to the agency's executed authorization.
+
+3. **The `pre_release_window_days` field is binding.** SUBP-005 ingests only records with a projected release date inside `[today, today + pre_release_window_days]`, and the daily Inngest job deletes records that age out of the window without resulting in successful release-day handoff. Default is 60 days; admins may extend with explicit justification, but the validator rejects values < 30 (operationally too short to coordinate housing) or > 180 (operationally unjustified — a stale record at six months is risk without value).
+
+4. **`no_recidivism_prediction_attestation` is non-optional.** The validator (`validateKyDocDsaTerms`) refuses to accept a terms object without `no_recidivism_prediction_attestation === true`. The intake form's submit button is disabled until the attestation checkbox is checked. There is no draft path that bypasses attestation. If a future use case requires an actuarial-scoring DSA (e.g., a separate research study), it gets a different agreement and a different ADR — do not weaken this validator.
+
+5. **Audit every read.** Per § 4.3 of the template: every individual-record read of a pre-release record goes through `logAuditEvent` via the SUBP-005 access path. The audit table is the source of truth for the cooperation obligation in § 6.3 of the template.
+
+6. **No re-disclosure to law enforcement, parole, or probation.** Coalition surfaces shall not provide pre-release records, derived analytics, or even confirmation-of-existence to law enforcement, parole, or probation authorities except under court order or written KY DOC authorization. Cross-domain joins that would correlate pre-release records with non-coalition surveillance data are blocked at the `dtrs/data-access.ts` policy gate. This is rule 6 because it is the most likely drift vector — well-intentioned data requests from sister agencies that would amount to re-purposing the data for surveillance.
+
+### What does NOT change
+
+- ADR 0006 (DCBS state-as-guardian) is unchanged. Foster youth continue to flow under the state's custodial authority, with `agency='dcbs'`. SUBP-005's gates do not consume DCBS DSAs.
+- ADR 0007 (OASIS abuser-blind) is unchanged. DV survivor records continue to flow under the OASIS contract; KY DOC pre-release records are a distinct cohort with no overlap.
+- The shared `partner_agreements` registry is unchanged structurally — KY DOC adds a third `agency` discriminator under the existing `kind='dsa'`, the same pattern DTRS-011 and DTRS-012 introduced.
+- The generic OPRT-002 expiration watcher is unchanged — it watches all agreements regardless of kind/agency. KY DOC DSAs benefit automatically.
+
+### Why this design and not alternatives
+
+**Alternative A — separate `ky_doc_pre_release_records` table and a parallel KY-DOC-specific agreement-tracking table.** Rejected: re-litigates ADR 0004's "one agreement registry" decision, and worse, separates the policy (pre-release window, attestation) from the agreement that authorizes it. If the registry and the table drift, the policy enforcement drifts with them. SUBP-005's pre-release record table is a separate concern and does not require its own agreement registry.
+
+**Alternative B — encode the pre-release window in `src/lib/dtrs/data-access.ts` as code, with the DSA being purely informational.** Rejected: the window is a *contractual* commitment. KY DOC needs to be able to point at a specific number in a signed instrument when their inspector general asks how long the Coalition retains pre-release records. Encoding it in `terms.pre_release_window_days` makes the agreement and the enforcement point the same artifact.
+
+**Alternative C — make `no_recidivism_prediction_attestation` an optional advisory field.** Rejected: the prohibition against using reentry data for recidivism scoring is the contract's most consequential commitment. Making it optional creates a path where it gets dropped by accident. Strict validation here is a feature, not a limitation. If a research study ever wants to use anonymized reentry outcomes for recidivism modeling, it is a separate IRB-supervised activity outside this agreement.
+
+**Alternative D — reuse the OASIS abuser-blind redaction-policy machinery for pre-release records.** Considered. The threat model is different enough that the redaction shape doesn't translate cleanly: there's no "abuser" adversary in the reentry context, and the fields that need protection are different (criminal history, prior placement, sentence length — none of which are in the abuser-blind redaction vocabulary). Reusing it would force concepts that don't fit. KY DOC gets its own narrow primitives: the window-bound, the attestation, and the no-LE-disclosure rule.
+
+## Consequences
+
+**What we get:**
+
+- DTRS-013 ships a working KY DOC DSA workflow in 5 points: registry-extension, window-bounded ingest contract, attestation enforcement at the validator. Same shape as DTRS-011 / DTRS-012 — minimal new surface area.
+- SUBP-005's pre-release ingest middleware reads `terms.pre_release_window_days` and `terms.individual_records_authorized` as its single source of truth. Changing either is a contract amendment with a new agreement row; the rendered template (`template_rendered`) preserves the legal artifact (ADR 0004 immutability).
+- The OPRT-002 expiration watcher serves KY DOC for free. When an agreement's `end_date` lapses, all downstream gates fail closed automatically.
+- Cross-cutting: `getActiveKyDocDsa(partnerOrgId)` is exposed via the dtrs barrel for any future SUBP-* reentry-adjacent stories (parole-supervision integration, expungement support — both out of scope for SUBP-005) to reuse the gate.
+- Audit-on-read is the default, not an opt-in. SUBP-005's middleware is the only path to pre-release records, and the middleware always logs.
+
+**What we don't get:**
+
+- Per-individual consent variation. The KY DOC DSA covers all pre-release individuals KY DOC identifies as Daviess County residents within the window. Individual opt-outs are managed at KY DOC's intake / pre-release planning meeting, not in the Coalition's database. Coalition-side opt-outs are out of scope for Sprint 12.
+- A redaction policy with the OASIS-shaped granularity. Pre-release records do not have a "current address" to suppress (the individual is in custody), so the OASIS redaction shape doesn't apply. Per-field redaction may become necessary if the cohort scope expands to include parole-supervision data; that's a future ADR.
+- Real-time enforcement of the window across all already-ingested records. The Inngest delete job runs daily; between its runs there is a brief window where a record may be just past the configured window. This is acceptable for the Sprint 12 scope; if it becomes a problem (e.g., a DSA amendment shortens the window), we add an immediate sweep on agreement-status-change.
+- Automatic enforcement of "no LE disclosure." Rule 6 is implemented as code review + boundary lint + the policy gate at `dtrs/data-access.ts`, not as a runtime LE-detection check. A future sprint may add a Sentry / log alert that fires when a pre-release record is read by an admin role outside the SUBP-005 caseworker surface.
+
+**What we should watch for:**
+
+1. **Drift between `terms.pre_release_window_days` and SUBP-005's ingest behavior.** This is the contract's most fragile point. Mitigations: (a) the middleware reads the value per-request, never caches; (b) add a contract test that exercises the window boundary at 0 / window-1 / window / window+1 days; (c) any code change to the middleware that touches the window logic requires reviewing the policy in this ADR.
+2. **Templates becoming living documents.** Same concern as ADR 0004 / 0007: `template_rendered` is set once at signing and treated as immutable. The form does not expose an edit path on rows with `status='active'`. Editing the template-version goes through a new agreement row.
+3. **Multiple active KY DOC DSAs for the same partner.** Pathological — only one should be active at a time. Don't enforce uniqueness at the DB (consistent with ADR 0004); let the form's "active-agreement warning" banner surface the conflict and let the admin supersede explicitly.
+4. **Notification of breach to KY DOC.** § 4.4 of the template requires breach notification within 72 hours. There's no automated piping for this today (Sentry-only); a follow-up story should add a notification path that pages KY DOC's data steward when a breach event lands. Until then, ops must monitor Sentry for `dtrs.ky_doc.*` errors and notify manually.
+5. **Pressure to integrate parole / probation.** Once the reentry pathway is working, sister agencies will ask "can you also share with us?" Rule 6 is the answer. Maintain it.
+
+## Implementation checklist (DTRS-013 picks this up)
+
+- [x] Lib: extend `src/lib/dtrs/partner-agreements.ts` with `KyDocDsaTerms`, `KY_DOC_DSA_SCOPE_OPTIONS`, `KY_DOC_PRE_RELEASE_WINDOW_DEFAULT_DAYS`, `KY_DOC_PRE_RELEASE_WINDOW_MIN_DAYS`, `KY_DOC_PRE_RELEASE_WINDOW_MAX_DAYS`, `validateKyDocDsaTerms`. Update `validateAgreementTerms` dispatcher to handle `agency==='ky_doc'`.
+- [x] Parser: add `parseKyDocDsaAgreementForm` in `src/app/actions/partner-agreements-parse.ts` (sibling pure module per the `'use server'` × vitest quirk).
+- [x] Action: add `recordKyDocDsaAgreementAction` in `src/app/actions/partner-agreements.ts`.
+- [x] Query: add `getActiveKyDocDsa(partnerOrgId)` in `src/db/queries/partner-agreements.ts` using JSONB `terms->>'agency' = 'ky_doc'` filter.
+- [x] Form component: `src/components/dtrs/kydoc-dsa-agreement-form.tsx` with pre-release-window selector + no-recidivism-prediction attestation checkbox.
+- [x] Admin page: `src/app/app/admin/agreements/kydoc/page.tsx`.
+- [x] Public template: `src/app/agreements/kydoc/template/page.tsx` (template version `kydoc-dsa-v1`).
+- [x] Tests: validator tests in `src/lib/dtrs/partner-agreements.test.ts`; parser tests in `src/app/actions/partner-agreements.test.ts`.
+- [ ] SUBP-005 picks this up in a follow-up PR — its ingest middleware reads `getActiveKyDocDsa()` and `terms.pre_release_window_days`.

--- a/src/app/actions/partner-agreements-parse.ts
+++ b/src/app/actions/partner-agreements-parse.ts
@@ -11,6 +11,10 @@
 import {
   DCBS_DSA_SCOPE_OPTIONS,
   FERPA_SCOPE_OPTIONS,
+  KY_DOC_DSA_SCOPE_OPTIONS,
+  KY_DOC_PRE_RELEASE_WINDOW_DEFAULT_DAYS,
+  KY_DOC_PRE_RELEASE_WINDOW_MAX_DAYS,
+  KY_DOC_PRE_RELEASE_WINDOW_MIN_DAYS,
   OASIS_DEFAULT_REDACTION_POLICY,
   OASIS_DSA_SCOPE_OPTIONS,
   OASIS_REDACTABLE_FIELDS,
@@ -21,6 +25,7 @@ import {
 const FERPA_SCOPE_VALUES = FERPA_SCOPE_OPTIONS.map((o) => o.value);
 const DCBS_DSA_SCOPE_VALUES = DCBS_DSA_SCOPE_OPTIONS.map((o) => o.value);
 const OASIS_DSA_SCOPE_VALUES = OASIS_DSA_SCOPE_OPTIONS.map((o) => o.value);
+const KY_DOC_DSA_SCOPE_VALUES = KY_DOC_DSA_SCOPE_OPTIONS.map((o) => o.value);
 const OASIS_REDACTION_TREATMENTS: readonly OasisRedactionTreatment[] = [
   'share',
   'suppress',
@@ -474,6 +479,189 @@ export function parseOasisDsaAgreementForm(
         },
         redaction_policy: redaction_policy as OasisRedactionPolicy,
         abuser_blind_attestation: true,
+        data_destruction_due,
+      },
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// DTRS-013 — KY DOC DSA parser
+// ---------------------------------------------------------------------------
+
+export type ParsedKyDocDsaAgreementInput = {
+  partnerOrgId: string;
+  effectiveDate: string;
+  endDate: string | null;
+  signedByPartner: string | null;
+  notes: string | null;
+  terms: {
+    kind: 'dsa';
+    agency: 'ky_doc';
+    scope: string[];
+    agency_legal_name: string;
+    state_contact: { name: string; title: string; email: string; phone?: string };
+    population_focus: 'pre_release';
+    pre_release_window_days: number;
+    individual_records_authorized: boolean;
+    no_recidivism_prediction_attestation: true;
+    data_destruction_due: 'on_termination' | 'after_3_years' | 'after_5_years';
+  };
+};
+
+/**
+ * Parse + validate a FormData from the KY DOC DSA agreement intake form.
+ *
+ * Per ADR 0009, the no-recidivism-prediction attestation is required (the
+ * form's submit button is disabled until checked, and this parser fails closed
+ * if the box was bypassed). The pre-release window must fall within
+ * [KY_DOC_PRE_RELEASE_WINDOW_MIN_DAYS, KY_DOC_PRE_RELEASE_WINDOW_MAX_DAYS];
+ * empty input falls back to KY_DOC_PRE_RELEASE_WINDOW_DEFAULT_DAYS.
+ *
+ * FormData shape:
+ *   partnerOrgId                            — uuid of the KY DOC partner_org
+ *   effectiveDate                           — YYYY-MM-DD (required)
+ *   endDate                                 — YYYY-MM-DD (optional)
+ *   signedByPartner                         — text (optional)
+ *   notes                                   — text (optional)
+ *   agency_legal_name                       — text (required)
+ *   state_contact_name                      — text (required)
+ *   state_contact_title                     — text (required)
+ *   state_contact_email                     — text (required, basic format check)
+ *   state_contact_phone                     — text (optional)
+ *   scope_{value}                           — checkbox "on" when checked
+ *   pre_release_window_days                 — integer in [MIN, MAX]; defaults to DEFAULT
+ *   individual_records_authorized           — "true" | "false"
+ *   no_recidivism_prediction_attestation    — "true" required (any other value rejected)
+ *   data_destruction_due                    — 'on_termination' | 'after_3_years' | 'after_5_years'
+ */
+export function parseKyDocDsaAgreementForm(
+  formData: FormData,
+): { ok: true; input: ParsedKyDocDsaAgreementInput } | { ok: false; error: string } {
+  const str = (key: string) => (formData.get(key) ?? '').toString().trim();
+
+  const partnerOrgId = str('partnerOrgId');
+  if (!partnerOrgId) return { ok: false, error: 'KY DOC partner is required.' };
+
+  const effectiveDateRaw = str('effectiveDate');
+  if (!effectiveDateRaw) return { ok: false, error: 'Effective date is required.' };
+  if (Number.isNaN(Date.parse(effectiveDateRaw))) {
+    return { ok: false, error: 'Effective date is not a valid date.' };
+  }
+
+  const endDateRaw = str('endDate');
+  let endDate: string | null = null;
+  if (endDateRaw) {
+    if (Number.isNaN(Date.parse(endDateRaw))) {
+      return { ok: false, error: 'End date is not a valid date.' };
+    }
+    if (endDateRaw < effectiveDateRaw) {
+      return { ok: false, error: 'End date must be on or after effective date.' };
+    }
+    endDate = endDateRaw;
+  }
+
+  const signedByPartner = str('signedByPartner') || null;
+
+  const notes = str('notes') || null;
+  if (notes && notes.length > 2000) {
+    return { ok: false, error: 'Notes must be 2 000 characters or fewer.' };
+  }
+
+  const agency_legal_name = str('agency_legal_name');
+  if (!agency_legal_name) {
+    return { ok: false, error: 'Agency legal name is required.' };
+  }
+
+  const sc_name = str('state_contact_name');
+  if (!sc_name) return { ok: false, error: 'KY DOC contact name is required.' };
+
+  const sc_title = str('state_contact_title');
+  if (!sc_title) return { ok: false, error: 'KY DOC contact title is required.' };
+
+  const sc_email = str('state_contact_email');
+  if (!sc_email) return { ok: false, error: 'KY DOC contact email is required.' };
+  if (!sc_email.includes('@')) {
+    return { ok: false, error: 'KY DOC contact email must be a valid email address.' };
+  }
+
+  const sc_phone = str('state_contact_phone') || undefined;
+
+  const scope: string[] = [];
+  for (const opt of KY_DOC_DSA_SCOPE_VALUES) {
+    const val = formData.get(`scope_${opt}`);
+    if (val === 'on' || val === 'true' || val === opt) {
+      scope.push(opt);
+    }
+  }
+  if (scope.length === 0) {
+    return { ok: false, error: 'At least one data scope must be selected.' };
+  }
+
+  const windowRaw = str('pre_release_window_days');
+  let pre_release_window_days = KY_DOC_PRE_RELEASE_WINDOW_DEFAULT_DAYS;
+  if (windowRaw) {
+    const n = Number(windowRaw);
+    if (!Number.isInteger(n)) {
+      return { ok: false, error: 'Pre-release window must be a whole number of days.' };
+    }
+    if (n < KY_DOC_PRE_RELEASE_WINDOW_MIN_DAYS || n > KY_DOC_PRE_RELEASE_WINDOW_MAX_DAYS) {
+      return {
+        ok: false,
+        error:
+          `Pre-release window must be between ${KY_DOC_PRE_RELEASE_WINDOW_MIN_DAYS} ` +
+          `and ${KY_DOC_PRE_RELEASE_WINDOW_MAX_DAYS} days (ADR 0009 § Decision.3).`,
+      };
+    }
+    pre_release_window_days = n;
+  }
+
+  const indivAuthRaw = str('individual_records_authorized');
+  if (indivAuthRaw !== 'true' && indivAuthRaw !== 'false') {
+    return { ok: false, error: 'Individual-records authorization selection is required.' };
+  }
+  const individual_records_authorized = indivAuthRaw === 'true';
+
+  const attestationRaw = str('no_recidivism_prediction_attestation');
+  if (attestationRaw !== 'true') {
+    return {
+      ok: false,
+      error:
+        'The no-recidivism-prediction attestation must be checked. Recording a KY DOC DSA without it is not permitted (ADR 0009).',
+    };
+  }
+
+  const VALID_DESTRUCTION = ['on_termination', 'after_3_years', 'after_5_years'] as const;
+  type DestructionValue = (typeof VALID_DESTRUCTION)[number];
+  const destructionRaw = str('data_destruction_due');
+  if (!VALID_DESTRUCTION.includes(destructionRaw as DestructionValue)) {
+    return { ok: false, error: 'Data destruction policy selection is required.' };
+  }
+  const data_destruction_due = destructionRaw as DestructionValue;
+
+  return {
+    ok: true,
+    input: {
+      partnerOrgId,
+      effectiveDate: effectiveDateRaw,
+      endDate,
+      signedByPartner,
+      notes,
+      terms: {
+        kind: 'dsa',
+        agency: 'ky_doc',
+        scope,
+        agency_legal_name,
+        state_contact: {
+          name: sc_name,
+          title: sc_title,
+          email: sc_email,
+          phone: sc_phone,
+        },
+        population_focus: 'pre_release',
+        pre_release_window_days,
+        individual_records_authorized,
+        no_recidivism_prediction_attestation: true,
         data_destruction_due,
       },
     },

--- a/src/app/actions/partner-agreements.test.ts
+++ b/src/app/actions/partner-agreements.test.ts
@@ -8,6 +8,7 @@
 import { describe, expect, it } from 'vitest';
 import {
   parseDcbsDsaAgreementForm,
+  parseKyDocDsaAgreementForm,
   parseMouAgreementForm,
   parseOasisDsaAgreementForm,
   parsePartnerAgreementForm,
@@ -616,6 +617,191 @@ describe('parseOasisDsaAgreementForm', () => {
 
   it('rejects notes longer than 2000 chars', () => {
     const r = parseOasisDsaAgreementForm(makeOasisFormData({ notes: 'x'.repeat(2001) }));
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toMatch(/2 000 characters/i);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseKyDocDsaAgreementForm (DTRS-013)
+// ---------------------------------------------------------------------------
+
+function makeKyDocFormData(overrides: Record<string, string> = {}): FormData {
+  const fd = new FormData();
+  fd.set('partnerOrgId', 'kydoc-uuid-001');
+  fd.set('effectiveDate', '2026-11-01');
+  fd.set('agency_legal_name', 'Kentucky Department of Corrections');
+  fd.set('state_contact_name', 'Reentry Coordinator');
+  fd.set('state_contact_title', 'Reentry Services Branch Manager');
+  fd.set('state_contact_email', 'reentry@ky.gov');
+  fd.set('scope_pre_release_roster', 'on');
+  fd.set('individual_records_authorized', 'true');
+  fd.set('no_recidivism_prediction_attestation', 'true');
+  fd.set('data_destruction_due', 'on_termination');
+  // pre_release_window_days omitted = parser falls back to default (60).
+  for (const [k, v] of Object.entries(overrides)) {
+    if (v === '__DELETE__') {
+      fd.delete(k);
+    } else {
+      fd.set(k, v);
+    }
+  }
+  return fd;
+}
+
+describe('parseKyDocDsaAgreementForm', () => {
+  it('returns ok:true for a valid form (defaults to 60-day pre-release window)', () => {
+    const r = parseKyDocDsaAgreementForm(makeKyDocFormData());
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.input.partnerOrgId).toBe('kydoc-uuid-001');
+    expect(r.input.terms.kind).toBe('dsa');
+    expect(r.input.terms.agency).toBe('ky_doc');
+    expect(r.input.terms.scope).toContain('pre_release_roster');
+    expect(r.input.terms.population_focus).toBe('pre_release');
+    expect(r.input.terms.pre_release_window_days).toBe(60);
+    expect(r.input.terms.individual_records_authorized).toBe(true);
+    expect(r.input.terms.no_recidivism_prediction_attestation).toBe(true);
+  });
+
+  it('rejects missing partnerOrgId', () => {
+    const r = parseKyDocDsaAgreementForm(makeKyDocFormData({ partnerOrgId: '' }));
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toMatch(/ky doc partner/i);
+  });
+
+  it('rejects missing agency_legal_name', () => {
+    const r = parseKyDocDsaAgreementForm(makeKyDocFormData({ agency_legal_name: '' }));
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toMatch(/agency legal name/i);
+  });
+
+  it('rejects missing state_contact_name', () => {
+    const r = parseKyDocDsaAgreementForm(makeKyDocFormData({ state_contact_name: '' }));
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toMatch(/contact name/i);
+  });
+
+  it('rejects state_contact_email without @', () => {
+    const r = parseKyDocDsaAgreementForm(
+      makeKyDocFormData({ state_contact_email: 'not-an-email' }),
+    );
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toMatch(/valid email/i);
+  });
+
+  it('rejects no scope checkboxes selected', () => {
+    const r = parseKyDocDsaAgreementForm(makeKyDocFormData({ scope_pre_release_roster: '' }));
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toMatch(/at least one data scope/i);
+  });
+
+  it('collects multiple scope checkboxes', () => {
+    const r = parseKyDocDsaAgreementForm(
+      makeKyDocFormData({
+        scope_release_date_changes: 'on',
+        scope_supports_in_place: 'on',
+        scope_reentry_eligibility: 'on',
+      }),
+    );
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.input.terms.scope.sort()).toEqual([
+      'pre_release_roster',
+      'reentry_eligibility',
+      'release_date_changes',
+      'supports_in_place',
+    ]);
+  });
+
+  it('accepts pre_release_window_days at the lower bound (30)', () => {
+    const r = parseKyDocDsaAgreementForm(makeKyDocFormData({ pre_release_window_days: '30' }));
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.input.terms.pre_release_window_days).toBe(30);
+  });
+
+  it('accepts pre_release_window_days at the upper bound (180)', () => {
+    const r = parseKyDocDsaAgreementForm(makeKyDocFormData({ pre_release_window_days: '180' }));
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.input.terms.pre_release_window_days).toBe(180);
+  });
+
+  it('rejects pre_release_window_days below the minimum', () => {
+    const r = parseKyDocDsaAgreementForm(makeKyDocFormData({ pre_release_window_days: '14' }));
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toMatch(/pre-release window must be between/i);
+  });
+
+  it('rejects pre_release_window_days above the maximum', () => {
+    const r = parseKyDocDsaAgreementForm(makeKyDocFormData({ pre_release_window_days: '365' }));
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toMatch(/pre-release window must be between/i);
+  });
+
+  it('rejects non-integer pre_release_window_days', () => {
+    const r = parseKyDocDsaAgreementForm(makeKyDocFormData({ pre_release_window_days: '60.5' }));
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toMatch(/whole number of days/i);
+  });
+
+  it('rejects missing individual_records_authorized', () => {
+    const r = parseKyDocDsaAgreementForm(makeKyDocFormData({ individual_records_authorized: '' }));
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toMatch(/individual-records authorization/i);
+  });
+
+  it('rejects no_recidivism_prediction_attestation missing', () => {
+    const r = parseKyDocDsaAgreementForm(
+      makeKyDocFormData({ no_recidivism_prediction_attestation: '' }),
+    );
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toMatch(/no-recidivism-prediction attestation/i);
+  });
+
+  it('rejects no_recidivism_prediction_attestation set to anything other than "true"', () => {
+    const r = parseKyDocDsaAgreementForm(
+      makeKyDocFormData({ no_recidivism_prediction_attestation: 'false' }),
+    );
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toMatch(/no-recidivism-prediction attestation/i);
+  });
+
+  it('rejects unknown data_destruction_due value', () => {
+    const r = parseKyDocDsaAgreementForm(
+      makeKyDocFormData({ data_destruction_due: 'never_required' }),
+    );
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toMatch(/data destruction policy/i);
+  });
+
+  it('accepts open-ended agreement (no endDate)', () => {
+    const r = parseKyDocDsaAgreementForm(makeKyDocFormData({ endDate: '' }));
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.input.endDate).toBeNull();
+  });
+
+  it('rejects endDate before effectiveDate', () => {
+    const r = parseKyDocDsaAgreementForm(
+      makeKyDocFormData({ effectiveDate: '2026-11-01', endDate: '2026-10-01' }),
+    );
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toMatch(/end date must be on or after/i);
+  });
+
+  it('includes optional state_contact_phone when provided', () => {
+    const r = parseKyDocDsaAgreementForm(
+      makeKyDocFormData({ state_contact_phone: '(502) 564-4726' }),
+    );
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.input.terms.state_contact.phone).toBe('(502) 564-4726');
+  });
+
+  it('rejects notes longer than 2000 chars', () => {
+    const r = parseKyDocDsaAgreementForm(makeKyDocFormData({ notes: 'x'.repeat(2001) }));
     expect(r.ok).toBe(false);
     if (!r.ok) expect(r.error).toMatch(/2 000 characters/i);
   });

--- a/src/app/actions/partner-agreements.ts
+++ b/src/app/actions/partner-agreements.ts
@@ -4,9 +4,10 @@ import * as Sentry from '@sentry/nextjs';
 import { revalidatePath } from 'next/cache';
 import { recordAgreement, updateAgreementStatus } from '@/db/queries/partner-agreements';
 import { requireRole } from '@/lib/auth';
-import type { DcbsDsaTerms, FerpaTerms, MouTerms, OasisDsaTerms } from '@/lib/dtrs';
+import type { DcbsDsaTerms, FerpaTerms, KyDocDsaTerms, MouTerms, OasisDsaTerms } from '@/lib/dtrs';
 import {
   parseDcbsDsaAgreementForm,
+  parseKyDocDsaAgreementForm,
   parseMouAgreementForm,
   parseOasisDsaAgreementForm,
   parsePartnerAgreementForm,
@@ -30,6 +31,7 @@ const KNOWN_DOMAIN_PREFIXES = [
   'Invalid DCBS-DSA scope',
   'Invalid OASIS-DSA scope',
   'Invalid OASIS-DSA redaction_policy',
+  'Invalid KY-DOC-DSA scope',
 ] as const;
 
 export type RecordFerpaAgreementResult =
@@ -200,6 +202,62 @@ export async function recordOasisDsaAgreementAction(
   }
 }
 
+export type RecordKyDocDsaAgreementResult =
+  | { ok: true; agreementId: string }
+  | { ok: false; error: string };
+
+/**
+ * Admin-only server action: parse the DTRS-013 KY DOC DSA intake FormData and
+ * persist via `recordAgreement` (terms validation + audit log happen inside
+ * that query function). The validator strictly enforces
+ * `no_recidivism_prediction_attestation === true` (ADR 0009); the parser also
+ * fails closed if the attestation checkbox is missing from the form.
+ */
+export async function recordKyDocDsaAgreementAction(
+  formData: FormData,
+): Promise<RecordKyDocDsaAgreementResult> {
+  const user = await requireRole(['admin']);
+
+  const parsed = parseKyDocDsaAgreementForm(formData);
+  if (!parsed.ok) return { ok: false, error: parsed.error };
+
+  try {
+    const { effectiveDate, endDate, signedByPartner, notes, partnerOrgId, terms } = parsed.input;
+
+    const agreement = await recordAgreement({
+      partnerOrgId,
+      kind: 'dsa',
+      status: 'active',
+      effectiveDate: effectiveDate || null,
+      endDate: endDate || null,
+      signedByPartner: signedByPartner || null,
+      signedByCoalitionUserId: user.id,
+      templateVersion: 'kydoc-dsa-v1',
+      templateRendered: null,
+      // parseKyDocDsaAgreementForm validates scope + window + attestation;
+      // the narrow cast bridges the parser's structural type to the domain type.
+      // recordAgreement re-validates via validateAgreementTerms before any insert.
+      terms: terms as KyDocDsaTerms,
+      notes: notes || null,
+      actorUserId: user.id,
+    });
+
+    revalidatePath('/app/admin/agreements/kydoc');
+    return { ok: true, agreementId: agreement.id };
+  } catch (err) {
+    Sentry.captureException(err);
+    console.error('[partner-agreements.recordKyDocDsa] failed', err);
+    const raw = err instanceof Error ? err.message : '';
+    const isKnown = KNOWN_DOMAIN_PREFIXES.some((prefix) =>
+      raw.toLowerCase().startsWith(prefix.toLowerCase()),
+    );
+    const error = isKnown
+      ? raw
+      : 'Recording the agreement failed — please retry. The error has been logged.';
+    return { ok: false, error };
+  }
+}
+
 export type RecordMouAgreementResult =
   | { ok: true; agreementId: string }
   | { ok: false; error: string };
@@ -266,6 +324,7 @@ export async function updateAgreementStatusAction(
     revalidatePath('/app/admin/agreements/ferpa');
     revalidatePath('/app/admin/agreements/dcbs');
     revalidatePath('/app/admin/agreements/oasis');
+    revalidatePath('/app/admin/agreements/kydoc');
     return { ok: true };
   } catch (err) {
     Sentry.captureException(err);

--- a/src/app/agreements/kydoc/template/page.tsx
+++ b/src/app/agreements/kydoc/template/page.tsx
@@ -1,0 +1,344 @@
+/**
+ * Public KY DOC Data-Sharing Agreement template page — no auth required.
+ * Template version: kydoc-dsa-v1
+ *
+ * KY DOC reviews this page before signing. The signed copy is recorded in the
+ * coalition's partner-agreements registry per ADR 0004; the privacy contract
+ * enforced is documented in ADR 0009.
+ *
+ * NOT a legal instrument — this is a starting point that counsel and KY DOC's
+ * legal office will review and may amend. Fields marked [TBD] require partner-
+ * specific detail before execution.
+ */
+
+export const dynamic = 'force-static';
+
+export default function KyDocDsaTemplatePage() {
+  return (
+    <div className="mx-auto max-w-3xl px-4 py-8 md:py-12 print:py-4">
+      {/* Header */}
+      <header className="mb-8 border-b pb-6">
+        <p className="text-xs font-medium uppercase tracking-widest text-muted-foreground">
+          Template Version: kydoc-dsa-v1 &bull; Daviess County Homeless Coalition
+        </p>
+        <h1 className="mt-2 font-serif text-3xl font-bold">
+          Data-Sharing Agreement
+          <br />
+          (Reentry Pathway)
+        </h1>
+        <p className="mt-2 text-sm text-muted-foreground">
+          Between the Daviess County Homeless Coalition (&ldquo;Coalition&rdquo;) and the Kentucky
+          Department of Corrections (&ldquo;KY DOC&rdquo;)
+        </p>
+      </header>
+
+      <article className="prose prose-sm max-w-none dark:prose-invert space-y-6 text-sm leading-relaxed">
+        {/* Section 1 — Recitals */}
+        <section>
+          <h2 className="text-base font-semibold">1. Recitals</h2>
+          <p>
+            <strong>1.1 Coalition purpose.</strong> The Daviess County Homeless Coalition
+            (&ldquo;Coalition&rdquo;) is a county-level coordinating body working to prevent and end
+            homelessness in Daviess County, Kentucky.
+          </p>
+          <p>
+            <strong>1.2 KY DOC mission.</strong> The Kentucky Department of Corrections operates
+            adult correctional institutions, supervises probation and parole, and coordinates
+            reentry services under <strong>KRS Chapter 197</strong>. KY DOC&apos;s Reentry Services
+            Branch supports the federal Second Chance Act framework (42 U.S.C. § 17501 et seq.) and
+            the Kentucky Reentry Council mandate.
+          </p>
+          <p>
+            <strong>1.3 Pathway purpose.</strong> Roughly half of all individuals released from
+            state correctional institutions return to homelessness within their first year, and
+            return to incarceration is significantly more likely for those who do. The Coalition
+            coordinates housing-stability services, healthcare reactivation (Medicaid resumption),
+            employment supports, and family-connection coordination; KY DOC coordinates pre-release
+            planning, transition home placement, and warm handoff. This Agreement structures the
+            limited data flow necessary to coordinate those services in the period before release —
+            the operational window where coordination is possible.
+          </p>
+          <p>
+            <strong>1.4 No recidivism prediction.</strong> The Coalition&apos;s purpose is to help a
+            person succeed at reentry. The Coalition shall <strong>not</strong> use, derive, or
+            permit the derivation of actuarial recidivism scoring, risk-of-reoffense modeling, or
+            any predictive analytics that classify individuals on probability of reoffending using
+            the data shared under this Agreement. This commitment is non-negotiable and is
+            independent of the Coalition&apos;s general analytics work; reentry data is fenced from
+            recidivism analytics by software policy and contract.
+          </p>
+          <p>
+            <strong>1.5 Voluntary participation.</strong> This Agreement is voluntary. Either party
+            may withdraw with thirty (30) days written notice (see § 9). Withdrawal does not affect
+            services already initiated for an individual and does not relieve the Coalition of its
+            data destruction obligations under § 5.
+          </p>
+        </section>
+
+        {/* Section 2 — Data scope */}
+        <section>
+          <h2 className="text-base font-semibold">2. Data Scope</h2>
+          <p>
+            KY DOC may share with the Coalition the following categories of records, limited to
+            individuals who (a) are currently in KY DOC custody, (b) have a Daviess County address
+            of record or have designated Daviess County as their reentry destination, and (c) have a
+            projected release date within the pre-release window specified in Schedule A:
+          </p>
+          <ul className="list-disc pl-6 space-y-1">
+            <li>
+              <strong>Pre-release roster.</strong> Identifiers (KY DOC inmate ID, DOB, projected
+              release date, designated reentry destination), sufficient to enable warm handoff
+              coordination.
+            </li>
+            <li>
+              <strong>Release-date changes.</strong> Updates when projected release dates shift
+              (transfers, parole grants, sentence expirations, expungements).
+            </li>
+            <li>
+              <strong>Supports-in-place.</strong> KY DOC&apos;s pre-release plan: housing intent,
+              employment plan, healthcare resumption (Medicaid restoration status), substance-use
+              treatment continuity, family-connection plan.
+            </li>
+            <li>
+              <strong>Reentry-program eligibility.</strong> Eligibility flags for reentry programs
+              the Coalition coordinates (housing voucher cohorts, Medicaid resumption queues,
+              treatment-program slots).
+            </li>
+          </ul>
+          <p>
+            The specific data classes covered by this Agreement are identified in the attached
+            Schedule A, which is incorporated by reference. [TBD — KY DOC and Coalition complete
+            Schedule A before execution.]
+          </p>
+          <p>
+            KY DOC shall <strong>not</strong> share substance-use-treatment records (42 CFR Part 2),
+            mental-health diagnostic detail, communications-with-counsel records, victim-impact
+            statements, prior-offense narrative detail, or any data not explicitly listed in
+            Schedule A without a separate written amendment to this Agreement.
+          </p>
+        </section>
+
+        {/* Section 3 — Pre-release window */}
+        <section>
+          <h2 className="text-base font-semibold">3. Pre-Release Window (Bounded Data Flow)</h2>
+          <p>
+            <strong>3.1 Window as contract.</strong> The Coalition shall receive data only for
+            individuals whose projected release date falls within the pre-release window specified
+            in Schedule A. The default window is sixty (60) days; the agreed window may range
+            between thirty (30) and one hundred eighty (180) days as Schedule A specifies. Records
+            that age out of the window without a successful warm handoff are deleted from Coalition
+            systems within seven (7) days of expiration.
+          </p>
+          <p>
+            <strong>3.2 Software enforcement.</strong> The Coalition&apos;s ingest middleware reads
+            Schedule A&apos;s window length as the contract-of-record. KY DOC may verify enforcement
+            by inspecting the agreement record in the Coalition&apos;s registry and the audit log of
+            the daily window-expiration job.
+          </p>
+          <p>
+            <strong>3.3 Window amendments.</strong> Any change to the pre-release window length is a
+            contract amendment and requires written authorization from both parties. The Coalition
+            shall not extend the window administratively.
+          </p>
+        </section>
+
+        {/* Section 4 — Data security */}
+        <section>
+          <h2 className="text-base font-semibold">4. Data Security and Access Controls</h2>
+          <p>
+            <strong>4.1 Authorized readers.</strong> The Coalition shall restrict access to
+            pre-release records to assigned reentry caseworkers, supervising caseworkers, and admins
+            on a strict need-to-know basis. The list of authorized readers is maintained by the
+            Coalition&apos;s data steward and provided to KY DOC upon request.
+          </p>
+          <p>
+            <strong>4.2 No re-disclosure to law enforcement.</strong> The Coalition shall not
+            disclose pre-release records, derived analytics, or even confirmation-of-existence to
+            law enforcement, parole, probation, or the courts except (a) under a valid court order
+            that the Coalition&apos;s counsel has reviewed, or (b) under separate written
+            authorization from KY DOC. This includes informal requests; data sharing for
+            surveillance purposes is outside the scope of this Agreement.
+          </p>
+          <p>
+            <strong>4.3 Audit logging.</strong> Every read of an individual&apos;s pre-release
+            record is audit-logged. The audit table is the source of truth for the cooperation
+            obligation in § 6.3.
+          </p>
+          <p>
+            <strong>4.4 Breach notification.</strong> Any unauthorized access, disclosure, or loss
+            of pre-release records must be reported to KY DOC within seventy-two (72) hours of
+            discovery, with a written incident report within seven (7) days and immediate suspension
+            of the data flow pending review.
+          </p>
+        </section>
+
+        {/* Section 5 — Data destruction */}
+        <section>
+          <h2 className="text-base font-semibold">5. Data Retention and Destruction</h2>
+          <p>
+            <strong>5.1 Default retention.</strong> Records that age out of the pre-release window
+            without a successful warm handoff are deleted within seven (7) days. Records of
+            individuals who are successfully handed off are retained per Schedule A&apos;s data
+            destruction policy: destruction upon agreement termination is the default; longer
+            retention windows (3 years, 5 years) are available only with explicit written
+            justification and KY DOC approval.
+          </p>
+          <p>
+            <strong>5.2 Destruction on termination.</strong> Upon termination, the Coalition shall
+            securely destroy or return all pre-release records (including backup copies) within
+            thirty (30) days. &ldquo;Destruction&rdquo; means irreversible deletion from all systems
+            and media holding the records.
+          </p>
+          <p>
+            <strong>5.3 Certification.</strong> The Coalition shall provide KY DOC with written
+            certification of destruction. KY DOC may inspect destruction logs upon reasonable
+            notice.
+          </p>
+        </section>
+
+        {/* Section 6 — Coordination and reporting */}
+        <section>
+          <h2 className="text-base font-semibold">6. Coordination and Reporting</h2>
+          <p>
+            <strong>6.1 Joint case-coordination.</strong> The Coalition and KY DOC shall coordinate
+            at a cadence agreed upon in Schedule B (default: monthly). The agenda shall include
+            progress on warm handoffs, emerging risks, and any data-flow questions.
+          </p>
+          <p>
+            <strong>6.2 Aggregate reporting.</strong> The Coalition shall provide KY DOC with
+            quarterly aggregate reports on outcomes for the cohort: number of individuals
+            successfully connected to housing on day-of-release, Medicaid-resumption rates, and
+            employment-engagement rates. <strong>No</strong> recidivism / re-incarceration metrics
+            shall be derived or reported under this Agreement; that is the explicit prohibition in §
+            1.4.
+          </p>
+          <p>
+            <strong>6.3 Audit cooperation.</strong> The Coalition shall, upon reasonable notice,
+            provide KY DOC with access to audit logs and access-control records for the purpose of
+            verifying compliance with this Agreement.
+          </p>
+        </section>
+
+        {/* Section 7 — Term */}
+        <section>
+          <h2 className="text-base font-semibold">7. Term</h2>
+          <p>
+            This Agreement is effective on the date last signed below and continues until the
+            earlier of (a) the end date specified in Schedule A, (b) termination under § 9, or (c)
+            written mutual agreement to terminate.
+          </p>
+        </section>
+
+        {/* Section 8 — Amendments */}
+        <section>
+          <h2 className="text-base font-semibold">8. Amendments</h2>
+          <p>
+            Any amendment to this Agreement, including changes to Schedule A or to the pre-release
+            window under § 3, must be in writing and signed by authorized representatives of both
+            parties. The Coalition will publish a new template version for material amendments; the
+            signed copy recorded in the Coalition&apos;s registry is the authoritative instrument.
+          </p>
+        </section>
+
+        {/* Section 9 — Withdrawal */}
+        <section>
+          <h2 className="text-base font-semibold">9. Withdrawal</h2>
+          <p>
+            Either party may terminate this Agreement at any time by providing thirty (30) days
+            written notice to the other party. Notice may be delivered by email to the contacts
+            identified in Schedule B. Upon termination, the Coalition&apos;s data destruction
+            obligations under § 5 take effect immediately. KY DOC may suspend data flow at any time
+            without notice if compliance is in question; suspension is not termination.
+          </p>
+        </section>
+
+        {/* Section 10 — Governing law */}
+        <section>
+          <h2 className="text-base font-semibold">10. Governing Law</h2>
+          <p>
+            This Agreement is governed by the laws of the Commonwealth of Kentucky, including{' '}
+            <strong>KRS Chapter 197</strong> (Department of Corrections) and{' '}
+            <strong>KRS Chapter 439</strong> (probation and parole), and applicable federal law
+            (Second Chance Act, 42 U.S.C. § 17501 et seq.). Any dispute arising under this Agreement
+            shall be resolved through good-faith negotiation between the Coalition&apos;s data
+            steward and KY DOC&apos;s Reentry Services Branch Manager before seeking other remedies.
+          </p>
+        </section>
+
+        {/* Signatory blocks */}
+        <section className="mt-8">
+          <h2 className="text-base font-semibold">Signatories</h2>
+          <div className="mt-4 grid gap-8 sm:grid-cols-2">
+            <div className="space-y-4">
+              <p className="font-medium">Daviess County Homeless Coalition</p>
+              <div className="space-y-2">
+                <div className="border-b border-foreground/30 pb-0.5">
+                  <p className="mt-4 text-xs text-muted-foreground">Authorized signature</p>
+                </div>
+                <div className="border-b border-foreground/30 pb-0.5">
+                  <p className="mt-4 text-xs text-muted-foreground">Printed name &amp; title</p>
+                </div>
+                <div className="border-b border-foreground/30 pb-0.5">
+                  <p className="mt-4 text-xs text-muted-foreground">Date</p>
+                </div>
+              </div>
+            </div>
+            <div className="space-y-4">
+              <p className="font-medium">
+                Kentucky Department of
+                <br />
+                Corrections (KY DOC)
+              </p>
+              <div className="space-y-2">
+                <div className="border-b border-foreground/30 pb-0.5">
+                  <p className="mt-4 text-xs text-muted-foreground">Authorized signature</p>
+                </div>
+                <div className="border-b border-foreground/30 pb-0.5">
+                  <p className="mt-4 text-xs text-muted-foreground">Printed name &amp; title</p>
+                </div>
+                <div className="border-b border-foreground/30 pb-0.5">
+                  <p className="mt-4 text-xs text-muted-foreground">Date</p>
+                </div>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        {/* Schedule placeholders */}
+        <section className="mt-6">
+          <h2 className="text-base font-semibold">Schedule A — Data Classes &amp; Window</h2>
+          <p className="text-muted-foreground italic">
+            [TBD — to be completed by KY DOC and Coalition before execution. Enumerate the specific
+            data elements, file format, transmission method, frequency, the pre-release window
+            length (30–180 days; default 60), and the agreed retention period.]
+          </p>
+        </section>
+
+        <section className="mt-4">
+          <h2 className="text-base font-semibold">Schedule B — Contacts</h2>
+          <p className="text-muted-foreground italic">
+            [TBD — list Coalition data steward and KY DOC Reentry Services Branch Manager (or
+            designee) names, emails, and phone numbers. Include after-hours emergency contact for
+            breach notification under § 4.4.]
+          </p>
+        </section>
+      </article>
+
+      {/* Footer note */}
+      <footer className="mt-10 border-t pt-6 text-xs text-muted-foreground">
+        <p>
+          This page is the public template (version <code className="font-mono">kydoc-dsa-v1</code>
+          ). The signed copy is recorded in the coalition&apos;s partner-agreements registry per{' '}
+          <strong>ADR 0004</strong>; the privacy contract this agreement enforces is documented in{' '}
+          <strong>ADR 0009</strong>. This template is a starting point — KY DOC and Coalition should
+          review it with counsel before execution. Fields marked [TBD] require partner- specific
+          detail.
+        </p>
+        <p className="mt-2">
+          References: KRS Chapter 197 (Department of Corrections); KRS Chapter 439 (Probation and
+          Parole); Second Chance Act, 42 U.S.C. § 17501 et seq.; Kentucky Reentry Council mandate.
+        </p>
+      </footer>
+    </div>
+  );
+}

--- a/src/app/app/admin/agreements/kydoc/page.tsx
+++ b/src/app/app/admin/agreements/kydoc/page.tsx
@@ -1,0 +1,145 @@
+import { eq } from 'drizzle-orm';
+import Link from 'next/link';
+import { KyDocDsaAgreementForm } from '@/components/dtrs/kydoc-dsa-agreement-form';
+import { db } from '@/db/client';
+import { getActiveKyDocDsa, listAgreementsForPartner } from '@/db/queries/partner-agreements';
+import { partnerOrgs } from '@/db/schema/partner-orgs';
+import { requireRole } from '@/lib/auth';
+
+export const dynamic = 'force-dynamic';
+
+export default async function KyDocAgreementsPage() {
+  await requireRole(['admin']);
+
+  // KY DOC is type='government' in the seeded directory. The admin picks the
+  // KY DOC partner from the list — other government partners (e.g. DCBS, OASIS
+  // sister-agencies that also seeded as government) won't typically execute a
+  // reentry DSA, but they'd appear here for selection clarity.
+  const partners = await db
+    .select({ id: partnerOrgs.id, name: partnerOrgs.name })
+    .from(partnerOrgs)
+    .where(eq(partnerOrgs.type, 'government'))
+    .orderBy(partnerOrgs.name);
+
+  if (partners.length === 0) {
+    return (
+      <div className="mx-auto max-w-2xl space-y-4 p-4 md:p-6">
+        <header>
+          <h1 className="font-serif text-3xl font-bold text-primary">
+            KY DOC data-sharing agreements
+          </h1>
+          <p className="mt-1 text-sm text-muted-foreground">
+            Record KY DOC DSAs for the reentry pathway.
+          </p>
+        </header>
+        <div className="rounded-md border border-border bg-muted/20 p-6 text-sm">
+          <p className="font-semibold">No government-type partner orgs found.</p>
+          <p className="mt-2 text-muted-foreground">
+            Add a partner org with <code className="font-mono">type = &apos;government&apos;</code>{' '}
+            (e.g. &quot;Kentucky Department of Corrections&quot;) before recording a DSA. Contact
+            the coalition data steward to add partners.
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  const activeAgreements: Record<
+    string,
+    { id: string; effectiveDate: string | null; status: string } | undefined
+  > = {};
+
+  await Promise.all(
+    partners.map(async (p) => {
+      const active = await getActiveKyDocDsa(p.id);
+      if (active) {
+        activeAgreements[p.id] = {
+          id: active.id,
+          effectiveDate: active.effectiveDate,
+          status: active.status,
+        };
+      }
+    }),
+  );
+
+  // List all DSA agreements (any status, any agency) for these government
+  // partners. Most rows here will be KY DOC, but a non-KY-DOC DSA on a
+  // government partner (e.g. DCBS amendments, future agency expansions) would
+  // also appear with its kind/agency clearly tagged.
+  const allAgreements = (
+    await Promise.all(partners.map((p) => listAgreementsForPartner(p.id, { status: 'any' })))
+  ).flat();
+
+  const partnerIndex = Object.fromEntries(partners.map((p) => [p.id, p.name]));
+
+  return (
+    <div className="mx-auto max-w-3xl space-y-8 p-4 md:p-6">
+      <header>
+        <h1 className="font-serif text-3xl font-bold text-primary">
+          KY DOC data-sharing agreements
+        </h1>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Record and track DSAs with the Kentucky Department of Corrections for the reentry pathway.
+          The agreement establishes a bounded pre-release window during which KY DOC may share
+          records of Daviess County residents approaching release. KY DOC should review the{' '}
+          <Link
+            href="/agreements/kydoc/template"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="underline underline-offset-2 hover:text-foreground"
+          >
+            agreement template
+          </Link>{' '}
+          before signing. See <strong>ADR 0009</strong> for the privacy contract this agreement
+          enforces — including the no-recidivism-prediction commitment and the no-LE-disclosure
+          rule.
+        </p>
+      </header>
+
+      {allAgreements.length > 0 && (
+        <section className="space-y-3">
+          <h2 className="text-base font-semibold">Recorded agreements</h2>
+          <div className="overflow-x-auto rounded-md border border-border">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="border-b bg-muted/30 text-left">
+                  <th className="px-3 py-2 font-medium">Partner</th>
+                  <th className="px-3 py-2 font-medium">Kind</th>
+                  <th className="px-3 py-2 font-medium">Status</th>
+                  <th className="px-3 py-2 font-medium">Effective</th>
+                  <th className="px-3 py-2 font-medium">Ends</th>
+                </tr>
+              </thead>
+              <tbody>
+                {allAgreements.map((a) => (
+                  <tr key={a.id} className="border-b last:border-0">
+                    <td className="px-3 py-2">{partnerIndex[a.partnerOrgId] ?? a.partnerOrgId}</td>
+                    <td className="px-3 py-2 font-mono text-xs uppercase">{a.kind}</td>
+                    <td className="px-3 py-2">
+                      <span
+                        className={
+                          a.status === 'active'
+                            ? 'rounded bg-emerald-100 px-1.5 py-0.5 text-[10px] font-medium text-emerald-700 dark:bg-emerald-900/40 dark:text-emerald-400'
+                            : 'rounded bg-muted px-1.5 py-0.5 text-[10px] font-medium text-muted-foreground'
+                        }
+                      >
+                        {a.status}
+                      </span>
+                    </td>
+                    <td className="px-3 py-2 tabular-nums">{a.effectiveDate ?? '—'}</td>
+                    <td className="px-3 py-2 tabular-nums">{a.endDate ?? 'open'}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </section>
+      )}
+
+      <section className="space-y-4">
+        <h2 className="text-base font-semibold">Record a new KY DOC DSA</h2>
+        <KyDocDsaAgreementForm partners={partners} activeAgreements={activeAgreements} />
+      </section>
+    </div>
+  );
+}

--- a/src/components/dtrs/kydoc-dsa-agreement-form.tsx
+++ b/src/components/dtrs/kydoc-dsa-agreement-form.tsx
@@ -1,0 +1,483 @@
+'use client';
+
+import Link from 'next/link';
+import { useId, useState, useTransition } from 'react';
+import { recordKyDocDsaAgreementAction } from '@/app/actions/partner-agreements';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+// Deep imports: 'use client' files are exempt from the barrel rule (ADR 0001 / FND-040b).
+import {
+  KY_DOC_DSA_SCOPE_OPTIONS,
+  KY_DOC_PRE_RELEASE_WINDOW_DEFAULT_DAYS,
+  KY_DOC_PRE_RELEASE_WINDOW_MAX_DAYS,
+  KY_DOC_PRE_RELEASE_WINDOW_MIN_DAYS,
+} from '@/lib/dtrs/partner-agreements';
+
+type GovernmentOption = {
+  id: string;
+  name: string;
+};
+
+type ActiveAgreement = {
+  id: string;
+  effectiveDate: string | null;
+  status: string;
+};
+
+type Props = {
+  partners: GovernmentOption[];
+  /** Map of partnerOrgId → active KY DOC DSA agreement (if one exists). */
+  activeAgreements: Record<string, ActiveAgreement | undefined>;
+};
+
+const DESTRUCTION_OPTIONS = [
+  {
+    value: 'on_termination',
+    label: 'Upon agreement termination (recommended for pre-release records)',
+  },
+  { value: 'after_3_years', label: 'After 3 years of program completion' },
+  { value: 'after_5_years', label: 'After 5 years of program completion' },
+] as const;
+
+const DEFAULT_AGENCY_LEGAL_NAME = 'Kentucky Department of Corrections';
+
+export function KyDocDsaAgreementForm({ partners, activeAgreements }: Props) {
+  const formId = useId();
+
+  const [selectedPartnerId, setSelectedPartnerId] = useState(partners[0]?.id ?? '');
+  const [effectiveDate, setEffectiveDate] = useState('');
+  const [endDate, setEndDate] = useState('');
+  const [signedByPartner, setSignedByPartner] = useState('');
+  const [agencyLegalName, setAgencyLegalName] = useState(DEFAULT_AGENCY_LEGAL_NAME);
+  const [contactName, setContactName] = useState('');
+  const [contactTitle, setContactTitle] = useState('');
+  const [contactEmail, setContactEmail] = useState('');
+  const [contactPhone, setContactPhone] = useState('');
+  const [selectedScope, setSelectedScope] = useState<Set<string>>(new Set());
+  const [windowDays, setWindowDays] = useState<string>(
+    String(KY_DOC_PRE_RELEASE_WINDOW_DEFAULT_DAYS),
+  );
+  const [individualAuth, setIndividualAuth] = useState<'true' | 'false'>('true');
+  const [attested, setAttested] = useState(false);
+  const [dataDestruction, setDataDestruction] = useState<string>('on_termination');
+  const [notes, setNotes] = useState('');
+
+  const [pending, startTransition] = useTransition();
+  const [result, setResult] = useState<
+    { ok: true; agreementId: string } | { ok: false; error: string } | null
+  >(null);
+
+  const existingAgreement = selectedPartnerId ? activeAgreements[selectedPartnerId] : undefined;
+
+  const toggleScope = (value: string) => {
+    setSelectedScope((prev) => {
+      const next = new Set(prev);
+      if (next.has(value)) {
+        next.delete(value);
+      } else {
+        next.add(value);
+      }
+      return next;
+    });
+  };
+
+  const resetForm = () => {
+    setEffectiveDate('');
+    setEndDate('');
+    setSignedByPartner('');
+    setContactName('');
+    setContactTitle('');
+    setContactEmail('');
+    setContactPhone('');
+    setSelectedScope(new Set());
+    setWindowDays(String(KY_DOC_PRE_RELEASE_WINDOW_DEFAULT_DAYS));
+    setIndividualAuth('true');
+    setAttested(false);
+    setDataDestruction('on_termination');
+    setNotes('');
+    setResult(null);
+  };
+
+  const onSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    setResult(null);
+    const fd = new FormData(e.currentTarget);
+    startTransition(async () => {
+      const r = await recordKyDocDsaAgreementAction(fd);
+      setResult(r);
+      if (r.ok) resetForm();
+    });
+  };
+
+  if (result?.ok) {
+    return (
+      <div className="rounded-md border border-emerald-500/40 bg-emerald-500/5 p-4 text-sm">
+        <p className="font-semibold text-emerald-700 dark:text-emerald-400">KY DOC DSA recorded.</p>
+        <p className="mt-1 text-muted-foreground">
+          Agreement ID: <code className="font-mono text-xs">{result.agreementId}</code>
+        </p>
+        <div className="mt-3 flex gap-2">
+          <Button type="button" variant="outline" onClick={() => setResult(null)}>
+            Record another
+          </Button>
+          <Link
+            href="/app/admin/agreements/kydoc"
+            className="inline-flex items-center rounded-md border border-input bg-background px-3 py-2 text-sm hover:bg-accent"
+          >
+            Back to list
+          </Link>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <form onSubmit={onSubmit} className="space-y-6">
+      {/* Partner selector */}
+      <div className="space-y-1">
+        <Label htmlFor={`${formId}-partner`}>KY DOC partner</Label>
+        <select
+          id={`${formId}-partner`}
+          name="partnerOrgId"
+          value={selectedPartnerId}
+          onChange={(e) => {
+            setSelectedPartnerId(e.target.value);
+            setResult(null);
+          }}
+          disabled={pending}
+          className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        >
+          {partners.map((p) => (
+            <option key={p.id} value={p.id}>
+              {p.name}
+            </option>
+          ))}
+        </select>
+        {existingAgreement && (
+          <p className="text-xs text-amber-600 dark:text-amber-400">
+            This partner already has an active KY DOC DSA (effective:{' '}
+            {existingAgreement.effectiveDate ?? 'open'}). Recording a new agreement will not
+            automatically supersede it — update the old agreement status separately.
+          </p>
+        )}
+      </div>
+
+      {/* Template preview link */}
+      <div className="rounded-md border border-border bg-muted/20 p-3 text-sm">
+        <p className="text-muted-foreground">
+          Before recording, KY DOC should review the{' '}
+          <Link
+            href="/agreements/kydoc/template"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="underline underline-offset-2 hover:text-foreground"
+          >
+            KY DOC DSA template
+          </Link>
+          . The template version recorded here is{' '}
+          <code className="font-mono text-xs">kydoc-dsa-v1</code>.
+        </p>
+      </div>
+
+      {/* Dates */}
+      <div className="grid gap-4 sm:grid-cols-2">
+        <div className="space-y-1">
+          <Label htmlFor={`${formId}-effective`}>Effective date *</Label>
+          <Input
+            id={`${formId}-effective`}
+            name="effectiveDate"
+            type="date"
+            value={effectiveDate}
+            onChange={(e) => setEffectiveDate(e.target.value)}
+            required
+            disabled={pending}
+          />
+        </div>
+        <div className="space-y-1">
+          <Label htmlFor={`${formId}-end`}>
+            End date{' '}
+            <span className="font-normal text-muted-foreground text-xs">
+              (optional — open-ended if blank)
+            </span>
+          </Label>
+          <Input
+            id={`${formId}-end`}
+            name="endDate"
+            type="date"
+            value={endDate}
+            onChange={(e) => setEndDate(e.target.value)}
+            disabled={pending}
+          />
+        </div>
+      </div>
+
+      {/* Signed by partner */}
+      <div className="space-y-1">
+        <Label htmlFor={`${formId}-signed-by`}>
+          Signed by (KY DOC){' '}
+          <span className="font-normal text-muted-foreground text-xs">(name + title)</span>
+        </Label>
+        <Input
+          id={`${formId}-signed-by`}
+          name="signedByPartner"
+          type="text"
+          value={signedByPartner}
+          onChange={(e) => setSignedByPartner(e.target.value)}
+          placeholder="e.g. Cookie Crews, Commissioner"
+          disabled={pending}
+        />
+      </div>
+
+      {/* Agency legal name */}
+      <div className="space-y-1">
+        <Label htmlFor={`${formId}-legal-name`}>Agency legal name *</Label>
+        <Input
+          id={`${formId}-legal-name`}
+          name="agency_legal_name"
+          type="text"
+          value={agencyLegalName}
+          onChange={(e) => setAgencyLegalName(e.target.value)}
+          required
+          disabled={pending}
+        />
+      </div>
+
+      {/* Agency contact */}
+      <fieldset className="space-y-3">
+        <legend className="text-sm font-medium">KY DOC contact</legend>
+        <div className="grid gap-3 sm:grid-cols-2">
+          <div className="space-y-1">
+            <Label htmlFor={`${formId}-contact-name`}>Name *</Label>
+            <Input
+              id={`${formId}-contact-name`}
+              name="state_contact_name"
+              type="text"
+              value={contactName}
+              onChange={(e) => setContactName(e.target.value)}
+              required
+              disabled={pending}
+              placeholder="Full name"
+            />
+          </div>
+          <div className="space-y-1">
+            <Label htmlFor={`${formId}-contact-title`}>Title *</Label>
+            <Input
+              id={`${formId}-contact-title`}
+              name="state_contact_title"
+              type="text"
+              value={contactTitle}
+              onChange={(e) => setContactTitle(e.target.value)}
+              required
+              disabled={pending}
+              placeholder="e.g. Reentry Services Branch Manager"
+            />
+          </div>
+          <div className="space-y-1">
+            <Label htmlFor={`${formId}-contact-email`}>Email *</Label>
+            <Input
+              id={`${formId}-contact-email`}
+              name="state_contact_email"
+              type="email"
+              value={contactEmail}
+              onChange={(e) => setContactEmail(e.target.value)}
+              required
+              disabled={pending}
+              placeholder="reentry@ky.gov"
+            />
+          </div>
+          <div className="space-y-1">
+            <Label htmlFor={`${formId}-contact-phone`}>
+              Phone <span className="font-normal text-muted-foreground text-xs">(optional)</span>
+            </Label>
+            <Input
+              id={`${formId}-contact-phone`}
+              name="state_contact_phone"
+              type="tel"
+              value={contactPhone}
+              onChange={(e) => setContactPhone(e.target.value)}
+              disabled={pending}
+              placeholder="(502) 564-4726"
+            />
+          </div>
+        </div>
+      </fieldset>
+
+      {/* Scope checkboxes */}
+      <fieldset className="space-y-3">
+        <legend className="text-sm font-medium">
+          Data scope *{' '}
+          <span className="font-normal text-muted-foreground text-xs">
+            (select all that apply — at least one required)
+          </span>
+        </legend>
+        <div className="space-y-2">
+          {KY_DOC_DSA_SCOPE_OPTIONS.map((opt) => {
+            const inputId = `${formId}-scope-${opt.value}`;
+            return (
+              <label key={opt.value} className="flex items-start gap-2 text-sm">
+                <input
+                  type="checkbox"
+                  id={inputId}
+                  name={`scope_${opt.value}`}
+                  value="on"
+                  checked={selectedScope.has(opt.value)}
+                  onChange={() => toggleScope(opt.value)}
+                  disabled={pending}
+                  className="mt-0.5 h-4 w-4 rounded border-input"
+                />
+                <span>{opt.label}</span>
+              </label>
+            );
+          })}
+        </div>
+      </fieldset>
+
+      {/* Pre-release window */}
+      <fieldset className="space-y-2 rounded-md border border-border bg-muted/10 p-4">
+        <legend className="px-1 text-sm font-semibold text-foreground">Pre-release window</legend>
+        <p className="text-xs text-muted-foreground">
+          Number of days before projected release that KY DOC may share an individual&apos;s record.
+          SUBP-005&apos;s ingest middleware reads this as the contract-of-record (ADR 0009 §
+          Decision.3). Default {KY_DOC_PRE_RELEASE_WINDOW_DEFAULT_DAYS} days; range{' '}
+          {KY_DOC_PRE_RELEASE_WINDOW_MIN_DAYS}–{KY_DOC_PRE_RELEASE_WINDOW_MAX_DAYS}.
+        </p>
+        <div className="flex items-center gap-2">
+          <Input
+            id={`${formId}-window`}
+            name="pre_release_window_days"
+            type="number"
+            min={KY_DOC_PRE_RELEASE_WINDOW_MIN_DAYS}
+            max={KY_DOC_PRE_RELEASE_WINDOW_MAX_DAYS}
+            step={1}
+            value={windowDays}
+            onChange={(e) => setWindowDays(e.target.value)}
+            disabled={pending}
+            className="w-32"
+          />
+          <span className="text-sm text-muted-foreground">days</span>
+        </div>
+      </fieldset>
+
+      {/* Individual records authorization */}
+      <fieldset className="space-y-2">
+        <legend className="text-sm font-medium">Individual-records authorization *</legend>
+        <p className="text-xs text-muted-foreground">
+          Mirrors DCBS pattern. SUBP-005 reads this flag before enabling per-individual views; if
+          false, the agreement is informational only and no individual records may be persisted.
+        </p>
+        <div className="space-y-2">
+          <label className="flex items-center gap-1.5 text-sm">
+            <input
+              type="radio"
+              name="individual_records_authorized"
+              value="true"
+              checked={individualAuth === 'true'}
+              onChange={() => setIndividualAuth('true')}
+              disabled={pending}
+              className="h-4 w-4"
+            />
+            Authorized — KY DOC has executed authorization for individual-record sharing
+          </label>
+          <label className="flex items-center gap-1.5 text-sm">
+            <input
+              type="radio"
+              name="individual_records_authorized"
+              value="false"
+              checked={individualAuth === 'false'}
+              onChange={() => setIndividualAuth('false')}
+              disabled={pending}
+              className="h-4 w-4"
+            />
+            Not authorized — informational agreement only
+          </label>
+        </div>
+      </fieldset>
+
+      {/* No-recidivism-prediction attestation */}
+      <fieldset className="space-y-2 rounded-md border border-amber-500/40 bg-amber-500/5 p-4">
+        <legend className="px-1 text-sm font-semibold text-amber-700 dark:text-amber-400">
+          Required attestation
+        </legend>
+        <label className="flex items-start gap-2 text-sm">
+          <input
+            type="checkbox"
+            name="no_recidivism_prediction_attestation"
+            value="true"
+            checked={attested}
+            onChange={(e) => setAttested(e.target.checked)}
+            disabled={pending}
+            className="mt-0.5 h-4 w-4"
+            required
+          />
+          <span>
+            I attest that the Coalition will not use this data for actuarial recidivism scoring,
+            risk-of-reoffense modeling, or any law-enforcement / parole / probation surveillance
+            purpose, as required by ADR 0009 and the Second Chance Act framework. I have authority
+            to record this KY DOC DSA on behalf of the coalition.
+          </span>
+        </label>
+      </fieldset>
+
+      {/* Data destruction policy */}
+      <fieldset className="space-y-2">
+        <legend className="text-sm font-medium">Data destruction policy *</legend>
+        <div className="space-y-2">
+          {DESTRUCTION_OPTIONS.map((opt) => (
+            <label key={opt.value} className="flex items-center gap-1.5 text-sm">
+              <input
+                type="radio"
+                name="data_destruction_due"
+                value={opt.value}
+                checked={dataDestruction === opt.value}
+                onChange={() => setDataDestruction(opt.value)}
+                disabled={pending}
+                className="h-4 w-4"
+              />
+              {opt.label}
+            </label>
+          ))}
+        </div>
+      </fieldset>
+
+      {/* Notes */}
+      <div className="space-y-1">
+        <Label htmlFor={`${formId}-notes`}>
+          Notes{' '}
+          <span className="font-normal text-muted-foreground text-xs">
+            (optional — no individual identifiers)
+          </span>
+        </Label>
+        <textarea
+          id={`${formId}-notes`}
+          name="notes"
+          rows={3}
+          value={notes}
+          onChange={(e) => setNotes(e.target.value)}
+          disabled={pending}
+          maxLength={2000}
+          className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50"
+          placeholder="Optional context about this agreement"
+        />
+      </div>
+
+      {result && !result.ok ? (
+        <p role="alert" className="text-sm text-destructive">
+          {result.error}
+        </p>
+      ) : null}
+
+      <div className="flex gap-2">
+        <Button type="submit" disabled={pending || !attested}>
+          {pending ? 'Recording…' : 'Record KY DOC DSA'}
+        </Button>
+        <Link
+          href="/app/admin/agreements/kydoc"
+          className="inline-flex items-center rounded-md border border-input bg-background px-3 py-2 text-sm hover:bg-accent"
+        >
+          Cancel
+        </Link>
+      </div>
+    </form>
+  );
+}

--- a/src/db/queries/partner-agreements.ts
+++ b/src/db/queries/partner-agreements.ts
@@ -63,7 +63,7 @@ export async function getActiveAgreementByKind(
  * SUBP-004's abuser-blind middleware reads the active agreement before every
  * survivor-record write and exposes the redaction policy as the contract-of-
  * record. The JSONB filter `terms->>'agency' = 'oasis'` discriminates OASIS
- * agreements from DCBS / future KY DOC under the shared `dsa` kind (ADR 0004).
+ * agreements from DCBS / KY DOC under the shared `dsa` kind (ADR 0004).
  *
  * Returns `null` when no active OASIS DSA exists; SUBP-004 must fail closed
  * in that case (ADR 0007 § 3.1).
@@ -78,6 +78,34 @@ export async function getActiveOasisDsa(partnerOrgId: string): Promise<PartnerAg
         eq(partnerAgreements.kind, 'dsa'),
         eq(partnerAgreements.status, 'active'),
         sql`(${partnerAgreements.terms}->>'agency') = 'oasis'`,
+      ),
+    )
+    .limit(1);
+  return rows[0] ?? null;
+}
+
+/**
+ * Return the active KY DOC Data-Sharing Agreement for a partner, or null.
+ *
+ * SUBP-005's pre-release ingest middleware reads the active agreement before
+ * every record write and exposes `terms.pre_release_window_days` and
+ * `terms.individual_records_authorized` as the contract-of-record. The JSONB
+ * filter `terms->>'agency' = 'ky_doc'` discriminates KY DOC agreements from
+ * DCBS / OASIS under the shared `dsa` kind (ADR 0004 / ADR 0009).
+ *
+ * Returns `null` when no active KY DOC DSA exists; SUBP-005 must fail closed
+ * in that case (ADR 0009 § Decision.1).
+ */
+export async function getActiveKyDocDsa(partnerOrgId: string): Promise<PartnerAgreement | null> {
+  const rows = await db
+    .select()
+    .from(partnerAgreements)
+    .where(
+      and(
+        eq(partnerAgreements.partnerOrgId, partnerOrgId),
+        eq(partnerAgreements.kind, 'dsa'),
+        eq(partnerAgreements.status, 'active'),
+        sql`(${partnerAgreements.terms}->>'agency') = 'ky_doc'`,
       ),
     )
     .limit(1);

--- a/src/lib/dtrs/partner-agreements.test.ts
+++ b/src/lib/dtrs/partner-agreements.test.ts
@@ -2,11 +2,16 @@ import { describe, expect, it } from 'vitest';
 import {
   DCBS_DSA_SCOPE_OPTIONS,
   FERPA_SCOPE_OPTIONS,
+  KY_DOC_DSA_SCOPE_OPTIONS,
+  KY_DOC_PRE_RELEASE_WINDOW_DEFAULT_DAYS,
+  KY_DOC_PRE_RELEASE_WINDOW_MAX_DAYS,
+  KY_DOC_PRE_RELEASE_WINDOW_MIN_DAYS,
   OASIS_DEFAULT_REDACTION_POLICY,
   OASIS_DSA_SCOPE_OPTIONS,
   validateAgreementTerms,
   validateDcbsDsaTerms,
   validateFerpaTerms,
+  validateKyDocDsaTerms,
   validateMouTerms,
   validateOasisDsaTerms,
 } from './partner-agreements';
@@ -365,10 +370,10 @@ describe('validateAgreementTerms', () => {
     );
   });
 
-  it("rejects dsa with agency='ky_doc' (DTRS-012 not yet shipped)", () => {
+  it('rejects dsa with an unsupported agency (intake story not yet shipped)', () => {
     expect(() =>
-      validateAgreementTerms('dsa', { kind: 'dsa', agency: 'ky_doc', scope: [] }),
-    ).toThrow("DSA agency 'ky_doc' not yet supported");
+      validateAgreementTerms('dsa', { kind: 'dsa', agency: 'va_health', scope: [] }),
+    ).toThrow("DSA agency 'va_health' not yet supported");
   });
 
   it('rejects dsa with non-object input', () => {
@@ -549,5 +554,190 @@ describe('validateOasisDsaTerms', () => {
       survivor_home_address: '123 Real St',
     });
     expect(result).not.toHaveProperty('survivor_home_address');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// validateKyDocDsaTerms (DTRS-013)
+// ---------------------------------------------------------------------------
+
+const validKyDocDsa = {
+  kind: 'dsa',
+  agency: 'ky_doc',
+  scope: ['pre_release_roster', 'release_date_changes'],
+  agency_legal_name: 'Kentucky Department of Corrections',
+  state_contact: {
+    name: 'Reentry Coordinator',
+    title: 'Reentry Services Branch Manager',
+    email: 'reentry@ky.gov',
+    phone: '(502) 564-4726',
+  },
+  population_focus: 'pre_release',
+  pre_release_window_days: KY_DOC_PRE_RELEASE_WINDOW_DEFAULT_DAYS,
+  individual_records_authorized: true,
+  no_recidivism_prediction_attestation: true,
+  data_destruction_due: 'on_termination',
+};
+
+describe('validateKyDocDsaTerms', () => {
+  it('accepts a valid KY DOC DSA terms object', () => {
+    const result = validateKyDocDsaTerms(validKyDocDsa);
+    expect(result.kind).toBe('dsa');
+    expect(result.agency).toBe('ky_doc');
+    expect(result.scope).toEqual(['pre_release_roster', 'release_date_changes']);
+    expect(result.population_focus).toBe('pre_release');
+    expect(result.pre_release_window_days).toBe(KY_DOC_PRE_RELEASE_WINDOW_DEFAULT_DAYS);
+    expect(result.individual_records_authorized).toBe(true);
+    expect(result.no_recidivism_prediction_attestation).toBe(true);
+  });
+
+  it('accepts all valid scope values', () => {
+    const allScopes = KY_DOC_DSA_SCOPE_OPTIONS.map((o) => o.value);
+    const result = validateKyDocDsaTerms({ ...validKyDocDsa, scope: allScopes });
+    expect(result.scope).toEqual(allScopes);
+  });
+
+  it('accepts all valid data_destruction_due values', () => {
+    for (const val of ['on_termination', 'after_3_years', 'after_5_years'] as const) {
+      const result = validateKyDocDsaTerms({ ...validKyDocDsa, data_destruction_due: val });
+      expect(result.data_destruction_due).toBe(val);
+    }
+  });
+
+  it('accepts pre_release_window_days at the lower bound', () => {
+    const result = validateKyDocDsaTerms({
+      ...validKyDocDsa,
+      pre_release_window_days: KY_DOC_PRE_RELEASE_WINDOW_MIN_DAYS,
+    });
+    expect(result.pre_release_window_days).toBe(KY_DOC_PRE_RELEASE_WINDOW_MIN_DAYS);
+  });
+
+  it('accepts pre_release_window_days at the upper bound', () => {
+    const result = validateKyDocDsaTerms({
+      ...validKyDocDsa,
+      pre_release_window_days: KY_DOC_PRE_RELEASE_WINDOW_MAX_DAYS,
+    });
+    expect(result.pre_release_window_days).toBe(KY_DOC_PRE_RELEASE_WINDOW_MAX_DAYS);
+  });
+
+  it('accepts terms without optional phone', () => {
+    const noPhone = {
+      ...validKyDocDsa,
+      state_contact: { name: 'A', title: 'T', email: 'a@x.com' },
+    };
+    const result = validateKyDocDsaTerms(noPhone);
+    expect(result.state_contact.phone).toBeUndefined();
+  });
+
+  it('rejects non-object input', () => {
+    expect(() => validateKyDocDsaTerms(null)).toThrow('must be an object');
+    expect(() => validateKyDocDsaTerms('dsa')).toThrow('must be an object');
+  });
+
+  it('rejects wrong kind', () => {
+    expect(() => validateKyDocDsaTerms({ ...validKyDocDsa, kind: 'mou' })).toThrow('kind: "dsa"');
+  });
+
+  it('rejects wrong agency', () => {
+    expect(() => validateKyDocDsaTerms({ ...validKyDocDsa, agency: 'oasis' })).toThrow(
+      'agency must be "ky_doc"',
+    );
+  });
+
+  it('rejects empty scope array', () => {
+    expect(() => validateKyDocDsaTerms({ ...validKyDocDsa, scope: [] })).toThrow(
+      'at least one scope value',
+    );
+  });
+
+  it('rejects an invalid scope value', () => {
+    expect(() => validateKyDocDsaTerms({ ...validKyDocDsa, scope: ['recidivism_score'] })).toThrow(
+      'Invalid KY-DOC-DSA scope value: "recidivism_score"',
+    );
+  });
+
+  it('rejects empty agency_legal_name', () => {
+    expect(() => validateKyDocDsaTerms({ ...validKyDocDsa, agency_legal_name: '' })).toThrow(
+      'non-empty agency_legal_name',
+    );
+  });
+
+  it('rejects missing state_contact name', () => {
+    expect(() =>
+      validateKyDocDsaTerms({
+        ...validKyDocDsa,
+        state_contact: { name: '', title: 'T', email: 'a@x.com' },
+      }),
+    ).toThrow('non-empty name');
+  });
+
+  it('rejects wrong population_focus', () => {
+    expect(() =>
+      validateKyDocDsaTerms({ ...validKyDocDsa, population_focus: 'parole_supervision' }),
+    ).toThrow('population_focus must be "pre_release"');
+  });
+
+  it('rejects pre_release_window_days below the minimum', () => {
+    expect(() =>
+      validateKyDocDsaTerms({
+        ...validKyDocDsa,
+        pre_release_window_days: KY_DOC_PRE_RELEASE_WINDOW_MIN_DAYS - 1,
+      }),
+    ).toThrow('pre_release_window_days must be an integer in');
+  });
+
+  it('rejects pre_release_window_days above the maximum', () => {
+    expect(() =>
+      validateKyDocDsaTerms({
+        ...validKyDocDsa,
+        pre_release_window_days: KY_DOC_PRE_RELEASE_WINDOW_MAX_DAYS + 1,
+      }),
+    ).toThrow('pre_release_window_days must be an integer in');
+  });
+
+  it('rejects non-integer pre_release_window_days', () => {
+    expect(() =>
+      validateKyDocDsaTerms({ ...validKyDocDsa, pre_release_window_days: 60.5 }),
+    ).toThrow('pre_release_window_days must be an integer in');
+  });
+
+  it('rejects non-boolean individual_records_authorized', () => {
+    expect(() =>
+      validateKyDocDsaTerms({ ...validKyDocDsa, individual_records_authorized: 'yes' }),
+    ).toThrow('individual_records_authorized must be a boolean');
+  });
+
+  it('rejects no_recidivism_prediction_attestation = false (the cornerstone of the contract)', () => {
+    expect(() =>
+      validateKyDocDsaTerms({ ...validKyDocDsa, no_recidivism_prediction_attestation: false }),
+    ).toThrow('no_recidivism_prediction_attestation must be true');
+  });
+
+  it('rejects no_recidivism_prediction_attestation missing entirely', () => {
+    const { no_recidivism_prediction_attestation: _omit, ...withoutAttestation } = validKyDocDsa;
+    void _omit;
+    expect(() => validateKyDocDsaTerms(withoutAttestation)).toThrow(
+      'no_recidivism_prediction_attestation must be true',
+    );
+  });
+
+  it('rejects invalid data_destruction_due', () => {
+    expect(() =>
+      validateKyDocDsaTerms({ ...validKyDocDsa, data_destruction_due: 'never_required' }),
+    ).toThrow('data_destruction_due must be one of');
+  });
+
+  it('strips extra/unexpected keys (does not pass through to JSONB)', () => {
+    const result = validateKyDocDsaTerms({
+      ...validKyDocDsa,
+      recidivism_score: 0.42,
+    });
+    expect(result).not.toHaveProperty('recidivism_score');
+  });
+
+  it("dispatches dsa+agency='ky_doc' to validateKyDocDsaTerms", () => {
+    const result = validateAgreementTerms('dsa', validKyDocDsa);
+    expect(result.kind).toBe('dsa');
+    if (result.kind === 'dsa') expect(result.agency).toBe('ky_doc');
   });
 });

--- a/src/lib/dtrs/partner-agreements.ts
+++ b/src/lib/dtrs/partner-agreements.ts
@@ -1,17 +1,16 @@
 /**
- * Partner-agreements domain logic — DTRS-010, DTRS-011.
+ * Partner-agreements domain logic — DTRS-010, DTRS-011, DTRS-012, DTRS-013.
  *
  * Discriminated-union types for the `terms` JSONB column in
  * `partner_agreements`. Each agreement kind owns its terms shape. As of
- * Sprint 10: `ferpa`, `mou`, and `dsa` (DCBS variant only) are fully
- * specified. `baa`, `qsoa`, `memo_of_cooperation` carry a permissive
- * placeholder until their stories ship; `dsa` with `agency='ky_doc'` is
- * blocked until DTRS-012.
+ * Sprint 12: `ferpa`, `mou`, and `dsa` (DCBS / OASIS / KY DOC variants) are
+ * fully specified. `baa`, `qsoa`, `memo_of_cooperation` carry a permissive
+ * placeholder until their stories ship.
  *
  * Validators (`validateFerpaTerms`, `validateMouTerms`, `validateDcbsDsaTerms`,
- * `validateAgreementTerms`) are pure functions — throw on invalid shape,
- * return typed value on success. They run BEFORE any DB insert so bad data
- * never reaches storage.
+ * `validateOasisDsaTerms`, `validateKyDocDsaTerms`, `validateAgreementTerms`)
+ * are pure functions — throw on invalid shape, return typed value on success.
+ * They run BEFORE any DB insert so bad data never reaches storage.
  */
 
 import type { PartnerAgreementKind } from '@/db/schema/enums';
@@ -130,6 +129,47 @@ export const OASIS_REDACTABLE_FIELDS = [
 export type OasisRedactableField = (typeof OASIS_REDACTABLE_FIELDS)[number];
 export type OasisRedactionTreatment = 'share' | 'suppress' | 'aggregate_only';
 export type OasisRedactionPolicy = Record<OasisRedactableField, OasisRedactionTreatment>;
+
+/**
+ * KY DOC DSA data classes — the pre-release cohort the coalition may receive
+ * from the Kentucky Department of Corrections to support reentry coordination
+ * (SUBP-005). Subjects are in state custody at the time of receipt; the legal
+ * authority executing the agreement is KY DOC under KRS Chapter 197 and the
+ * Second Chance Act (42 U.S.C. § 17501 et seq.). See ADR 0009.
+ *
+ * Single source of truth — the intake form renders checkboxes from this array.
+ */
+export const KY_DOC_DSA_SCOPE_OPTIONS = [
+  {
+    value: 'pre_release_roster' as const,
+    label: 'Pre-release roster (Daviess County residents within the configured window)',
+  },
+  {
+    value: 'release_date_changes' as const,
+    label: 'Release-date changes (transfers, parole grants, sentence expirations)',
+  },
+  {
+    value: 'supports_in_place' as const,
+    label: 'Supports-in-place (KY DOC pre-release plan: housing / employment / healthcare)',
+  },
+  {
+    value: 'reentry_eligibility' as const,
+    label: 'Reentry-program eligibility (housing voucher, Medicaid resumption, treatment programs)',
+  },
+] as const;
+
+export type KyDocDsaScopeValue = (typeof KY_DOC_DSA_SCOPE_OPTIONS)[number]['value'];
+
+/**
+ * Pre-release window bounds. The window is the number of days before
+ * projected release that KY DOC may share an individual's record with the
+ * Coalition. Below 30 days is operationally too short for housing
+ * coordination; above 180 is risk without value (records drift, identifying
+ * data sits in the system longer than necessary). See ADR 0009 § Decision.3.
+ */
+export const KY_DOC_PRE_RELEASE_WINDOW_DEFAULT_DAYS = 60;
+export const KY_DOC_PRE_RELEASE_WINDOW_MIN_DAYS = 30;
+export const KY_DOC_PRE_RELEASE_WINDOW_MAX_DAYS = 180;
 
 /**
  * Default redaction policy — abuser-blind by default. Locations and
@@ -281,10 +321,76 @@ export type OasisDsaTerms = {
 };
 
 /**
- * Union of all DSA-kind terms shapes. The `agency` discriminator is the
- * narrowing key. KY DOC reentry (SUBP-005) will add a third sibling.
+ * KY DOC Data-Sharing Agreement terms (DTRS-013). Authorizes individual-record
+ * sharing for the reentry pathway (SUBP-005), bounded by a configurable
+ * pre-release window.
+ *
+ * Distinguished from DCBS (ADR 0006, foster aging-out — same state-as-custodian
+ * shape, but no time-bounded window) and OASIS (ADR 0007, voluntary survivor
+ * enrollment with abuser-blind redaction): KY DOC subjects are in state custody
+ * at the time of receipt, and the cohort is bounded both ways — by Daviess
+ * County residency and by the pre-release window. See ADR 0009 for the
+ * privacy contract.
+ *
+ * `individual_records_authorized` is the runtime gate for SUBP-005 (mirrors
+ * DCBS pattern). `pre_release_window_days` bounds which records may flow.
+ * `no_recidivism_prediction_attestation` MUST be `true` when status='active' —
+ * the validator enforces this; the Coalition contractually commits to never
+ * use this data for actuarial recidivism scoring.
  */
-export type DsaTerms = DcbsDsaTerms | OasisDsaTerms;
+export type KyDocDsaTerms = {
+  kind: 'dsa';
+  agency: 'ky_doc';
+  /** Which data classes are covered by this agreement. */
+  scope: KyDocDsaScopeValue[];
+  /** Full legal name of the executing agency office (e.g. "Kentucky Department of Corrections"). */
+  agency_legal_name: string;
+  /** Single point of contact at KY DOC (reentry coordinator, regional warden, or designee). */
+  state_contact: {
+    name: string;
+    title: string;
+    email: string;
+    phone?: string;
+  };
+  /**
+   * Population scope of this agreement. Sprint 12 ships `pre_release` only;
+   * future amendments may expand to `parole_supervision` or `expungement_support`
+   * — each requires a separate ADR.
+   */
+  population_focus: 'pre_release';
+  /**
+   * Number of days before projected release that KY DOC may share an
+   * individual's record with the Coalition. SUBP-005's ingest middleware
+   * reads this as its single source of truth. Bounded by
+   * KY_DOC_PRE_RELEASE_WINDOW_MIN_DAYS / KY_DOC_PRE_RELEASE_WINDOW_MAX_DAYS.
+   */
+  pre_release_window_days: number;
+  /**
+   * MUST be true for any individual-record ingest. SUBP-005 reads this flag
+   * before enabling per-individual views; if false, the agreement is
+   * informational only and no individual records may be persisted.
+   */
+  individual_records_authorized: boolean;
+  /**
+   * MUST be true to record this agreement as `status='active'`. The admin
+   * checks this box in the intake form after reviewing the no-recidivism-
+   * prediction commitment. Validator throws if not true.
+   */
+  no_recidivism_prediction_attestation: boolean;
+  /**
+   * Records-retention deadline. Reentry best practice favors `on_termination`
+   * or `after_3_years` — pre-release records that have outlived the warm-
+   * handoff window add risk without operational value.
+   */
+  data_destruction_due: 'on_termination' | 'after_3_years' | 'after_5_years';
+};
+
+/**
+ * Union of all DSA-kind terms shapes. The `agency` discriminator is the
+ * narrowing key. As of Sprint 12: DCBS (foster), OASIS (DV survivor), and
+ * KY DOC (reentry) are fully specified.
+ */
+export type DsaTerms = DcbsDsaTerms | OasisDsaTerms | KyDocDsaTerms;
 
 /**
  * Placeholder for agreement kinds whose intake stories haven't shipped yet
@@ -708,15 +814,161 @@ export function validateOasisDsaTerms(input: unknown): OasisDsaTerms {
   };
 }
 
+const KY_DOC_DSA_SCOPE_VALUES = KY_DOC_DSA_SCOPE_OPTIONS.map((o) => o.value);
+
+/**
+ * Validate KY DOC-DSA terms (DTRS-013). Throws on invalid; returns typed
+ * value on success. See ADR 0009 for the privacy contract this validator
+ * enforces.
+ *
+ * **Strict no-recidivism-prediction enforcement:**
+ * `no_recidivism_prediction_attestation` MUST be `true`. Recording a KY DOC
+ * DSA without it is an architectural bug — the prohibition is the contract,
+ * not an option. If a future research / IRB-supervised study needs different
+ * terms, that gets a separate agreement and a separate ADR.
+ *
+ * **Pre-release window bounds:** `pre_release_window_days` must fall within
+ * `[KY_DOC_PRE_RELEASE_WINDOW_MIN_DAYS, KY_DOC_PRE_RELEASE_WINDOW_MAX_DAYS]`.
+ * SUBP-005's ingest middleware reads this as its single source of truth.
+ */
+export function validateKyDocDsaTerms(input: unknown): KyDocDsaTerms {
+  if (typeof input !== 'object' || input === null) {
+    throw new Error('DSA terms must be an object');
+  }
+
+  const {
+    kind,
+    agency,
+    scope,
+    agency_legal_name,
+    state_contact,
+    population_focus,
+    pre_release_window_days,
+    individual_records_authorized,
+    no_recidivism_prediction_attestation,
+    data_destruction_due,
+  } = input as {
+    kind?: unknown;
+    agency?: unknown;
+    scope?: unknown;
+    agency_legal_name?: unknown;
+    state_contact?: unknown;
+    population_focus?: unknown;
+    pre_release_window_days?: unknown;
+    individual_records_authorized?: unknown;
+    no_recidivism_prediction_attestation?: unknown;
+    data_destruction_due?: unknown;
+  };
+
+  if (kind !== 'dsa') {
+    throw new Error('DSA terms must have kind: "dsa"');
+  }
+  if (agency !== 'ky_doc') {
+    throw new Error('DSA terms.agency must be "ky_doc" for KY DOC agreements');
+  }
+
+  if (!Array.isArray(scope) || scope.length === 0) {
+    throw new Error('DSA terms must include at least one scope value');
+  }
+  for (const s of scope as unknown[]) {
+    if (!KY_DOC_DSA_SCOPE_VALUES.includes(s as KyDocDsaScopeValue)) {
+      throw new Error(
+        `Invalid KY-DOC-DSA scope value: "${String(s)}" (allowed: ${KY_DOC_DSA_SCOPE_VALUES.join(', ')})`,
+      );
+    }
+  }
+
+  if (typeof agency_legal_name !== 'string' || !agency_legal_name.trim()) {
+    throw new Error('DSA terms must include a non-empty agency_legal_name');
+  }
+
+  if (typeof state_contact !== 'object' || state_contact === null) {
+    throw new Error('DSA terms must include a state_contact object');
+  }
+  const {
+    name: scName,
+    title: scTitle,
+    email: scEmail,
+    phone: scPhone,
+  } = state_contact as {
+    name?: unknown;
+    title?: unknown;
+    email?: unknown;
+    phone?: unknown;
+  };
+  if (typeof scName !== 'string' || !scName.trim()) {
+    throw new Error('DSA state_contact must include a non-empty name');
+  }
+  if (typeof scTitle !== 'string' || !scTitle.trim()) {
+    throw new Error('DSA state_contact must include a non-empty title');
+  }
+  if (typeof scEmail !== 'string' || !scEmail.trim()) {
+    throw new Error('DSA state_contact must include a non-empty email');
+  }
+  if (scPhone !== undefined && typeof scPhone !== 'string') {
+    throw new Error('DSA state_contact.phone must be a string when provided');
+  }
+
+  if (population_focus !== 'pre_release') {
+    throw new Error('DSA terms.population_focus must be "pre_release" (Sprint 12 scope)');
+  }
+
+  if (
+    typeof pre_release_window_days !== 'number' ||
+    !Number.isInteger(pre_release_window_days) ||
+    pre_release_window_days < KY_DOC_PRE_RELEASE_WINDOW_MIN_DAYS ||
+    pre_release_window_days > KY_DOC_PRE_RELEASE_WINDOW_MAX_DAYS
+  ) {
+    throw new Error(
+      `DSA terms.pre_release_window_days must be an integer in ` +
+        `[${KY_DOC_PRE_RELEASE_WINDOW_MIN_DAYS}, ${KY_DOC_PRE_RELEASE_WINDOW_MAX_DAYS}] ` +
+        `(see ADR 0009 § Decision.3)`,
+    );
+  }
+
+  if (typeof individual_records_authorized !== 'boolean') {
+    throw new Error('DSA terms.individual_records_authorized must be a boolean');
+  }
+
+  if (no_recidivism_prediction_attestation !== true) {
+    throw new Error(
+      'DSA terms.no_recidivism_prediction_attestation must be true — the no-recidivism-prediction ' +
+        'commitment is the KY DOC contract (ADR 0009). Recording without attestation is not permitted.',
+    );
+  }
+
+  const validDestruction = ['on_termination', 'after_3_years', 'after_5_years'] as const;
+  if (!validDestruction.includes(data_destruction_due as (typeof validDestruction)[number])) {
+    throw new Error(`DSA data_destruction_due must be one of: ${validDestruction.join(', ')}`);
+  }
+
+  return {
+    kind: 'dsa',
+    agency: 'ky_doc',
+    scope: scope as KyDocDsaScopeValue[],
+    agency_legal_name,
+    state_contact: {
+      name: scName,
+      title: scTitle,
+      email: scEmail,
+      phone: scPhone as string | undefined,
+    },
+    population_focus: 'pre_release',
+    pre_release_window_days,
+    individual_records_authorized,
+    no_recidivism_prediction_attestation: true,
+    data_destruction_due: data_destruction_due as KyDocDsaTerms['data_destruction_due'],
+  };
+}
+
 /**
  * Dispatcher — picks the right validator for the given agreement kind.
  *
  * Placeholder kinds (baa, qsoa, memo_of_cooperation) are intentionally
  * fail-closed: they throw until their intake stories ship and a real validator
  * is wired in. `dsa` is dispatched on the `agency` discriminator: `dcbs`
- * (DTRS-011) and `oasis` (DTRS-012) are supported; `ky_doc` reentry is
- * blocked until SUBP-005's prerequisite DTRS story lands. See ADR 0004 for
- * the registry plan.
+ * (DTRS-011), `oasis` (DTRS-012), and `ky_doc` (DTRS-013) are supported.
+ * See ADR 0004 for the registry plan.
  */
 export function validateAgreementTerms(
   kind: PartnerAgreementKind,
@@ -734,8 +986,9 @@ export function validateAgreementTerms(
       const agency = (input as { agency?: unknown }).agency;
       if (agency === 'dcbs') return validateDcbsDsaTerms(input);
       if (agency === 'oasis') return validateOasisDsaTerms(input);
+      if (agency === 'ky_doc') return validateKyDocDsaTerms(input);
       if (typeof agency !== 'string' || !agency) {
-        throw new Error("DSA terms.agency is required (e.g. 'dcbs', 'oasis')");
+        throw new Error("DSA terms.agency is required (e.g. 'dcbs', 'oasis', 'ky_doc')");
       }
       throw new Error(
         `DSA agency '${agency}' not yet supported — its intake story has not shipped. ` +


### PR DESCRIPTION
## Summary

Sprint 12 lead ticket. Issue [#142](https://github.com/DobbsBoldry/homeless/issues/142). Closes the data-sharing-agreement layer for the reentry pathway — gates SUBP-005 (#134) on a signed KY DOC DSA with a configurable pre-release window.

- Mirrors the OASIS ([#370](https://github.com/DobbsBoldry/homeless/pull/370)) and DCBS ([#364](https://github.com/DobbsBoldry/homeless/pull/364)) pattern on the existing `partner_agreements` registry — no schema changes, third agency under `kind='dsa'`.
- New ADR 0009 — KY DOC reentry privacy contract. State-as-custodian (KRS Ch. 197), bounded pre-release window (30–180 days, default 60), no-recidivism-prediction commitment, no-LE-disclosure rule. Inherits the OPRT-002 expiration watcher unchanged.

## What ships

- **ADR 0009** — `docs/adr/0009-ky-doc-reentry-data-sharing-privacy-contract.md`, the contract.
- **Lib** — `KyDocDsaTerms`, `KY_DOC_DSA_SCOPE_OPTIONS`, window-bound constants, `validateKyDocDsaTerms`. Dispatcher wired.
- **Parser** — `parseKyDocDsaAgreementForm` (sibling-pure-module per the `'use server'` × vitest quirk).
- **Action** — `recordKyDocDsaAgreementAction`. Admin-gated; revalidates the kydoc admin path.
- **Query** — `getActiveKyDocDsa(partnerOrgId)` for SUBP-005 to consume.
- **Form** — `KyDocDsaAgreementForm` with pre-release-window input (number, bounded), individual-records radio, no-recidivism-prediction attestation.
- **Admin page** — `/app/admin/agreements/kydoc` (filters partner_orgs by `type='government'`).
- **Public template** — `/agreements/kydoc/template` (template version `kydoc-dsa-v1`).
- **Tests** — 37 new (validator + parser); 176 dtrs/agreements tests pass.

## Privacy contract highlights (ADR 0009)

1. No record may be persisted without an active KY DOC DSA.
2. `individual_records_authorized` is the runtime authorization gate (mirrors DCBS).
3. `pre_release_window_days` is binding — SUBP-005 ingests only records inside the window; daily Inngest job deletes records that age out.
4. **`no_recidivism_prediction_attestation` is non-optional.** Validator throws if ≠ true. The Coalition contractually commits to never use this data for actuarial recidivism scoring.
5. Audit every read.
6. **No re-disclosure to law enforcement, parole, or probation** absent court order or written KY DOC authorization.

## What's NOT in this PR

- **SUBP-005 ingest middleware** — separate Sprint 12 ticket (#134). DTRS-013 ships the agreement layer; SUBP-005 picks up the runtime gate via `getActiveKyDocDsa()` and `terms.pre_release_window_days`.
- **Admin agreements hub card** — there's an open hub at [#375](https://github.com/DobbsBoldry/homeless/pull/375) which I branched ahead of; recommend whoever merges later adds a KY DOC card there.
- **Renames/issue title cleanup** — I retitled #142 from `[DTRS-012]` to `[DTRS-013]` (DTRS-012 ID was consumed by OASIS). The PR description here references DTRS-013 throughout.

## Test plan

- [ ] `pnpm exec vitest run src/lib/dtrs/partner-agreements.test.ts src/app/actions/partner-agreements.test.ts` — 176 pass
- [ ] `pnpm exec biome check` — clean
- [ ] `pnpm exec tsc --noEmit` — clean
- [ ] `pnpm exec next build` — `/app/admin/agreements/kydoc` (dynamic), `/agreements/kydoc/template` (static) compile
- [ ] `pnpm exec tsx scripts/check-domain-boundaries.mts` — clean
- [ ] Manual: open `/agreements/kydoc/template` (no auth) — renders the legal template
- [ ] Manual: open `/app/admin/agreements/kydoc` as admin — renders form + recorded-agreements table; submitting with attestation unchecked is blocked client-side and server-side
- [ ] Manual: submit with `pre_release_window_days = 14` — rejected with the bounds message; `30` and `180` accepted; default `60` applied when blank

🤖 Generated with [Claude Code](https://claude.com/claude-code)