### PR TITLE
feat(CWT-018): caseworker mobile responsive UI

### DIFF
--- a/src/app/app/clients/dv-survivors/page.tsx
+++ b/src/app/app/clients/dv-survivors/page.tsx
@@ -126,68 +126,110 @@ export default async function DvSurvivorsPage() {
           </p>
         </div>
       ) : (
-        <div className="overflow-x-auto rounded-md border border-border">
-          <table className="w-full text-sm">
-            <thead>
-              <tr className="border-b bg-muted/30 text-left">
-                <th className="px-3 py-2 font-medium">Case</th>
-                <th className="px-3 py-2 font-medium">Risk tier</th>
-                <th className="px-3 py-2 font-medium">Status</th>
-                <th className="px-3 py-2 font-medium">Enrolled</th>
-                <th className="px-3 py-2 font-medium">Safety plan</th>
-              </tr>
-            </thead>
-            <tbody>
-              {[...rows]
-                .sort((a, b) => {
-                  const r = (RISK_ORDER[a.riskTier] ?? 9) - (RISK_ORDER[b.riskTier] ?? 9);
-                  if (r !== 0) return r;
-                  return new Date(b.enrolledAt).getTime() - new Date(a.enrolledAt).getTime();
-                })
-                .map((s) => (
-                  <tr key={s.id} className="border-b last:border-0 hover:bg-muted/10">
-                    <td className="px-3 py-2">
+        (() => {
+          const sorted = [...rows].sort((a, b) => {
+            const r = (RISK_ORDER[a.riskTier] ?? 9) - (RISK_ORDER[b.riskTier] ?? 9);
+            if (r !== 0) return r;
+            return new Date(b.enrolledAt).getTime() - new Date(a.enrolledAt).getTime();
+          });
+          return (
+            <>
+              {/* Desktop: table. Mobile: card stack (no horizontal scroll). */}
+              <div className="hidden overflow-x-auto rounded-md border border-border md:block">
+                <table className="w-full text-sm">
+                  <thead>
+                    <tr className="border-b bg-muted/30 text-left">
+                      <th className="px-3 py-2 font-medium">Case</th>
+                      <th className="px-3 py-2 font-medium">Risk tier</th>
+                      <th className="px-3 py-2 font-medium">Status</th>
+                      <th className="px-3 py-2 font-medium">Enrolled</th>
+                      <th className="px-3 py-2 font-medium">Safety plan</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {sorted.map((s) => (
+                      <tr key={s.id} className="border-b last:border-0 hover:bg-muted/10">
+                        <td className="px-3 py-2">
+                          <Link
+                            href={`/app/clients/dv-survivors/${s.id}`}
+                            className="font-medium hover:underline"
+                          >
+                            {s.oasisCaseId}
+                          </Link>
+                        </td>
+                        <td className="px-3 py-2">
+                          <span
+                            className={`rounded px-1.5 py-0.5 text-[10px] font-medium ${RISK_BADGE[s.riskTier] ?? ''}`}
+                          >
+                            {s.riskTier.replace(/_/g, ' ')}
+                          </span>
+                        </td>
+                        <td className="px-3 py-2">
+                          <span
+                            className={`rounded px-1.5 py-0.5 text-[10px] font-medium ${STATUS_BADGE[s.status] ?? ''}`}
+                          >
+                            {s.status}
+                          </span>
+                        </td>
+                        <td className="px-3 py-2 tabular-nums text-xs text-muted-foreground">
+                          {new Date(s.enrolledAt).toISOString().slice(0, 10)}
+                        </td>
+                        <td className="px-3 py-2">
+                          {s.safetyPlanOnFile ? (
+                            <span className="text-emerald-700 dark:text-emerald-400">on file</span>
+                          ) : (
+                            <span className="text-muted-foreground">none</span>
+                          )}
+                          {s.safetyPlanLastReviewedAt && (
+                            <span className="ml-1 text-[10px] text-muted-foreground">
+                              (rev {new Date(s.safetyPlanLastReviewedAt).toISOString().slice(0, 10)}
+                              )
+                            </span>
+                          )}
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+              <ul className="space-y-2 md:hidden">
+                {sorted.map((s) => (
+                  <li key={s.id} className="rounded-md border border-border bg-card p-3 text-sm">
+                    <div className="flex items-start justify-between gap-2">
                       <Link
                         href={`/app/clients/dv-survivors/${s.id}`}
                         className="font-medium hover:underline"
                       >
                         {s.oasisCaseId}
                       </Link>
-                    </td>
-                    <td className="px-3 py-2">
                       <span
-                        className={`rounded px-1.5 py-0.5 text-[10px] font-medium ${RISK_BADGE[s.riskTier] ?? ''}`}
+                        className={`shrink-0 rounded px-1.5 py-0.5 text-[10px] font-medium ${RISK_BADGE[s.riskTier] ?? ''}`}
                       >
                         {s.riskTier.replace(/_/g, ' ')}
                       </span>
-                    </td>
-                    <td className="px-3 py-2">
-                      <span
-                        className={`rounded px-1.5 py-0.5 text-[10px] font-medium ${STATUS_BADGE[s.status] ?? ''}`}
-                      >
-                        {s.status}
-                      </span>
-                    </td>
-                    <td className="px-3 py-2 tabular-nums text-xs text-muted-foreground">
-                      {new Date(s.enrolledAt).toISOString().slice(0, 10)}
-                    </td>
-                    <td className="px-3 py-2">
-                      {s.safetyPlanOnFile ? (
-                        <span className="text-emerald-700 dark:text-emerald-400">on file</span>
-                      ) : (
-                        <span className="text-muted-foreground">none</span>
-                      )}
-                      {s.safetyPlanLastReviewedAt && (
-                        <span className="ml-1 text-[10px] text-muted-foreground">
-                          (rev {new Date(s.safetyPlanLastReviewedAt).toISOString().slice(0, 10)})
-                        </span>
-                      )}
-                    </td>
-                  </tr>
+                    </div>
+                    <dl className="mt-2 grid grid-cols-2 gap-x-3 gap-y-1 text-xs text-muted-foreground">
+                      <div>
+                        <dt className="inline font-medium">Status: </dt>
+                        <dd className="inline">{s.status}</dd>
+                      </div>
+                      <div>
+                        <dt className="inline font-medium">Enrolled: </dt>
+                        <dd className="inline tabular-nums">
+                          {new Date(s.enrolledAt).toISOString().slice(0, 10)}
+                        </dd>
+                      </div>
+                      <div className="col-span-2">
+                        <dt className="inline font-medium">Safety plan: </dt>
+                        <dd className="inline">{s.safetyPlanOnFile ? 'on file' : 'none'}</dd>
+                      </div>
+                    </dl>
+                  </li>
                 ))}
-            </tbody>
-          </table>
-        </div>
+              </ul>
+            </>
+          );
+        })()
       )}
     </div>
   );

--- a/src/app/app/clients/families/page.tsx
+++ b/src/app/app/clients/families/page.tsx
@@ -79,56 +79,97 @@ export default async function FamiliesPage() {
           </p>
         </div>
       ) : (
-        <div className="overflow-x-auto rounded-md border border-border">
-          <table className="w-full text-sm">
-            <thead>
-              <tr className="border-b bg-muted/30 text-left">
-                <th className="px-3 py-2 font-medium">Family</th>
-                <th className="px-3 py-2 font-medium">Stability risk</th>
-                <th className="px-3 py-2 font-medium">Children</th>
-                <th className="px-3 py-2 font-medium">Housing</th>
-                <th className="px-3 py-2 font-medium">Entry</th>
-              </tr>
-            </thead>
-            <tbody>
-              {[...enriched]
-                .sort((a, b) => {
-                  const r = (RISK_ORDER[a.risk.risk] ?? 9) - (RISK_ORDER[b.risk.risk] ?? 9);
-                  if (r !== 0) return r;
-                  return (
-                    new Date(b.family.createdAt).getTime() - new Date(a.family.createdAt).getTime()
-                  );
-                })
-                .map(({ family: f, risk, childCount }) => (
-                  <tr key={f.id} className="border-b last:border-0 hover:bg-muted/10">
-                    <td className="px-3 py-2">
+        (() => {
+          const sorted = [...enriched].sort((a, b) => {
+            const r = (RISK_ORDER[a.risk.risk] ?? 9) - (RISK_ORDER[b.risk.risk] ?? 9);
+            if (r !== 0) return r;
+            return new Date(b.family.createdAt).getTime() - new Date(a.family.createdAt).getTime();
+          });
+          return (
+            <>
+              {/* Desktop: table. Mobile: card stack (no horizontal scroll). */}
+              <div className="hidden overflow-x-auto rounded-md border border-border md:block">
+                <table className="w-full text-sm">
+                  <thead>
+                    <tr className="border-b bg-muted/30 text-left">
+                      <th className="px-3 py-2 font-medium">Family</th>
+                      <th className="px-3 py-2 font-medium">Stability risk</th>
+                      <th className="px-3 py-2 font-medium">Children</th>
+                      <th className="px-3 py-2 font-medium">Housing</th>
+                      <th className="px-3 py-2 font-medium">Entry</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {sorted.map(({ family: f, risk, childCount }) => (
+                      <tr key={f.id} className="border-b last:border-0 hover:bg-muted/10">
+                        <td className="px-3 py-2">
+                          <Link
+                            href={`/app/clients/families/${f.id}`}
+                            className="font-medium hover:underline"
+                          >
+                            {f.primaryCaregiverName}
+                          </Link>
+                          <div className="text-[10px] text-muted-foreground">
+                            household {f.householdSize}
+                          </div>
+                        </td>
+                        <td className="px-3 py-2">
+                          <span
+                            className={`rounded px-1.5 py-0.5 text-[10px] font-medium ${RISK_BADGE[risk.risk] ?? ''}`}
+                          >
+                            {risk.risk}
+                          </span>
+                        </td>
+                        <td className="px-3 py-2 tabular-nums">{childCount}</td>
+                        <td className="px-3 py-2 capitalize">
+                          {f.currentHousingStatus.replace(/_/g, ' ')}
+                        </td>
+                        <td className="px-3 py-2 capitalize">{f.entrySignal.replace(/_/g, ' ')}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+              <ul className="space-y-2 md:hidden">
+                {sorted.map(({ family: f, risk, childCount }) => (
+                  <li key={f.id} className="rounded-md border border-border bg-card p-3 text-sm">
+                    <div className="flex items-start justify-between gap-2">
                       <Link
                         href={`/app/clients/families/${f.id}`}
                         className="font-medium hover:underline"
                       >
                         {f.primaryCaregiverName}
                       </Link>
-                      <div className="text-[10px] text-muted-foreground">
-                        household {f.householdSize}
-                      </div>
-                    </td>
-                    <td className="px-3 py-2">
                       <span
-                        className={`rounded px-1.5 py-0.5 text-[10px] font-medium ${RISK_BADGE[risk.risk] ?? ''}`}
+                        className={`shrink-0 rounded px-1.5 py-0.5 text-[10px] font-medium ${RISK_BADGE[risk.risk] ?? ''}`}
                       >
                         {risk.risk}
                       </span>
-                    </td>
-                    <td className="px-3 py-2 tabular-nums">{childCount}</td>
-                    <td className="px-3 py-2 capitalize">
-                      {f.currentHousingStatus.replace(/_/g, ' ')}
-                    </td>
-                    <td className="px-3 py-2 capitalize">{f.entrySignal.replace(/_/g, ' ')}</td>
-                  </tr>
+                    </div>
+                    <dl className="mt-2 grid grid-cols-2 gap-x-3 gap-y-1 text-xs text-muted-foreground">
+                      <div>
+                        <dt className="inline font-medium">Household: </dt>
+                        <dd className="inline tabular-nums">{f.householdSize}</dd>
+                      </div>
+                      <div>
+                        <dt className="inline font-medium">Children: </dt>
+                        <dd className="inline tabular-nums">{childCount}</dd>
+                      </div>
+                      <div className="capitalize">
+                        <dt className="inline font-medium">Housing: </dt>
+                        <dd className="inline">{f.currentHousingStatus.replace(/_/g, ' ')}</dd>
+                      </div>
+                      <div className="capitalize">
+                        <dt className="inline font-medium">Entry: </dt>
+                        <dd className="inline">{f.entrySignal.replace(/_/g, ' ')}</dd>
+                      </div>
+                    </dl>
+                  </li>
                 ))}
-            </tbody>
-          </table>
-        </div>
+              </ul>
+            </>
+          );
+        })()
       )}
     </div>
   );

--- a/src/app/app/clients/foster-aging-out/page.tsx
+++ b/src/app/app/clients/foster-aging-out/page.tsx
@@ -77,64 +77,113 @@ export default async function FosterAgingOutPage() {
           </p>
         </div>
       ) : (
-        <div className="overflow-x-auto rounded-md border border-border">
-          <table className="w-full text-sm">
-            <thead>
-              <tr className="border-b bg-muted/30 text-left">
-                <th className="px-3 py-2 font-medium">Name</th>
-                <th className="px-3 py-2 font-medium">Days to 18</th>
-                <th className="px-3 py-2 font-medium">Tier</th>
-                <th className="px-3 py-2 font-medium">Placement</th>
-                <th className="px-3 py-2 font-medium">Supports</th>
-                <th className="px-3 py-2 font-medium">Alerts</th>
-              </tr>
-            </thead>
-            <tbody>
-              {ranked.map(({ youth: y, days, tier }) => {
-                const supports = countSupportsInPlace(y.supportsInPlace);
-                const unackCount = unackByYouth[y.id] ?? 0;
-                return (
-                  <tr key={y.id} className="border-b last:border-0 hover:bg-muted/10">
-                    <td className="px-3 py-2">
-                      <Link
-                        href={`/app/clients/foster-aging-out/${y.id}`}
-                        className="font-medium hover:underline"
-                      >
-                        {y.legalFirstName} {y.legalLastName}
-                      </Link>
-                      <div className="text-[10px] font-mono text-muted-foreground">
-                        case {y.dcbsCaseId}
-                      </div>
-                    </td>
-                    <td className="px-3 py-2 tabular-nums">
-                      {days < 0 ? `+${Math.abs(days)}d past` : `${days}d`}
-                    </td>
-                    <td className="px-3 py-2">
-                      <span
-                        className={`rounded px-1.5 py-0.5 text-[10px] font-medium ${TIER_BADGE[tier] ?? ''}`}
-                      >
-                        {tier}
-                      </span>
-                    </td>
-                    <td className="px-3 py-2 capitalize">{y.placementType.replace(/_/g, ' ')}</td>
-                    <td className="px-3 py-2">
-                      <span className="text-muted-foreground">{supports}/4</span>
-                    </td>
-                    <td className="px-3 py-2">
-                      {unackCount > 0 ? (
-                        <span className="rounded bg-amber-100 px-1.5 py-0.5 text-[10px] font-medium text-amber-700 dark:bg-amber-900/40 dark:text-amber-400">
-                          {unackCount} unack
+        <>
+          {/* Desktop: table. Mobile: card stack (no horizontal scroll). */}
+          <div className="hidden overflow-x-auto rounded-md border border-border md:block">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="border-b bg-muted/30 text-left">
+                  <th className="px-3 py-2 font-medium">Name</th>
+                  <th className="px-3 py-2 font-medium">Days to 18</th>
+                  <th className="px-3 py-2 font-medium">Tier</th>
+                  <th className="px-3 py-2 font-medium">Placement</th>
+                  <th className="px-3 py-2 font-medium">Supports</th>
+                  <th className="px-3 py-2 font-medium">Alerts</th>
+                </tr>
+              </thead>
+              <tbody>
+                {ranked.map(({ youth: y, days, tier }) => {
+                  const supports = countSupportsInPlace(y.supportsInPlace);
+                  const unackCount = unackByYouth[y.id] ?? 0;
+                  return (
+                    <tr key={y.id} className="border-b last:border-0 hover:bg-muted/10">
+                      <td className="px-3 py-2">
+                        <Link
+                          href={`/app/clients/foster-aging-out/${y.id}`}
+                          className="font-medium hover:underline"
+                        >
+                          {y.legalFirstName} {y.legalLastName}
+                        </Link>
+                        <div className="text-[10px] font-mono text-muted-foreground">
+                          case {y.dcbsCaseId}
+                        </div>
+                      </td>
+                      <td className="px-3 py-2 tabular-nums">
+                        {days < 0 ? `+${Math.abs(days)}d past` : `${days}d`}
+                      </td>
+                      <td className="px-3 py-2">
+                        <span
+                          className={`rounded px-1.5 py-0.5 text-[10px] font-medium ${TIER_BADGE[tier] ?? ''}`}
+                        >
+                          {tier}
                         </span>
-                      ) : (
-                        <span className="text-muted-foreground">—</span>
-                      )}
-                    </td>
-                  </tr>
-                );
-              })}
-            </tbody>
-          </table>
-        </div>
+                      </td>
+                      <td className="px-3 py-2 capitalize">{y.placementType.replace(/_/g, ' ')}</td>
+                      <td className="px-3 py-2">
+                        <span className="text-muted-foreground">{supports}/4</span>
+                      </td>
+                      <td className="px-3 py-2">
+                        {unackCount > 0 ? (
+                          <span className="rounded bg-amber-100 px-1.5 py-0.5 text-[10px] font-medium text-amber-700 dark:bg-amber-900/40 dark:text-amber-400">
+                            {unackCount} unack
+                          </span>
+                        ) : (
+                          <span className="text-muted-foreground">—</span>
+                        )}
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+          <ul className="space-y-2 md:hidden">
+            {ranked.map(({ youth: y, days, tier }) => {
+              const supports = countSupportsInPlace(y.supportsInPlace);
+              const unackCount = unackByYouth[y.id] ?? 0;
+              return (
+                <li key={y.id} className="rounded-md border border-border bg-card p-3 text-sm">
+                  <div className="flex items-start justify-between gap-2">
+                    <Link
+                      href={`/app/clients/foster-aging-out/${y.id}`}
+                      className="font-medium hover:underline"
+                    >
+                      {y.legalFirstName} {y.legalLastName}
+                    </Link>
+                    <span
+                      className={`shrink-0 rounded px-1.5 py-0.5 text-[10px] font-medium ${TIER_BADGE[tier] ?? ''}`}
+                    >
+                      {tier}
+                    </span>
+                  </div>
+                  <div className="font-mono text-[10px] text-muted-foreground">
+                    case {y.dcbsCaseId}
+                  </div>
+                  <dl className="mt-2 grid grid-cols-2 gap-x-3 gap-y-1 text-xs text-muted-foreground">
+                    <div>
+                      <dt className="inline font-medium">To 18: </dt>
+                      <dd className="inline tabular-nums">
+                        {days < 0 ? `+${Math.abs(days)}d past` : `${days}d`}
+                      </dd>
+                    </div>
+                    <div>
+                      <dt className="inline font-medium">Supports: </dt>
+                      <dd className="inline">{supports}/4</dd>
+                    </div>
+                    <div className="capitalize">
+                      <dt className="inline font-medium">Placement: </dt>
+                      <dd className="inline">{y.placementType.replace(/_/g, ' ')}</dd>
+                    </div>
+                    <div>
+                      <dt className="inline font-medium">Alerts: </dt>
+                      <dd className="inline">{unackCount > 0 ? `${unackCount} unack` : '—'}</dd>
+                    </div>
+                  </dl>
+                </li>
+              );
+            })}
+          </ul>
+        </>
       )}
     </div>
   );

--- a/src/app/app/clients/reentry/page.tsx
+++ b/src/app/app/clients/reentry/page.tsx
@@ -64,67 +64,121 @@ export default async function ReentryListPage() {
           </p>
         </div>
       ) : (
-        <div className="overflow-x-auto rounded-md border border-border">
-          <table className="w-full text-sm">
-            <thead>
-              <tr className="border-b bg-muted/30 text-left">
-                <th className="px-3 py-2 font-medium">Name</th>
-                <th className="px-3 py-2 font-medium">Days to release</th>
-                <th className="px-3 py-2 font-medium">Tier</th>
-                <th className="px-3 py-2 font-medium">Release type</th>
-                <th className="px-3 py-2 font-medium">Destination</th>
-                <th className="px-3 py-2 font-medium">Supports</th>
-                <th className="px-3 py-2 font-medium">Status</th>
-              </tr>
-            </thead>
-            <tbody>
-              {ranked.map(({ subject: s, days, tier }) => {
-                const supports = countPreReleaseSupportsInPlace(s.supportsInPlace);
-                return (
-                  <tr key={s.id} className="border-b last:border-0 hover:bg-muted/10">
-                    <td className="px-3 py-2">
-                      <Link
-                        href={`/app/clients/reentry/${s.id}`}
-                        className="font-medium hover:underline"
-                      >
-                        {s.legalFirstName} {s.legalLastName}
-                      </Link>
-                      <div className="text-[10px] font-mono text-muted-foreground">
-                        inmate {s.kyDocInmateId}
-                      </div>
-                    </td>
-                    <td className="px-3 py-2 tabular-nums">
-                      {days < 0 ? `+${Math.abs(days)}d past` : `${days}d`}
-                    </td>
-                    <td className="px-3 py-2">
-                      <span
-                        className={`rounded px-1.5 py-0.5 text-[10px] font-medium ${TIER_BADGE[tier] ?? ''}`}
-                      >
-                        {tier}
-                      </span>
-                    </td>
-                    <td className="px-3 py-2 capitalize">{s.releaseType.replace(/_/g, ' ')}</td>
-                    <td className="px-3 py-2 text-xs text-muted-foreground">
-                      {s.designatedDestination}
-                    </td>
-                    <td className="px-3 py-2">
-                      <span className="text-muted-foreground">{supports}/5</span>
-                    </td>
-                    <td className="px-3 py-2">
-                      {s.status === 'handed_off' ? (
-                        <span className="rounded bg-emerald-100 px-1.5 py-0.5 text-[10px] font-medium text-emerald-700 dark:bg-emerald-900/40 dark:text-emerald-400">
-                          handed off
+        <>
+          {/* Desktop: table. Mobile: card stack (no horizontal scroll). */}
+          <div className="hidden overflow-x-auto rounded-md border border-border md:block">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="border-b bg-muted/30 text-left">
+                  <th className="px-3 py-2 font-medium">Name</th>
+                  <th className="px-3 py-2 font-medium">Days to release</th>
+                  <th className="px-3 py-2 font-medium">Tier</th>
+                  <th className="px-3 py-2 font-medium">Release type</th>
+                  <th className="px-3 py-2 font-medium">Destination</th>
+                  <th className="px-3 py-2 font-medium">Supports</th>
+                  <th className="px-3 py-2 font-medium">Status</th>
+                </tr>
+              </thead>
+              <tbody>
+                {ranked.map(({ subject: s, days, tier }) => {
+                  const supports = countPreReleaseSupportsInPlace(s.supportsInPlace);
+                  return (
+                    <tr key={s.id} className="border-b last:border-0 hover:bg-muted/10">
+                      <td className="px-3 py-2">
+                        <Link
+                          href={`/app/clients/reentry/${s.id}`}
+                          className="font-medium hover:underline"
+                        >
+                          {s.legalFirstName} {s.legalLastName}
+                        </Link>
+                        <div className="text-[10px] font-mono text-muted-foreground">
+                          inmate {s.kyDocInmateId}
+                        </div>
+                      </td>
+                      <td className="px-3 py-2 tabular-nums">
+                        {days < 0 ? `+${Math.abs(days)}d past` : `${days}d`}
+                      </td>
+                      <td className="px-3 py-2">
+                        <span
+                          className={`rounded px-1.5 py-0.5 text-[10px] font-medium ${TIER_BADGE[tier] ?? ''}`}
+                        >
+                          {tier}
                         </span>
-                      ) : (
-                        <span className="text-muted-foreground">active</span>
-                      )}
-                    </td>
-                  </tr>
-                );
-              })}
-            </tbody>
-          </table>
-        </div>
+                      </td>
+                      <td className="px-3 py-2 capitalize">{s.releaseType.replace(/_/g, ' ')}</td>
+                      <td className="px-3 py-2 text-xs text-muted-foreground">
+                        {s.designatedDestination}
+                      </td>
+                      <td className="px-3 py-2">
+                        <span className="text-muted-foreground">{supports}/5</span>
+                      </td>
+                      <td className="px-3 py-2">
+                        {s.status === 'handed_off' ? (
+                          <span className="rounded bg-emerald-100 px-1.5 py-0.5 text-[10px] font-medium text-emerald-700 dark:bg-emerald-900/40 dark:text-emerald-400">
+                            handed off
+                          </span>
+                        ) : (
+                          <span className="text-muted-foreground">active</span>
+                        )}
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+          <ul className="space-y-2 md:hidden">
+            {ranked.map(({ subject: s, days, tier }) => {
+              const supports = countPreReleaseSupportsInPlace(s.supportsInPlace);
+              return (
+                <li key={s.id} className="rounded-md border border-border bg-card p-3 text-sm">
+                  <div className="flex items-start justify-between gap-2">
+                    <Link
+                      href={`/app/clients/reentry/${s.id}`}
+                      className="font-medium hover:underline"
+                    >
+                      {s.legalFirstName} {s.legalLastName}
+                    </Link>
+                    <span
+                      className={`shrink-0 rounded px-1.5 py-0.5 text-[10px] font-medium ${TIER_BADGE[tier] ?? ''}`}
+                    >
+                      {tier}
+                    </span>
+                  </div>
+                  <div className="font-mono text-[10px] text-muted-foreground">
+                    inmate {s.kyDocInmateId}
+                  </div>
+                  <dl className="mt-2 grid grid-cols-2 gap-x-3 gap-y-1 text-xs text-muted-foreground">
+                    <div>
+                      <dt className="inline font-medium">Release: </dt>
+                      <dd className="inline tabular-nums">
+                        {days < 0 ? `+${Math.abs(days)}d past` : `${days}d`}
+                      </dd>
+                    </div>
+                    <div>
+                      <dt className="inline font-medium">Supports: </dt>
+                      <dd className="inline">{supports}/5</dd>
+                    </div>
+                    <div className="capitalize">
+                      <dt className="inline font-medium">Type: </dt>
+                      <dd className="inline">{s.releaseType.replace(/_/g, ' ')}</dd>
+                    </div>
+                    <div>
+                      <dt className="inline font-medium">Status: </dt>
+                      <dd className="inline">
+                        {s.status === 'handed_off' ? 'handed off' : 'active'}
+                      </dd>
+                    </div>
+                    <div className="col-span-2">
+                      <dt className="inline font-medium">Destination: </dt>
+                      <dd className="inline">{s.designatedDestination}</dd>
+                    </div>
+                  </dl>
+                </li>
+              );
+            })}
+          </ul>
+        </>
       )}
     </div>
   );

--- a/src/app/app/coalition/beds/page.tsx
+++ b/src/app/app/coalition/beds/page.tsx
@@ -75,7 +75,7 @@ export default async function BedAvailabilityBoardPage({
       <BedBoardFilters />
 
       <Card>
-        <CardContent className="grid grid-cols-4 gap-3 text-center">
+        <CardContent className="grid grid-cols-2 gap-3 text-center sm:grid-cols-4">
           <div>
             <p className="text-xs uppercase tracking-wide text-muted-foreground">
               Free {filterActive ? '(filtered)' : ''}

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -4,7 +4,9 @@ import { cva, type VariantProps } from 'class-variance-authority';
 import { cn } from '@/lib/utils';
 
 const buttonVariants = cva(
-  "group/button inline-flex shrink-0 items-center justify-center rounded-lg border border-transparent bg-clip-padding text-sm font-medium whitespace-nowrap transition-all outline-none select-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 active:not-aria-[haspopup]:translate-y-px disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+  // CWT-018: `max-sm:min-h-11` enforces a 44px minimum touch-target height on
+  // mobile (<640px) without changing the compact desktop density.
+  "group/button inline-flex shrink-0 items-center justify-center rounded-lg border border-transparent bg-clip-padding text-sm font-medium whitespace-nowrap transition-all outline-none select-none max-sm:min-h-11 focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 active:not-aria-[haspopup]:translate-y-px disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
   {
     variants: {
       variant: {
@@ -25,12 +27,13 @@ const buttonVariants = cva(
         xs: "h-6 gap-1 rounded-[min(var(--radius-md),10px)] px-2 text-xs in-data-[slot=button-group]:rounded-lg has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&_svg:not([class*='size-'])]:size-3",
         sm: "h-7 gap-1 rounded-[min(var(--radius-md),12px)] px-2.5 text-[0.8rem] in-data-[slot=button-group]:rounded-lg has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&_svg:not([class*='size-'])]:size-3.5",
         lg: 'h-9 gap-1.5 px-2.5 has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2',
-        icon: 'size-8',
+        // Icon buttons get a full 44x44 tap area on mobile (max-sm:size-11).
+        icon: 'size-8 max-sm:size-11',
         'icon-xs':
-          "size-6 rounded-[min(var(--radius-md),10px)] in-data-[slot=button-group]:rounded-lg [&_svg:not([class*='size-'])]:size-3",
+          "size-6 rounded-[min(var(--radius-md),10px)] in-data-[slot=button-group]:rounded-lg max-sm:size-11 [&_svg:not([class*='size-'])]:size-3",
         'icon-sm':
-          'size-7 rounded-[min(var(--radius-md),12px)] in-data-[slot=button-group]:rounded-lg',
-        'icon-lg': 'size-9',
+          'size-7 rounded-[min(var(--radius-md),12px)] in-data-[slot=button-group]:rounded-lg max-sm:size-11',
+        'icon-lg': 'size-9 max-sm:size-11',
       },
     },
     defaultVariants: {


### PR DESCRIPTION
Refs #96

## Summary

Closes the remaining mobile-responsiveness gaps for the caseworker UI. The app shell was already mobile-aware (hamburger `mobile-nav` at <640px, single-column layout, `p-4 md:p-6`, responsive card grids), so this focuses on the three concrete gaps the AC surfaced.

## Changes

- **44px touch targets** — `button.tsx` now applies `max-sm:min-h-11` on the base (and `max-sm:size-11` to icon variants), giving every button a ≥44px tap target **on mobile** while leaving the compact desktop density untouched (a global height bump would have wrecked desktop dense layouts).
- **Tables → cards on mobile** — the caseworker pathway lists (families, DV survivors, reentry, foster aging-out) render the `<table>` only at `md+` (`hidden md:block`) and a card stack on mobile (`md:hidden`), eliminating horizontal scroll at 375px. Same data, mobile-legible layout.
- **Cramped grid** — bed-availability stats grid is `grid-cols-2 sm:grid-cols-4` so the four KPIs aren't squeezed on narrow screens.

## Acceptance criteria

- [x] All caseworker routes usable at 375px+ — pathway list tables no longer force horizontal scroll; shell/cards/padding already responsive *(rendered verification: see note)*
- [x] Hamburger/bottom-nav at <640px — already present (`mobile-nav.tsx`, `md:hidden`); verified retained
- [x] Tables → card layouts on mobile — implemented for the four caseworker pathway lists
- [x] 44px minimum touch targets — enforced on mobile via `max-sm:min-h-11` / `max-sm:size-11`
- [~] No horizontal scroll at 375px — implemented; **needs QA rendered verification** (see note)
- [~] Lighthouse mobile ≥ 75 (case list + case detail) — **needs QA/Lighthouse verification** (see note)
- [x] No desktop regression at ≥1024px — desktop markup unchanged (table path + compact button sizes preserved); `next build` clean *(rendered verification: see note)*

## Verification

- `pnpm lint` (no --write) — clean (1 pre-existing unrelated info)
- `pnpm typecheck` — clean
- `pnpm lint:boundaries` — clean
- `pnpm test` — **840 passed (51 files)**, no regression (presentational change — no data-flow logic to unit-test)
- `pnpm build` (next build) — ✓ compiled; all changed routes emit

## Note for QA — visual verification handoff

`/app/*` is Clerk-gated and the repo has **no dev-auth bypass / seeded dev session**, so this unattended dev loop cannot headlessly render the pages to measure 375px horizontal scroll or run Lighthouse. The responsive code follows standard Tailwind idioms (`hidden md:block` / `md:hidden`, `max-sm:` touch sizing) and builds cleanly, but the three rendered/perf criteria above are marked `~` and need a human/QA visual pass at 375px + a Lighthouse run on the case list & case detail. Recommend filing a follow-up to add a dev-auth bypass so future responsive/visual work can be verified in-loop (happy to do that as a separate ticket).
