### PR TITLE
feat(DTRS-015): VA HUD-VASH data-sharing agreement workflow + ADR 0010

### DIFF
--- a/docs/adr/0010-va-hudvash-data-sharing-privacy-contract.md
+++ b/docs/adr/0010-va-hudvash-data-sharing-privacy-contract.md
@@ -1,0 +1,113 @@
+# ADR 0010 — VA HUD-VASH data-sharing privacy contract (clinical context, voucher window, no service-denial prediction)
+
+**Status:** Accepted — 2026-05-04
+**Driver:** Sprint 13. DTRS-015 ([#379](https://github.com/DobbsBoldry/homeless/issues/379)) introduces the inbound flow for the U.S. Department of Veterans Affairs HUD-VASH program (HUD-Veterans Affairs Supportive Housing) to support SUBP-006 (Veteran pathway, [#135](https://github.com/DobbsBoldry/homeless/issues/135)). The veteran use case is the fourth state-or-federally-authorized data-sharing relationship after DCBS (ADR 0006), OASIS (ADR 0007), and KY DOC (ADR 0009). It needs its own privacy contract because the cohort, the threat model, and the statutory regime differ from all three.
+
+## Context
+
+Sprint 12 closed the reentry entry under ADR 0009 (KY DOC, state-as-custodian during incarceration, narrow pre-release window, no recidivism prediction). Sprint 13 starts the veteran entry, which is structurally distinct from KY DOC in three important ways:
+
+| | KY DOC (ADR 0009) | VA HUD-VASH (this ADR) |
+|---|---|---|
+| Cohort | Incarcerated people approaching release | Veterans engaged with HUD-VASH (eligible / vouchered / leasing / leased) |
+| Custodial authority | The state, as custodian during incarceration (KRS Chapter 197) | The veteran themselves (voluntary HUD-VASH enrollment + ROI under 38 CFR § 1.526 / § 17.41) plus the VA as covered entity for clinical data |
+| Threat model | (a) stigma-driven housing/employment denial; (b) misuse for recidivism prediction; (c) re-identification by parole / law-enforcement secondary use | (a) MH/SUD diagnosis stigma → employer / landlord / insurer denial; (b) misuse for **service-denial prediction** (e.g., "this veteran will fail the voucher, deprioritize"); (c) re-identification by VA OIG / external benefits fraud reviewers |
+| Default rule | Authorized to share narrow pre-release fields under DOC DSA | Authorized to share voucher-status + service-coordination fields under joint VA / local PHA DSA; **no service-denial inference, no insurer-bound disclosure** |
+| Cohort scale | Tens to low hundreds of pre-release individuals | Tens of veterans actively in HUD-VASH (Daviess County: ~25-50 active vouchers across the local PHA's allocation) |
+| Statutory regime | KRS Chapter 197, KRS Chapter 439, federal Second Chance Act (42 U.S.C. § 17501 et seq.) | **38 U.S.C. § 7332** (confidentiality of MH/SUD records — stricter than HIPAA), **38 CFR Part 1** (VA records confidentiality), **42 U.S.C. § 290dd-2** (federal SUD records — Part 2), **42 U.S.C. § 11403** (HUD-VASH authorization), HIPAA (45 CFR Part 164) |
+| Re-disclosure | Forbidden without KY DOC authorization; **explicit prohibition on disclosure to law enforcement, parole, or probation absent court order** | Forbidden without VA authorization; **explicit prohibition on disclosure to insurers, employer background-check vendors, or any party for service-denial determinations**; 38 U.S.C. § 7332 + 42 U.S.C. § 290dd-2 layer additional re-disclosure restrictions on MH/SUD content |
+| Window of receipt | **Bounded** — pre-release window (default 60 days) before projected release, plus a short tail post-release | **Bounded by voucher lifecycle** — from voucher issuance through the active housing-search and lease-stabilization period (default 120 days, matching HUD's standard voucher term plus typical extension) |
+| Audit obligation | Coalition-side audit log + KY DOC audit cooperation; breach → KY DOC notification within 72 hours | **Coalition-side audit log on every read**, joint VA + PHA audit cooperation, breach → mandatory VA Privacy Officer notification within 72 hours and HUD field-office notification within 5 business days |
+
+**Why a voucher window matters.** HUD-VASH operates on a clock: HUD's standard housing-choice voucher gives the veteran 60 days to find housing, with a 60-day extension at PHA discretion. After lease-up, the coalition's coordination role is to support stabilization (typically 90 days post-lease) before transitioning to standard VA case management. Records older than the active coordination window add nothing operationally — VA case managers continue their work directly with the veteran — and add risk (stale clinical data, drift between voucher status and lease status, increased blast radius). The contract therefore makes the window a structural property of the data flow: VA shares only records inside the window, the Coalition deletes records that age out, and the runtime gate enforces both directions. Default of 120 days covers issuance + standard search + extension; admin may extend with explicit justification, but the validator rejects values < 60 (operationally too short — HUD's minimum voucher term is 60 days) or > 240 (operationally unjustified — at 8 months the veteran is either housed and stable or has lost the voucher).
+
+**Why "no service-denial prediction" is in the contract.** HUD-VASH support is fundamentally different from triage. The Coalition's purpose is to help every veteran with a voucher succeed at lease-up by lining up landlords, application support, and ancillary benefits. It is *not* to predict which veterans will fail the voucher and deprioritize their cases. The contract makes this explicit because the same data (voucher status, MH/SUD continuity, service-connection rating, prior-housing history) could in principle be repurposed for actuarial scoring of "voucher-failure risk" — and there is a documented pattern of well-intentioned housing tools drifting in that direction once the data is in hand, with the result of deprioritizing exactly the veterans who need the most support. Encoding the prohibition in the agreement, not just the policy, makes drift a contractual breach rather than a code-review failure.
+
+**Why MH/SUD content is treated specially.** 38 U.S.C. § 7332 and 42 U.S.C. § 290dd-2 (Part 2) impose stricter re-disclosure rules on mental-health and substance-use records than ordinary HIPAA. The contract treats `treatment_continuity` as the *fact* of an active treatment relationship (shareable) but not the diagnosis, treatment plan, or session content (out of scope). SUBP-006's surfaces never receive 7332/Part 2 protected content; the VA case manager retains it. The DSA codifies this scope boundary so that an inadvertent expansion is a contract breach.
+
+The platform already has the registry infrastructure ([ADR 0004 modular monolith / partner_agreements](./0004-modular-monolith.md)), the per-partner-org agreement-recording pattern ([DTRS-010 FERPA #359](https://github.com/DobbsBoldry/homeless/pull/359), [DTRS-011 DCBS #364](https://github.com/DobbsBoldry/homeless/pull/364), [DTRS-012 OASIS #370](https://github.com/DobbsBoldry/homeless/pull/370), [DTRS-013 KY DOC #376](https://github.com/DobbsBoldry/homeless/pull/376)), and the generic expiration watcher ([OPRT-002 #368](https://github.com/DobbsBoldry/homeless/pull/368)). The question this ADR answers is: where does the veteran-specific privacy contract live, and what is the source of truth for SUBP-006's runtime gates?
+
+## Decision
+
+**Use the existing `partner_agreements` registry (ADR 0004) with `kind='dsa'` and `agency='va_hudvash'`. Encode the veteran-specific contract — voucher-search window length, individual-records authorization, no-service-denial-prediction acknowledgement, MH/SUD scope boundary, and population focus — as structured fields on the JSONB `terms`. Treat the agreement's stored terms as the contract-of-record for SUBP-006's veteran gates.** Persist any veteran roster record under the gate of an active VA HUD-VASH DSA whose `individual_records_authorized` flag is `true` and whose `voucher_search_window_days` covers the record's voucher horizon.
+
+### Privacy contract — six rules
+
+1. **No veteran record may be persisted without an active VA HUD-VASH DSA.** SUBP-006's ingest path reads `getActiveVaHudVashDsa(vaPartnerOrgId)` before every write batch and fails closed if no active agreement exists. Same gate applies on every read for reporting. Per ADR 0004 § 3.1.
+
+2. **`individual_records_authorized` is the runtime authorization gate.** Mirrors DCBS / KY DOC. SUBP-006 reads this flag before enabling per-individual views; if `false`, the agreement is informational only and no individual records may be persisted. The intake form requires a default `true` only if the admin can attest to the joint VA + local PHA executed authorization.
+
+3. **The `voucher_search_window_days` field is binding.** SUBP-006 ingests only records whose voucher-issuance date plus the window covers `today`, and the daily Inngest job deletes records that age out without resulting in a successful lease-up handoff. Default is 120 days; admins may extend with explicit justification, but the validator rejects values < 60 (HUD's operational minimum) or > 240 (operationally unjustified — stale at 8 months).
+
+4. **`no_service_denial_prediction_attestation` is non-optional.** The validator (`validateVaHudVashDsaTerms`) refuses to accept a terms object without `no_service_denial_prediction_attestation === true`. The intake form's submit button is disabled until the attestation checkbox is checked. There is no draft path that bypasses attestation. If a future use case requires triage-style scoring (e.g., a HUD-funded research evaluation), it gets a different agreement and a different ADR — do not weaken this validator.
+
+5. **Audit every read.** Per § 4.3 of the template: every individual-record read of a veteran record goes through `logAuditEvent` via the SUBP-006 access path. The audit table is the source of truth for the cooperation obligation in § 6.3 of the template.
+
+6. **No re-disclosure to insurers, employment-screening vendors, or for service-denial determinations.** Coalition surfaces shall not provide veteran records, derived analytics, or even confirmation-of-existence to insurance carriers, employer background-check vendors, or any party requesting data for the purpose of denying or limiting services to the veteran. Cross-domain joins that would correlate veteran records with non-coalition surveillance, claims, or background-check data are blocked at the `dtrs/data-access.ts` policy gate. This is rule 6 because it is the most likely drift vector — well-intentioned data requests from sister programs that would amount to re-purposing the data for service-eligibility scoring.
+
+### MH/SUD scope boundary
+
+Beyond the six rules, the DSA explicitly bounds the MH/SUD content the Coalition may receive:
+
+- **Permitted:** the *fact* of an active treatment relationship (boolean flag), continuity status (`in_place` / `at_risk` / `lapsed`), and the VA case manager's contact info for warm handoff.
+- **Forbidden:** diagnosis codes, treatment plan content, session notes, medication lists, lab results, or any other 38 U.S.C. § 7332 or 42 U.S.C. § 290dd-2 protected content.
+
+This boundary is encoded in the `treatment_scope` enum on `VaHudVashDsaTerms` (`status_only` is the only permitted value at v1; future amendments would require a new ADR, IRB-equivalent VA Privacy Office review, and a separate Qualified Service Organization Agreement under 42 CFR Part 2).
+
+### What does NOT change
+
+- ADR 0006 (DCBS state-as-guardian) is unchanged. Foster youth continue to flow under the state's custodial authority, with `agency='dcbs'`. SUBP-006's gates do not consume DCBS DSAs.
+- ADR 0007 (OASIS abuser-blind) is unchanged.
+- ADR 0009 (KY DOC reentry) is unchanged. Reentry pre-release records and veteran records are distinct cohorts; veterans returning from incarceration who are eligible for HUD-VASH would be covered by both DSAs simultaneously, with the more restrictive privacy treatment applying to any field present in both.
+- The shared `partner_agreements` registry is unchanged structurally — VA HUD-VASH adds a fourth `agency` discriminator under the existing `kind='dsa'`, the same pattern DTRS-011 / DTRS-012 / DTRS-013 introduced.
+- The generic OPRT-002 expiration watcher is unchanged — it watches all agreements regardless of kind/agency. VA HUD-VASH DSAs benefit automatically.
+
+### Why this design and not alternatives
+
+**Alternative A — separate `va_hudvash_records` table and a parallel VA-specific agreement-tracking table.** Rejected: re-litigates ADR 0004's "one agreement registry" decision and separates the policy (voucher window, attestations, MH/SUD scope) from the agreement that authorizes it. SUBP-006's veteran record table is a separate concern and does not require its own agreement registry.
+
+**Alternative B — encode the voucher window in `src/lib/dtrs/data-access.ts` as code, with the DSA being purely informational.** Rejected: the window is a *contractual* commitment. The VA Privacy Office and the local PHA need to be able to point at a specific number in a signed instrument. Encoding it in `terms.voucher_search_window_days` makes the agreement and the enforcement point the same artifact.
+
+**Alternative C — make `no_service_denial_prediction_attestation` an optional advisory field.** Rejected: the prohibition against using veteran data for service-denial scoring is the contract's most consequential commitment. Making it optional creates a path where it gets dropped by accident. Strict validation here is a feature, not a limitation.
+
+**Alternative D — allow MH/SUD diagnosis content under a Qualified Service Organization Agreement (QSOA).** Considered. Adding QSOA-protected content would unlock richer triage but would also require a separate agreement type (QSOA per 42 CFR Part 2 § 2.11), additional Coalition-side personnel-training requirements, and a redaction-policy machinery similar to ADR 0007. Out of scope for Sprint 13 — when the VA / local QSOA is needed, that gets its own ADR and agreement kind (`kind='qsoa'`, currently a placeholder in the registry).
+
+**Alternative E — reuse the OASIS abuser-blind redaction-policy machinery for MH/SUD content.** Considered. The threat model is different enough that the redaction shape doesn't translate cleanly: in OASIS the adversary is a known third party (the abuser); in HUD-VASH the adversaries are diffuse (insurers, employers, eligibility-screening systems). Redaction by field-suppression is the right answer for OASIS; bounded *scope* (status_only) is the right answer for VA HUD-VASH. Reusing OASIS would force concepts that don't fit.
+
+## Consequences
+
+**What we get:**
+
+- DTRS-015 ships a working VA HUD-VASH DSA workflow in 5 points: registry-extension, voucher-window-bounded ingest contract, attestation enforcement at the validator, MH/SUD scope boundary at the type level. Same shape as DTRS-011 / DTRS-012 / DTRS-013 — minimal new surface area.
+- SUBP-006's veteran ingest middleware reads `terms.voucher_search_window_days` and `terms.individual_records_authorized` as its single source of truth. Changing either is a contract amendment with a new agreement row; the rendered template (`template_rendered`) preserves the legal artifact (ADR 0004 immutability).
+- The OPRT-002 expiration watcher serves VA HUD-VASH for free.
+- Cross-cutting: `getActiveVaHudVashDsa(partnerOrgId)` is exposed via the dtrs barrel for any future SUBP-* veteran-adjacent stories (Veterans Treatment Court coordination, HCHV grant tracking, SSVF outreach — all out of scope for SUBP-006) to reuse the gate.
+- Audit-on-read is the default, not an opt-in. SUBP-006's middleware is the only path to veteran records, and the middleware always logs.
+
+**What we don't get:**
+
+- MH/SUD diagnosis content. Out of scope at v1; requires a separate QSOA + ADR.
+- Per-individual consent variation. The DSA covers all veterans the local PHA + VA identifies as actively engaged with HUD-VASH within the window. Individual opt-outs are managed at VA / PHA intake, not in the Coalition's database. Coalition-side opt-outs are out of scope for Sprint 13.
+- Real-time enforcement of the window across all already-ingested records. The Inngest delete job runs daily; between its runs there is a brief window where a record may be just past the configured window. This is acceptable for the Sprint 13 scope.
+- Automatic enforcement of "no insurer / employer disclosure." Rule 6 is implemented as code review + boundary lint + the policy gate at `dtrs/data-access.ts`, not as a runtime detection check. A future sprint may add a Sentry / log alert.
+
+**What we should watch for:**
+
+1. **Drift between `terms.voucher_search_window_days` and SUBP-006's ingest behavior.** This is the contract's most fragile point. Mitigations: (a) the middleware reads the value per-request, never caches; (b) add a contract test that exercises the window boundary at 0 / window-1 / window / window+1 days; (c) any code change to the middleware that touches the window logic requires reviewing the policy in this ADR.
+2. **Templates becoming living documents.** Same concern as ADR 0004 / 0007 / 0009: `template_rendered` is set once at signing and treated as immutable.
+3. **Multiple active VA HUD-VASH DSAs for the same partner.** Pathological — only one should be active at a time. Don't enforce uniqueness at the DB; let the form's "active-agreement warning" banner surface the conflict.
+4. **Notification of breach to VA + HUD.** § 4.4 of the template requires VA Privacy Office notification within 72 hours and HUD field-office notification within 5 business days. There's no automated piping for this today (Sentry-only); a follow-up story should add a notification path.
+5. **Pressure to expand MH/SUD scope.** Once the veteran pathway is working, sister programs will ask "can you also share treatment plans?" The MH/SUD scope boundary is the answer. Maintain it; expansion requires a new ADR + QSOA.
+6. **Joint authorization complexity.** Unlike DCBS (single state agency), VA HUD-VASH involves both the VA Medical Center / VAMC HUD-VASH team and the local Public Housing Authority that holds the voucher allocation. The agreement template requires both signatories. A change in either party's leadership or program structure may require a new agreement.
+
+## Implementation checklist (DTRS-015 picks this up)
+
+- [ ] Lib: extend `src/lib/dtrs/partner-agreements.ts` with `VaHudVashDsaTerms`, `VA_HUDVASH_DSA_SCOPE_OPTIONS`, `VA_HUDVASH_VOUCHER_WINDOW_DEFAULT_DAYS`, `VA_HUDVASH_VOUCHER_WINDOW_MIN_DAYS`, `VA_HUDVASH_VOUCHER_WINDOW_MAX_DAYS`, `validateVaHudVashDsaTerms`. Update `validateAgreementTerms` dispatcher to handle `agency==='va_hudvash'`.
+- [ ] Parser: add `parseVaHudVashDsaAgreementForm` in `src/app/actions/partner-agreements-parse.ts`.
+- [ ] Action: add `recordVaHudVashDsaAgreementAction` in `src/app/actions/partner-agreements.ts`.
+- [ ] Query: add `getActiveVaHudVashDsa(partnerOrgId)` in `src/db/queries/partner-agreements.ts` using JSONB `terms->>'agency' = 'va_hudvash'` filter.
+- [ ] Form component: `src/components/dtrs/vahudvash-dsa-agreement-form.tsx` with voucher-window selector + no-service-denial-prediction attestation checkbox.
+- [ ] Admin page: `src/app/app/admin/agreements/vahudvash/page.tsx`.
+- [ ] Public template: `src/app/agreements/vahudvash/template/page.tsx` (template version `vahudvash-dsa-v1`).
+- [ ] Tests: validator tests in `src/lib/dtrs/partner-agreements.test.ts`; parser tests in `src/app/actions/partner-agreements.test.ts`.
+- [ ] SUBP-006 picks this up in a follow-up PR — its veteran ingest middleware reads `getActiveVaHudVashDsa()` and `terms.voucher_search_window_days`.

--- a/src/app/actions/partner-agreements-parse.ts
+++ b/src/app/actions/partner-agreements-parse.ts
@@ -20,12 +20,17 @@ import {
   OASIS_REDACTABLE_FIELDS,
   type OasisRedactionPolicy,
   type OasisRedactionTreatment,
+  VA_HUDVASH_DSA_SCOPE_OPTIONS,
+  VA_HUDVASH_VOUCHER_WINDOW_DEFAULT_DAYS,
+  VA_HUDVASH_VOUCHER_WINDOW_MAX_DAYS,
+  VA_HUDVASH_VOUCHER_WINDOW_MIN_DAYS,
 } from '@/lib/dtrs';
 
 const FERPA_SCOPE_VALUES = FERPA_SCOPE_OPTIONS.map((o) => o.value);
 const DCBS_DSA_SCOPE_VALUES = DCBS_DSA_SCOPE_OPTIONS.map((o) => o.value);
 const OASIS_DSA_SCOPE_VALUES = OASIS_DSA_SCOPE_OPTIONS.map((o) => o.value);
 const KY_DOC_DSA_SCOPE_VALUES = KY_DOC_DSA_SCOPE_OPTIONS.map((o) => o.value);
+const VA_HUDVASH_DSA_SCOPE_VALUES = VA_HUDVASH_DSA_SCOPE_OPTIONS.map((o) => o.value);
 const OASIS_REDACTION_TREATMENTS: readonly OasisRedactionTreatment[] = [
   'share',
   'suppress',
@@ -666,6 +671,215 @@ export function parseKyDocDsaAgreementForm(
       },
     },
   };
+}
+
+// ---------------------------------------------------------------------------
+// DTRS-015 — VA HUD-VASH DSA parser
+// ---------------------------------------------------------------------------
+
+export type ParsedVaHudVashDsaAgreementInput = {
+  partnerOrgId: string;
+  effectiveDate: string;
+  endDate: string | null;
+  signedByPartner: string | null;
+  notes: string | null;
+  terms: {
+    kind: 'dsa';
+    agency: 'va_hudvash';
+    scope: string[];
+    vamc_legal_name: string;
+    vamc_contact: { name: string; title: string; email: string; phone?: string };
+    pha_legal_name: string;
+    pha_contact: { name: string; title: string; email: string; phone?: string };
+    population_focus: 'hud_vash';
+    voucher_search_window_days: number;
+    individual_records_authorized: boolean;
+    no_service_denial_prediction_attestation: true;
+    treatment_scope: 'status_only';
+    data_destruction_due: 'on_termination' | 'after_3_years' | 'after_5_years';
+  };
+};
+
+/**
+ * Parse + validate a FormData from the VA HUD-VASH DSA agreement intake form.
+ *
+ * Per ADR 0010, the no-service-denial-prediction attestation is required (the
+ * form's submit button is disabled until checked, and this parser fails closed
+ * if the box was bypassed). The voucher-search window must fall within
+ * [VA_HUDVASH_VOUCHER_WINDOW_MIN_DAYS, VA_HUDVASH_VOUCHER_WINDOW_MAX_DAYS];
+ * empty input falls back to VA_HUDVASH_VOUCHER_WINDOW_DEFAULT_DAYS. The
+ * `treatment_scope` is locked to `'status_only'` at v1.
+ *
+ * FormData shape:
+ *   partnerOrgId                                      — uuid of the VA HUD-VASH partner_org
+ *   effectiveDate                                     — YYYY-MM-DD (required)
+ *   endDate                                           — YYYY-MM-DD (optional)
+ *   signedByPartner                                   — text (optional)
+ *   notes                                             — text (optional)
+ *   vamc_legal_name                                   — text (required)
+ *   vamc_contact_name / _title / _email / _phone      — VA HUD-VASH coordinator contact
+ *   pha_legal_name                                    — text (required)
+ *   pha_contact_name / _title / _email / _phone       — local PHA contact
+ *   scope_{value}                                     — checkbox "on" when checked
+ *   voucher_search_window_days                        — integer in [MIN, MAX]; defaults to DEFAULT
+ *   individual_records_authorized                     — "true" | "false"
+ *   no_service_denial_prediction_attestation          — "true" required (any other value rejected)
+ *   data_destruction_due                              — 'on_termination' | 'after_3_years' | 'after_5_years'
+ */
+export function parseVaHudVashDsaAgreementForm(
+  formData: FormData,
+): { ok: true; input: ParsedVaHudVashDsaAgreementInput } | { ok: false; error: string } {
+  const str = (key: string) => (formData.get(key) ?? '').toString().trim();
+
+  const partnerOrgId = str('partnerOrgId');
+  if (!partnerOrgId) return { ok: false, error: 'VA HUD-VASH partner is required.' };
+
+  const effectiveDateRaw = str('effectiveDate');
+  if (!effectiveDateRaw) return { ok: false, error: 'Effective date is required.' };
+  if (Number.isNaN(Date.parse(effectiveDateRaw))) {
+    return { ok: false, error: 'Effective date is not a valid date.' };
+  }
+
+  const endDateRaw = str('endDate');
+  let endDate: string | null = null;
+  if (endDateRaw) {
+    if (Number.isNaN(Date.parse(endDateRaw))) {
+      return { ok: false, error: 'End date is not a valid date.' };
+    }
+    if (endDateRaw < effectiveDateRaw) {
+      return { ok: false, error: 'End date must be on or after effective date.' };
+    }
+    endDate = endDateRaw;
+  }
+
+  const signedByPartner = str('signedByPartner') || null;
+
+  const notes = str('notes') || null;
+  if (notes && notes.length > 2000) {
+    return { ok: false, error: 'Notes must be 2 000 characters or fewer.' };
+  }
+
+  const vamc_legal_name = str('vamc_legal_name');
+  if (!vamc_legal_name) {
+    return { ok: false, error: 'VAMC legal name is required.' };
+  }
+
+  const vamcContact = readContactFields(formData, 'vamc_contact', 'VA HUD-VASH');
+  if (!vamcContact.ok) return vamcContact;
+
+  const pha_legal_name = str('pha_legal_name');
+  if (!pha_legal_name) {
+    return { ok: false, error: 'PHA legal name is required.' };
+  }
+
+  const phaContact = readContactFields(formData, 'pha_contact', 'PHA');
+  if (!phaContact.ok) return phaContact;
+
+  const scope: string[] = [];
+  for (const opt of VA_HUDVASH_DSA_SCOPE_VALUES) {
+    const val = formData.get(`scope_${opt}`);
+    if (val === 'on' || val === 'true' || val === opt) {
+      scope.push(opt);
+    }
+  }
+  if (scope.length === 0) {
+    return { ok: false, error: 'At least one data scope must be selected.' };
+  }
+
+  const windowRaw = str('voucher_search_window_days');
+  let voucher_search_window_days = VA_HUDVASH_VOUCHER_WINDOW_DEFAULT_DAYS;
+  if (windowRaw) {
+    const n = Number(windowRaw);
+    if (!Number.isInteger(n)) {
+      return { ok: false, error: 'Voucher-search window must be a whole number of days.' };
+    }
+    if (n < VA_HUDVASH_VOUCHER_WINDOW_MIN_DAYS || n > VA_HUDVASH_VOUCHER_WINDOW_MAX_DAYS) {
+      return {
+        ok: false,
+        error:
+          `Voucher-search window must be between ${VA_HUDVASH_VOUCHER_WINDOW_MIN_DAYS} ` +
+          `and ${VA_HUDVASH_VOUCHER_WINDOW_MAX_DAYS} days (ADR 0010 § Decision.3).`,
+      };
+    }
+    voucher_search_window_days = n;
+  }
+
+  const indivAuthRaw = str('individual_records_authorized');
+  if (indivAuthRaw !== 'true' && indivAuthRaw !== 'false') {
+    return { ok: false, error: 'Individual-records authorization selection is required.' };
+  }
+  const individual_records_authorized = indivAuthRaw === 'true';
+
+  const attestationRaw = str('no_service_denial_prediction_attestation');
+  if (attestationRaw !== 'true') {
+    return {
+      ok: false,
+      error:
+        'The no-service-denial-prediction attestation must be checked. Recording a VA HUD-VASH DSA without it is not permitted (ADR 0010).',
+    };
+  }
+
+  const VALID_DESTRUCTION = ['on_termination', 'after_3_years', 'after_5_years'] as const;
+  type DestructionValue = (typeof VALID_DESTRUCTION)[number];
+  const destructionRaw = str('data_destruction_due');
+  if (!VALID_DESTRUCTION.includes(destructionRaw as DestructionValue)) {
+    return { ok: false, error: 'Data destruction policy selection is required.' };
+  }
+  const data_destruction_due = destructionRaw as DestructionValue;
+
+  return {
+    ok: true,
+    input: {
+      partnerOrgId,
+      effectiveDate: effectiveDateRaw,
+      endDate,
+      signedByPartner,
+      notes,
+      terms: {
+        kind: 'dsa',
+        agency: 'va_hudvash',
+        scope,
+        vamc_legal_name,
+        vamc_contact: vamcContact.contact,
+        pha_legal_name,
+        pha_contact: phaContact.contact,
+        population_focus: 'hud_vash',
+        voucher_search_window_days,
+        individual_records_authorized,
+        no_service_denial_prediction_attestation: true,
+        treatment_scope: 'status_only',
+        data_destruction_due,
+      },
+    },
+  };
+}
+
+interface ParsedContact {
+  name: string;
+  title: string;
+  email: string;
+  phone?: string;
+}
+
+function readContactFields(
+  formData: FormData,
+  prefix: string,
+  label: string,
+): { ok: true; contact: ParsedContact } | { ok: false; error: string } {
+  const str = (key: string) => (formData.get(key) ?? '').toString().trim();
+  const name = str(`${prefix}_name`);
+  if (!name) return { ok: false, error: `${label} contact name is required.` };
+  const title = str(`${prefix}_title`);
+  if (!title) return { ok: false, error: `${label} contact title is required.` };
+  const email = str(`${prefix}_email`);
+  if (!email) return { ok: false, error: `${label} contact email is required.` };
+  if (!email.includes('@')) {
+    return { ok: false, error: `${label} contact email must be a valid email address.` };
+  }
+  const phoneRaw = str(`${prefix}_phone`);
+  const contact: ParsedContact = { name, title, email };
+  if (phoneRaw) contact.phone = phoneRaw;
+  return { ok: true, contact };
 }
 
 // ---------------------------------------------------------------------------

--- a/src/app/actions/partner-agreements.test.ts
+++ b/src/app/actions/partner-agreements.test.ts
@@ -12,6 +12,7 @@ import {
   parseMouAgreementForm,
   parseOasisDsaAgreementForm,
   parsePartnerAgreementForm,
+  parseVaHudVashDsaAgreementForm,
 } from './partner-agreements-parse';
 
 function makeFormData(overrides: Record<string, string> = {}): FormData {
@@ -802,6 +803,240 @@ describe('parseKyDocDsaAgreementForm', () => {
 
   it('rejects notes longer than 2000 chars', () => {
     const r = parseKyDocDsaAgreementForm(makeKyDocFormData({ notes: 'x'.repeat(2001) }));
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toMatch(/2 000 characters/i);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseVaHudVashDsaAgreementForm (DTRS-015)
+// ---------------------------------------------------------------------------
+
+function makeVaHudVashFormData(overrides: Record<string, string> = {}): FormData {
+  const fd = new FormData();
+  fd.set('partnerOrgId', 'vahudvash-uuid-001');
+  fd.set('effectiveDate', '2026-12-01');
+  fd.set('vamc_legal_name', 'Robley Rex VA Medical Center HUD-VASH Program');
+  fd.set('vamc_contact_name', 'VASH Coordinator');
+  fd.set('vamc_contact_title', 'HUD-VASH Program Coordinator');
+  fd.set('vamc_contact_email', 'vash.coordinator@va.gov');
+  fd.set('pha_legal_name', 'Housing Authority of Owensboro');
+  fd.set('pha_contact_name', 'Voucher Administrator');
+  fd.set('pha_contact_title', 'HCV Program Manager');
+  fd.set('pha_contact_email', 'hcv@owensborohousing.org');
+  fd.set('scope_voucher_status_roster', 'on');
+  fd.set('individual_records_authorized', 'true');
+  fd.set('no_service_denial_prediction_attestation', 'true');
+  fd.set('data_destruction_due', 'on_termination');
+  // voucher_search_window_days omitted = parser falls back to default (120).
+  for (const [k, v] of Object.entries(overrides)) {
+    if (v === '__DELETE__') {
+      fd.delete(k);
+    } else {
+      fd.set(k, v);
+    }
+  }
+  return fd;
+}
+
+describe('parseVaHudVashDsaAgreementForm', () => {
+  it('returns ok:true for a valid form (defaults to 120-day voucher-search window)', () => {
+    const r = parseVaHudVashDsaAgreementForm(makeVaHudVashFormData());
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.input.partnerOrgId).toBe('vahudvash-uuid-001');
+    expect(r.input.terms.kind).toBe('dsa');
+    expect(r.input.terms.agency).toBe('va_hudvash');
+    expect(r.input.terms.scope).toContain('voucher_status_roster');
+    expect(r.input.terms.population_focus).toBe('hud_vash');
+    expect(r.input.terms.voucher_search_window_days).toBe(120);
+    expect(r.input.terms.individual_records_authorized).toBe(true);
+    expect(r.input.terms.no_service_denial_prediction_attestation).toBe(true);
+    expect(r.input.terms.treatment_scope).toBe('status_only');
+  });
+
+  it('rejects missing partnerOrgId', () => {
+    const r = parseVaHudVashDsaAgreementForm(makeVaHudVashFormData({ partnerOrgId: '' }));
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toMatch(/va hud-vash partner/i);
+  });
+
+  it('rejects missing vamc_legal_name', () => {
+    const r = parseVaHudVashDsaAgreementForm(makeVaHudVashFormData({ vamc_legal_name: '' }));
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toMatch(/vamc legal name/i);
+  });
+
+  it('rejects missing vamc_contact_name', () => {
+    const r = parseVaHudVashDsaAgreementForm(makeVaHudVashFormData({ vamc_contact_name: '' }));
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toMatch(/contact name/i);
+  });
+
+  it('rejects vamc_contact_email without @', () => {
+    const r = parseVaHudVashDsaAgreementForm(
+      makeVaHudVashFormData({ vamc_contact_email: 'not-an-email' }),
+    );
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toMatch(/valid email/i);
+  });
+
+  it('rejects missing pha_legal_name', () => {
+    const r = parseVaHudVashDsaAgreementForm(makeVaHudVashFormData({ pha_legal_name: '' }));
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toMatch(/pha legal name/i);
+  });
+
+  it('rejects missing pha_contact_title', () => {
+    const r = parseVaHudVashDsaAgreementForm(makeVaHudVashFormData({ pha_contact_title: '' }));
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toMatch(/contact title/i);
+  });
+
+  it('rejects no scope checkboxes selected', () => {
+    const r = parseVaHudVashDsaAgreementForm(
+      makeVaHudVashFormData({ scope_voucher_status_roster: '' }),
+    );
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toMatch(/at least one data scope/i);
+  });
+
+  it('collects multiple scope checkboxes', () => {
+    const r = parseVaHudVashDsaAgreementForm(
+      makeVaHudVashFormData({
+        scope_eligibility_changes: 'on',
+        scope_supports_in_place: 'on',
+        scope_coordination_eligibility: 'on',
+      }),
+    );
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.input.terms.scope.sort()).toEqual([
+      'coordination_eligibility',
+      'eligibility_changes',
+      'supports_in_place',
+      'voucher_status_roster',
+    ]);
+  });
+
+  it('accepts voucher_search_window_days at the lower bound (60)', () => {
+    const r = parseVaHudVashDsaAgreementForm(
+      makeVaHudVashFormData({ voucher_search_window_days: '60' }),
+    );
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.input.terms.voucher_search_window_days).toBe(60);
+  });
+
+  it('accepts voucher_search_window_days at the upper bound (240)', () => {
+    const r = parseVaHudVashDsaAgreementForm(
+      makeVaHudVashFormData({ voucher_search_window_days: '240' }),
+    );
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.input.terms.voucher_search_window_days).toBe(240);
+  });
+
+  it('rejects voucher_search_window_days below the minimum', () => {
+    const r = parseVaHudVashDsaAgreementForm(
+      makeVaHudVashFormData({ voucher_search_window_days: '30' }),
+    );
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toMatch(/voucher-search window must be between/i);
+  });
+
+  it('rejects voucher_search_window_days above the maximum', () => {
+    const r = parseVaHudVashDsaAgreementForm(
+      makeVaHudVashFormData({ voucher_search_window_days: '365' }),
+    );
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toMatch(/voucher-search window must be between/i);
+  });
+
+  it('rejects non-integer voucher_search_window_days', () => {
+    const r = parseVaHudVashDsaAgreementForm(
+      makeVaHudVashFormData({ voucher_search_window_days: '120.5' }),
+    );
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toMatch(/whole number of days/i);
+  });
+
+  it('rejects missing individual_records_authorized', () => {
+    const r = parseVaHudVashDsaAgreementForm(
+      makeVaHudVashFormData({ individual_records_authorized: '' }),
+    );
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toMatch(/individual-records authorization/i);
+  });
+
+  it('parses individual_records_authorized=false correctly', () => {
+    const r = parseVaHudVashDsaAgreementForm(
+      makeVaHudVashFormData({ individual_records_authorized: 'false' }),
+    );
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.input.terms.individual_records_authorized).toBe(false);
+  });
+
+  it('rejects no_service_denial_prediction_attestation missing', () => {
+    const r = parseVaHudVashDsaAgreementForm(
+      makeVaHudVashFormData({ no_service_denial_prediction_attestation: '' }),
+    );
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toMatch(/no-service-denial-prediction attestation/i);
+  });
+
+  it('rejects no_service_denial_prediction_attestation set to anything other than "true"', () => {
+    const r = parseVaHudVashDsaAgreementForm(
+      makeVaHudVashFormData({ no_service_denial_prediction_attestation: 'false' }),
+    );
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toMatch(/no-service-denial-prediction attestation/i);
+  });
+
+  it('rejects unknown data_destruction_due value', () => {
+    const r = parseVaHudVashDsaAgreementForm(
+      makeVaHudVashFormData({ data_destruction_due: 'never_required' }),
+    );
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toMatch(/data destruction policy/i);
+  });
+
+  it('accepts open-ended agreement (no endDate)', () => {
+    const r = parseVaHudVashDsaAgreementForm(makeVaHudVashFormData({ endDate: '' }));
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.input.endDate).toBeNull();
+  });
+
+  it('rejects endDate before effectiveDate', () => {
+    const r = parseVaHudVashDsaAgreementForm(
+      makeVaHudVashFormData({ effectiveDate: '2026-12-01', endDate: '2026-11-01' }),
+    );
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toMatch(/end date must be on or after/i);
+  });
+
+  it('includes optional vamc_contact_phone when provided', () => {
+    const r = parseVaHudVashDsaAgreementForm(
+      makeVaHudVashFormData({ vamc_contact_phone: '(502) 287-4000' }),
+    );
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.input.terms.vamc_contact.phone).toBe('(502) 287-4000');
+  });
+
+  it('includes optional pha_contact_phone when provided', () => {
+    const r = parseVaHudVashDsaAgreementForm(
+      makeVaHudVashFormData({ pha_contact_phone: '(270) 685-3408' }),
+    );
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.input.terms.pha_contact.phone).toBe('(270) 685-3408');
+  });
+
+  it('rejects notes longer than 2000 chars', () => {
+    const r = parseVaHudVashDsaAgreementForm(makeVaHudVashFormData({ notes: 'x'.repeat(2001) }));
     expect(r.ok).toBe(false);
     if (!r.ok) expect(r.error).toMatch(/2 000 characters/i);
   });

--- a/src/app/actions/partner-agreements.ts
+++ b/src/app/actions/partner-agreements.ts
@@ -4,13 +4,21 @@ import * as Sentry from '@sentry/nextjs';
 import { revalidatePath } from 'next/cache';
 import { recordAgreement, updateAgreementStatus } from '@/db/queries/partner-agreements';
 import { requireRole } from '@/lib/auth';
-import type { DcbsDsaTerms, FerpaTerms, KyDocDsaTerms, MouTerms, OasisDsaTerms } from '@/lib/dtrs';
+import type {
+  DcbsDsaTerms,
+  FerpaTerms,
+  KyDocDsaTerms,
+  MouTerms,
+  OasisDsaTerms,
+  VaHudVashDsaTerms,
+} from '@/lib/dtrs';
 import {
   parseDcbsDsaAgreementForm,
   parseKyDocDsaAgreementForm,
   parseMouAgreementForm,
   parseOasisDsaAgreementForm,
   parsePartnerAgreementForm,
+  parseVaHudVashDsaAgreementForm,
 } from './partner-agreements-parse';
 
 /**
@@ -32,6 +40,9 @@ const KNOWN_DOMAIN_PREFIXES = [
   'Invalid OASIS-DSA scope',
   'Invalid OASIS-DSA redaction_policy',
   'Invalid KY-DOC-DSA scope',
+  'Invalid VA-HUDVASH-DSA scope',
+  'DSA vamc_contact',
+  'DSA pha_contact',
 ] as const;
 
 export type RecordFerpaAgreementResult =
@@ -258,6 +269,64 @@ export async function recordKyDocDsaAgreementAction(
   }
 }
 
+export type RecordVaHudVashDsaAgreementResult =
+  | { ok: true; agreementId: string }
+  | { ok: false; error: string };
+
+/**
+ * Admin-only server action: parse the DTRS-015 VA HUD-VASH DSA intake FormData
+ * and persist via `recordAgreement` (terms validation + audit log happen inside
+ * that query function). The validator strictly enforces
+ * `no_service_denial_prediction_attestation === true` and
+ * `treatment_scope === 'status_only'` (ADR 0010); the parser also fails closed
+ * if the attestation checkbox is missing from the form.
+ */
+export async function recordVaHudVashDsaAgreementAction(
+  formData: FormData,
+): Promise<RecordVaHudVashDsaAgreementResult> {
+  const user = await requireRole(['admin']);
+
+  const parsed = parseVaHudVashDsaAgreementForm(formData);
+  if (!parsed.ok) return { ok: false, error: parsed.error };
+
+  try {
+    const { effectiveDate, endDate, signedByPartner, notes, partnerOrgId, terms } = parsed.input;
+
+    const agreement = await recordAgreement({
+      partnerOrgId,
+      kind: 'dsa',
+      status: 'active',
+      effectiveDate: effectiveDate || null,
+      endDate: endDate || null,
+      signedByPartner: signedByPartner || null,
+      signedByCoalitionUserId: user.id,
+      templateVersion: 'vahudvash-dsa-v1',
+      templateRendered: null,
+      // parseVaHudVashDsaAgreementForm validates scope + window + attestation +
+      // treatment_scope; the narrow cast bridges the parser's structural type
+      // to the domain type. recordAgreement re-validates via
+      // validateAgreementTerms before any insert.
+      terms: terms as VaHudVashDsaTerms,
+      notes: notes || null,
+      actorUserId: user.id,
+    });
+
+    revalidatePath('/app/admin/agreements/vahudvash');
+    return { ok: true, agreementId: agreement.id };
+  } catch (err) {
+    Sentry.captureException(err);
+    console.error('[partner-agreements.recordVaHudVashDsa] failed', err);
+    const raw = err instanceof Error ? err.message : '';
+    const isKnown = KNOWN_DOMAIN_PREFIXES.some((prefix) =>
+      raw.toLowerCase().startsWith(prefix.toLowerCase()),
+    );
+    const error = isKnown
+      ? raw
+      : 'Recording the agreement failed — please retry. The error has been logged.';
+    return { ok: false, error };
+  }
+}
+
 export type RecordMouAgreementResult =
   | { ok: true; agreementId: string }
   | { ok: false; error: string };
@@ -325,6 +394,7 @@ export async function updateAgreementStatusAction(
     revalidatePath('/app/admin/agreements/dcbs');
     revalidatePath('/app/admin/agreements/oasis');
     revalidatePath('/app/admin/agreements/kydoc');
+    revalidatePath('/app/admin/agreements/vahudvash');
     return { ok: true };
   } catch (err) {
     Sentry.captureException(err);

--- a/src/app/agreements/vahudvash/template/page.tsx
+++ b/src/app/agreements/vahudvash/template/page.tsx
@@ -1,0 +1,389 @@
+/**
+ * Public VA HUD-VASH Data-Sharing Agreement template page — no auth required.
+ * Template version: vahudvash-dsa-v1
+ *
+ * Both the local VAMC HUD-VASH program and the local Public Housing Authority
+ * review this page before signing. The signed copy is recorded in the
+ * coalition's partner-agreements registry per ADR 0004; the privacy contract
+ * enforced is documented in ADR 0010.
+ *
+ * NOT a legal instrument — this is a starting point that counsel, the VA
+ * Privacy Office, and the local PHA's legal staff will review and may amend.
+ * Fields marked [TBD] require partner-specific detail before execution.
+ */
+
+export const dynamic = 'force-static';
+
+export default function VaHudVashDsaTemplatePage() {
+  return (
+    <div className="mx-auto max-w-3xl px-4 py-8 md:py-12 print:py-4">
+      {/* Header */}
+      <header className="mb-8 border-b pb-6">
+        <p className="text-xs font-medium uppercase tracking-widest text-muted-foreground">
+          Template Version: vahudvash-dsa-v1 &bull; Daviess County Homeless Coalition
+        </p>
+        <h1 className="mt-2 font-serif text-3xl font-bold">
+          Data-Sharing Agreement
+          <br />
+          (HUD-VASH Veteran Pathway)
+        </h1>
+        <p className="mt-2 text-sm text-muted-foreground">
+          Among the Daviess County Homeless Coalition (&ldquo;Coalition&rdquo;), the U.S. Department
+          of Veterans Affairs Medical Center HUD-VASH program (&ldquo;VAMC&rdquo;), and the local
+          Public Housing Authority (&ldquo;PHA&rdquo;)
+        </p>
+      </header>
+
+      <article className="prose prose-sm max-w-none dark:prose-invert space-y-6 text-sm leading-relaxed">
+        {/* Section 1 — Recitals */}
+        <section>
+          <h2 className="text-base font-semibold">1. Recitals</h2>
+          <p>
+            <strong>1.1 Coalition purpose.</strong> The Daviess County Homeless Coalition
+            (&ldquo;Coalition&rdquo;) is a county-level coordinating body working to prevent and end
+            homelessness in Daviess County, Kentucky.
+          </p>
+          <p>
+            <strong>1.2 VAMC mission.</strong> The local VA Medical Center operates HUD-VASH (
+            <strong>HUD-Veterans Affairs Supportive Housing</strong>) under{' '}
+            <strong>42 U.S.C. § 11403</strong> and provides clinical case management, mental-health
+            and substance-use treatment, and primary care to enrolled veterans, governed by{' '}
+            <strong>38 U.S.C. § 7332</strong>, <strong>38 CFR Part 1</strong>, and HIPAA (
+            <strong>45 CFR Part 164</strong>).
+          </p>
+          <p>
+            <strong>1.3 PHA role.</strong> The local Public Housing Authority administers the
+            HUD-VASH housing-choice voucher allocation. PHA voucher administration is governed by{' '}
+            <strong>24 CFR Part 982</strong> and HUD&apos;s HUD-VASH operating requirements.
+          </p>
+          <p>
+            <strong>1.4 Pathway purpose.</strong> Veterans engaged with HUD-VASH face a clock: HUD
+            vouchers are typically valid for 60 days from issuance, with a discretionary 60-day
+            extension. Lease-up requires landlord engagement, application support, and ancillary
+            benefits coordination — the operational window where Coalition support meaningfully
+            improves outcomes. This Agreement structures the limited data flow necessary to
+            coordinate housing-search and lease-stabilization services across that window.
+          </p>
+          <p>
+            <strong>1.5 No service-denial prediction.</strong> The Coalition&apos;s purpose is to
+            help every voucher-holding veteran succeed at lease-up. The Coalition shall{' '}
+            <strong>not</strong> use, derive, or permit the derivation of voucher-failure scoring,
+            deprioritization analytics, or any predictive scoring that classifies veterans on
+            probability of voucher loss using the data shared under this Agreement. The Coalition
+            shall not provide any data shared under this Agreement to insurers, employer
+            background-check vendors, or any third party for the purpose of denying or limiting
+            services to the veteran. This commitment is non-negotiable.
+          </p>
+          <p>
+            <strong>1.6 MH/SUD scope boundary.</strong> Mental-health and substance-use treatment
+            content (diagnosis codes, treatment plan content, session notes, medication lists) is
+            governed by 38 U.S.C. § 7332 and 42 U.S.C. § 290dd-2 (Part 2). Such content is{' '}
+            <strong>out of scope</strong> for this Agreement. The Coalition may receive only the
+            fact of an active treatment relationship (continuity-status enum) and the VA case
+            manager&apos;s contact information for warm handoff. Expansion to QSOA-protected content
+            requires a separate Qualified Service Organization Agreement under 42 CFR Part 2.
+          </p>
+          <p>
+            <strong>1.7 Voluntary participation.</strong> This Agreement is voluntary. Any party may
+            withdraw with thirty (30) days written notice (see § 9). Withdrawal does not affect
+            services already initiated for an individual and does not relieve the Coalition of its
+            data destruction obligations under § 5.
+          </p>
+        </section>
+
+        {/* Section 2 — Data scope */}
+        <section>
+          <h2 className="text-base font-semibold">2. Data Scope</h2>
+          <p>
+            VAMC and PHA may share with the Coalition the following categories of records, limited
+            to veterans who (a) are enrolled in HUD-VASH, (b) have a Daviess County voucher or
+            search area, and (c) are within the voucher-search window specified in Schedule A:
+          </p>
+          <ul className="list-disc pl-6 space-y-1">
+            <li>
+              <strong>Voucher-status roster.</strong> Identifiers (PHA case number, DOB, voucher
+              issuance date, voucher status: eligible / vouchered / searching / leased / expiring),
+              sufficient to enable warm-handoff coordination.
+            </li>
+            <li>
+              <strong>Eligibility changes.</strong> Updates when service-connection ratings shift,
+              when income changes affect HUD-VASH continued eligibility, or when voucher status
+              transitions.
+            </li>
+            <li>
+              <strong>Supports-in-place.</strong> VA-side supports: case-management engagement
+              status, treatment-continuity status (status_only — no diagnostic content),
+              primary-care continuity, and the assigned VA case manager&apos;s contact for warm
+              handoff.
+            </li>
+            <li>
+              <strong>Adjacent-program eligibility.</strong> Eligibility flags for adjacent programs
+              the Coalition coordinates (SSVF, Veterans Treatment Court, HCHV grant programs).
+            </li>
+          </ul>
+          <p>
+            The specific data classes covered by this Agreement are identified in the attached
+            Schedule A, which is incorporated by reference. [TBD — VAMC, PHA, and Coalition complete
+            Schedule A before execution.]
+          </p>
+          <p>
+            VAMC shall <strong>not</strong> share substance-use-treatment records (42 CFR Part 2),
+            mental-health diagnostic detail, treatment plan content, session notes, medication
+            lists, communications-with-counsel records, or any data not explicitly listed in
+            Schedule A without a separate written amendment to this Agreement. PHA shall not share
+            third-party household income detail beyond what is necessary to confirm continued HUD-
+            VASH eligibility.
+          </p>
+        </section>
+
+        {/* Section 3 — Voucher window */}
+        <section>
+          <h2 className="text-base font-semibold">3. Voucher-Search Window (Bounded Data Flow)</h2>
+          <p>
+            <strong>3.1 Window as contract.</strong> The Coalition shall receive data only for
+            veterans whose voucher issuance date plus the window covers the present date. The
+            default window is one hundred twenty (120) days; the agreed window may range between
+            sixty (60) and two hundred forty (240) days as Schedule A specifies. Records that age
+            out of the window without a successful warm handoff or lease-up are deleted from
+            Coalition systems within seven (7) days of expiration.
+          </p>
+          <p>
+            <strong>3.2 Software enforcement.</strong> The Coalition&apos;s ingest middleware reads
+            Schedule A&apos;s window length as the contract-of-record. VAMC and PHA may verify
+            enforcement by inspecting the agreement record in the Coalition&apos;s registry and the
+            audit log of the daily window-expiration job.
+          </p>
+          <p>
+            <strong>3.3 Window amendments.</strong> Any change to the voucher-search window length
+            is a contract amendment and requires written authorization from all parties. The
+            Coalition shall not extend the window administratively.
+          </p>
+        </section>
+
+        {/* Section 4 — Data security */}
+        <section>
+          <h2 className="text-base font-semibold">4. Data Security and Access Controls</h2>
+          <p>
+            <strong>4.1 Authorized readers.</strong> The Coalition shall restrict access to veteran
+            records to assigned veteran-pathway caseworkers, supervising caseworkers, and admins on
+            a strict need-to-know basis. The list of authorized readers is maintained by the
+            Coalition&apos;s data steward and provided to VAMC and PHA upon request.
+          </p>
+          <p>
+            <strong>4.2 No re-disclosure to insurers, employers, or for service-denial.</strong> The
+            Coalition shall not disclose veteran records, derived analytics, or even
+            confirmation-of-existence to insurers, employer background-check vendors, eligibility-
+            screening systems, or any party requesting data for the purpose of denying or limiting
+            services to the veteran. This includes informal requests; data sharing for
+            service-eligibility scoring is outside the scope of this Agreement.
+          </p>
+          <p>
+            <strong>4.3 Audit logging.</strong> Every read of an individual&apos;s veteran record is
+            audit-logged. The audit table is the source of truth for the cooperation obligation in §
+            6.3.
+          </p>
+          <p>
+            <strong>4.4 Breach notification.</strong> Any unauthorized access, disclosure, or loss
+            of veteran records must be reported to the VA Privacy Officer within seventy-two (72)
+            hours of discovery and to the HUD field office within five (5) business days, with a
+            written incident report within seven (7) days and immediate suspension of the data flow
+            pending review.
+          </p>
+        </section>
+
+        {/* Section 5 — Data destruction */}
+        <section>
+          <h2 className="text-base font-semibold">5. Data Retention and Destruction</h2>
+          <p>
+            <strong>5.1 Default retention.</strong> Records that age out of the voucher-search
+            window without a successful warm handoff or lease-up are deleted within seven (7) days.
+            Records of veterans who are successfully housed are retained per Schedule A&apos;s data
+            destruction policy: destruction upon agreement termination is the default; longer
+            retention windows (3 years, 5 years) are available only with explicit written
+            justification and joint VAMC + PHA approval.
+          </p>
+          <p>
+            <strong>5.2 Destruction on termination.</strong> Upon termination, the Coalition shall
+            securely destroy or return all veteran records (including backup copies) within thirty
+            (30) days. &ldquo;Destruction&rdquo; means irreversible deletion from all systems and
+            media holding the records.
+          </p>
+          <p>
+            <strong>5.3 Certification.</strong> The Coalition shall provide VAMC and PHA with
+            written certification of destruction. Either party may inspect destruction logs upon
+            reasonable notice.
+          </p>
+        </section>
+
+        {/* Section 6 — Coordination and reporting */}
+        <section>
+          <h2 className="text-base font-semibold">6. Coordination and Reporting</h2>
+          <p>
+            <strong>6.1 Joint case-coordination.</strong> The Coalition, VAMC, and PHA shall
+            coordinate at a cadence agreed upon in Schedule B (default: monthly). The agenda shall
+            include progress on lease-ups, voucher-expiration risks, and any data-flow questions.
+          </p>
+          <p>
+            <strong>6.2 Aggregate reporting.</strong> The Coalition shall provide VAMC and PHA with
+            quarterly aggregate reports on outcomes for the cohort: number of veterans successfully
+            leased within the voucher-search window, time-to-lease distribution, and
+            voucher-expiration rates. <strong>No</strong> service-denial scoring, deprioritization
+            recommendations, or insurer-bound metrics shall be derived or reported under this
+            Agreement; that is the explicit prohibition in § 1.5.
+          </p>
+          <p>
+            <strong>6.3 Audit cooperation.</strong> The Coalition shall, upon reasonable notice,
+            provide VAMC and PHA with access to audit logs and access-control records for the
+            purpose of verifying compliance with this Agreement.
+          </p>
+        </section>
+
+        {/* Section 7 — Term */}
+        <section>
+          <h2 className="text-base font-semibold">7. Term</h2>
+          <p>
+            This Agreement is effective on the date last signed below and continues until the
+            earlier of (a) the end date specified in Schedule A, (b) termination under § 9, or (c)
+            written mutual agreement to terminate.
+          </p>
+        </section>
+
+        {/* Section 8 — Amendments */}
+        <section>
+          <h2 className="text-base font-semibold">8. Amendments</h2>
+          <p>
+            Any amendment to this Agreement, including changes to Schedule A or to the voucher-
+            search window under § 3, must be in writing and signed by authorized representatives of
+            all three parties. The Coalition will publish a new template version for material
+            amendments; the signed copy recorded in the Coalition&apos;s registry is the
+            authoritative instrument.
+          </p>
+        </section>
+
+        {/* Section 9 — Withdrawal */}
+        <section>
+          <h2 className="text-base font-semibold">9. Withdrawal</h2>
+          <p>
+            Any party may terminate this Agreement at any time by providing thirty (30) days written
+            notice to the other parties. Notice may be delivered by email to the contacts identified
+            in Schedule B. Upon termination, the Coalition&apos;s data destruction obligations under
+            § 5 take effect immediately. VAMC or PHA may suspend data flow at any time without
+            notice if compliance is in question; suspension is not termination.
+          </p>
+        </section>
+
+        {/* Section 10 — Governing law */}
+        <section>
+          <h2 className="text-base font-semibold">10. Governing Law</h2>
+          <p>
+            This Agreement is governed by federal law, including <strong>38 U.S.C. § 7332</strong>{' '}
+            (VA confidentiality), <strong>42 U.S.C. § 11403</strong> (HUD-VASH authorization),{' '}
+            <strong>42 U.S.C. § 290dd-2</strong> and <strong>42 CFR Part 2</strong> (federal SUD
+            confidentiality), HIPAA (<strong>45 CFR Part 164</strong>),{' '}
+            <strong>24 CFR Part 982</strong> (HUD voucher administration), and applicable Kentucky
+            law. Any dispute arising under this Agreement shall be resolved through good-faith
+            negotiation among the Coalition&apos;s data steward, the VAMC HUD-VASH coordinator, and
+            the PHA HCV director before seeking other remedies.
+          </p>
+        </section>
+
+        {/* Signatory blocks */}
+        <section className="mt-8">
+          <h2 className="text-base font-semibold">Signatories</h2>
+          <div className="mt-4 grid gap-8 sm:grid-cols-3">
+            <div className="space-y-4">
+              <p className="font-medium">
+                Daviess County
+                <br />
+                Homeless Coalition
+              </p>
+              <div className="space-y-2">
+                <div className="border-b border-foreground/30 pb-0.5">
+                  <p className="mt-4 text-xs text-muted-foreground">Authorized signature</p>
+                </div>
+                <div className="border-b border-foreground/30 pb-0.5">
+                  <p className="mt-4 text-xs text-muted-foreground">Printed name &amp; title</p>
+                </div>
+                <div className="border-b border-foreground/30 pb-0.5">
+                  <p className="mt-4 text-xs text-muted-foreground">Date</p>
+                </div>
+              </div>
+            </div>
+            <div className="space-y-4">
+              <p className="font-medium">
+                VA Medical Center
+                <br />
+                HUD-VASH Program (VAMC)
+              </p>
+              <div className="space-y-2">
+                <div className="border-b border-foreground/30 pb-0.5">
+                  <p className="mt-4 text-xs text-muted-foreground">Authorized signature</p>
+                </div>
+                <div className="border-b border-foreground/30 pb-0.5">
+                  <p className="mt-4 text-xs text-muted-foreground">Printed name &amp; title</p>
+                </div>
+                <div className="border-b border-foreground/30 pb-0.5">
+                  <p className="mt-4 text-xs text-muted-foreground">Date</p>
+                </div>
+              </div>
+            </div>
+            <div className="space-y-4">
+              <p className="font-medium">
+                Local Public
+                <br />
+                Housing Authority (PHA)
+              </p>
+              <div className="space-y-2">
+                <div className="border-b border-foreground/30 pb-0.5">
+                  <p className="mt-4 text-xs text-muted-foreground">Authorized signature</p>
+                </div>
+                <div className="border-b border-foreground/30 pb-0.5">
+                  <p className="mt-4 text-xs text-muted-foreground">Printed name &amp; title</p>
+                </div>
+                <div className="border-b border-foreground/30 pb-0.5">
+                  <p className="mt-4 text-xs text-muted-foreground">Date</p>
+                </div>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        {/* Schedule placeholders */}
+        <section className="mt-6">
+          <h2 className="text-base font-semibold">Schedule A — Data Classes &amp; Window</h2>
+          <p className="text-muted-foreground italic">
+            [TBD — to be completed by VAMC, PHA, and Coalition before execution. Enumerate the
+            specific data elements, file format, transmission method, frequency, the voucher- search
+            window length (60–240 days; default 120), and the agreed retention period.]
+          </p>
+        </section>
+
+        <section className="mt-4">
+          <h2 className="text-base font-semibold">Schedule B — Contacts</h2>
+          <p className="text-muted-foreground italic">
+            [TBD — list Coalition data steward, VAMC HUD-VASH coordinator, and PHA HCV director (or
+            designees) names, emails, and phone numbers. Include after-hours emergency contact for
+            breach notification under § 4.4.]
+          </p>
+        </section>
+      </article>
+
+      {/* Footer note */}
+      <footer className="mt-10 border-t pt-6 text-xs text-muted-foreground">
+        <p>
+          This page is the public template (version{' '}
+          <code className="font-mono">vahudvash-dsa-v1</code>). The signed copy is recorded in the
+          coalition&apos;s partner-agreements registry per <strong>ADR 0004</strong>; the privacy
+          contract this agreement enforces is documented in <strong>ADR 0010</strong>. This template
+          is a starting point — VAMC, PHA, and Coalition should review it with counsel before
+          execution. Fields marked [TBD] require partner-specific detail.
+        </p>
+        <p className="mt-2">
+          References: 38 U.S.C. § 7332 (VA confidentiality); 42 U.S.C. § 11403 (HUD-VASH); 42 U.S.C.
+          § 290dd-2 + 42 CFR Part 2 (federal SUD confidentiality); HIPAA (45 CFR Part 164); 24 CFR
+          Part 982 (HUD vouchers); 38 CFR Part 1 (VA records confidentiality).
+        </p>
+      </footer>
+    </div>
+  );
+}

--- a/src/app/app/admin/agreements/vahudvash/page.tsx
+++ b/src/app/app/admin/agreements/vahudvash/page.tsx
@@ -1,0 +1,146 @@
+import { inArray } from 'drizzle-orm';
+import Link from 'next/link';
+import { VaHudVashDsaAgreementForm } from '@/components/dtrs/vahudvash-dsa-agreement-form';
+import { db } from '@/db/client';
+import { getActiveVaHudVashDsa, listAgreementsForPartner } from '@/db/queries/partner-agreements';
+import { partnerOrgs } from '@/db/schema/partner-orgs';
+import { requireRole } from '@/lib/auth';
+
+export const dynamic = 'force-dynamic';
+
+export default async function VaHudVashAgreementsPage() {
+  await requireRole(['admin']);
+
+  // VA HUD-VASH DSAs are joint instruments with the local PHA. The directory
+  // surfaces both 'government' (VAMC) and 'community_org' (PHA) entries so
+  // the admin can pick whichever org row was used to record the agreement.
+  // Either side can be the partner_org_id of record per ADR 0010.
+  const partners = await db
+    .select({ id: partnerOrgs.id, name: partnerOrgs.name })
+    .from(partnerOrgs)
+    .where(inArray(partnerOrgs.type, ['government', 'community_org']))
+    .orderBy(partnerOrgs.name);
+
+  if (partners.length === 0) {
+    return (
+      <div className="mx-auto max-w-2xl space-y-4 p-4 md:p-6">
+        <header>
+          <h1 className="font-serif text-3xl font-bold text-primary">
+            VA HUD-VASH data-sharing agreements
+          </h1>
+          <p className="mt-1 text-sm text-muted-foreground">
+            Record VA HUD-VASH DSAs for the veteran pathway.
+          </p>
+        </header>
+        <div className="rounded-md border border-border bg-muted/20 p-6 text-sm">
+          <p className="font-semibold">No eligible partner orgs found.</p>
+          <p className="mt-2 text-muted-foreground">
+            Add a partner org with <code className="font-mono">type = &apos;government&apos;</code>{' '}
+            (e.g. &quot;Louisville VA Medical Center&quot;) and one with{' '}
+            <code className="font-mono">type = &apos;community_org&apos;</code> (the local PHA)
+            before recording a DSA. Contact the coalition data steward to add partners.
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  const activeAgreements: Record<
+    string,
+    { id: string; effectiveDate: string | null; status: string } | undefined
+  > = {};
+
+  await Promise.all(
+    partners.map(async (p) => {
+      const active = await getActiveVaHudVashDsa(p.id);
+      if (active) {
+        activeAgreements[p.id] = {
+          id: active.id,
+          effectiveDate: active.effectiveDate,
+          status: active.status,
+        };
+      }
+    }),
+  );
+
+  // Use a small partner index so we can match the 'where the agreement is
+  // partner-of-record' display. Keep the table to all DSA agreements for these
+  // partners; non-VA-HUDVASH DSAs are clearly tagged by kind.
+  const allAgreements = (
+    await Promise.all(partners.map((p) => listAgreementsForPartner(p.id, { status: 'any' })))
+  ).flat();
+
+  const partnerIndex = Object.fromEntries(partners.map((p) => [p.id, p.name]));
+
+  return (
+    <div className="mx-auto max-w-3xl space-y-8 p-4 md:p-6">
+      <header>
+        <h1 className="font-serif text-3xl font-bold text-primary">
+          VA HUD-VASH data-sharing agreements
+        </h1>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Record and track DSAs with the local VA Medical Center HUD-VASH program (joint with the
+          local Public Housing Authority) for the veteran pathway. The agreement establishes a
+          bounded voucher-search window during which the VA may share records of veterans with
+          active HUD-VASH vouchers. Both signatories should review the{' '}
+          <Link
+            href="/agreements/vahudvash/template"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="underline underline-offset-2 hover:text-foreground"
+          >
+            agreement template
+          </Link>{' '}
+          before signing. See <strong>ADR 0010</strong> for the privacy contract this agreement
+          enforces — including the no-service-denial-prediction commitment, the MH/SUD scope
+          boundary, and the no-insurer-disclosure rule.
+        </p>
+      </header>
+
+      {allAgreements.length > 0 && (
+        <section className="space-y-3">
+          <h2 className="text-base font-semibold">Recorded agreements</h2>
+          <div className="overflow-x-auto rounded-md border border-border">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="border-b bg-muted/30 text-left">
+                  <th className="px-3 py-2 font-medium">Partner</th>
+                  <th className="px-3 py-2 font-medium">Kind</th>
+                  <th className="px-3 py-2 font-medium">Status</th>
+                  <th className="px-3 py-2 font-medium">Effective</th>
+                  <th className="px-3 py-2 font-medium">Ends</th>
+                </tr>
+              </thead>
+              <tbody>
+                {allAgreements.map((a) => (
+                  <tr key={a.id} className="border-b last:border-0">
+                    <td className="px-3 py-2">{partnerIndex[a.partnerOrgId] ?? a.partnerOrgId}</td>
+                    <td className="px-3 py-2 font-mono text-xs uppercase">{a.kind}</td>
+                    <td className="px-3 py-2">
+                      <span
+                        className={
+                          a.status === 'active'
+                            ? 'rounded bg-emerald-100 px-1.5 py-0.5 text-[10px] font-medium text-emerald-700 dark:bg-emerald-900/40 dark:text-emerald-400'
+                            : 'rounded bg-muted px-1.5 py-0.5 text-[10px] font-medium text-muted-foreground'
+                        }
+                      >
+                        {a.status}
+                      </span>
+                    </td>
+                    <td className="px-3 py-2 tabular-nums">{a.effectiveDate ?? '—'}</td>
+                    <td className="px-3 py-2 tabular-nums">{a.endDate ?? 'open'}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </section>
+      )}
+
+      <section className="space-y-4">
+        <h2 className="text-base font-semibold">Record a new VA HUD-VASH DSA</h2>
+        <VaHudVashDsaAgreementForm partners={partners} activeAgreements={activeAgreements} />
+      </section>
+    </div>
+  );
+}

--- a/src/components/dtrs/vahudvash-dsa-agreement-form.tsx
+++ b/src/components/dtrs/vahudvash-dsa-agreement-form.tsx
@@ -1,0 +1,597 @@
+'use client';
+
+import Link from 'next/link';
+import { useId, useState, useTransition } from 'react';
+import { recordVaHudVashDsaAgreementAction } from '@/app/actions/partner-agreements';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+// Deep imports: 'use client' files are exempt from the barrel rule (ADR 0001 / FND-040b).
+import {
+  VA_HUDVASH_DSA_SCOPE_OPTIONS,
+  VA_HUDVASH_VOUCHER_WINDOW_DEFAULT_DAYS,
+  VA_HUDVASH_VOUCHER_WINDOW_MAX_DAYS,
+  VA_HUDVASH_VOUCHER_WINDOW_MIN_DAYS,
+} from '@/lib/dtrs/partner-agreements';
+
+type GovernmentOption = {
+  id: string;
+  name: string;
+};
+
+type ActiveAgreement = {
+  id: string;
+  effectiveDate: string | null;
+  status: string;
+};
+
+type Props = {
+  partners: GovernmentOption[];
+  /** Map of partnerOrgId → active VA HUD-VASH DSA agreement (if one exists). */
+  activeAgreements: Record<string, ActiveAgreement | undefined>;
+};
+
+const DESTRUCTION_OPTIONS = [
+  {
+    value: 'on_termination',
+    label: 'Upon agreement termination (recommended for veteran records)',
+  },
+  { value: 'after_3_years', label: 'After 3 years of program completion' },
+  { value: 'after_5_years', label: 'After 5 years of program completion' },
+] as const;
+
+const DEFAULT_VAMC_LEGAL_NAME =
+  'U.S. Department of Veterans Affairs — VA Medical Center HUD-VASH Program';
+
+export function VaHudVashDsaAgreementForm({ partners, activeAgreements }: Props) {
+  const formId = useId();
+
+  const [selectedPartnerId, setSelectedPartnerId] = useState(partners[0]?.id ?? '');
+  const [effectiveDate, setEffectiveDate] = useState('');
+  const [endDate, setEndDate] = useState('');
+  const [signedByPartner, setSignedByPartner] = useState('');
+
+  const [vamcLegalName, setVamcLegalName] = useState(DEFAULT_VAMC_LEGAL_NAME);
+  const [vamcContactName, setVamcContactName] = useState('');
+  const [vamcContactTitle, setVamcContactTitle] = useState('');
+  const [vamcContactEmail, setVamcContactEmail] = useState('');
+  const [vamcContactPhone, setVamcContactPhone] = useState('');
+
+  const [phaLegalName, setPhaLegalName] = useState('');
+  const [phaContactName, setPhaContactName] = useState('');
+  const [phaContactTitle, setPhaContactTitle] = useState('');
+  const [phaContactEmail, setPhaContactEmail] = useState('');
+  const [phaContactPhone, setPhaContactPhone] = useState('');
+
+  const [selectedScope, setSelectedScope] = useState<Set<string>>(new Set());
+  const [windowDays, setWindowDays] = useState<string>(
+    String(VA_HUDVASH_VOUCHER_WINDOW_DEFAULT_DAYS),
+  );
+  const [individualAuth, setIndividualAuth] = useState<'true' | 'false'>('true');
+  const [attested, setAttested] = useState(false);
+  const [dataDestruction, setDataDestruction] = useState<string>('on_termination');
+  const [notes, setNotes] = useState('');
+
+  const [pending, startTransition] = useTransition();
+  const [result, setResult] = useState<
+    { ok: true; agreementId: string } | { ok: false; error: string } | null
+  >(null);
+
+  const existingAgreement = selectedPartnerId ? activeAgreements[selectedPartnerId] : undefined;
+
+  const toggleScope = (value: string) => {
+    setSelectedScope((prev) => {
+      const next = new Set(prev);
+      if (next.has(value)) {
+        next.delete(value);
+      } else {
+        next.add(value);
+      }
+      return next;
+    });
+  };
+
+  const resetForm = () => {
+    setEffectiveDate('');
+    setEndDate('');
+    setSignedByPartner('');
+    setVamcContactName('');
+    setVamcContactTitle('');
+    setVamcContactEmail('');
+    setVamcContactPhone('');
+    setPhaLegalName('');
+    setPhaContactName('');
+    setPhaContactTitle('');
+    setPhaContactEmail('');
+    setPhaContactPhone('');
+    setSelectedScope(new Set());
+    setWindowDays(String(VA_HUDVASH_VOUCHER_WINDOW_DEFAULT_DAYS));
+    setIndividualAuth('true');
+    setAttested(false);
+    setDataDestruction('on_termination');
+    setNotes('');
+    setResult(null);
+  };
+
+  const onSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    setResult(null);
+    const fd = new FormData(e.currentTarget);
+    startTransition(async () => {
+      const r = await recordVaHudVashDsaAgreementAction(fd);
+      setResult(r);
+      if (r.ok) resetForm();
+    });
+  };
+
+  if (result?.ok) {
+    return (
+      <div className="rounded-md border border-emerald-500/40 bg-emerald-500/5 p-4 text-sm">
+        <p className="font-semibold text-emerald-700 dark:text-emerald-400">
+          VA HUD-VASH DSA recorded.
+        </p>
+        <p className="mt-1 text-muted-foreground">
+          Agreement ID: <code className="font-mono text-xs">{result.agreementId}</code>
+        </p>
+        <div className="mt-3 flex gap-2">
+          <Button type="button" variant="outline" onClick={() => setResult(null)}>
+            Record another
+          </Button>
+          <Link
+            href="/app/admin/agreements/vahudvash"
+            className="inline-flex items-center rounded-md border border-input bg-background px-3 py-2 text-sm hover:bg-accent"
+          >
+            Back to list
+          </Link>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <form onSubmit={onSubmit} className="space-y-6">
+      {/* Partner selector */}
+      <div className="space-y-1">
+        <Label htmlFor={`${formId}-partner`}>VA HUD-VASH partner</Label>
+        <select
+          id={`${formId}-partner`}
+          name="partnerOrgId"
+          value={selectedPartnerId}
+          onChange={(e) => {
+            setSelectedPartnerId(e.target.value);
+            setResult(null);
+          }}
+          disabled={pending}
+          className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        >
+          {partners.map((p) => (
+            <option key={p.id} value={p.id}>
+              {p.name}
+            </option>
+          ))}
+        </select>
+        {existingAgreement && (
+          <p className="text-xs text-amber-600 dark:text-amber-400">
+            This partner already has an active VA HUD-VASH DSA (effective:{' '}
+            {existingAgreement.effectiveDate ?? 'open'}). Recording a new agreement will not
+            automatically supersede it — update the old agreement status separately.
+          </p>
+        )}
+      </div>
+
+      {/* Template preview link */}
+      <div className="rounded-md border border-border bg-muted/20 p-3 text-sm">
+        <p className="text-muted-foreground">
+          Before recording, both VA HUD-VASH and the local PHA should review the{' '}
+          <Link
+            href="/agreements/vahudvash/template"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="underline underline-offset-2 hover:text-foreground"
+          >
+            VA HUD-VASH DSA template
+          </Link>
+          . The template version recorded here is{' '}
+          <code className="font-mono text-xs">vahudvash-dsa-v1</code>.
+        </p>
+      </div>
+
+      {/* Dates */}
+      <div className="grid gap-4 sm:grid-cols-2">
+        <div className="space-y-1">
+          <Label htmlFor={`${formId}-effective`}>Effective date *</Label>
+          <Input
+            id={`${formId}-effective`}
+            name="effectiveDate"
+            type="date"
+            value={effectiveDate}
+            onChange={(e) => setEffectiveDate(e.target.value)}
+            required
+            disabled={pending}
+          />
+        </div>
+        <div className="space-y-1">
+          <Label htmlFor={`${formId}-end`}>
+            End date{' '}
+            <span className="font-normal text-muted-foreground text-xs">
+              (optional — open-ended if blank)
+            </span>
+          </Label>
+          <Input
+            id={`${formId}-end`}
+            name="endDate"
+            type="date"
+            value={endDate}
+            onChange={(e) => setEndDate(e.target.value)}
+            disabled={pending}
+          />
+        </div>
+      </div>
+
+      {/* Signed by partner */}
+      <div className="space-y-1">
+        <Label htmlFor={`${formId}-signed-by`}>
+          Signed by{' '}
+          <span className="font-normal text-muted-foreground text-xs">
+            (joint VAMC + PHA signatories)
+          </span>
+        </Label>
+        <Input
+          id={`${formId}-signed-by`}
+          name="signedByPartner"
+          type="text"
+          value={signedByPartner}
+          onChange={(e) => setSignedByPartner(e.target.value)}
+          placeholder="e.g. VAMC Director + PHA Executive Director"
+          disabled={pending}
+        />
+      </div>
+
+      {/* VAMC fields */}
+      <fieldset className="space-y-3 rounded-md border border-border bg-muted/10 p-4">
+        <legend className="px-1 text-sm font-semibold text-foreground">
+          VA Medical Center (HUD-VASH program)
+        </legend>
+        <div className="space-y-1">
+          <Label htmlFor={`${formId}-vamc-legal`}>VAMC legal name *</Label>
+          <Input
+            id={`${formId}-vamc-legal`}
+            name="vamc_legal_name"
+            type="text"
+            value={vamcLegalName}
+            onChange={(e) => setVamcLegalName(e.target.value)}
+            required
+            disabled={pending}
+          />
+        </div>
+        <div className="grid gap-3 sm:grid-cols-2">
+          <div className="space-y-1">
+            <Label htmlFor={`${formId}-vamc-name`}>Contact name *</Label>
+            <Input
+              id={`${formId}-vamc-name`}
+              name="vamc_contact_name"
+              type="text"
+              value={vamcContactName}
+              onChange={(e) => setVamcContactName(e.target.value)}
+              required
+              disabled={pending}
+              placeholder="HUD-VASH coordinator"
+            />
+          </div>
+          <div className="space-y-1">
+            <Label htmlFor={`${formId}-vamc-title`}>Contact title *</Label>
+            <Input
+              id={`${formId}-vamc-title`}
+              name="vamc_contact_title"
+              type="text"
+              value={vamcContactTitle}
+              onChange={(e) => setVamcContactTitle(e.target.value)}
+              required
+              disabled={pending}
+              placeholder="e.g. HUD-VASH Coordinator, Louisville VAMC"
+            />
+          </div>
+          <div className="space-y-1">
+            <Label htmlFor={`${formId}-vamc-email`}>Contact email *</Label>
+            <Input
+              id={`${formId}-vamc-email`}
+              name="vamc_contact_email"
+              type="email"
+              value={vamcContactEmail}
+              onChange={(e) => setVamcContactEmail(e.target.value)}
+              required
+              disabled={pending}
+              placeholder="hudvash@va.gov"
+            />
+          </div>
+          <div className="space-y-1">
+            <Label htmlFor={`${formId}-vamc-phone`}>
+              Phone <span className="font-normal text-muted-foreground text-xs">(optional)</span>
+            </Label>
+            <Input
+              id={`${formId}-vamc-phone`}
+              name="vamc_contact_phone"
+              type="tel"
+              value={vamcContactPhone}
+              onChange={(e) => setVamcContactPhone(e.target.value)}
+              disabled={pending}
+              placeholder="(502) 287-4000"
+            />
+          </div>
+        </div>
+      </fieldset>
+
+      {/* PHA fields */}
+      <fieldset className="space-y-3 rounded-md border border-border bg-muted/10 p-4">
+        <legend className="px-1 text-sm font-semibold text-foreground">
+          Local Public Housing Authority (voucher allocation)
+        </legend>
+        <div className="space-y-1">
+          <Label htmlFor={`${formId}-pha-legal`}>PHA legal name *</Label>
+          <Input
+            id={`${formId}-pha-legal`}
+            name="pha_legal_name"
+            type="text"
+            value={phaLegalName}
+            onChange={(e) => setPhaLegalName(e.target.value)}
+            required
+            disabled={pending}
+            placeholder="e.g. Owensboro Housing Authority"
+          />
+        </div>
+        <div className="grid gap-3 sm:grid-cols-2">
+          <div className="space-y-1">
+            <Label htmlFor={`${formId}-pha-name`}>Contact name *</Label>
+            <Input
+              id={`${formId}-pha-name`}
+              name="pha_contact_name"
+              type="text"
+              value={phaContactName}
+              onChange={(e) => setPhaContactName(e.target.value)}
+              required
+              disabled={pending}
+            />
+          </div>
+          <div className="space-y-1">
+            <Label htmlFor={`${formId}-pha-title`}>Contact title *</Label>
+            <Input
+              id={`${formId}-pha-title`}
+              name="pha_contact_title"
+              type="text"
+              value={phaContactTitle}
+              onChange={(e) => setPhaContactTitle(e.target.value)}
+              required
+              disabled={pending}
+              placeholder="e.g. HCV Director"
+            />
+          </div>
+          <div className="space-y-1">
+            <Label htmlFor={`${formId}-pha-email`}>Contact email *</Label>
+            <Input
+              id={`${formId}-pha-email`}
+              name="pha_contact_email"
+              type="email"
+              value={phaContactEmail}
+              onChange={(e) => setPhaContactEmail(e.target.value)}
+              required
+              disabled={pending}
+            />
+          </div>
+          <div className="space-y-1">
+            <Label htmlFor={`${formId}-pha-phone`}>
+              Phone <span className="font-normal text-muted-foreground text-xs">(optional)</span>
+            </Label>
+            <Input
+              id={`${formId}-pha-phone`}
+              name="pha_contact_phone"
+              type="tel"
+              value={phaContactPhone}
+              onChange={(e) => setPhaContactPhone(e.target.value)}
+              disabled={pending}
+            />
+          </div>
+        </div>
+      </fieldset>
+
+      {/* Scope checkboxes */}
+      <fieldset className="space-y-3">
+        <legend className="text-sm font-medium">
+          Data scope *{' '}
+          <span className="font-normal text-muted-foreground text-xs">
+            (select all that apply — at least one required)
+          </span>
+        </legend>
+        <div className="space-y-2">
+          {VA_HUDVASH_DSA_SCOPE_OPTIONS.map((opt) => {
+            const inputId = `${formId}-scope-${opt.value}`;
+            return (
+              <label key={opt.value} htmlFor={inputId} className="flex items-start gap-2 text-sm">
+                <input
+                  type="checkbox"
+                  id={inputId}
+                  name={`scope_${opt.value}`}
+                  value="on"
+                  checked={selectedScope.has(opt.value)}
+                  onChange={() => toggleScope(opt.value)}
+                  disabled={pending}
+                  className="mt-0.5 h-4 w-4 rounded border-input"
+                />
+                <span>{opt.label}</span>
+              </label>
+            );
+          })}
+        </div>
+        <p className="text-xs text-muted-foreground">
+          MH/SUD diagnosis content, treatment plans, session notes, and medication lists are
+          <strong> intentionally absent</strong> from this scope. v1 only permits the <em>fact</em>{' '}
+          of an active treatment relationship (status_only). Expanding to QSOA-protected content
+          requires a separate agreement and ADR (see ADR 0010).
+        </p>
+      </fieldset>
+
+      {/* Voucher-search window */}
+      <fieldset className="space-y-2 rounded-md border border-border bg-muted/10 p-4">
+        <legend className="px-1 text-sm font-semibold text-foreground">
+          Voucher-search window
+        </legend>
+        <p className="text-xs text-muted-foreground">
+          Number of days after voucher issuance during which VA HUD-VASH may share an individual
+          veteran&apos;s record. SUBP-006&apos;s ingest middleware reads this as the contract-of-
+          record (ADR 0010 § Decision.3). Default {VA_HUDVASH_VOUCHER_WINDOW_DEFAULT_DAYS} days;
+          range {VA_HUDVASH_VOUCHER_WINDOW_MIN_DAYS}–{VA_HUDVASH_VOUCHER_WINDOW_MAX_DAYS}.
+        </p>
+        <div className="flex items-center gap-2">
+          <Input
+            id={`${formId}-window`}
+            name="voucher_search_window_days"
+            type="number"
+            min={VA_HUDVASH_VOUCHER_WINDOW_MIN_DAYS}
+            max={VA_HUDVASH_VOUCHER_WINDOW_MAX_DAYS}
+            step={1}
+            value={windowDays}
+            onChange={(e) => setWindowDays(e.target.value)}
+            disabled={pending}
+            className="w-32"
+          />
+          <span className="text-sm text-muted-foreground">days</span>
+        </div>
+      </fieldset>
+
+      {/* Individual records authorization */}
+      <fieldset className="space-y-2">
+        <legend className="text-sm font-medium">Individual-records authorization *</legend>
+        <p className="text-xs text-muted-foreground">
+          Mirrors KY DOC pattern. SUBP-006 reads this flag before enabling per-individual views; if
+          false, the agreement is informational only and no individual records may be persisted.
+        </p>
+        <div className="space-y-2">
+          <label className="flex items-center gap-1.5 text-sm">
+            <input
+              type="radio"
+              name="individual_records_authorized"
+              value="true"
+              checked={individualAuth === 'true'}
+              onChange={() => setIndividualAuth('true')}
+              disabled={pending}
+              className="h-4 w-4"
+            />
+            Authorized — joint VAMC + PHA have executed authorization for individual-record sharing
+          </label>
+          <label className="flex items-center gap-1.5 text-sm">
+            <input
+              type="radio"
+              name="individual_records_authorized"
+              value="false"
+              checked={individualAuth === 'false'}
+              onChange={() => setIndividualAuth('false')}
+              disabled={pending}
+              className="h-4 w-4"
+            />
+            Not authorized — informational agreement only
+          </label>
+        </div>
+      </fieldset>
+
+      {/* Locked treatment_scope reminder + hidden field */}
+      <input type="hidden" name="treatment_scope" value="status_only" />
+      <fieldset className="space-y-2 rounded-md border border-sky-500/40 bg-sky-500/5 p-4">
+        <legend className="px-1 text-sm font-semibold text-sky-700 dark:text-sky-400">
+          MH/SUD scope boundary (locked at v1)
+        </legend>
+        <p className="text-xs text-muted-foreground">
+          The <code className="font-mono text-xs">treatment_scope</code> field is locked to{' '}
+          <code className="font-mono text-xs">status_only</code> at v1: only the <em>fact</em> of an
+          active treatment relationship may flow (continuity-status enum + VA case-manager contact
+          for warm handoff). Diagnosis codes, treatment plan content, session notes, and medication
+          lists remain with the VA case manager. Expanding requires a separate QSOA + ADR.
+        </p>
+      </fieldset>
+
+      {/* No-service-denial-prediction attestation */}
+      <fieldset className="space-y-2 rounded-md border border-amber-500/40 bg-amber-500/5 p-4">
+        <legend className="px-1 text-sm font-semibold text-amber-700 dark:text-amber-400">
+          Required attestation
+        </legend>
+        <label className="flex items-start gap-2 text-sm">
+          <input
+            type="checkbox"
+            name="no_service_denial_prediction_attestation"
+            value="true"
+            checked={attested}
+            onChange={(e) => setAttested(e.target.checked)}
+            disabled={pending}
+            className="mt-0.5 h-4 w-4"
+            required
+          />
+          <span>
+            I attest that the Coalition will not use this data to predict voucher-failure,
+            deprioritize veteran cases, or feed any service-denial determination by insurers,
+            employers, eligibility-screening vendors, or any third party, as required by ADR 0010
+            and the VA HUD-VASH framework. I have authority to record this DSA on behalf of the
+            coalition.
+          </span>
+        </label>
+      </fieldset>
+
+      {/* Data destruction policy */}
+      <fieldset className="space-y-2">
+        <legend className="text-sm font-medium">Data destruction policy *</legend>
+        <div className="space-y-2">
+          {DESTRUCTION_OPTIONS.map((opt) => (
+            <label key={opt.value} className="flex items-center gap-1.5 text-sm">
+              <input
+                type="radio"
+                name="data_destruction_due"
+                value={opt.value}
+                checked={dataDestruction === opt.value}
+                onChange={() => setDataDestruction(opt.value)}
+                disabled={pending}
+                className="h-4 w-4"
+              />
+              {opt.label}
+            </label>
+          ))}
+        </div>
+      </fieldset>
+
+      {/* Notes */}
+      <div className="space-y-1">
+        <Label htmlFor={`${formId}-notes`}>
+          Notes{' '}
+          <span className="font-normal text-muted-foreground text-xs">
+            (optional — no individual identifiers)
+          </span>
+        </Label>
+        <textarea
+          id={`${formId}-notes`}
+          name="notes"
+          rows={3}
+          value={notes}
+          onChange={(e) => setNotes(e.target.value)}
+          disabled={pending}
+          maxLength={2000}
+          className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50"
+          placeholder="Optional context about this agreement"
+        />
+      </div>
+
+      {result && !result.ok ? (
+        <p role="alert" className="text-sm text-destructive">
+          {result.error}
+        </p>
+      ) : null}
+
+      <div className="flex gap-2">
+        <Button type="submit" disabled={pending || !attested}>
+          {pending ? 'Recording…' : 'Record VA HUD-VASH DSA'}
+        </Button>
+        <Link
+          href="/app/admin/agreements/vahudvash"
+          className="inline-flex items-center rounded-md border border-input bg-background px-3 py-2 text-sm hover:bg-accent"
+        >
+          Cancel
+        </Link>
+      </div>
+    </form>
+  );
+}

--- a/src/db/queries/partner-agreements.ts
+++ b/src/db/queries/partner-agreements.ts
@@ -113,6 +113,36 @@ export async function getActiveKyDocDsa(partnerOrgId: string): Promise<PartnerAg
 }
 
 /**
+ * Return the active VA HUD-VASH Data-Sharing Agreement for a partner, or null.
+ *
+ * SUBP-006's veteran ingest middleware reads the active agreement before every
+ * record write and exposes `terms.voucher_search_window_days` and
+ * `terms.individual_records_authorized` as the contract-of-record. The JSONB
+ * filter `terms->>'agency' = 'va_hudvash'` discriminates VA HUD-VASH agreements
+ * from DCBS / OASIS / KY DOC under the shared `dsa` kind (ADR 0004 / ADR 0010).
+ *
+ * Returns `null` when no active VA HUD-VASH DSA exists; SUBP-006 must fail
+ * closed in that case (ADR 0010 § Decision.1).
+ */
+export async function getActiveVaHudVashDsa(
+  partnerOrgId: string,
+): Promise<PartnerAgreement | null> {
+  const rows = await db
+    .select()
+    .from(partnerAgreements)
+    .where(
+      and(
+        eq(partnerAgreements.partnerOrgId, partnerOrgId),
+        eq(partnerAgreements.kind, 'dsa'),
+        eq(partnerAgreements.status, 'active'),
+        sql`(${partnerAgreements.terms}->>'agency') = 'va_hudvash'`,
+      ),
+    )
+    .limit(1);
+  return rows[0] ?? null;
+}
+
+/**
  * Insert a new agreement row. Validates `terms` via `validateAgreementTerms`
  * before the insert — throws on invalid shape, so the caller never needs to
  * re-check. The normalized/typed return value is used in the insert so that

--- a/src/lib/dtrs/partner-agreements.test.ts
+++ b/src/lib/dtrs/partner-agreements.test.ts
@@ -8,12 +8,17 @@ import {
   KY_DOC_PRE_RELEASE_WINDOW_MIN_DAYS,
   OASIS_DEFAULT_REDACTION_POLICY,
   OASIS_DSA_SCOPE_OPTIONS,
+  VA_HUDVASH_DSA_SCOPE_OPTIONS,
+  VA_HUDVASH_VOUCHER_WINDOW_DEFAULT_DAYS,
+  VA_HUDVASH_VOUCHER_WINDOW_MAX_DAYS,
+  VA_HUDVASH_VOUCHER_WINDOW_MIN_DAYS,
   validateAgreementTerms,
   validateDcbsDsaTerms,
   validateFerpaTerms,
   validateKyDocDsaTerms,
   validateMouTerms,
   validateOasisDsaTerms,
+  validateVaHudVashDsaTerms,
 } from './partner-agreements';
 
 // ---------------------------------------------------------------------------
@@ -739,5 +744,230 @@ describe('validateKyDocDsaTerms', () => {
     const result = validateAgreementTerms('dsa', validKyDocDsa);
     expect(result.kind).toBe('dsa');
     if (result.kind === 'dsa') expect(result.agency).toBe('ky_doc');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// validateVaHudVashDsaTerms (DTRS-015)
+// ---------------------------------------------------------------------------
+
+const validVaHudVashDsa = {
+  kind: 'dsa',
+  agency: 'va_hudvash',
+  scope: ['voucher_status_roster', 'eligibility_changes'],
+  vamc_legal_name: 'Robley Rex VA Medical Center HUD-VASH Program',
+  vamc_contact: {
+    name: 'VASH Coordinator',
+    title: 'HUD-VASH Program Coordinator',
+    email: 'vash.coordinator@va.gov',
+    phone: '(502) 287-4000',
+  },
+  pha_legal_name: 'Housing Authority of Owensboro',
+  pha_contact: {
+    name: 'Voucher Administrator',
+    title: 'HCV Program Manager',
+    email: 'hcv@owensborohousing.org',
+    phone: '(270) 685-3408',
+  },
+  population_focus: 'hud_vash',
+  voucher_search_window_days: VA_HUDVASH_VOUCHER_WINDOW_DEFAULT_DAYS,
+  individual_records_authorized: true,
+  no_service_denial_prediction_attestation: true,
+  treatment_scope: 'status_only',
+  data_destruction_due: 'on_termination',
+};
+
+describe('validateVaHudVashDsaTerms', () => {
+  it('accepts a valid VA HUD-VASH DSA terms object', () => {
+    const result = validateVaHudVashDsaTerms(validVaHudVashDsa);
+    expect(result.kind).toBe('dsa');
+    expect(result.agency).toBe('va_hudvash');
+    expect(result.scope).toEqual(['voucher_status_roster', 'eligibility_changes']);
+    expect(result.population_focus).toBe('hud_vash');
+    expect(result.voucher_search_window_days).toBe(VA_HUDVASH_VOUCHER_WINDOW_DEFAULT_DAYS);
+    expect(result.individual_records_authorized).toBe(true);
+    expect(result.no_service_denial_prediction_attestation).toBe(true);
+    expect(result.treatment_scope).toBe('status_only');
+    expect(result.vamc_legal_name).toBe('Robley Rex VA Medical Center HUD-VASH Program');
+    expect(result.pha_legal_name).toBe('Housing Authority of Owensboro');
+  });
+
+  it('accepts all valid scope values', () => {
+    const allScopes = VA_HUDVASH_DSA_SCOPE_OPTIONS.map((o) => o.value);
+    const result = validateVaHudVashDsaTerms({ ...validVaHudVashDsa, scope: allScopes });
+    expect(result.scope).toEqual(allScopes);
+  });
+
+  it('accepts all valid data_destruction_due values', () => {
+    for (const val of ['on_termination', 'after_3_years', 'after_5_years'] as const) {
+      const result = validateVaHudVashDsaTerms({ ...validVaHudVashDsa, data_destruction_due: val });
+      expect(result.data_destruction_due).toBe(val);
+    }
+  });
+
+  it('accepts voucher_search_window_days at the lower bound', () => {
+    const result = validateVaHudVashDsaTerms({
+      ...validVaHudVashDsa,
+      voucher_search_window_days: VA_HUDVASH_VOUCHER_WINDOW_MIN_DAYS,
+    });
+    expect(result.voucher_search_window_days).toBe(VA_HUDVASH_VOUCHER_WINDOW_MIN_DAYS);
+  });
+
+  it('accepts voucher_search_window_days at the upper bound', () => {
+    const result = validateVaHudVashDsaTerms({
+      ...validVaHudVashDsa,
+      voucher_search_window_days: VA_HUDVASH_VOUCHER_WINDOW_MAX_DAYS,
+    });
+    expect(result.voucher_search_window_days).toBe(VA_HUDVASH_VOUCHER_WINDOW_MAX_DAYS);
+  });
+
+  it('accepts terms without optional contact phones', () => {
+    const noPhone = {
+      ...validVaHudVashDsa,
+      vamc_contact: { name: 'A', title: 'T', email: 'a@va.gov' },
+      pha_contact: { name: 'B', title: 'U', email: 'b@pha.org' },
+    };
+    const result = validateVaHudVashDsaTerms(noPhone);
+    expect(result.vamc_contact.phone).toBeUndefined();
+    expect(result.pha_contact.phone).toBeUndefined();
+  });
+
+  it('rejects non-object input', () => {
+    expect(() => validateVaHudVashDsaTerms(null)).toThrow('must be an object');
+    expect(() => validateVaHudVashDsaTerms('dsa')).toThrow('must be an object');
+  });
+
+  it('rejects wrong kind', () => {
+    expect(() => validateVaHudVashDsaTerms({ ...validVaHudVashDsa, kind: 'mou' })).toThrow(
+      'kind: "dsa"',
+    );
+  });
+
+  it('rejects wrong agency', () => {
+    expect(() => validateVaHudVashDsaTerms({ ...validVaHudVashDsa, agency: 'ky_doc' })).toThrow(
+      'agency must be "va_hudvash"',
+    );
+  });
+
+  it('rejects empty scope array', () => {
+    expect(() => validateVaHudVashDsaTerms({ ...validVaHudVashDsa, scope: [] })).toThrow(
+      'at least one scope value',
+    );
+  });
+
+  it('rejects an invalid scope value', () => {
+    expect(() =>
+      validateVaHudVashDsaTerms({ ...validVaHudVashDsa, scope: ['mh_sud_diagnosis'] }),
+    ).toThrow('Invalid VA-HUDVASH-DSA scope value: "mh_sud_diagnosis"');
+  });
+
+  it('rejects empty vamc_legal_name', () => {
+    expect(() => validateVaHudVashDsaTerms({ ...validVaHudVashDsa, vamc_legal_name: '' })).toThrow(
+      'non-empty vamc_legal_name',
+    );
+  });
+
+  it('rejects empty pha_legal_name', () => {
+    expect(() => validateVaHudVashDsaTerms({ ...validVaHudVashDsa, pha_legal_name: '' })).toThrow(
+      'non-empty pha_legal_name',
+    );
+  });
+
+  it('rejects missing vamc_contact name', () => {
+    expect(() =>
+      validateVaHudVashDsaTerms({
+        ...validVaHudVashDsa,
+        vamc_contact: { name: '', title: 'T', email: 'a@va.gov' },
+      }),
+    ).toThrow('vamc_contact must include a non-empty name');
+  });
+
+  it('rejects missing pha_contact email', () => {
+    expect(() =>
+      validateVaHudVashDsaTerms({
+        ...validVaHudVashDsa,
+        pha_contact: { name: 'B', title: 'U', email: '' },
+      }),
+    ).toThrow('pha_contact must include a non-empty email');
+  });
+
+  it('rejects wrong population_focus', () => {
+    expect(() =>
+      validateVaHudVashDsaTerms({ ...validVaHudVashDsa, population_focus: 'ssvf' }),
+    ).toThrow('population_focus must be "hud_vash"');
+  });
+
+  it('rejects voucher_search_window_days below the minimum', () => {
+    expect(() =>
+      validateVaHudVashDsaTerms({
+        ...validVaHudVashDsa,
+        voucher_search_window_days: VA_HUDVASH_VOUCHER_WINDOW_MIN_DAYS - 1,
+      }),
+    ).toThrow('voucher_search_window_days must be an integer in');
+  });
+
+  it('rejects voucher_search_window_days above the maximum', () => {
+    expect(() =>
+      validateVaHudVashDsaTerms({
+        ...validVaHudVashDsa,
+        voucher_search_window_days: VA_HUDVASH_VOUCHER_WINDOW_MAX_DAYS + 1,
+      }),
+    ).toThrow('voucher_search_window_days must be an integer in');
+  });
+
+  it('rejects non-integer voucher_search_window_days', () => {
+    expect(() =>
+      validateVaHudVashDsaTerms({ ...validVaHudVashDsa, voucher_search_window_days: 120.5 }),
+    ).toThrow('voucher_search_window_days must be an integer in');
+  });
+
+  it('rejects non-boolean individual_records_authorized', () => {
+    expect(() =>
+      validateVaHudVashDsaTerms({ ...validVaHudVashDsa, individual_records_authorized: 'yes' }),
+    ).toThrow('individual_records_authorized must be a boolean');
+  });
+
+  it('rejects no_service_denial_prediction_attestation = false (the cornerstone of the contract)', () => {
+    expect(() =>
+      validateVaHudVashDsaTerms({
+        ...validVaHudVashDsa,
+        no_service_denial_prediction_attestation: false,
+      }),
+    ).toThrow('no_service_denial_prediction_attestation must be true');
+  });
+
+  it('rejects no_service_denial_prediction_attestation missing entirely', () => {
+    const { no_service_denial_prediction_attestation: _omit, ...withoutAttestation } =
+      validVaHudVashDsa;
+    void _omit;
+    expect(() => validateVaHudVashDsaTerms(withoutAttestation)).toThrow(
+      'no_service_denial_prediction_attestation must be true',
+    );
+  });
+
+  it('rejects treatment_scope other than "status_only" (MH/SUD scope boundary)', () => {
+    expect(() =>
+      validateVaHudVashDsaTerms({ ...validVaHudVashDsa, treatment_scope: 'qsoa_protected' }),
+    ).toThrow('treatment_scope must be "status_only"');
+  });
+
+  it('rejects invalid data_destruction_due', () => {
+    expect(() =>
+      validateVaHudVashDsaTerms({ ...validVaHudVashDsa, data_destruction_due: 'never_required' }),
+    ).toThrow('data_destruction_due must be one of');
+  });
+
+  it('strips extra/unexpected keys (does not pass through to JSONB)', () => {
+    const result = validateVaHudVashDsaTerms({
+      ...validVaHudVashDsa,
+      service_denial_score: 0.42,
+    });
+    expect(result).not.toHaveProperty('service_denial_score');
+  });
+
+  it("dispatches dsa+agency='va_hudvash' to validateVaHudVashDsaTerms", () => {
+    const result = validateAgreementTerms('dsa', validVaHudVashDsa);
+    expect(result.kind).toBe('dsa');
+    if (result.kind === 'dsa') expect(result.agency).toBe('va_hudvash');
   });
 });

--- a/src/lib/dtrs/partner-agreements.ts
+++ b/src/lib/dtrs/partner-agreements.ts
@@ -8,7 +8,8 @@
  * placeholder until their stories ship.
  *
  * Validators (`validateFerpaTerms`, `validateMouTerms`, `validateDcbsDsaTerms`,
- * `validateOasisDsaTerms`, `validateKyDocDsaTerms`, `validateAgreementTerms`)
+ * `validateOasisDsaTerms`, `validateKyDocDsaTerms`, `validateVaHudVashDsaTerms`,
+ * `validateAgreementTerms`)
  * are pure functions — throw on invalid shape, return typed value on success.
  * They run BEFORE any DB insert so bad data never reaches storage.
  */
@@ -170,6 +171,58 @@ export type KyDocDsaScopeValue = (typeof KY_DOC_DSA_SCOPE_OPTIONS)[number]['valu
 export const KY_DOC_PRE_RELEASE_WINDOW_DEFAULT_DAYS = 60;
 export const KY_DOC_PRE_RELEASE_WINDOW_MIN_DAYS = 30;
 export const KY_DOC_PRE_RELEASE_WINDOW_MAX_DAYS = 180;
+
+/**
+ * VA HUD-VASH DSA data classes — the veteran cohort the coalition may receive
+ * from the U.S. Department of Veterans Affairs joint with the local Public
+ * Housing Authority. Veterans are voluntarily enrolled with HUD-VASH; the
+ * authorities executing the agreement are the local VA Medical Center
+ * HUD-VASH team and the local PHA holding the voucher allocation, under
+ * 38 U.S.C. § 7332, 38 CFR Part 1, 42 U.S.C. § 11403, and HIPAA. See ADR 0010.
+ *
+ * Single source of truth — the intake form renders checkboxes from this array.
+ *
+ * Notably absent: any field that would carry 38 U.S.C. § 7332 or 42 U.S.C.
+ * § 290dd-2 protected MH/SUD content (diagnosis codes, treatment plan content,
+ * session notes, medication lists). Those remain with the VA case manager.
+ * The MH/SUD scope boundary is enforced separately via `treatment_scope`.
+ */
+export const VA_HUDVASH_DSA_SCOPE_OPTIONS = [
+  {
+    value: 'voucher_status_roster' as const,
+    label: 'Voucher-status roster (eligible / vouchered / searching / leased)',
+  },
+  {
+    value: 'eligibility_changes' as const,
+    label:
+      'Eligibility changes (service-connection rating shifts, income changes affecting continued eligibility)',
+  },
+  {
+    value: 'supports_in_place' as const,
+    label:
+      'Supports-in-place (case-management engagement, treatment-continuity status, primary-care continuity)',
+  },
+  {
+    value: 'coordination_eligibility' as const,
+    label: 'Adjacent-program eligibility (SSVF, Veterans Treatment Court, HCHV grant programs)',
+  },
+] as const;
+
+export type VaHudVashDsaScopeValue = (typeof VA_HUDVASH_DSA_SCOPE_OPTIONS)[number]['value'];
+
+/**
+ * Voucher-search window bounds. The window is the number of days after
+ * voucher issuance during which VA HUD-VASH may share an individual
+ * veteran's record with the Coalition for housing-search and lease-
+ * stabilization coordination. Below 60 days is below HUD's operational
+ * minimum voucher term; above 240 is risk without value (records drift,
+ * identifying data sits in the system longer than necessary, the veteran
+ * is by then either housed-and-stable or has lost the voucher). See
+ * ADR 0010 § Decision.3.
+ */
+export const VA_HUDVASH_VOUCHER_WINDOW_DEFAULT_DAYS = 120;
+export const VA_HUDVASH_VOUCHER_WINDOW_MIN_DAYS = 60;
+export const VA_HUDVASH_VOUCHER_WINDOW_MAX_DAYS = 240;
 
 /**
  * Default redaction policy — abuser-blind by default. Locations and
@@ -386,11 +439,99 @@ export type KyDocDsaTerms = {
 };
 
 /**
- * Union of all DSA-kind terms shapes. The `agency` discriminator is the
- * narrowing key. As of Sprint 12: DCBS (foster), OASIS (DV survivor), and
- * KY DOC (reentry) are fully specified.
+ * VA HUD-VASH Data-Sharing Agreement terms (DTRS-015). Authorizes individual-
+ * record sharing for the veteran pathway (SUBP-006), bounded by a configurable
+ * voucher-search window.
+ *
+ * Distinguished from KY DOC (ADR 0009, state-as-custodian during incarceration,
+ * pre-release window): VA HUD-VASH veterans are voluntarily enrolled and the
+ * window is voucher-lifecycle bounded, not custody-bounded. Distinguished from
+ * OASIS (ADR 0007, abuser-blind redaction): the threat model is diffuse
+ * (insurers, employers, eligibility-screening systems) rather than a known
+ * third party, so the contract uses *bounded scope* rather than per-field
+ * suppression. See ADR 0010 for the privacy contract.
+ *
+ * `individual_records_authorized` is the runtime gate for SUBP-006.
+ * `voucher_search_window_days` bounds which records may flow.
+ * `no_service_denial_prediction_attestation` MUST be `true` when status='active'
+ * — the validator enforces this; the Coalition contractually commits to never
+ * use this data to predict voucher-failure or deprioritize veteran cases.
+ * `treatment_scope` codifies the MH/SUD scope boundary at the type level —
+ * v1 only permits `'status_only'`, meaning the *fact* of an active treatment
+ * relationship may be shared but never diagnosis, treatment plan, or session
+ * content. Expansion would require a separate QSOA + ADR.
  */
-export type DsaTerms = DcbsDsaTerms | OasisDsaTerms | KyDocDsaTerms;
+export type VaHudVashDsaTerms = {
+  kind: 'dsa';
+  agency: 'va_hudvash';
+  /** Which data classes are covered by this agreement. */
+  scope: VaHudVashDsaScopeValue[];
+  /** Full legal name of the executing VA Medical Center HUD-VASH program. */
+  vamc_legal_name: string;
+  /** Single point of contact at the VA HUD-VASH program. */
+  vamc_contact: {
+    name: string;
+    title: string;
+    email: string;
+    phone?: string;
+  };
+  /** Full legal name of the local Public Housing Authority co-signer. */
+  pha_legal_name: string;
+  /** Single point of contact at the PHA. */
+  pha_contact: {
+    name: string;
+    title: string;
+    email: string;
+    phone?: string;
+  };
+  /**
+   * Population scope of this agreement. Sprint 13 ships `hud_vash` only;
+   * future amendments may expand to `ssvf`, `hchv`, or `vtc` — each requires
+   * a separate ADR.
+   */
+  population_focus: 'hud_vash';
+  /**
+   * Number of days after voucher issuance during which the VA may share an
+   * individual veteran's record with the Coalition. SUBP-006's ingest
+   * middleware reads this as its single source of truth. Bounded by
+   * VA_HUDVASH_VOUCHER_WINDOW_MIN_DAYS / VA_HUDVASH_VOUCHER_WINDOW_MAX_DAYS.
+   */
+  voucher_search_window_days: number;
+  /**
+   * MUST be true for any individual-record ingest. SUBP-006 reads this flag
+   * before enabling per-individual views; if false, the agreement is
+   * informational only and no individual records may be persisted.
+   */
+  individual_records_authorized: boolean;
+  /**
+   * MUST be true to record this agreement as `status='active'`. The admin
+   * checks this box in the intake form after reviewing the no-service-
+   * denial-prediction commitment. Validator throws if not true.
+   */
+  no_service_denial_prediction_attestation: boolean;
+  /**
+   * MH/SUD scope boundary. v1 only permits `'status_only'`: the *fact* of an
+   * active treatment relationship may be shared (boolean / continuity-status
+   * enum), but never diagnosis codes, treatment plan content, session notes,
+   * or medication lists. Expanding to `'qsoa_protected'` would require a
+   * separate Qualified Service Organization Agreement under 42 CFR Part 2,
+   * additional Coalition-side personnel-training requirements, and a new ADR.
+   */
+  treatment_scope: 'status_only';
+  /**
+   * Records-retention deadline. HUD-VASH best practice favors `on_termination`
+   * or `after_3_years` — veteran records that have outlived the voucher-search
+   * window add risk without operational value.
+   */
+  data_destruction_due: 'on_termination' | 'after_3_years' | 'after_5_years';
+};
+
+/**
+ * Union of all DSA-kind terms shapes. The `agency` discriminator is the
+ * narrowing key. As of Sprint 13: DCBS (foster), OASIS (DV survivor), KY DOC
+ * (reentry), and VA HUD-VASH (veterans) are fully specified.
+ */
+export type DsaTerms = DcbsDsaTerms | OasisDsaTerms | KyDocDsaTerms | VaHudVashDsaTerms;
 
 /**
  * Placeholder for agreement kinds whose intake stories haven't shipped yet
@@ -961,14 +1102,190 @@ export function validateKyDocDsaTerms(input: unknown): KyDocDsaTerms {
   };
 }
 
+const VA_HUDVASH_DSA_SCOPE_VALUES = VA_HUDVASH_DSA_SCOPE_OPTIONS.map((o) => o.value);
+
+/**
+ * Validate VA HUD-VASH DSA terms (DTRS-015). Throws on invalid; returns typed
+ * value on success. See ADR 0010 for the privacy contract this validator
+ * enforces.
+ *
+ * **Strict no-service-denial-prediction enforcement:**
+ * `no_service_denial_prediction_attestation` MUST be `true`. Recording a VA
+ * HUD-VASH DSA without it is an architectural bug — the prohibition is the
+ * contract, not an option.
+ *
+ * **Voucher-search window bounds:** `voucher_search_window_days` must fall
+ * within `[VA_HUDVASH_VOUCHER_WINDOW_MIN_DAYS, VA_HUDVASH_VOUCHER_WINDOW_MAX_DAYS]`.
+ *
+ * **MH/SUD scope boundary:** `treatment_scope` MUST equal `'status_only'` at v1.
+ * Expansion to QSOA-protected content requires a separate agreement kind + ADR.
+ */
+export function validateVaHudVashDsaTerms(input: unknown): VaHudVashDsaTerms {
+  if (typeof input !== 'object' || input === null) {
+    throw new Error('DSA terms must be an object');
+  }
+
+  const {
+    kind,
+    agency,
+    scope,
+    vamc_legal_name,
+    vamc_contact,
+    pha_legal_name,
+    pha_contact,
+    population_focus,
+    voucher_search_window_days,
+    individual_records_authorized,
+    no_service_denial_prediction_attestation,
+    treatment_scope,
+    data_destruction_due,
+  } = input as {
+    kind?: unknown;
+    agency?: unknown;
+    scope?: unknown;
+    vamc_legal_name?: unknown;
+    vamc_contact?: unknown;
+    pha_legal_name?: unknown;
+    pha_contact?: unknown;
+    population_focus?: unknown;
+    voucher_search_window_days?: unknown;
+    individual_records_authorized?: unknown;
+    no_service_denial_prediction_attestation?: unknown;
+    treatment_scope?: unknown;
+    data_destruction_due?: unknown;
+  };
+
+  if (kind !== 'dsa') {
+    throw new Error('DSA terms must have kind: "dsa"');
+  }
+  if (agency !== 'va_hudvash') {
+    throw new Error('DSA terms.agency must be "va_hudvash" for VA HUD-VASH agreements');
+  }
+
+  if (!Array.isArray(scope) || scope.length === 0) {
+    throw new Error('DSA terms must include at least one scope value');
+  }
+  for (const s of scope as unknown[]) {
+    if (!VA_HUDVASH_DSA_SCOPE_VALUES.includes(s as VaHudVashDsaScopeValue)) {
+      throw new Error(
+        `Invalid VA-HUDVASH-DSA scope value: "${String(s)}" (allowed: ${VA_HUDVASH_DSA_SCOPE_VALUES.join(', ')})`,
+      );
+    }
+  }
+
+  if (typeof vamc_legal_name !== 'string' || !vamc_legal_name.trim()) {
+    throw new Error('DSA terms must include a non-empty vamc_legal_name');
+  }
+  const validatedVamcContact = validateContact(vamc_contact, 'vamc_contact');
+
+  if (typeof pha_legal_name !== 'string' || !pha_legal_name.trim()) {
+    throw new Error('DSA terms must include a non-empty pha_legal_name');
+  }
+  const validatedPhaContact = validateContact(pha_contact, 'pha_contact');
+
+  if (population_focus !== 'hud_vash') {
+    throw new Error('DSA terms.population_focus must be "hud_vash" (Sprint 13 scope)');
+  }
+
+  if (
+    typeof voucher_search_window_days !== 'number' ||
+    !Number.isInteger(voucher_search_window_days) ||
+    voucher_search_window_days < VA_HUDVASH_VOUCHER_WINDOW_MIN_DAYS ||
+    voucher_search_window_days > VA_HUDVASH_VOUCHER_WINDOW_MAX_DAYS
+  ) {
+    throw new Error(
+      `DSA terms.voucher_search_window_days must be an integer in ` +
+        `[${VA_HUDVASH_VOUCHER_WINDOW_MIN_DAYS}, ${VA_HUDVASH_VOUCHER_WINDOW_MAX_DAYS}] ` +
+        `(see ADR 0010 § Decision.3)`,
+    );
+  }
+
+  if (typeof individual_records_authorized !== 'boolean') {
+    throw new Error('DSA terms.individual_records_authorized must be a boolean');
+  }
+
+  if (no_service_denial_prediction_attestation !== true) {
+    throw new Error(
+      'DSA terms.no_service_denial_prediction_attestation must be true — the no-service-denial-' +
+        'prediction commitment is the VA HUD-VASH contract (ADR 0010). Recording without ' +
+        'attestation is not permitted.',
+    );
+  }
+
+  if (treatment_scope !== 'status_only') {
+    throw new Error(
+      'DSA terms.treatment_scope must be "status_only" (Sprint 13 scope). Expanding to ' +
+        'QSOA-protected MH/SUD content requires a separate agreement kind and ADR (see ADR 0010).',
+    );
+  }
+
+  const validDestruction = ['on_termination', 'after_3_years', 'after_5_years'] as const;
+  if (!validDestruction.includes(data_destruction_due as (typeof validDestruction)[number])) {
+    throw new Error(`DSA data_destruction_due must be one of: ${validDestruction.join(', ')}`);
+  }
+
+  return {
+    kind: 'dsa',
+    agency: 'va_hudvash',
+    scope: scope as VaHudVashDsaScopeValue[],
+    vamc_legal_name,
+    vamc_contact: validatedVamcContact,
+    pha_legal_name,
+    pha_contact: validatedPhaContact,
+    population_focus: 'hud_vash',
+    voucher_search_window_days,
+    individual_records_authorized,
+    no_service_denial_prediction_attestation: true,
+    treatment_scope: 'status_only',
+    data_destruction_due: data_destruction_due as VaHudVashDsaTerms['data_destruction_due'],
+  };
+}
+
+interface ContactRecord {
+  name: string;
+  title: string;
+  email: string;
+  phone?: string;
+}
+
+function validateContact(input: unknown, label: string): ContactRecord {
+  if (typeof input !== 'object' || input === null) {
+    throw new Error(`DSA terms must include a ${label} object`);
+  }
+  const { name, title, email, phone } = input as {
+    name?: unknown;
+    title?: unknown;
+    email?: unknown;
+    phone?: unknown;
+  };
+  if (typeof name !== 'string' || !name.trim()) {
+    throw new Error(`DSA ${label} must include a non-empty name`);
+  }
+  if (typeof title !== 'string' || !title.trim()) {
+    throw new Error(`DSA ${label} must include a non-empty title`);
+  }
+  if (typeof email !== 'string' || !email.trim()) {
+    throw new Error(`DSA ${label} must include a non-empty email`);
+  }
+  if (phone !== undefined && typeof phone !== 'string') {
+    throw new Error(`DSA ${label}.phone must be a string when provided`);
+  }
+  return {
+    name,
+    title,
+    email,
+    ...(phone !== undefined ? { phone: phone as string } : {}),
+  };
+}
+
 /**
  * Dispatcher — picks the right validator for the given agreement kind.
  *
  * Placeholder kinds (baa, qsoa, memo_of_cooperation) are intentionally
  * fail-closed: they throw until their intake stories ship and a real validator
  * is wired in. `dsa` is dispatched on the `agency` discriminator: `dcbs`
- * (DTRS-011), `oasis` (DTRS-012), and `ky_doc` (DTRS-013) are supported.
- * See ADR 0004 for the registry plan.
+ * (DTRS-011), `oasis` (DTRS-012), `ky_doc` (DTRS-013), and `va_hudvash`
+ * (DTRS-015) are supported. See ADR 0004 for the registry plan.
  */
 export function validateAgreementTerms(
   kind: PartnerAgreementKind,
@@ -987,8 +1304,11 @@ export function validateAgreementTerms(
       if (agency === 'dcbs') return validateDcbsDsaTerms(input);
       if (agency === 'oasis') return validateOasisDsaTerms(input);
       if (agency === 'ky_doc') return validateKyDocDsaTerms(input);
+      if (agency === 'va_hudvash') return validateVaHudVashDsaTerms(input);
       if (typeof agency !== 'string' || !agency) {
-        throw new Error("DSA terms.agency is required (e.g. 'dcbs', 'oasis', 'ky_doc')");
+        throw new Error(
+          "DSA terms.agency is required (e.g. 'dcbs', 'oasis', 'ky_doc', 'va_hudvash')",
+        );
       }
       throw new Error(
         `DSA agency '${agency}' not yet supported — its intake story has not shipped. ` +


### PR DESCRIPTION
Refs #379

## Summary

Adds the VA HUD-VASH data-sharing agreement workflow — sister story to DTRS-011 (DCBS) / DTRS-012 (OASIS) / DTRS-013 (KY DOC). Introduces an `agency='va_hudvash'` variant under the existing `kind='dsa'` partner-agreements registry, providing the agreement infrastructure **SUBP-006 (Veteran pathway, #135)** needs before any individual veteran records can be ingested.

VA HUD-VASH differs from the custodial KY DOC model in two ways encoded here:
- **Dual signer** — both the VAMC HUD-VASH program and the local PHA (voucher holder) execute the agreement; the form and terms carry two contacts.
- **Bounded scope, not per-field suppression** — the threat model is diffuse (insurers, employers, eligibility screens), so the contract uses a voucher-search window + a hard MH/SUD scope boundary (`treatment_scope` locked to `'status_only'`) rather than OASIS-style abuser-blind redaction.

## Acceptance criteria

- [x] ADR 0010 published — VA HUD-VASH data-sharing privacy contract.
- [x] `VaHudVashDsaTerms` type + `VA_HUDVASH_DSA_SCOPE_OPTIONS` + `VA_HUDVASH_VOUCHER_WINDOW_*` constants in `src/lib/dtrs/partner-agreements.ts`.
- [x] `validateVaHudVashDsaTerms` + `validateAgreementTerms` dispatcher branch for `agency='va_hudvash'`.
- [x] `parseVaHudVashDsaAgreementForm` parser + `recordVaHudVashDsaAgreementAction` server action.
- [x] `getActiveVaHudVashDsa(partnerOrgId)` query.
- [x] Form component `src/components/dtrs/vahudvash-dsa-agreement-form.tsx` (voucher-window selector + no-service-denial-prediction attestation, dual VAMC/PHA signer).
- [x] Admin page `src/app/app/admin/agreements/vahudvash/page.tsx`.
- [x] Public template `src/app/agreements/vahudvash/template/page.tsx` (template version `vahudvash-dsa-v1`).
- [x] Validator + parser tests.
- [x] Definition of Done (see below).

## Verification

- `pnpm lint` (biome, no --write) — clean (1 pre-existing info in `scripts/check-domain-boundaries.mts`, unrelated/on main)
- `pnpm typecheck` — clean
- `pnpm lint:boundaries` — domain boundaries clean
- `pnpm test` — **789 passed (47 files)**; +44 new tests across validator + parser
- `pnpm build` (next build) — ✓ compiled successfully; `/agreements/vahudvash/template` (static) and `/app/admin/agreements/vahudvash` (dynamic) routes emit

## Notes

- PHI fence respected — no real PHI; agreement metadata only.
- Query getters follow the established thin-wrapper convention over `getActiveAgreementByKind`; the pure filter (`findActiveAgreement`) is unit-tested, per the repo's 'use server'×vitest quirk — so no DB-mock getter test was added, matching the KY DOC/OASIS siblings.
- This branch carried pre-existing uncommitted implementation work (validator/parser/action/query/form/pages/ADR); this PR completes it by adding the missing validator + parser test coverage and the full DoD verification pass. Only DTRS-015 files were committed (local-only `config.env`/`.loops/`/research docs were excluded).