### PR TITLE
fix(FND-388): clean drizzle migrate from zero + verify snapshot drift healed

### DIFF
--- a/drizzle/migrations/0001_FND-003_clerk_user_mirror.sql
+++ b/drizzle/migrations/0001_FND-003_clerk_user_mirror.sql
@@ -1,4 +1,10 @@
-CREATE TYPE "public"."user_role" AS ENUM('attorney', 'caseworker', 'ed_coordinator', 'shelter_staff', 'admin');--> statement-breakpoint
+-- FND-388: 'pending' is created here (not via a later ALTER TYPE ADD VALUE) so
+-- a clean `drizzle-kit migrate` from zero succeeds. The postgres-js migrator
+-- runs the whole chain in ONE transaction, so a value ADDED by 0004 cannot be
+-- used as a DEFAULT by 0005 in the same transaction ("unsafe use of new value").
+-- Defining 'pending' at type-creation time sidesteps that; 0004's
+-- `ADD VALUE IF NOT EXISTS 'pending'` then becomes a harmless no-op on fresh DBs.
+CREATE TYPE "public"."user_role" AS ENUM('pending', 'attorney', 'caseworker', 'ed_coordinator', 'shelter_staff', 'admin');--> statement-breakpoint
 CREATE TABLE "users" (
 	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
 	"clerk_user_id" text NOT NULL,

--- a/drizzle/migrations/0004_FND-193_pending_role_enum.sql
+++ b/drizzle/migrations/0004_FND-193_pending_role_enum.sql
@@ -1,5 +1,8 @@
--- Postgres requires ALTER TYPE ADD VALUE to commit before the new value can
--- be used. We split into two separate migration files (0004 + 0005) so each
--- runs in its own transaction. See:
--- https://www.postgresql.org/docs/current/sql-altertype.html#SQL-ALTERTYPE-NOTES
+-- FND-388: 'pending' is now defined at type-creation in 0001, because the
+-- postgres-js migrator runs the whole chain in a single transaction (so the
+-- 0004/0005 file split does NOT give a commit boundary — 0005's SET DEFAULT
+-- would hit "unsafe use of new value"). This statement is kept as an
+-- idempotent no-op (IF NOT EXISTS) so the historical chain replays cleanly on
+-- both fresh DBs (value already exists -> skipped) and any older DB that
+-- predates the 0001 hoist (value gets added here).
 ALTER TYPE "public"."user_role" ADD VALUE IF NOT EXISTS 'pending' BEFORE 'attorney';


### PR DESCRIPTION
Refs #388

## Summary

Fixes the two migration-chain health problems from #388.

### 1. Clean `drizzle-kit migrate` from zero now succeeds

**Root cause (diagnosed empirically):** the postgres-js migrator runs the entire migration chain in a **single transaction**. The 0004/0005 file split (intended to give a commit boundary) therefore doesn't help — `'pending'`, added via `ALTER TYPE … ADD VALUE` in 0004, can't be used as a `DEFAULT` in 0005 within the same transaction, so Postgres throws *"unsafe use of new value 'pending'"*.

**Fix:** define `'pending'` at **type-creation time** in `0001`'s `CREATE TYPE` (a creation-time value is safe to use in the same transaction). `0004`'s `ADD VALUE IF NOT EXISTS 'pending'` becomes a harmless no-op on fresh DBs and still covers any older DB that predates the hoist. Both files carry explanatory comments.

### 2. `db:generate` snapshot drift — already healed

`pnpm db:generate` on the unchanged schema now reports **"No schema changes, nothing to migrate"** — the full-state snapshots that landed with INDC-019 (#389) and SUBP-006a (#390) brought the latest snapshot in sync with the schema, so forward generation no longer over-emits. Rewriting all historical intermediate snapshots is unnecessary: the migrator ignores snapshots entirely, and `generate` only reads the latest one.

## Acceptance criteria

- [x] Clean `drizzle-kit migrate` run with no errors — verified 0000→0045 on a throwaway Postgres (previously failed at 0005)
- [x] `db:generate` produces an empty diff on unchanged schema (snapshot matches schema)
- [x] All migration files follow `NNNN_*` naming (audited — no leftover drizzle random names)

## Verification

- **Red→green:** reproduced the failure on a clean Postgres (fails at 0005 `SET DEFAULT 'pending'`), applied the fix, re-ran — `MIGRATE OK`; confirmed `users.role` default `'pending'` and enum `{pending,attorney,caseworker,ed_coordinator,shelter_staff,admin}`.
- `db:generate` → "No schema changes".
- `pnpm lint` / `typecheck` / `lint:boundaries` / **845 tests** / `next build` all clean (change is SQL-only; no app code touched).

## Notes

- Editing historical migration SQL is safe here: dev/prod are `db:push`-managed (no journal-applied environments to break), and the whole point is that clean `migrate` (CI / fresh / disaster-recovery) currently can't complete.
- PHI fence: N/A (migration tooling only).
