### PR TITLE
feat(COOR-012): inter-agency consent-gated handoff primitive

### DIFF
--- a/STATE.md
+++ b/STATE.md
@@ -1,6 +1,6 @@
 # STATE.md — what's now
 
-**Last updated:** 2026-04-27 — Sprint 8 closed (faith-based opt-in foundation shipped)
+**Last updated:** 2026-05-04 — Sprint 12 closed (SUBP-005 #377 merged); Sprint 13 active (Veterans + handoff + funder visibility)
 
 This file is the cheap context file. Open it at the start of a session and you skip 5–10 minutes of "what was I doing." Two paragraphs, bullets, no essays. If a section gets long, summarize and link out.
 
@@ -8,18 +8,44 @@ This file is the cheap context file. Open it at the start of a session and you s
 
 ## Current focus
 
-**Sprint 8 closed — faith-based opt-in foundation.** All three DTRS stories shipped: schema + privacy contract (#354 / [ADR 0003](docs/adr/0003-faith-aggregate-privacy-contract.md)), Catholic Charities admin intake form (#355), per-ministry coordination signals read view + queries (#356). The platform can now receive aggregate-only data from faith partners without ever modeling individual records — privacy by structural impossibility, not just policy. Phase 3 reverse-channel (signals back to ministries) explicitly deferred per the strategy doc.
+**Sprint 12 closed (~23 pts shipped).** DTRS-013 KY DOC ([#376](https://github.com/DobbsBoldry/homeless/pull/376) / [ADR 0009](docs/adr/0009-ky-doc-data-sharing.md)), SUBP-005 reentry pathway ([#377](https://github.com/DobbsBoldry/homeless/pull/377)), plus PRVN-001 ED first-time-homeless flag ([#373](https://github.com/DobbsBoldry/homeless/pull/373)) and PRVN-006 outreach pre-positioning ([#374](https://github.com/DobbsBoldry/homeless/pull/374)) pulled forward from S13 candidates. SUBP epic now 5 of 7 pathways shipped. **COOR-012 (5pt) and INDC-019 (2pt) deferred** to S13.
 
-This was the first sprint built using the [`superpowers:subagent-driven-development`](https://github.com/jasonkneen/superpowers) skill — implementer subagent + spec-compliance reviewer + code-quality reviewer per ticket. Spec reviewer caught a hardcoded `suppressedCount=0` on DTRS-008; quality reviewer caught a typo + error-leak + a11y miss on DTRS-008, and partial-coverage signaling + window-boundary exclusion on DTRS-009. All resolved before merge.
+**Sprint 13 — "Veterans + handoff + funder visibility."** Rounds out the SUBP epic with HUD-VASH, closes the carryover handoff loop, and gives funders/coalition leadership their first demand-side visibility.
 
-**Sprint 9 candidate** (per `product-vision/roadmap.html` "What ships in Phase 2"): schools integration. [#125 PRVN-003](https://github.com/DobbsBoldry/homeless/issues/125) (McKinney-Vento liaison referral receiver, 5pt) + [#126 PRVN-004](https://github.com/DobbsBoldry/homeless/issues/126) (closed-loop reporting school↔coalition, 5pt) + [#140 DTRS-010](https://github.com/DobbsBoldry/homeless/issues/140) (FERPA-compliant school data agreement template, 5pt). 15pt total. Faith partnerships now have receiving infrastructure; schools are the next entry per the strategy doc's sequence.
+| # | Pts | Story |
+|---|---|---|
+| [#120](https://github.com/DobbsBoldry/homeless/issues/120) COOR-012 | 5 | Inter-agency handoff workflow — **carryover from S12; do first** |
+| [#135](https://github.com/DobbsBoldry/homeless/issues/135) SUBP-006 | 8 | Veteran pathway (HUD-VASH; VFW Owensboro) — reuses agreement→pathway pattern |
+| [#147](https://github.com/DobbsBoldry/homeless/issues/147) OPRT-007 | 5 | Funder-portal generator (per-funder views into outcomes) |
+| [#121](https://github.com/DobbsBoldry/homeless/issues/121) COOR-013 | 5 | 7-14 day demand forecasting per shelter |
+| **stretch** [#252](https://github.com/DobbsBoldry/homeless/issues/252) INDC-019 | 2 | Preserve grant history on consent re-grant (carryover) |
 
-**Other open work:** [#12 OPRT-002 MOU registry](https://github.com/DobbsBoldry/homeless/issues/12) (net-new, unsized) — every faith ministry will eventually need an MOU; ship this when partnerships need it.
+**Sprint goal:** Veterans pathway ships using the validated agreement template; coalition leadership and funders get their first dedicated views.
 
-**Sync items to address:** ESUC-001/002 closed as `NOT_PLANNED` on 2026-04-27 (project-board cleanup) — but the PHI fence is still real. Either reopen them or update CLAUDE.md/ADR-0002 to reflect that the BAA actually closed. Bo's call — flagged but not yet acted on.
+**Sequencing:** COOR-012 first (clears S12 slip). SUBP-006 starts in parallel — spike VA/HUD-VASH agreement template fit before committing the full 8 (split out as DTRS-015 if it diverges from KY DOC/OASIS shape). OPRT-007 + COOR-013 independent; either order. INDC-019 only if rest finishes early.
+
+**Sprint 13 dates:** 2026-05-05 → 2026-05-18. Mid-sprint check 2026-05-11.
 
 ## Just shipped (most recent first)
 
+- **#377** — SUBP-005 reentry pathway: 60-day pre-release window automation, KY DOC gate, window sweep. Validates agreement→pathway pattern (template for SUBP-006 Veterans).
+- **#376** — DTRS-013 KY DOC reentry data-sharing workflow + [ADR 0009](docs/adr/0009-ky-doc-data-sharing.md). Third instance of the per-partner agreement pattern (after DCBS, OASIS).
+- **#375** — Nav: expose 8 orphaned routes + agreements hub.
+- **#374** — PRVN-006 outreach pre-positioning priorities (ZIP-aggregate). Pulled forward from S13 candidate slate.
+- **#373** — PRVN-001 ED first-time-homeless flag + alert view. Pulled forward from S13 candidate slate.
+- **#372** — SUBP-007 families w/ children pathway + school-stability engine.
+- **#371** — SUBP-004 DV survivor pathway + abuser-blind middleware ([ADR 0008](docs/adr/0008-abuser-blind-middleware.md)). Structural separation of survivor records from abuser-accessible queries.
+- **#370** — DTRS-012 OASIS data-sharing agreement workflow + [ADR 0007](docs/adr/0007-oasis-data-sharing.md). Generic per-partner agreement template; KY DOC will reuse this as DTRS-013 in Sprint 12.
+- **#368** — OPRT-002 MOU admin UI + generic agreement expiration watcher (Inngest). One watcher serves DCBS, OASIS, KY DOC, faith MOUs alike.
+- **#367** — SUBP-002 TEAMKY Former Foster Youth Medicaid extension automation.
+- **#366** — SUBP-001 foster aging-out countdown engine + caseworker surface.
+- **#365** — pin pnpm to 9.15.9 via railpack.json (Railway deploy fix).
+- **#364** — DTRS-011 DCBS data-sharing agreement workflow + [ADR 0006](docs/adr/0006-dcbs-data-sharing.md). The pattern that DTRS-012/013 inherit from.
+- **#363** — PRVN-004 school liaison aggregate insights (connection rate, status distribution, time-to-connect).
+- **#362** — COOR-014 closed-loop referral confirmation (liaison sees what happened to the referral).
+- **#361** — PRVN-003 McKinney-Vento school referral receiver (FERPA fork).
+- **#359** — DTRS-010 FERPA-compliant partner-agreements registry + intake.
+- **#358** — ADR 0004 + ADR 0005 schools-entry architectural spike.
 - **#356** — DTRS-009 per-ministry coordination signals (admin read view + queries). Seven privacy-respecting reads + two pure aggregator helpers. `compareMinistryWindows` carries a `partial` flag so all-suppressed windows don't get misread as "trending down." Overlap window semantics so monthly submissions aren't dropped by trailing 28-day filters.
 - **#355** — DTRS-008 Catholic Charities aggregate intake form. Admin-gated form with live cell-size suppression preview + audit-logged submit. Catholic Charities of the Diocese of Owensboro seeded as the first opted-in ministry.
 - **#354** — DTRS-007 faith-aggregate schema + cell-size suppression + [ADR 0003](docs/adr/0003-faith-aggregate-privacy-contract.md). Four tables, no individual-record column anywhere — privacy by structural impossibility.
@@ -38,15 +64,20 @@ This was the first sprint built using the [`superpowers:subagent-driven-developm
 - **#334** — EVDT-227 trigger to auto-bump `eviction_response_packets.updated_at`.
 - **#333** — FND-020 domain-boundary lint + [ADR 0001](docs/adr/0001-modular-monolith.md).
 
-## Next pickup
+## Next pickup (Sprint 13 — "Veterans + handoff + funder visibility")
 
 | # | Pts | What | Notes |
 |---|---|---|---|
-| [#125](https://github.com/DobbsBoldry/homeless/issues/125) PRVN-003 | 5 | McKinney-Vento liaison referral receiver | Sprint 9 candidate (schools entry per roadmap.html). |
-| [#126](https://github.com/DobbsBoldry/homeless/issues/126) PRVN-004 | 5 | Closed-loop reporting school↔coalition | Sprint 9 candidate; pairs with PRVN-003. |
-| [#140](https://github.com/DobbsBoldry/homeless/issues/140) DTRS-010 | 5 | FERPA-compliant school data agreement template + intake | Sprint 9 candidate; receiving-infra equivalent of DTRS-008 for schools. |
-| [#12](https://github.com/DobbsBoldry/homeless/issues/12) OPRT-002 | ? | MOU registry | Net-new, unsized; ship when partnerships need MOU tracking. |
-| Sprint 10+ | many | DCBS / foster aging-out (SUBP-001/002/003 + DTRS-011) | Per roadmap.html sequence after schools. |
+| [#120](https://github.com/DobbsBoldry/homeless/issues/120) COOR-012 | 5 | Inter-agency handoff workflow | Carryover from S12. Consent-gated context transfer. **Do FIRST** — clears the slip. |
+| [#135](https://github.com/DobbsBoldry/homeless/issues/135) SUBP-006 | 8 | Veteran pathway (HUD-VASH; VFW Owensboro) | Reuses agreement→pathway pattern. Spike VA agreement template fit before committing — split as DTRS-015 if it diverges. |
+| [#147](https://github.com/DobbsBoldry/homeless/issues/147) OPRT-007 | 5 | Funder-portal generator | Per-funder views into outcomes. Scope tightly: one funder, one report template, no auth-tenancy redesign. |
+| [#121](https://github.com/DobbsBoldry/homeless/issues/121) COOR-013 | 5 | 7-14 day demand forecasting per shelter | Coalition leadership visibility; pairs with OPRT-007. |
+| **stretch** [#252](https://github.com/DobbsBoldry/homeless/issues/252) INDC-019 | 2 | Preserve grant history on consent re-grant | Only if rest finishes early. |
+
+**Sprint 14+ candidate threads** (not yet committed):
+- "Prevention edge wrap-up": PRVN-005 (utility shutoff heat-map, 8) + PRVN-007 (macro demand forecasting, 8) + PRVN-002 (school attendance signal, 13)
+- "Coalition operational depth": COOR-009 (all 6 shelters integrated, 5) + COOR-010 (donation matching, 5) + COOR-011 (volunteer skill matching, 8)
+- "INDC client-facing": INDC-020 (companion home screen, 5) + INDC-013 (benefits screening, 5) + INDC-015 (mood check-in, 5)
 
 ## Known quirks (check here first)
 

--- a/drizzle/migrations/0043_COOR-012_case_handoffs.sql
+++ b/drizzle/migrations/0043_COOR-012_case_handoffs.sql
@@ -1,0 +1,78 @@
+-- COOR-012 — inter-agency consent-gated handoff primitive.
+--
+-- One table: `case_handoffs`. Two new enums: `case_handoff_status`,
+-- `case_handoff_scope_kind`. The state machine + gates live in
+-- src/lib/coor/handoff.ts (initiate/accept/decline/revoke/expire) and
+-- src/lib/coor/handoff-context.ts (the consent-gated reader).
+--
+-- Pre-acceptance handoffs aged past `expires_at` are flipped to 'expired'
+-- by the daily Inngest sweep. Terminal-state rows are kept for audit.
+
+CREATE TYPE "public"."case_handoff_status" AS ENUM (
+  'pending_consent',
+  'pending_acceptance',
+  'accepted',
+  'declined',
+  'revoked',
+  'expired'
+);--> statement-breakpoint
+
+CREATE TYPE "public"."case_handoff_scope_kind" AS ENUM (
+  'intakes',
+  'case_notes',
+  'service_events',
+  'consents'
+);--> statement-breakpoint
+
+CREATE TABLE "case_handoffs" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  "synthetic_person_ref" text NOT NULL,
+  -- Initiating partner org. ON DELETE RESTRICT — admin must explicitly
+  -- terminate any open handoffs before removing an org.
+  "from_partner_org_id" uuid NOT NULL,
+  -- Receiving partner org.
+  "to_partner_org_id" uuid NOT NULL,
+  "initiated_by_user_id" uuid NOT NULL,
+  "responded_by_user_id" uuid,
+  "status" "case_handoff_status" NOT NULL DEFAULT 'pending_consent',
+  "purpose" text NOT NULL,
+  -- jsonb array of case_handoff_scope_kind values; validated at the
+  -- application layer before insert.
+  "requested_scope" jsonb NOT NULL,
+  -- person_partner_consents row authorising the receiver. ON DELETE SET
+  -- NULL so loadHandoffContext fails closed if the consent is purged.
+  "consent_id" uuid,
+  "decline_reason" text,
+  "expires_at" timestamp with time zone NOT NULL,
+  "accepted_at" timestamp with time zone,
+  "closed_at" timestamp with time zone,
+  "created_at" timestamp with time zone NOT NULL DEFAULT now(),
+  "updated_at" timestamp with time zone NOT NULL DEFAULT now(),
+  CONSTRAINT "case_handoffs_distinct_orgs" CHECK (from_partner_org_id <> to_partner_org_id)
+);--> statement-breakpoint
+
+ALTER TABLE "case_handoffs"
+  ADD CONSTRAINT "case_handoffs_from_partner_org_id_fk"
+  FOREIGN KEY ("from_partner_org_id") REFERENCES "public"."partner_orgs"("id") ON DELETE RESTRICT;--> statement-breakpoint
+
+ALTER TABLE "case_handoffs"
+  ADD CONSTRAINT "case_handoffs_to_partner_org_id_fk"
+  FOREIGN KEY ("to_partner_org_id") REFERENCES "public"."partner_orgs"("id") ON DELETE RESTRICT;--> statement-breakpoint
+
+ALTER TABLE "case_handoffs"
+  ADD CONSTRAINT "case_handoffs_initiated_by_user_id_fk"
+  FOREIGN KEY ("initiated_by_user_id") REFERENCES "public"."users"("id") ON DELETE RESTRICT;--> statement-breakpoint
+
+ALTER TABLE "case_handoffs"
+  ADD CONSTRAINT "case_handoffs_responded_by_user_id_fk"
+  FOREIGN KEY ("responded_by_user_id") REFERENCES "public"."users"("id") ON DELETE SET NULL;--> statement-breakpoint
+
+ALTER TABLE "case_handoffs"
+  ADD CONSTRAINT "case_handoffs_consent_id_fk"
+  FOREIGN KEY ("consent_id") REFERENCES "public"."person_partner_consents"("id") ON DELETE SET NULL;--> statement-breakpoint
+
+CREATE INDEX "case_handoffs_to_partner_idx" ON "case_handoffs" USING btree ("to_partner_org_id", "status");--> statement-breakpoint
+CREATE INDEX "case_handoffs_from_partner_idx" ON "case_handoffs" USING btree ("from_partner_org_id", "status");--> statement-breakpoint
+CREATE INDEX "case_handoffs_person_ref_idx" ON "case_handoffs" USING btree ("synthetic_person_ref");--> statement-breakpoint
+CREATE INDEX "case_handoffs_status_idx" ON "case_handoffs" USING btree ("status");--> statement-breakpoint
+CREATE INDEX "case_handoffs_expires_at_idx" ON "case_handoffs" USING btree ("expires_at");

--- a/drizzle/migrations/meta/_journal.json
+++ b/drizzle/migrations/meta/_journal.json
@@ -302,6 +302,13 @@
       "when": 1777910400000,
       "tag": "0042_SUBP-005_pre_release_subjects",
       "breakpoints": true
+    },
+    {
+      "idx": 43,
+      "version": "7",
+      "when": 1778256000000,
+      "tag": "0043_COOR-012_case_handoffs",
+      "breakpoints": true
     }
   ]
 }

--- a/scripts/gen-synthetic-handoffs.ts
+++ b/scripts/gen-synthetic-handoffs.ts
@@ -1,0 +1,264 @@
+#!/usr/bin/env tsx
+/**
+ * COOR-012 — synthetic case_handoffs seed.
+ *
+ * Idempotent. Re-running:
+ *   - Ensures both `audubon-area-community-services` and `kla-owensboro`
+ *     have an active `memo_of_cooperation` partner_agreement (so the
+ *     governance gate clears).
+ *   - Ensures person_partner_consents rows exist for the two handoffs
+ *     that need them (synthetic refs SYN-HANDOFF-001 / SYN-HANDOFF-002).
+ *   - Inserts ~5 case_handoffs spanning the lifecycle:
+ *       1. pending_consent      — fresh, no consent yet.
+ *       2. pending_acceptance   — consent on file, awaiting receiver.
+ *       3. accepted             — receiver took it; loadHandoffContext OK.
+ *       4. declined             — receiver said no.
+ *       5. expired              — pre-acceptance row past expires_at.
+ *
+ * Usage:
+ *   pnpm tsx scripts/gen-synthetic-handoffs.ts
+ *   pnpm tsx scripts/gen-synthetic-handoffs.ts --reset
+ *
+ * --reset deletes existing synthetic handoffs (those with synthetic_person_ref
+ * starting `SYN-HANDOFF-`) before re-seeding.
+ */
+
+import { parseArgs } from 'node:util';
+import { config as loadEnv } from 'dotenv';
+import { and, eq, like } from 'drizzle-orm';
+import { db } from '@/db/client';
+import { recordAgreement } from '@/db/queries/partner-agreements';
+import { caseHandoffs } from '@/db/schema/case-handoffs';
+import type { CaseHandoffScopeKind, CaseHandoffStatus } from '@/db/schema/enums';
+import { partnerAgreements } from '@/db/schema/partner-agreements';
+import { partnerOrgs } from '@/db/schema/partner-orgs';
+import { personPartnerConsents } from '@/db/schema/person-partner-consents';
+import { users } from '@/db/schema/users';
+
+loadEnv({ path: ['.env.local', '.env'], override: true });
+
+const { values } = parseArgs({
+  options: {
+    reset: { type: 'boolean', default: false },
+  },
+});
+
+const FROM_SLUG = 'audubon-area-community-services';
+const TO_SLUG = 'kla-owensboro';
+const SYNTH_REF_PREFIX = 'SYN-HANDOFF-';
+
+interface SyntheticHandoff {
+  ref: string;
+  status: CaseHandoffStatus;
+  purpose: string;
+  scope: CaseHandoffScopeKind[];
+  needsConsent: boolean;
+  daysToExpiry: number; // negative = already expired
+  declineReason?: string;
+}
+
+const SYNTH: SyntheticHandoff[] = [
+  {
+    ref: `${SYNTH_REF_PREFIX}001`,
+    status: 'pending_consent',
+    purpose:
+      'Client moved into KLA service area for an active eviction case; needs handoff for legal defense.',
+    scope: ['intakes', 'case_notes'],
+    needsConsent: false,
+    daysToExpiry: 28,
+  },
+  {
+    ref: `${SYNTH_REF_PREFIX}002`,
+    status: 'pending_acceptance',
+    purpose:
+      'Consent on file; transferring case coordination after relocation. Awaiting KLA acceptance.',
+    scope: ['intakes', 'case_notes', 'service_events'],
+    needsConsent: true,
+    daysToExpiry: 25,
+  },
+  {
+    ref: `${SYNTH_REF_PREFIX}003`,
+    status: 'accepted',
+    purpose: 'Eviction defense handoff completed; receiver actively coordinating.',
+    scope: ['intakes', 'case_notes', 'service_events', 'consents'],
+    needsConsent: true,
+    daysToExpiry: 22,
+  },
+  {
+    ref: `${SYNTH_REF_PREFIX}004`,
+    status: 'declined',
+    purpose: 'Requested transfer of coordination after client relocation.',
+    scope: ['intakes', 'case_notes'],
+    needsConsent: true,
+    daysToExpiry: 18,
+    declineReason:
+      'Client outside KLA jurisdiction — recommend referral to Legal Aid Society of Louisville.',
+  },
+  {
+    ref: `${SYNTH_REF_PREFIX}005`,
+    status: 'expired',
+    purpose: 'Stale request; no consent ever recorded.',
+    scope: ['intakes'],
+    needsConsent: false,
+    daysToExpiry: -3,
+  },
+];
+
+async function findPartnerOrg(slug: string): Promise<string> {
+  const rows = await db
+    .select({ id: partnerOrgs.id })
+    .from(partnerOrgs)
+    .where(eq(partnerOrgs.slug, slug))
+    .limit(1);
+  if (!rows[0]) {
+    throw new Error(`Partner org '${slug}' not found. Run pnpm tsx src/db/seed.ts first.`);
+  }
+  return rows[0].id;
+}
+
+async function ensureActiveMou(partnerOrgId: string, signerUserId: string): Promise<void> {
+  // The handoff governance gate looks for ANY active partner_agreements row.
+  // We seed a `mou` because it has a real validator; `memo_of_cooperation`
+  // is a placeholder kind whose intake story hasn't shipped yet.
+  const existing = await db
+    .select({ id: partnerAgreements.id })
+    .from(partnerAgreements)
+    .where(
+      and(
+        eq(partnerAgreements.partnerOrgId, partnerOrgId),
+        eq(partnerAgreements.kind, 'mou'),
+        eq(partnerAgreements.status, 'active'),
+      ),
+    )
+    .limit(1);
+  if (existing[0]) return;
+  await recordAgreement({
+    partnerOrgId,
+    kind: 'mou',
+    status: 'active',
+    effectiveDate: '2026-01-01',
+    signedByPartner: 'Synthetic Coalition Coordinator',
+    signedByCoalitionUserId: signerUserId,
+    templateVersion: 'mou-phase1-v1',
+    templateRendered:
+      'Synthetic MOU between the coalition and the partner. ' +
+      'Established for COOR-012 inter-agency handoff demo seeding.',
+    terms: {
+      kind: 'mou',
+      phase: 'phase_1',
+      monthly_meeting_hours: 1,
+      withdrawal_notice_days: 30,
+    },
+    notes: 'Created by scripts/gen-synthetic-handoffs.ts',
+    actorUserId: signerUserId,
+  });
+}
+
+async function ensureConsent(syntheticPersonRef: string, partnerOrgId: string): Promise<string> {
+  const existing = await db
+    .select()
+    .from(personPartnerConsents)
+    .where(
+      and(
+        eq(personPartnerConsents.syntheticPersonRef, syntheticPersonRef),
+        eq(personPartnerConsents.partnerOrgId, partnerOrgId),
+      ),
+    )
+    .limit(1);
+  if (existing[0]) {
+    if (existing[0].revokedAt) {
+      // Reset to unrevoked for the synthetic seed.
+      await db
+        .update(personPartnerConsents)
+        .set({ revokedAt: null, updatedAt: new Date() })
+        .where(eq(personPartnerConsents.id, existing[0].id));
+    }
+    return existing[0].id;
+  }
+  const inserted = await db
+    .insert(personPartnerConsents)
+    .values({
+      syntheticPersonRef,
+      partnerOrgId,
+      notes: 'Synthetic seed for COOR-012 handoff demo.',
+    })
+    .returning();
+  return inserted[0]!.id;
+}
+
+async function pickAnyUserId(): Promise<string> {
+  const rows = await db.select({ id: users.id }).from(users).limit(1);
+  if (!rows[0]) {
+    throw new Error('No users in DB. Run pnpm tsx src/db/seed.ts first.');
+  }
+  return rows[0].id;
+}
+
+async function reset(): Promise<void> {
+  await db
+    .delete(caseHandoffs)
+    .where(like(caseHandoffs.syntheticPersonRef, `${SYNTH_REF_PREFIX}%`));
+  console.log(`[gen-synthetic-handoffs] cleared rows with ref like '${SYNTH_REF_PREFIX}%'`);
+}
+
+async function main() {
+  if (values.reset) {
+    await reset();
+  }
+
+  const fromOrgId = await findPartnerOrg(FROM_SLUG);
+  const toOrgId = await findPartnerOrg(TO_SLUG);
+  const userId = await pickAnyUserId();
+
+  await Promise.all([ensureActiveMou(fromOrgId, userId), ensureActiveMou(toOrgId, userId)]);
+
+  const now = new Date();
+  for (const synth of SYNTH) {
+    // Idempotency: skip if a handoff for this synthetic ref already exists.
+    const existing = await db
+      .select({ id: caseHandoffs.id })
+      .from(caseHandoffs)
+      .where(eq(caseHandoffs.syntheticPersonRef, synth.ref))
+      .limit(1);
+    if (existing[0]) {
+      console.log(`[gen-synthetic-handoffs] skip ${synth.ref} (status=${synth.status}) — exists`);
+      continue;
+    }
+
+    const consentId = synth.needsConsent ? await ensureConsent(synth.ref, toOrgId) : null;
+    const expiresAt = new Date(now);
+    expiresAt.setUTCDate(expiresAt.getUTCDate() + synth.daysToExpiry);
+
+    const acceptedAt = synth.status === 'accepted' ? new Date(now) : null;
+    const closedAt =
+      synth.status === 'declined' || synth.status === 'expired' ? new Date(now) : null;
+    const respondedByUserId =
+      synth.status === 'accepted' || synth.status === 'declined' ? userId : null;
+
+    await db.insert(caseHandoffs).values({
+      syntheticPersonRef: synth.ref,
+      fromPartnerOrgId: fromOrgId,
+      toPartnerOrgId: toOrgId,
+      initiatedByUserId: userId,
+      respondedByUserId,
+      status: synth.status,
+      purpose: synth.purpose,
+      requestedScope: synth.scope,
+      consentId,
+      declineReason: synth.declineReason ?? null,
+      expiresAt,
+      acceptedAt,
+      closedAt,
+    });
+    console.log(`[gen-synthetic-handoffs] inserted ${synth.ref} (status=${synth.status})`);
+  }
+
+  console.log('[gen-synthetic-handoffs] done.');
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });

--- a/src/app/actions/handoff.ts
+++ b/src/app/actions/handoff.ts
@@ -1,0 +1,129 @@
+'use server';
+
+/**
+ * COOR-012 — server-action wrappers around the inter-agency handoff
+ * primitive. UI surfaces (caseworker inbox, case-page initiate button) are
+ * CWT-022 territory; these actions are the API the UI will call when it
+ * lands.
+ *
+ * Each action requires a caseworker / admin role and revalidates the
+ * receiver inbox + the subject's reentry surface (to update the warm-
+ * handoff CTA). The state-machine errors surface as human-readable
+ * messages so a calling UI can render them inline.
+ */
+
+import * as Sentry from '@sentry/nextjs';
+import { revalidatePath } from 'next/cache';
+import type { CaseHandoffScopeKind } from '@/db/schema/enums';
+import { requireRole } from '@/lib/auth';
+import {
+  acceptHandoff,
+  declineHandoff,
+  HandoffGateDeniedError,
+  HandoffStateMachineError,
+  initiateHandoff,
+  recordHandoffConsent,
+  revokeHandoff,
+} from '@/lib/coor';
+
+export type HandoffActionResult =
+  | { ok: true; handoffId: string }
+  | { ok: false; error: string; reason?: string };
+
+interface InitiateInput {
+  syntheticPersonRef: string;
+  fromPartnerOrgId: string;
+  toPartnerOrgId: string;
+  purpose: string;
+  requestedScope: CaseHandoffScopeKind[];
+  consentId?: string;
+}
+
+export async function initiateHandoffAction(input: InitiateInput): Promise<HandoffActionResult> {
+  const user = await requireRole(['caseworker', 'admin']);
+  try {
+    const handoff = await initiateHandoff({
+      syntheticPersonRef: input.syntheticPersonRef,
+      fromPartnerOrgId: input.fromPartnerOrgId,
+      toPartnerOrgId: input.toPartnerOrgId,
+      initiatedByUserId: user.id,
+      purpose: input.purpose,
+      requestedScope: input.requestedScope,
+      consentId: input.consentId,
+    });
+    revalidatePath('/app/handoffs');
+    revalidatePath(`/app/clients/${input.syntheticPersonRef}`);
+    return { ok: true, handoffId: handoff.id };
+  } catch (err) {
+    return failureResult(err, 'initiate');
+  }
+}
+
+export async function recordHandoffConsentAction(
+  handoffId: string,
+  consentId: string,
+): Promise<HandoffActionResult> {
+  const user = await requireRole(['caseworker', 'admin']);
+  try {
+    const handoff = await recordHandoffConsent(handoffId, consentId, user.id);
+    revalidatePath('/app/handoffs');
+    revalidatePath(`/app/clients/${handoff.syntheticPersonRef}`);
+    return { ok: true, handoffId: handoff.id };
+  } catch (err) {
+    return failureResult(err, 'record_consent');
+  }
+}
+
+export async function acceptHandoffAction(handoffId: string): Promise<HandoffActionResult> {
+  const user = await requireRole(['caseworker', 'admin']);
+  try {
+    const handoff = await acceptHandoff(handoffId, user.id);
+    revalidatePath('/app/handoffs');
+    revalidatePath(`/app/clients/${handoff.syntheticPersonRef}`);
+    return { ok: true, handoffId: handoff.id };
+  } catch (err) {
+    return failureResult(err, 'accept');
+  }
+}
+
+export async function declineHandoffAction(
+  handoffId: string,
+  reason: string,
+): Promise<HandoffActionResult> {
+  const user = await requireRole(['caseworker', 'admin']);
+  if (!reason.trim()) {
+    return { ok: false, error: 'A decline reason is required.' };
+  }
+  try {
+    const handoff = await declineHandoff(handoffId, user.id, reason.trim());
+    revalidatePath('/app/handoffs');
+    revalidatePath(`/app/clients/${handoff.syntheticPersonRef}`);
+    return { ok: true, handoffId: handoff.id };
+  } catch (err) {
+    return failureResult(err, 'decline');
+  }
+}
+
+export async function revokeHandoffAction(handoffId: string): Promise<HandoffActionResult> {
+  const user = await requireRole(['caseworker', 'admin']);
+  try {
+    const handoff = await revokeHandoff(handoffId, user.id);
+    revalidatePath('/app/handoffs');
+    revalidatePath(`/app/clients/${handoff.syntheticPersonRef}`);
+    return { ok: true, handoffId: handoff.id };
+  } catch (err) {
+    return failureResult(err, 'revoke');
+  }
+}
+
+function failureResult(err: unknown, op: string): HandoffActionResult {
+  if (err instanceof HandoffGateDeniedError) {
+    return { ok: false, error: err.message, reason: err.reason };
+  }
+  if (err instanceof HandoffStateMachineError) {
+    return { ok: false, error: err.message, reason: err.reason };
+  }
+  Sentry.captureException(err);
+  console.error(`[handoff.${op}] failed`, err);
+  return { ok: false, error: 'Handoff action failed — please retry.' };
+}

--- a/src/db/queries/case-handoffs.ts
+++ b/src/db/queries/case-handoffs.ts
@@ -1,0 +1,146 @@
+/**
+ * COOR-012 — case_handoffs query layer.
+ *
+ * All DB I/O for the handoff state machine lives here. The domain library
+ * (`src/lib/coor/handoff.ts`) imports these and adds business logic +
+ * audit. This split lets us mock the DB at the query boundary in tests
+ * (mirrors the dcbs-gate / kydoc-gate pattern).
+ */
+
+import { and, eq, inArray, isNull, lte } from 'drizzle-orm';
+import { db } from '@/db/client';
+import { type CaseHandoff, caseHandoffs, type NewCaseHandoff } from '@/db/schema/case-handoffs';
+import type { CaseHandoffStatus } from '@/db/schema/enums';
+import { orgMemberships } from '@/db/schema/org-memberships';
+import { partnerAgreements } from '@/db/schema/partner-agreements';
+import { partnerOrgs } from '@/db/schema/partner-orgs';
+import {
+  type PersonPartnerConsent,
+  personPartnerConsents,
+} from '@/db/schema/person-partner-consents';
+
+type Tx = Parameters<Parameters<typeof db.transaction>[0]>[0];
+type DbHandle = typeof db | Tx;
+
+export interface OrgGateState {
+  id: string;
+  active: boolean;
+  hasActiveAgreement: boolean;
+}
+
+/**
+ * Single-org governance lookup. Returns null when the org doesn't exist.
+ * Used by `assertHandoffPermitted` to gate both sides of a handoff.
+ */
+export async function loadOrgGateState(orgId: string): Promise<OrgGateState | null> {
+  const orgRows = await db
+    .select({ id: partnerOrgs.id, active: partnerOrgs.active })
+    .from(partnerOrgs)
+    .where(eq(partnerOrgs.id, orgId))
+    .limit(1);
+  const org = orgRows[0];
+  if (!org) return null;
+
+  const active = await db
+    .select({ id: partnerAgreements.id })
+    .from(partnerAgreements)
+    .where(and(eq(partnerAgreements.partnerOrgId, orgId), eq(partnerAgreements.status, 'active')))
+    .limit(1);
+
+  return {
+    id: org.id,
+    active: org.active,
+    hasActiveAgreement: active.length > 0,
+  };
+}
+
+export async function getCaseHandoff(handoffId: string): Promise<CaseHandoff | null> {
+  const rows = await db.select().from(caseHandoffs).where(eq(caseHandoffs.id, handoffId)).limit(1);
+  return rows[0] ?? null;
+}
+
+export async function insertCaseHandoff(
+  value: NewCaseHandoff,
+  handle: DbHandle = db,
+): Promise<CaseHandoff> {
+  const rows = await handle.insert(caseHandoffs).values(value).returning();
+  return rows[0]!;
+}
+
+export interface UpdateCaseHandoffPatch {
+  status?: CaseHandoffStatus;
+  consentId?: string | null;
+  respondedByUserId?: string | null;
+  declineReason?: string | null;
+  acceptedAt?: Date | null;
+  closedAt?: Date | null;
+}
+
+export async function updateCaseHandoff(
+  handoffId: string,
+  patch: UpdateCaseHandoffPatch,
+  handle: DbHandle = db,
+): Promise<CaseHandoff> {
+  const rows = await handle
+    .update(caseHandoffs)
+    .set({ ...patch, updatedAt: new Date() })
+    .where(eq(caseHandoffs.id, handoffId))
+    .returning();
+  return rows[0]!;
+}
+
+/**
+ * Person-partner consent lookup, filtered to unrevoked rows. Null result
+ * means either the row doesn't exist or it's been revoked — both of which
+ * deny the handoff context read by design.
+ */
+export async function getActivePersonPartnerConsent(
+  consentId: string,
+): Promise<PersonPartnerConsent | null> {
+  const rows = await db
+    .select()
+    .from(personPartnerConsents)
+    .where(and(eq(personPartnerConsents.id, consentId), isNull(personPartnerConsents.revokedAt)))
+    .limit(1);
+  return rows[0] ?? null;
+}
+
+/**
+ * Plain consent fetch (revoked or not). The context loader needs this so
+ * the gate can distinguish 'not found' from 'revoked'.
+ */
+export async function getPersonPartnerConsent(
+  consentId: string,
+): Promise<PersonPartnerConsent | null> {
+  const rows = await db
+    .select()
+    .from(personPartnerConsents)
+    .where(eq(personPartnerConsents.id, consentId))
+    .limit(1);
+  return rows[0] ?? null;
+}
+
+export async function userBelongsToOrg(userId: string, partnerOrgId: string): Promise<boolean> {
+  const rows = await db
+    .select({ id: orgMemberships.id })
+    .from(orgMemberships)
+    .where(and(eq(orgMemberships.userId, userId), eq(orgMemberships.partnerOrgId, partnerOrgId)))
+    .limit(1);
+  return rows.length > 0;
+}
+
+/**
+ * Pre-acceptance handoffs whose `expires_at` is on or before `cutoff`.
+ * The Inngest sweep iterates these and flips them to `expired`.
+ */
+export async function listExpiringPreAcceptanceHandoffs(cutoff: Date): Promise<CaseHandoff[]> {
+  return db
+    .select()
+    .from(caseHandoffs)
+    .where(
+      and(
+        lte(caseHandoffs.expiresAt, cutoff),
+        inArray(caseHandoffs.status, ['pending_consent', 'pending_acceptance']),
+      ),
+    );
+}

--- a/src/db/schema/case-handoffs.ts
+++ b/src/db/schema/case-handoffs.ts
@@ -1,0 +1,119 @@
+/**
+ * COOR-012 — case_handoffs table.
+ *
+ * Inter-agency handoff primitive. One row per handoff request. The platform
+ * (the coalition) mediates: an initiating agency asks a receiving agency to
+ * take over (or share) coordination of a synthetic_person_ref. The receiver
+ * cannot read context until two gates clear:
+ *
+ *   1. Both partner orgs have an active `partner_agreements` row with the
+ *      coalition (governance gate).
+ *   2. The subject has an unrevoked `person_partner_consents` grant for the
+ *      receiving partner org (subject gate).
+ *
+ * Both gates are enforced in the domain library, not the schema. The DB
+ * stores the request + lifecycle; reads of transferred context route through
+ * `loadHandoffContext` which audits on every call.
+ *
+ * Bounded data flow: handoffs that sit in pre-acceptance states past
+ * `expires_at` are aged out by the daily Inngest sweep
+ * (`handoff-expiry-sweep.ts`). Terminal-state rows are kept for the audit
+ * trail.
+ *
+ * The UI surfaces (caseworker inbox, case-page initiate button, accept /
+ * decline buttons, notifications) are CWT-022 — this story is the primitive
+ * underneath.
+ */
+import { sql } from 'drizzle-orm';
+import { check, index, jsonb, pgTable, text, timestamp, uuid } from 'drizzle-orm/pg-core';
+import { type CaseHandoffScopeKind, caseHandoffStatusEnum } from './enums';
+import { partnerOrgs } from './partner-orgs';
+import { personPartnerConsents } from './person-partner-consents';
+import { users } from './users';
+
+export const caseHandoffs = pgTable(
+  'case_handoffs',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    /**
+     * Opaque ref to the subject of the handoff. Matches the
+     * `synthetic_person_ref` keyspace used by intakes / case notes /
+     * service events / consents. Real-identity mapping lives outside the
+     * platform until BAA + identity-management work.
+     */
+    syntheticPersonRef: text('synthetic_person_ref').notNull(),
+    /** Initiating partner org. */
+    fromPartnerOrgId: uuid('from_partner_org_id')
+      .notNull()
+      .references(() => partnerOrgs.id, { onDelete: 'restrict' }),
+    /** Receiving partner org. */
+    toPartnerOrgId: uuid('to_partner_org_id')
+      .notNull()
+      .references(() => partnerOrgs.id, { onDelete: 'restrict' }),
+    /** Caseworker (member of the initiating org) who initiated the handoff. */
+    initiatedByUserId: uuid('initiated_by_user_id')
+      .notNull()
+      .references(() => users.id, { onDelete: 'restrict' }),
+    /**
+     * Acting caseworker on the receiving side. Set when the handoff
+     * transitions out of `pending_acceptance` (accepted or declined).
+     */
+    respondedByUserId: uuid('responded_by_user_id').references(() => users.id, {
+      onDelete: 'set null',
+    }),
+    status: caseHandoffStatusEnum('status').notNull().default('pending_consent'),
+    /**
+     * Initiator's reason for the handoff. Plain text. Visible to the
+     * receiver — keep it operational ("relocating to receiver's service
+     * area"), not diagnostic.
+     */
+    purpose: text('purpose').notNull(),
+    /**
+     * What kinds of records the receiver is permitted to read once the
+     * handoff is accepted. Enforced by `loadHandoffContext`. Validated as
+     * a non-empty array of `CaseHandoffScopeKind` before insert.
+     */
+    requestedScope: jsonb('requested_scope').$type<CaseHandoffScopeKind[]>().notNull(),
+    /**
+     * Link to the unrevoked person_partner_consents row that authorises
+     * the receiver to see this person's data. Null while the row is in
+     * `pending_consent`. Set when the subject grants consent (or when
+     * the initiator confirms an existing grant covers this handoff).
+     *
+     * ON DELETE SET NULL: if the consent record is purged, the handoff
+     * can no longer satisfy the subject gate; `loadHandoffContext` then
+     * fails closed.
+     */
+    consentId: uuid('consent_id').references(() => personPartnerConsents.id, {
+      onDelete: 'set null',
+    }),
+    /**
+     * Receiver's stated reason if `status='declined'`. Free text.
+     */
+    declineReason: text('decline_reason'),
+    /**
+     * Soft expiration. Pre-acceptance rows past this are aged to `expired`
+     * by the daily sweep. Default: 30 days post-creation; set by the
+     * domain helper, not the DB.
+     */
+    expiresAt: timestamp('expires_at', { withTimezone: true }).notNull(),
+    /** Set when status flips to `accepted`. */
+    acceptedAt: timestamp('accepted_at', { withTimezone: true }),
+    /** Set when status flips to a terminal non-accepted state. */
+    closedAt: timestamp('closed_at', { withTimezone: true }),
+    createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),
+  },
+  (t) => [
+    index('case_handoffs_to_partner_idx').on(t.toPartnerOrgId, t.status),
+    index('case_handoffs_from_partner_idx').on(t.fromPartnerOrgId, t.status),
+    index('case_handoffs_person_ref_idx').on(t.syntheticPersonRef),
+    index('case_handoffs_status_idx').on(t.status),
+    index('case_handoffs_expires_at_idx').on(t.expiresAt),
+    // Receiver cannot equal initiator — a handoff to your own org is meaningless.
+    check('case_handoffs_distinct_orgs', sql`from_partner_org_id <> to_partner_org_id`),
+  ],
+);
+
+export type CaseHandoff = typeof caseHandoffs.$inferSelect;
+export type NewCaseHandoff = typeof caseHandoffs.$inferInsert;

--- a/src/db/schema/enums.ts
+++ b/src/db/schema/enums.ts
@@ -437,3 +437,56 @@ export const preReleaseTypeEnum = pgEnum('pre_release_release_type', [
 ]);
 
 export type PreReleaseType = (typeof preReleaseTypeEnum.enumValues)[number];
+
+// COOR-012 — inter-agency handoff workflow
+
+/**
+ * Lifecycle of a `case_handoffs` row.
+ *
+ *   - `pending_consent`     — request initiated; the subject has not (yet)
+ *                             granted `person_partner_consents` for the
+ *                             receiving partner org. The receiver cannot
+ *                             see anything until consent lands.
+ *   - `pending_acceptance`  — consent on file; the receiving org's
+ *                             caseworker hasn't accepted yet.
+ *   - `accepted`            — receiver accepted; `loadHandoffContext` reads
+ *                             are permitted while the consent stays unrevoked.
+ *   - `declined`            — receiver explicitly declined.
+ *   - `revoked`             — initiator (or subject via consent revocation)
+ *                             pulled the handoff before completion.
+ *   - `expired`             — daily sweep aged out a handoff that sat in
+ *                             `pending_consent` / `pending_acceptance` past
+ *                             its `expires_at`.
+ *
+ * Terminal states: `accepted`, `declined`, `revoked`, `expired`. Audit log
+ * carries every transition.
+ */
+export const caseHandoffStatusEnum = pgEnum('case_handoff_status', [
+  'pending_consent',
+  'pending_acceptance',
+  'accepted',
+  'declined',
+  'revoked',
+  'expired',
+]);
+
+export type CaseHandoffStatus = (typeof caseHandoffStatusEnum.enumValues)[number];
+
+/**
+ * Kinds of records the initiator may request the receiver be allowed to
+ * read. Stored as a JSONB array on `case_handoffs.requested_scope` and
+ * enforced by the `loadHandoffContext` reader — anything not in scope is
+ * not returned.
+ *
+ * Keep this list tight. Adding a new kind is a privacy-policy change, not
+ * a refactor. New kinds need a corresponding fetcher in
+ * `src/lib/coor/handoff-context.ts`.
+ */
+export const caseHandoffScopeKindEnum = pgEnum('case_handoff_scope_kind', [
+  'intakes',
+  'case_notes',
+  'service_events',
+  'consents',
+]);
+
+export type CaseHandoffScopeKind = (typeof caseHandoffScopeKindEnum.enumValues)[number];

--- a/src/db/schema/index.ts
+++ b/src/db/schema/index.ts
@@ -1,4 +1,5 @@
 export * from './audit-log';
+export * from './case-handoffs';
 export * from './client-documents';
 export * from './client-intakes';
 export * from './comms-advisories';

--- a/src/inngest/functions/handoff-expiry-sweep.ts
+++ b/src/inngest/functions/handoff-expiry-sweep.ts
@@ -1,0 +1,56 @@
+/**
+ * COOR-012 — daily handoff-expiry sweep.
+ *
+ * Pre-acceptance handoffs (status `pending_consent` or `pending_acceptance`)
+ * whose `expires_at` has passed are flipped to `expired`. Terminal-state
+ * rows are kept untouched for audit.
+ *
+ * Idempotent — replays only flip rows that are still in pre-acceptance.
+ * Per-row failures are captured and don't tank the sweep.
+ */
+import * as Sentry from '@sentry/nextjs';
+import { listExpiringPreAcceptanceHandoffs } from '@/db/queries/case-handoffs';
+import { expireHandoff } from '@/lib/coor';
+import { inngest } from '../client';
+
+interface SweepSummary {
+  scanned: number;
+  expired: number;
+}
+
+/**
+ * Cron: 45 6 * * * — daily at 6:45 UTC (after foster-aging-out 6:00 and
+ * pre-release window sweep 6:30 to avoid contention).
+ */
+export const handoffExpirySweep = inngest.createFunction(
+  {
+    id: 'handoff-expiry-sweep',
+    retries: 2,
+    triggers: [{ cron: '45 6 * * *' }],
+  },
+  async ({ step }) => {
+    const summary: SweepSummary = { scanned: 0, expired: 0 };
+    const now = new Date();
+
+    const candidates = await step.run('list-candidates', async () => {
+      return listExpiringPreAcceptanceHandoffs(now);
+    });
+
+    summary.scanned = candidates.length;
+
+    for (const handoff of candidates) {
+      try {
+        const result = await step.run(`expire:${handoff.id}`, async () => {
+          return expireHandoff(handoff.id);
+        });
+        if (result) summary.expired += 1;
+      } catch (err) {
+        Sentry.captureException(err, {
+          tags: { source: 'handoff-expiry-sweep', handoffId: handoff.id },
+        });
+      }
+    }
+
+    return summary;
+  },
+);

--- a/src/inngest/functions/index.ts
+++ b/src/inngest/functions/index.ts
@@ -7,6 +7,7 @@ import { expireBedHolds } from './expire-bed-holds';
 import { expireSmsConversations } from './expire-sms-conversations';
 import { familyStabilityScan } from './family-stability-scan';
 import { fosterAgingOutScan } from './foster-aging-out-scan';
+import { handoffExpirySweep } from './handoff-expiry-sweep';
 import { preReleaseWindowSweep } from './pre-release-window-sweep';
 import { userSignedUp } from './user-signed-up';
 
@@ -22,4 +23,5 @@ export const functions = [
   dvSafetyPlanStaleScan,
   familyStabilityScan,
   preReleaseWindowSweep,
+  handoffExpirySweep,
 ];

--- a/src/lib/coor/CLAUDE.md
+++ b/src/lib/coor/CLAUDE.md
@@ -1,0 +1,38 @@
+# CLAUDE.md — `coor` domain (Inter-Agency Coordination)
+
+## What this domain owns
+
+Cross-agency routing primitives. Today: the consent-gated case handoff (COOR-012). Future: referral routing across orgs, demand forecasting, donation matching.
+
+Distinct from `coordination/` (which owns the bed-availability primitive — different layer of "coordination"). The naming is unfortunate but locked in for now.
+
+## Key files
+
+- `handoff.ts` — state machine for `case_handoffs`. `initiateHandoff`, `recordHandoffConsent`, `acceptHandoff`, `declineHandoff`, `revokeHandoff`, `expireHandoff`, plus the `assertHandoffPermitted` governance gate. Pure helpers: `validateRequestedScope`, `computeExpiresAt`, `nextStatus`.
+- `handoff-context.ts` — the consent-gated reader. `loadHandoffContext` is the **only** path that returns transferred records; every call audits. Pure helper: `validateConsentForRead`.
+- `index.ts` — barrel export.
+
+## Cross-domain dependencies
+
+**Imports from (per [ADR 0001](../../../docs/adr/0001-modular-monolith.md)):** `audit`, `db/queries/case-handoffs`, plus pure schema types from `db/schema/*`. The fetchers in `handoff-context.ts` reach into `clientIntakes`, `clientCaseNotes`, `partnerServiceEvents`, `consents` — these are read-only references to tables owned by other domains (`cwt`, `dtrs`).
+
+**Imported by:** server actions in `src/app/actions/handoff.ts`. The CWT-022 caseworker UI will be the next consumer.
+
+## PHI status
+
+**Will-be-PHI post-BAA.** Today the handoff records reference `synthetic_person_ref` only, but the *purpose* of the handoff (free text) and the records the receiver pulls (intakes / case notes / service events) lift PHI as the platform matures. Treat the audit log on `case_handoff.context_read` as the forensic record of who saw what.
+
+## Conventions
+
+- **Two gates, every time.** `initiateHandoff` runs the governance gate (`assertHandoffPermitted`); `loadHandoffContext` runs governance + receiver-membership + consent. Don't add an alternate read path that bypasses either.
+- **Audit every transition AND every context read.** The `logAuditEvent` calls inside the state-machine functions and the context loader are not optional. Any new operation that mutates a handoff or returns its context MUST audit.
+- **Consent-pre-dates-accept rule.** A handoff that's already `accepted` should NOT auto-re-authorise after a revoke + new grant. The validator (`validateConsentForRead`) compares `consent.granted_at` to `handoff.accepted_at` — if the grant is newer, the read fails closed and the receiver must re-prompt for a fresh accept. Don't relax this.
+- **DB I/O lives in `@/db/queries/case-handoffs`, not here.** Tests mock that module to exercise the state machine without a Postgres. New mutations: add a query function, then call it from the lib.
+- **Scope kinds are a privacy contract.** Adding a new value to `case_handoff_scope_kind` is a privacy-policy change, not a refactor. New kinds need a fetcher in `handoff-context.ts` AND a corresponding case in `summarizeScope`. `triage_overrides` was intentionally dropped because the table has no `synthetic_person_ref` column.
+
+## Gotchas
+
+- **`partner_agreements` is the live signal, not `partner_orgs.data_sharing_tier`.** The seed sets the tier statically; the real "is this org currently authorised" answer is "do they have an active agreement on file?" The gate keys on the agreement, not the tier.
+- **`memo_of_cooperation` validator throws.** It's a placeholder kind whose intake story hasn't shipped. Synthetic seeds must use `mou` (which has a real validator) instead. See `scripts/gen-synthetic-handoffs.ts`.
+- **The expiry sweep is idempotent.** It calls `expireHandoff` per-row inside `step.run`; per-row failures are captured in Sentry and don't tank the sweep. Don't add a batched UPDATE — the per-row audit row is the point.
+- **UI surfaces are CWT-022, not here.** Caseworker inbox, case-page initiate button, accept/decline buttons, notifications all belong to the (8pt) CWT-022 layer that sits on top of these primitives. Don't add components in this domain.

--- a/src/lib/coor/handoff-context.test.ts
+++ b/src/lib/coor/handoff-context.test.ts
@@ -1,0 +1,115 @@
+/**
+ * COOR-012 — handoff context reader tests.
+ *
+ * Covers the pure consent validator and the summarizeScope helper. The
+ * full DB-driven loadHandoffContext path is intentionally not exercised
+ * here — the gate logic it composes is unit-tested via this validator
+ * plus the queries-mock pattern in handoff.test.ts.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { summarizeScope, validateConsentForRead } from './handoff-context';
+
+describe('validateConsentForRead', () => {
+  const baseInput = {
+    consentId: 'consent-1',
+    acceptedAt: new Date('2026-05-01T12:00:00Z'),
+    syntheticPersonRef: 'SYN-PERSON-001',
+    toPartnerOrgId: 'org-to',
+  };
+
+  const baseConsent = {
+    id: 'consent-1',
+    syntheticPersonRef: 'SYN-PERSON-001',
+    partnerOrgId: 'org-to',
+    grantedAt: new Date('2026-04-15T12:00:00Z'),
+    revokedAt: null as Date | null,
+  };
+
+  it('allows when consent matches and predates accept', () => {
+    expect(validateConsentForRead(baseInput, baseConsent)).toEqual({ allowed: true });
+  });
+
+  it('denies consent_missing when handoff has no consent_id', () => {
+    const result = validateConsentForRead({ ...baseInput, consentId: null }, baseConsent);
+    expect(result).toEqual({ allowed: false, reason: 'consent_missing' });
+  });
+
+  it('denies consent_missing when consent row is gone', () => {
+    const result = validateConsentForRead(baseInput, null);
+    expect(result).toEqual({ allowed: false, reason: 'consent_missing' });
+  });
+
+  it('denies consent_revoked when revoked_at is set', () => {
+    const result = validateConsentForRead(baseInput, {
+      ...baseConsent,
+      revokedAt: new Date('2026-04-20T12:00:00Z'),
+    });
+    expect(result).toEqual({ allowed: false, reason: 'consent_revoked' });
+  });
+
+  it('denies consent_missing when person ref does not match', () => {
+    const result = validateConsentForRead(baseInput, {
+      ...baseConsent,
+      syntheticPersonRef: 'SYN-PERSON-OTHER',
+    });
+    expect(result).toEqual({ allowed: false, reason: 'consent_missing' });
+  });
+
+  it('denies consent_missing when consent is for a different org', () => {
+    const result = validateConsentForRead(baseInput, {
+      ...baseConsent,
+      partnerOrgId: 'org-other',
+    });
+    expect(result).toEqual({ allowed: false, reason: 'consent_missing' });
+  });
+
+  it('denies consent_pre_dates_accept when consent was granted after accept', () => {
+    // The receiver accepted on 2026-05-01; this consent was granted later.
+    // That suggests a revoke-then-regrant flow that should re-trigger
+    // accept rather than silently re-authorise the prior accept.
+    const result = validateConsentForRead(baseInput, {
+      ...baseConsent,
+      grantedAt: new Date('2026-05-02T00:00:00Z'),
+    });
+    expect(result).toEqual({ allowed: false, reason: 'consent_pre_dates_accept' });
+  });
+
+  it('allows when consent grant exactly equals accept timestamp', () => {
+    const result = validateConsentForRead(baseInput, {
+      ...baseConsent,
+      grantedAt: new Date(baseInput.acceptedAt!),
+    });
+    expect(result).toEqual({ allowed: true });
+  });
+
+  it('skips the pre-dates check when handoff has no acceptedAt yet', () => {
+    // Should never happen for a status='accepted' handoff in practice, but
+    // guard the validator against bad input.
+    const result = validateConsentForRead(
+      { ...baseInput, acceptedAt: null },
+      { ...baseConsent, grantedAt: new Date('2030-01-01T00:00:00Z') },
+    );
+    expect(result).toEqual({ allowed: true });
+  });
+});
+
+describe('summarizeScope', () => {
+  it('marks each kind present in the scope', () => {
+    expect(summarizeScope(['intakes', 'consents'])).toEqual({
+      intakes: true,
+      case_notes: false,
+      service_events: false,
+      consents: true,
+    });
+  });
+
+  it('returns all-false for empty scope', () => {
+    expect(summarizeScope([])).toEqual({
+      intakes: false,
+      case_notes: false,
+      service_events: false,
+      consents: false,
+    });
+  });
+});

--- a/src/lib/coor/handoff-context.ts
+++ b/src/lib/coor/handoff-context.ts
@@ -1,0 +1,266 @@
+/**
+ * COOR-012 — handoff context reader.
+ *
+ * Single chokepoint for the receiving caseworker to actually fetch the
+ * transferred records. Enforces all four gates on every call:
+ *
+ *   1. Handoff status is `accepted`.
+ *   2. Requesting user is a member of the receiving partner org
+ *      (`org_memberships`).
+ *   3. The linked `person_partner_consents` row is unrevoked AND its
+ *      grant timestamp is on or before the accept timestamp (so a
+ *      revoke-then-regrant doesn't accidentally re-authorise a prior
+ *      accept).
+ *   4. Each returned record kind is in the handoff's `requested_scope`.
+ *
+ * Audit-log writes one `case_handoff.context_read` row per call, with
+ * the kinds returned and the count per kind. Failure modes also audit
+ * (`case_handoff.context_denied`) so a coordinator forensic review sees
+ * attempted reads that didn't satisfy a gate.
+ */
+
+import { and, asc, desc, eq, isNull } from 'drizzle-orm';
+import { db } from '@/db/client';
+import {
+  getCaseHandoff,
+  getPersonPartnerConsent,
+  userBelongsToOrg,
+} from '@/db/queries/case-handoffs';
+import type { CaseHandoff } from '@/db/schema/case-handoffs';
+import { type ClientCaseNote, clientCaseNotes } from '@/db/schema/client-case-notes';
+import { type ClientIntake, clientIntakes } from '@/db/schema/client-intakes';
+import { type Consent, consents } from '@/db/schema/consents';
+import type { CaseHandoffScopeKind } from '@/db/schema/enums';
+import { type PartnerServiceEvent, partnerServiceEvents } from '@/db/schema/partner-service-events';
+import { logAuditEvent } from '@/lib/audit';
+
+export type HandoffContextDenyReason =
+  | 'not_found'
+  | 'not_accepted'
+  | 'not_receiver_member'
+  | 'consent_missing'
+  | 'consent_revoked'
+  | 'consent_pre_dates_accept';
+
+export class HandoffContextDeniedError extends Error {
+  reason: HandoffContextDenyReason;
+  constructor(reason: HandoffContextDenyReason, message: string) {
+    super(message);
+    this.name = 'HandoffContextDeniedError';
+    this.reason = reason;
+  }
+}
+
+export interface HandoffContext {
+  handoff: CaseHandoff;
+  intakes: ClientIntake[];
+  caseNotes: ClientCaseNote[];
+  serviceEvents: PartnerServiceEvent[];
+  /**
+   * Subject's coalition-wide consents (the `consents` table), filtered by
+   * `subject_external_id === handoff.synthetic_person_ref` and unrevoked.
+   * Useful context for the receiver — they need to know what the subject
+   * has authorised.
+   */
+  consents: Consent[];
+}
+
+interface ConsentValidationInput {
+  consentId: string | null;
+  acceptedAt: Date | null;
+  syntheticPersonRef: string;
+  toPartnerOrgId: string;
+}
+
+interface ConsentRecord {
+  id: string;
+  syntheticPersonRef: string;
+  partnerOrgId: string;
+  grantedAt: Date;
+  revokedAt: Date | null;
+}
+
+/**
+ * Pure consent validator — no DB. Exercised directly by tests; the live
+ * loader passes the row it just fetched.
+ */
+export function validateConsentForRead(
+  input: ConsentValidationInput,
+  consent: ConsentRecord | null,
+): { allowed: true } | { allowed: false; reason: HandoffContextDenyReason } {
+  if (!input.consentId || !consent) {
+    return { allowed: false, reason: 'consent_missing' };
+  }
+  if (consent.revokedAt !== null) {
+    return { allowed: false, reason: 'consent_revoked' };
+  }
+  if (consent.syntheticPersonRef !== input.syntheticPersonRef) {
+    return { allowed: false, reason: 'consent_missing' };
+  }
+  if (consent.partnerOrgId !== input.toPartnerOrgId) {
+    return { allowed: false, reason: 'consent_missing' };
+  }
+  if (input.acceptedAt && consent.grantedAt > input.acceptedAt) {
+    return { allowed: false, reason: 'consent_pre_dates_accept' };
+  }
+  return { allowed: true };
+}
+
+/**
+ * Fetch the transferred context for a receiver caseworker.
+ *
+ * Throws `HandoffContextDeniedError` on any gate failure (with audit
+ * logged). Returns the scoped record set on success (also audited).
+ */
+export async function loadHandoffContext(
+  handoffId: string,
+  requestingUserId: string,
+): Promise<HandoffContext> {
+  const handoff = await getCaseHandoff(handoffId);
+  if (!handoff) {
+    await auditDeny(handoffId, requestingUserId, 'not_found', null);
+    throw new HandoffContextDeniedError('not_found', `Handoff ${handoffId} not found.`);
+  }
+
+  if (handoff.status !== 'accepted') {
+    await auditDeny(handoffId, requestingUserId, 'not_accepted', handoff);
+    throw new HandoffContextDeniedError(
+      'not_accepted',
+      `Handoff ${handoffId} is in status '${handoff.status}'; context is only readable when accepted.`,
+    );
+  }
+
+  const isMember = await userBelongsToOrg(requestingUserId, handoff.toPartnerOrgId);
+  if (!isMember) {
+    await auditDeny(handoffId, requestingUserId, 'not_receiver_member', handoff);
+    throw new HandoffContextDeniedError(
+      'not_receiver_member',
+      'Requesting user is not a member of the receiving partner org.',
+    );
+  }
+
+  const consentRow = handoff.consentId ? await getPersonPartnerConsent(handoff.consentId) : null;
+  const consentDecision = validateConsentForRead(
+    {
+      consentId: handoff.consentId,
+      acceptedAt: handoff.acceptedAt,
+      syntheticPersonRef: handoff.syntheticPersonRef,
+      toPartnerOrgId: handoff.toPartnerOrgId,
+    },
+    consentRow,
+  );
+  if (!consentDecision.allowed) {
+    await auditDeny(handoffId, requestingUserId, consentDecision.reason, handoff);
+    throw new HandoffContextDeniedError(
+      consentDecision.reason,
+      `Handoff ${handoffId}: consent gate denied (${consentDecision.reason}).`,
+    );
+  }
+
+  const scope = new Set(handoff.requestedScope);
+  const result: HandoffContext = {
+    handoff,
+    intakes: scope.has('intakes') ? await fetchIntakes(handoff.syntheticPersonRef) : [],
+    caseNotes: scope.has('case_notes') ? await fetchCaseNotes(handoff.syntheticPersonRef) : [],
+    serviceEvents: scope.has('service_events')
+      ? await fetchServiceEvents(handoff.syntheticPersonRef)
+      : [],
+    consents: scope.has('consents') ? await fetchConsents(handoff.syntheticPersonRef) : [],
+  };
+
+  await logAuditEvent({
+    actorUserId: requestingUserId,
+    action: 'case_handoff.context_read',
+    targetTable: 'case_handoffs',
+    targetId: handoffId,
+    metadata: {
+      synthetic_person_ref: handoff.syntheticPersonRef,
+      to_partner_org_id: handoff.toPartnerOrgId,
+      scope: handoff.requestedScope,
+      counts: {
+        intakes: result.intakes.length,
+        case_notes: result.caseNotes.length,
+        service_events: result.serviceEvents.length,
+        consents: result.consents.length,
+      },
+    },
+  });
+
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+// Per-kind fetchers (deep `db` use is acceptable here — these are the leaf
+// readers, not the gate logic that tests need to mock).
+// ---------------------------------------------------------------------------
+
+async function fetchIntakes(syntheticPersonRef: string): Promise<ClientIntake[]> {
+  return db
+    .select()
+    .from(clientIntakes)
+    .where(eq(clientIntakes.syntheticPersonRef, syntheticPersonRef))
+    .orderBy(desc(clientIntakes.createdAt));
+}
+
+async function fetchCaseNotes(syntheticPersonRef: string): Promise<ClientCaseNote[]> {
+  return db
+    .select()
+    .from(clientCaseNotes)
+    .where(eq(clientCaseNotes.syntheticPersonRef, syntheticPersonRef))
+    .orderBy(desc(clientCaseNotes.createdAt));
+}
+
+async function fetchServiceEvents(syntheticPersonRef: string): Promise<PartnerServiceEvent[]> {
+  return db
+    .select()
+    .from(partnerServiceEvents)
+    .where(eq(partnerServiceEvents.syntheticPersonRef, syntheticPersonRef))
+    .orderBy(desc(partnerServiceEvents.eventAt));
+}
+
+async function fetchConsents(syntheticPersonRef: string): Promise<Consent[]> {
+  return db
+    .select()
+    .from(consents)
+    .where(and(eq(consents.subjectExternalId, syntheticPersonRef), isNull(consents.revokedAt)))
+    .orderBy(asc(consents.grantedAt));
+}
+
+async function auditDeny(
+  handoffId: string,
+  requestingUserId: string,
+  reason: HandoffContextDenyReason,
+  handoff: CaseHandoff | null,
+): Promise<void> {
+  await logAuditEvent({
+    actorUserId: requestingUserId,
+    action: 'case_handoff.context_denied',
+    targetTable: 'case_handoffs',
+    targetId: handoffId,
+    metadata: {
+      reason,
+      status: handoff?.status,
+      to_partner_org_id: handoff?.toPartnerOrgId,
+      synthetic_person_ref: handoff?.syntheticPersonRef,
+    },
+  });
+}
+
+/**
+ * Subset of the scope kinds returned for a given handoff. Useful for UI
+ * surfaces that want to render "X intakes, Y notes" without re-fetching.
+ */
+export function summarizeScope(scope: readonly CaseHandoffScopeKind[]): {
+  intakes: boolean;
+  case_notes: boolean;
+  service_events: boolean;
+  consents: boolean;
+} {
+  const set = new Set(scope);
+  return {
+    intakes: set.has('intakes'),
+    case_notes: set.has('case_notes'),
+    service_events: set.has('service_events'),
+    consents: set.has('consents'),
+  };
+}

--- a/src/lib/coor/handoff.test.ts
+++ b/src/lib/coor/handoff.test.ts
@@ -1,0 +1,218 @@
+/**
+ * COOR-012 — handoff state machine + governance gate tests.
+ *
+ * Covers:
+ *   - validateRequestedScope (pure)
+ *   - computeExpiresAt (pure)
+ *   - nextStatus (pure)
+ *   - assertHandoffPermitted (mocked DB)
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  assertHandoffPermitted,
+  computeExpiresAt,
+  DEFAULT_HANDOFF_TTL_DAYS,
+  HandoffGateDeniedError,
+  nextStatus,
+  validateRequestedScope,
+} from './handoff';
+
+const loadOrgGateState = vi.fn();
+
+vi.mock('@/db/queries/case-handoffs', () => ({
+  loadOrgGateState: (...args: unknown[]) => loadOrgGateState(...args),
+}));
+
+beforeEach(() => {
+  loadOrgGateState.mockReset();
+});
+
+describe('validateRequestedScope', () => {
+  it('returns the unique scope kinds in array order', () => {
+    expect(validateRequestedScope(['intakes', 'case_notes'])).toEqual(['intakes', 'case_notes']);
+  });
+
+  it('dedupes repeats', () => {
+    expect(validateRequestedScope(['intakes', 'intakes', 'case_notes'])).toEqual([
+      'intakes',
+      'case_notes',
+    ]);
+  });
+
+  it('throws empty_scope on empty array', () => {
+    try {
+      validateRequestedScope([]);
+      expect.fail('expected throw');
+    } catch (err) {
+      expect(err).toBeInstanceOf(HandoffGateDeniedError);
+      expect((err as HandoffGateDeniedError).reason).toBe('empty_scope');
+    }
+  });
+
+  it('throws invalid_scope_kind on unknown kind', () => {
+    try {
+      validateRequestedScope(['intakes', 'medical_records']);
+      expect.fail('expected throw');
+    } catch (err) {
+      expect(err).toBeInstanceOf(HandoffGateDeniedError);
+      expect((err as HandoffGateDeniedError).reason).toBe('invalid_scope_kind');
+    }
+  });
+
+  it('rejects the dropped triage_overrides kind', () => {
+    // triage_overrides is intentionally NOT a scope kind because the table
+    // has no synthetic_person_ref column. Belt-and-suspenders check.
+    try {
+      validateRequestedScope(['triage_overrides']);
+      expect.fail('expected throw');
+    } catch (err) {
+      expect((err as HandoffGateDeniedError).reason).toBe('invalid_scope_kind');
+    }
+  });
+});
+
+describe('computeExpiresAt', () => {
+  it('adds the default 30 days to now', () => {
+    const now = new Date('2026-05-04T12:00:00Z');
+    const out = computeExpiresAt(now);
+    expect(out.toISOString()).toBe('2026-06-03T12:00:00.000Z');
+    expect(DEFAULT_HANDOFF_TTL_DAYS).toBe(30);
+  });
+
+  it('honors a custom TTL', () => {
+    const now = new Date('2026-05-04T12:00:00Z');
+    expect(computeExpiresAt(now, 7).toISOString()).toBe('2026-05-11T12:00:00.000Z');
+  });
+
+  it('does not mutate the input', () => {
+    const now = new Date('2026-05-04T12:00:00Z');
+    computeExpiresAt(now);
+    expect(now.toISOString()).toBe('2026-05-04T12:00:00.000Z');
+  });
+});
+
+describe('nextStatus', () => {
+  it('pending_consent → pending_acceptance on consent_recorded', () => {
+    expect(nextStatus('pending_consent', 'consent_recorded')).toBe('pending_acceptance');
+  });
+
+  it('pending_acceptance → accepted on accept', () => {
+    expect(nextStatus('pending_acceptance', 'accept')).toBe('accepted');
+  });
+
+  it('accept event is rejected outside pending_acceptance', () => {
+    expect(nextStatus('pending_consent', 'accept')).toBeNull();
+    expect(nextStatus('accepted', 'accept')).toBeNull();
+    expect(nextStatus('declined', 'accept')).toBeNull();
+  });
+
+  it('decline + revoke + expire allowed in either pre-acceptance state', () => {
+    for (const event of ['decline', 'revoke', 'expire'] as const) {
+      expect(nextStatus('pending_consent', event)).not.toBeNull();
+      expect(nextStatus('pending_acceptance', event)).not.toBeNull();
+    }
+  });
+
+  it('terminal states reject all events', () => {
+    for (const status of ['accepted', 'declined', 'revoked', 'expired'] as const) {
+      for (const event of ['consent_recorded', 'accept', 'decline', 'revoke', 'expire'] as const) {
+        expect(nextStatus(status, event)).toBeNull();
+      }
+    }
+  });
+});
+
+describe('assertHandoffPermitted', () => {
+  const activeOrg = { id: 'org-a', active: true, hasActiveAgreement: true };
+
+  it('allows when both orgs are active and have an agreement', async () => {
+    loadOrgGateState
+      .mockResolvedValueOnce({ ...activeOrg, id: 'org-from' })
+      .mockResolvedValueOnce({ ...activeOrg, id: 'org-to' });
+
+    await expect(assertHandoffPermitted('org-from', 'org-to')).resolves.toBeUndefined();
+  });
+
+  it('rejects same-org handoffs without hitting the DB', async () => {
+    try {
+      await assertHandoffPermitted('org-a', 'org-a');
+      expect.fail('expected throw');
+    } catch (err) {
+      expect((err as HandoffGateDeniedError).reason).toBe('same_org');
+    }
+    expect(loadOrgGateState).not.toHaveBeenCalled();
+  });
+
+  it('rejects unknown_from_org when initiator org missing', async () => {
+    loadOrgGateState
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce({ ...activeOrg, id: 'org-to' });
+    try {
+      await assertHandoffPermitted('org-missing', 'org-to');
+      expect.fail('expected throw');
+    } catch (err) {
+      expect((err as HandoffGateDeniedError).reason).toBe('unknown_from_org');
+    }
+  });
+
+  it('rejects unknown_to_org when receiver org missing', async () => {
+    loadOrgGateState
+      .mockResolvedValueOnce({ ...activeOrg, id: 'org-from' })
+      .mockResolvedValueOnce(null);
+    try {
+      await assertHandoffPermitted('org-from', 'org-missing');
+      expect.fail('expected throw');
+    } catch (err) {
+      expect((err as HandoffGateDeniedError).reason).toBe('unknown_to_org');
+    }
+  });
+
+  it('rejects from_org_inactive when initiator is deactivated', async () => {
+    loadOrgGateState
+      .mockResolvedValueOnce({ id: 'org-from', active: false, hasActiveAgreement: true })
+      .mockResolvedValueOnce({ ...activeOrg, id: 'org-to' });
+    try {
+      await assertHandoffPermitted('org-from', 'org-to');
+      expect.fail('expected throw');
+    } catch (err) {
+      expect((err as HandoffGateDeniedError).reason).toBe('from_org_inactive');
+    }
+  });
+
+  it('rejects to_org_inactive when receiver is deactivated', async () => {
+    loadOrgGateState
+      .mockResolvedValueOnce({ ...activeOrg, id: 'org-from' })
+      .mockResolvedValueOnce({ id: 'org-to', active: false, hasActiveAgreement: true });
+    try {
+      await assertHandoffPermitted('org-from', 'org-to');
+      expect.fail('expected throw');
+    } catch (err) {
+      expect((err as HandoffGateDeniedError).reason).toBe('to_org_inactive');
+    }
+  });
+
+  it('rejects from_org_no_active_agreement when initiator lacks an agreement', async () => {
+    loadOrgGateState
+      .mockResolvedValueOnce({ id: 'org-from', active: true, hasActiveAgreement: false })
+      .mockResolvedValueOnce({ ...activeOrg, id: 'org-to' });
+    try {
+      await assertHandoffPermitted('org-from', 'org-to');
+      expect.fail('expected throw');
+    } catch (err) {
+      expect((err as HandoffGateDeniedError).reason).toBe('from_org_no_active_agreement');
+    }
+  });
+
+  it('rejects to_org_no_active_agreement when receiver lacks an agreement', async () => {
+    loadOrgGateState
+      .mockResolvedValueOnce({ ...activeOrg, id: 'org-from' })
+      .mockResolvedValueOnce({ id: 'org-to', active: true, hasActiveAgreement: false });
+    try {
+      await assertHandoffPermitted('org-from', 'org-to');
+      expect.fail('expected throw');
+    } catch (err) {
+      expect((err as HandoffGateDeniedError).reason).toBe('to_org_no_active_agreement');
+    }
+  });
+});

--- a/src/lib/coor/handoff.ts
+++ b/src/lib/coor/handoff.ts
@@ -1,0 +1,462 @@
+/**
+ * COOR-012 — inter-agency handoff state machine.
+ *
+ * Pure-ish state transitions plus the two governance gates:
+ *   1. Both partner orgs must be active (`partner_orgs.active=true`) AND
+ *      have at least one active `partner_agreements` row with the
+ *      coalition. This is the *governance* gate.
+ *   2. The receiver must hold an unrevoked `person_partner_consents`
+ *      grant for the subject's `synthetic_person_ref`. This is the
+ *      *subject* gate. It can land either before or after the request
+ *      (a handoff sits in `pending_consent` until the grant exists).
+ *
+ * Reads of transferred context are NOT done here — see
+ * `handoff-context.ts`. This module only manages the handoff record.
+ *
+ * Audit-log calls are non-optional. Every state transition writes one row.
+ * DB I/O is delegated to `@/db/queries/case-handoffs` so the gate logic
+ * can be exercised under `vi.mock` without a Postgres instance.
+ */
+
+import { db } from '@/db/client';
+import {
+  getActivePersonPartnerConsent,
+  getCaseHandoff,
+  insertCaseHandoff,
+  loadOrgGateState,
+  updateCaseHandoff,
+} from '@/db/queries/case-handoffs';
+import type { CaseHandoff, NewCaseHandoff } from '@/db/schema/case-handoffs';
+import type { CaseHandoffScopeKind, CaseHandoffStatus } from '@/db/schema/enums';
+import { logAuditEvent } from '@/lib/audit';
+
+/** Default soft-expiration window for pre-acceptance handoffs. */
+export const DEFAULT_HANDOFF_TTL_DAYS = 30;
+
+const VALID_SCOPE_KINDS: ReadonlySet<CaseHandoffScopeKind> = new Set([
+  'intakes',
+  'case_notes',
+  'service_events',
+  'consents',
+]);
+
+export type HandoffGateDenyReason =
+  | 'unknown_from_org'
+  | 'unknown_to_org'
+  | 'same_org'
+  | 'from_org_inactive'
+  | 'to_org_inactive'
+  | 'from_org_no_active_agreement'
+  | 'to_org_no_active_agreement'
+  | 'empty_scope'
+  | 'invalid_scope_kind';
+
+export class HandoffGateDeniedError extends Error {
+  reason: HandoffGateDenyReason;
+  constructor(reason: HandoffGateDenyReason, message: string) {
+    super(message);
+    this.name = 'HandoffGateDeniedError';
+    this.reason = reason;
+  }
+}
+
+export type HandoffStateError =
+  | 'not_found'
+  | 'wrong_state_for_consent'
+  | 'wrong_state_for_accept'
+  | 'wrong_state_for_decline'
+  | 'wrong_state_for_revoke'
+  | 'consent_org_mismatch'
+  | 'consent_revoked'
+  | 'consent_subject_mismatch';
+
+export class HandoffStateMachineError extends Error {
+  reason: HandoffStateError;
+  constructor(reason: HandoffStateError, message: string) {
+    super(message);
+    this.name = 'HandoffStateMachineError';
+    this.reason = reason;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Pure helpers (no DB)
+// ---------------------------------------------------------------------------
+
+/**
+ * Validate the requested-scope array. Throws `HandoffGateDeniedError` on
+ * empty array or unknown kind. Pure — no DB.
+ */
+export function validateRequestedScope(scope: readonly string[]): CaseHandoffScopeKind[] {
+  if (!Array.isArray(scope) || scope.length === 0) {
+    throw new HandoffGateDeniedError(
+      'empty_scope',
+      'Handoff requested_scope must be a non-empty array of CaseHandoffScopeKind values.',
+    );
+  }
+  const seen = new Set<CaseHandoffScopeKind>();
+  for (const kind of scope) {
+    if (!VALID_SCOPE_KINDS.has(kind as CaseHandoffScopeKind)) {
+      throw new HandoffGateDeniedError(
+        'invalid_scope_kind',
+        `Unknown handoff scope kind: ${JSON.stringify(kind)}.`,
+      );
+    }
+    seen.add(kind as CaseHandoffScopeKind);
+  }
+  return [...seen];
+}
+
+/** Compute the expiration timestamp for a freshly-initiated handoff. */
+export function computeExpiresAt(now: Date, ttlDays = DEFAULT_HANDOFF_TTL_DAYS): Date {
+  const out = new Date(now);
+  out.setUTCDate(out.getUTCDate() + ttlDays);
+  return out;
+}
+
+/**
+ * Pure status transition rules. Returns the next status given the current
+ * state and the event, or null when the transition is not legal. Used by
+ * both the live state machine and the Inngest sweep.
+ */
+export function nextStatus(
+  current: CaseHandoffStatus,
+  event: 'consent_recorded' | 'accept' | 'decline' | 'revoke' | 'expire',
+): CaseHandoffStatus | null {
+  if (event === 'consent_recorded' && current === 'pending_consent') {
+    return 'pending_acceptance';
+  }
+  if (event === 'accept' && current === 'pending_acceptance') {
+    return 'accepted';
+  }
+  if (event === 'decline' && (current === 'pending_consent' || current === 'pending_acceptance')) {
+    return 'declined';
+  }
+  if (event === 'revoke' && (current === 'pending_consent' || current === 'pending_acceptance')) {
+    return 'revoked';
+  }
+  if (event === 'expire' && (current === 'pending_consent' || current === 'pending_acceptance')) {
+    return 'expired';
+  }
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Governance gate
+// ---------------------------------------------------------------------------
+
+/**
+ * Confirm that both orgs are eligible to participate in a handoff. Throws
+ * `HandoffGateDeniedError` on the first failing check.
+ */
+export async function assertHandoffPermitted(
+  fromPartnerOrgId: string,
+  toPartnerOrgId: string,
+): Promise<void> {
+  if (fromPartnerOrgId === toPartnerOrgId) {
+    throw new HandoffGateDeniedError(
+      'same_org',
+      'Handoff from and to the same org is not allowed.',
+    );
+  }
+  const [fromState, toState] = await Promise.all([
+    loadOrgGateState(fromPartnerOrgId),
+    loadOrgGateState(toPartnerOrgId),
+  ]);
+  if (!fromState) {
+    throw new HandoffGateDeniedError(
+      'unknown_from_org',
+      `from_partner_org_id ${fromPartnerOrgId} not found.`,
+    );
+  }
+  if (!toState) {
+    throw new HandoffGateDeniedError(
+      'unknown_to_org',
+      `to_partner_org_id ${toPartnerOrgId} not found.`,
+    );
+  }
+  if (!fromState.active) {
+    throw new HandoffGateDeniedError('from_org_inactive', 'Initiating partner org is inactive.');
+  }
+  if (!toState.active) {
+    throw new HandoffGateDeniedError('to_org_inactive', 'Receiving partner org is inactive.');
+  }
+  if (!fromState.hasActiveAgreement) {
+    throw new HandoffGateDeniedError(
+      'from_org_no_active_agreement',
+      'Initiating partner org has no active agreement on file with the coalition.',
+    );
+  }
+  if (!toState.hasActiveAgreement) {
+    throw new HandoffGateDeniedError(
+      'to_org_no_active_agreement',
+      'Receiving partner org has no active agreement on file with the coalition.',
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// State-machine operations
+// ---------------------------------------------------------------------------
+
+export interface InitiateHandoffInput {
+  syntheticPersonRef: string;
+  fromPartnerOrgId: string;
+  toPartnerOrgId: string;
+  initiatedByUserId: string;
+  purpose: string;
+  requestedScope: readonly string[];
+  /** Optional: existing person_partner_consents row that already authorises the receiver. */
+  consentId?: string;
+  /** Override default 30d TTL — primarily for tests. */
+  ttlDays?: number;
+  now?: Date;
+}
+
+/**
+ * Create a new handoff request. Routes through both gates; status starts at
+ * `pending_consent` unless a covering consent is supplied.
+ */
+export async function initiateHandoff(input: InitiateHandoffInput): Promise<CaseHandoff> {
+  const requestedScope = validateRequestedScope(input.requestedScope);
+  await assertHandoffPermitted(input.fromPartnerOrgId, input.toPartnerOrgId);
+
+  const now = input.now ?? new Date();
+  const consentId = input.consentId ?? null;
+  let initialStatus: CaseHandoffStatus = 'pending_consent';
+
+  if (consentId) {
+    const consent = await getActivePersonPartnerConsent(consentId);
+    assertConsentCoversHandoff(consent, input.syntheticPersonRef, input.toPartnerOrgId);
+    initialStatus = 'pending_acceptance';
+  }
+
+  const insertValue: NewCaseHandoff = {
+    syntheticPersonRef: input.syntheticPersonRef,
+    fromPartnerOrgId: input.fromPartnerOrgId,
+    toPartnerOrgId: input.toPartnerOrgId,
+    initiatedByUserId: input.initiatedByUserId,
+    purpose: input.purpose,
+    requestedScope,
+    consentId,
+    expiresAt: computeExpiresAt(now, input.ttlDays),
+    status: initialStatus,
+  };
+
+  return db.transaction(async (tx) => {
+    const inserted = await insertCaseHandoff(insertValue, tx);
+    await logAuditEvent({
+      actorUserId: input.initiatedByUserId,
+      action: 'case_handoff.initiated',
+      targetTable: 'case_handoffs',
+      targetId: inserted.id,
+      metadata: {
+        from_partner_org_id: input.fromPartnerOrgId,
+        to_partner_org_id: input.toPartnerOrgId,
+        synthetic_person_ref: input.syntheticPersonRef,
+        scope: requestedScope,
+        initial_status: initialStatus,
+      },
+      tx,
+    });
+    return inserted;
+  });
+}
+
+/**
+ * Link a freshly-granted consent to a handoff sitting in `pending_consent`,
+ * advancing it to `pending_acceptance`.
+ */
+export async function recordHandoffConsent(
+  handoffId: string,
+  consentId: string,
+  actorUserId: string,
+): Promise<CaseHandoff> {
+  const handoff = await loadHandoffOrThrow(handoffId);
+  const next = nextStatus(handoff.status, 'consent_recorded');
+  if (!next) {
+    throw new HandoffStateMachineError(
+      'wrong_state_for_consent',
+      `Handoff ${handoffId} is in status '${handoff.status}'; cannot record consent.`,
+    );
+  }
+  const consent = await getActivePersonPartnerConsent(consentId);
+  assertConsentCoversHandoff(consent, handoff.syntheticPersonRef, handoff.toPartnerOrgId);
+
+  return db.transaction(async (tx) => {
+    const updated = await updateCaseHandoff(handoffId, { consentId, status: next }, tx);
+    await logAuditEvent({
+      actorUserId,
+      action: 'case_handoff.consent_recorded',
+      targetTable: 'case_handoffs',
+      targetId: handoffId,
+      metadata: { consent_id: consentId, prior_status: handoff.status, status: next },
+      tx,
+    });
+    return updated;
+  });
+}
+
+/**
+ * Receiver-side accept. Caller is responsible for verifying the user belongs
+ * to `toPartnerOrgId` before invoking.
+ */
+export async function acceptHandoff(
+  handoffId: string,
+  acceptingUserId: string,
+): Promise<CaseHandoff> {
+  const handoff = await loadHandoffOrThrow(handoffId);
+  const next = nextStatus(handoff.status, 'accept');
+  if (!next) {
+    throw new HandoffStateMachineError(
+      'wrong_state_for_accept',
+      `Handoff ${handoffId} is in status '${handoff.status}'; only 'pending_acceptance' can be accepted.`,
+    );
+  }
+
+  const now = new Date();
+  return db.transaction(async (tx) => {
+    const updated = await updateCaseHandoff(
+      handoffId,
+      { status: next, respondedByUserId: acceptingUserId, acceptedAt: now },
+      tx,
+    );
+    await logAuditEvent({
+      actorUserId: acceptingUserId,
+      action: 'case_handoff.accepted',
+      targetTable: 'case_handoffs',
+      targetId: handoffId,
+      metadata: { prior_status: handoff.status },
+      tx,
+    });
+    return updated;
+  });
+}
+
+/** Receiver-side decline. */
+export async function declineHandoff(
+  handoffId: string,
+  decliningUserId: string,
+  reason: string,
+): Promise<CaseHandoff> {
+  const handoff = await loadHandoffOrThrow(handoffId);
+  const next = nextStatus(handoff.status, 'decline');
+  if (!next) {
+    throw new HandoffStateMachineError(
+      'wrong_state_for_decline',
+      `Handoff ${handoffId} is in status '${handoff.status}'; cannot decline.`,
+    );
+  }
+  const now = new Date();
+  return db.transaction(async (tx) => {
+    const updated = await updateCaseHandoff(
+      handoffId,
+      {
+        status: next,
+        respondedByUserId: decliningUserId,
+        declineReason: reason,
+        closedAt: now,
+      },
+      tx,
+    );
+    await logAuditEvent({
+      actorUserId: decliningUserId,
+      action: 'case_handoff.declined',
+      targetTable: 'case_handoffs',
+      targetId: handoffId,
+      metadata: { prior_status: handoff.status, reason },
+      tx,
+    });
+    return updated;
+  });
+}
+
+/** Initiator-side revoke. Subjects can also trigger revocation indirectly. */
+export async function revokeHandoff(
+  handoffId: string,
+  revokingUserId: string,
+): Promise<CaseHandoff> {
+  const handoff = await loadHandoffOrThrow(handoffId);
+  const next = nextStatus(handoff.status, 'revoke');
+  if (!next) {
+    throw new HandoffStateMachineError(
+      'wrong_state_for_revoke',
+      `Handoff ${handoffId} is in status '${handoff.status}'; cannot revoke.`,
+    );
+  }
+  const now = new Date();
+  return db.transaction(async (tx) => {
+    const updated = await updateCaseHandoff(handoffId, { status: next, closedAt: now }, tx);
+    await logAuditEvent({
+      actorUserId: revokingUserId,
+      action: 'case_handoff.revoked',
+      targetTable: 'case_handoffs',
+      targetId: handoffId,
+      metadata: { prior_status: handoff.status },
+      tx,
+    });
+    return updated;
+  });
+}
+
+/**
+ * Sweep transition for a single handoff — marks it `expired` and writes
+ * an audit row. Returns the updated row, or null if the row's current
+ * status no longer permits expiration (race-safe).
+ */
+export async function expireHandoff(handoffId: string): Promise<CaseHandoff | null> {
+  const handoff = await getCaseHandoff(handoffId);
+  if (!handoff) return null;
+  const next = nextStatus(handoff.status, 'expire');
+  if (!next) return null;
+  const now = new Date();
+  return db.transaction(async (tx) => {
+    const updated = await updateCaseHandoff(handoffId, { status: next, closedAt: now }, tx);
+    await logAuditEvent({
+      actorUserId: null,
+      action: 'case_handoff.expired',
+      targetTable: 'case_handoffs',
+      targetId: handoffId,
+      metadata: { prior_status: handoff.status, expires_at: handoff.expiresAt.toISOString() },
+      tx,
+    });
+    return updated;
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+async function loadHandoffOrThrow(handoffId: string): Promise<CaseHandoff> {
+  const row = await getCaseHandoff(handoffId);
+  if (!row) {
+    throw new HandoffStateMachineError('not_found', `Handoff ${handoffId} not found.`);
+  }
+  return row;
+}
+
+function assertConsentCoversHandoff(
+  consent: { syntheticPersonRef: string; partnerOrgId: string; revokedAt: Date | null } | null,
+  syntheticPersonRef: string,
+  toPartnerOrgId: string,
+): asserts consent is { syntheticPersonRef: string; partnerOrgId: string; revokedAt: null } {
+  if (!consent) {
+    throw new HandoffStateMachineError(
+      'consent_revoked',
+      'Consent record not found or already revoked.',
+    );
+  }
+  if (consent.partnerOrgId !== toPartnerOrgId) {
+    throw new HandoffStateMachineError(
+      'consent_org_mismatch',
+      'Consent is for a different partner org than this handoff.',
+    );
+  }
+  if (consent.syntheticPersonRef !== syntheticPersonRef) {
+    throw new HandoffStateMachineError(
+      'consent_subject_mismatch',
+      'Consent subject ref does not match the handoff subject ref.',
+    );
+  }
+}

--- a/src/lib/coor/index.ts
+++ b/src/lib/coor/index.ts
@@ -1,0 +1,12 @@
+/**
+ * COOR domain barrel — coordination workflows that route information
+ * between coalition partner orgs (consent-gated handoffs, future:
+ * referral routing, demand forecasting). Distinct from `coordination/`
+ * which owns the bed-availability primitive.
+ *
+ * Per ADR 0001, server-only code only — `'use client'` files must use
+ * deep imports (`@/lib/coor/handoff` etc.) to avoid pulling postgres
+ * into the browser bundle.
+ */
+export * from './handoff';
+export * from './handoff-context';


### PR DESCRIPTION
## Summary

Sprint 13 carryover from S12. COOR-012 (5pt) is the cross-agency primitive; CWT-022 (8pt) is the caseworker UI on top of this.

- New `case_handoffs` table + state machine in `src/lib/coor/handoff.ts` gated by (1) active `partner_agreements` on both sides + (2) `person_partner_consents` on the receiver. Audits every state transition.
- New `loadHandoffContext` reader in `src/lib/coor/handoff-context.ts` — single chokepoint for transferred records, enforces accept-state + receiver-org membership + consent-pre-dates-accept, audits every read AND every denial.
- Daily Inngest expiry sweep ages out pre-acceptance handoffs past `expires_at`.
- Server-action wrappers in `src/app/actions/handoff.ts` for the upcoming CWT-022 UI.

## Acceptance criteria

- [x] Schema: `case_handoffs` table + status / scope_kind enums (migration 0043).
- [x] Governance gate: both orgs active, both with at least one active agreement on file, distinct orgs.
- [x] Subject gate: `person_partner_consents` row required on the receiver before handoff exits `pending_consent`.
- [x] State machine: `pending_consent → pending_acceptance → accepted | declined | revoked | expired`. Pure transition table; tests cover all legal + illegal transitions.
- [x] Context reader enforces accept-state + receiver-membership + unrevoked consent + consent-pre-dates-accept (so revoke + regrant doesn't silently re-authorise a prior accept).
- [x] Audit row on every state transition + every context read (success and deny paths).
- [x] Daily Inngest sweep ages out pre-acceptance handoffs past `expires_at`. Idempotent per-row.
- [x] Synthetic seed for ~5 handoffs spanning every status.
- [x] Unit tests for pure helpers + governance gate (32 new cases).
- [x] Per-domain `src/lib/coor/CLAUDE.md` documents the two-gate convention.
- [x] `pnpm exec biome check` ✓
- [x] `pnpm exec tsc --noEmit` ✓
- [x] `pnpm exec vitest run` — 771/771 green.
- [x] `pnpm exec next build` ✓

## Out of scope (for CWT-022)

- Caseworker inbox surface (receiver-side list of incoming handoffs)
- Case-page initiate button + scope picker
- Accept / decline buttons
- SMS / email notifications

## Test plan

- [ ] Apply migration 0043 to staging — verify `case_handoffs` table + 2 enums created.
- [ ] Run `pnpm tsx scripts/gen-synthetic-handoffs.ts` against staging — should seed 5 handoffs across all statuses. NOTE: blocked locally by a pre-existing dev-DB inconsistency where `partner_agreements` is missing despite migration 0035 being recorded as applied. Worth investigating before merge if staging shares the same state.
- [ ] Sanity-check audit log: trigger one handoff via the server action and confirm `case_handoff.initiated` appears in `audit_log`.
- [ ] Verify Inngest dashboard shows `handoff-expiry-sweep` registered with cron `45 6 * * *`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)