### PR TITLE
feat(SUBP-006b): HUD-VASH voucher matching panel

### DIFF
--- a/drizzle/migrations/0046_SUBP-006b_voucher_matching.sql
+++ b/drizzle/migrations/0046_SUBP-006b_voucher_matching.sql
@@ -1,0 +1,35 @@
+CREATE TYPE "public"."hud_vash_voucher_status" AS ENUM('available', 'pending', 'leased');--> statement-breakpoint
+CREATE TYPE "public"."veteran_voucher_application_status" AS ENUM('applied', 'withdrawn');--> statement-breakpoint
+CREATE TABLE "hud_vash_vouchers" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"voucher_code" text NOT NULL,
+	"unit_type" text NOT NULL,
+	"bedrooms" integer NOT NULL,
+	"location" text NOT NULL,
+	"zip" text,
+	"accessible" boolean DEFAULT false NOT NULL,
+	"availability_status" "hud_vash_voucher_status" DEFAULT 'available' NOT NULL,
+	"notes" text,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "veteran_voucher_applications" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"veteran_id" uuid NOT NULL,
+	"voucher_id" uuid NOT NULL,
+	"status" "veteran_voucher_application_status" DEFAULT 'applied' NOT NULL,
+	"applied_by_user_id" uuid,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "veterans" ADD COLUMN "bedroom_need" integer;--> statement-breakpoint
+ALTER TABLE "veterans" ADD COLUMN "accessibility_need" boolean DEFAULT false NOT NULL;--> statement-breakpoint
+ALTER TABLE "veterans" ADD COLUMN "target_zip" text;--> statement-breakpoint
+ALTER TABLE "veteran_voucher_applications" ADD CONSTRAINT "veteran_voucher_applications_veteran_id_veterans_id_fk" FOREIGN KEY ("veteran_id") REFERENCES "public"."veterans"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "veteran_voucher_applications" ADD CONSTRAINT "veteran_voucher_applications_voucher_id_hud_vash_vouchers_id_fk" FOREIGN KEY ("voucher_id") REFERENCES "public"."hud_vash_vouchers"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "veteran_voucher_applications" ADD CONSTRAINT "veteran_voucher_applications_applied_by_user_id_users_id_fk" FOREIGN KEY ("applied_by_user_id") REFERENCES "public"."users"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "hud_vash_vouchers_status_idx" ON "hud_vash_vouchers" USING btree ("availability_status");--> statement-breakpoint
+CREATE UNIQUE INDEX "veteran_voucher_applications_unique_idx" ON "veteran_voucher_applications" USING btree ("veteran_id","voucher_id");--> statement-breakpoint
+CREATE INDEX "veteran_voucher_applications_veteran_idx" ON "veteran_voucher_applications" USING btree ("veteran_id");

--- a/drizzle/migrations/meta/0046_snapshot.json
+++ b/drizzle/migrations/meta/0046_snapshot.json
@@ -1,0 +1,7818 @@
+{
+  "id": "9afd9685-2a8c-4116-a48b-53dd36409846",
+  "prevId": "a0965f96-59ee-420b-b3d4-9447b6ec8cdf",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.audit_log": {
+      "name": "audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_table": {
+          "name": "target_table",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "audit_log_actor_idx": {
+          "name": "audit_log_actor_idx",
+          "columns": [
+            {
+              "expression": "actor_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_log_action_idx": {
+          "name": "audit_log_action_idx",
+          "columns": [
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_log_created_at_idx": {
+          "name": "audit_log_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audit_log_actor_user_id_users_id_fk": {
+          "name": "audit_log_actor_user_id_users_id_fk",
+          "tableFrom": "audit_log",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.case_handoffs": {
+      "name": "case_handoffs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "synthetic_person_ref": {
+          "name": "synthetic_person_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_partner_org_id": {
+          "name": "from_partner_org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_partner_org_id": {
+          "name": "to_partner_org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "initiated_by_user_id": {
+          "name": "initiated_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "responded_by_user_id": {
+          "name": "responded_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "case_handoff_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending_consent'"
+        },
+        "purpose": {
+          "name": "purpose",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requested_scope": {
+          "name": "requested_scope",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consent_id": {
+          "name": "consent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decline_reason": {
+          "name": "decline_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "closed_at": {
+          "name": "closed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "case_handoffs_to_partner_idx": {
+          "name": "case_handoffs_to_partner_idx",
+          "columns": [
+            {
+              "expression": "to_partner_org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "case_handoffs_from_partner_idx": {
+          "name": "case_handoffs_from_partner_idx",
+          "columns": [
+            {
+              "expression": "from_partner_org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "case_handoffs_person_ref_idx": {
+          "name": "case_handoffs_person_ref_idx",
+          "columns": [
+            {
+              "expression": "synthetic_person_ref",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "case_handoffs_status_idx": {
+          "name": "case_handoffs_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "case_handoffs_expires_at_idx": {
+          "name": "case_handoffs_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "case_handoffs_from_partner_org_id_partner_orgs_id_fk": {
+          "name": "case_handoffs_from_partner_org_id_partner_orgs_id_fk",
+          "tableFrom": "case_handoffs",
+          "tableTo": "partner_orgs",
+          "columnsFrom": [
+            "from_partner_org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "case_handoffs_to_partner_org_id_partner_orgs_id_fk": {
+          "name": "case_handoffs_to_partner_org_id_partner_orgs_id_fk",
+          "tableFrom": "case_handoffs",
+          "tableTo": "partner_orgs",
+          "columnsFrom": [
+            "to_partner_org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "case_handoffs_initiated_by_user_id_users_id_fk": {
+          "name": "case_handoffs_initiated_by_user_id_users_id_fk",
+          "tableFrom": "case_handoffs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "initiated_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "case_handoffs_responded_by_user_id_users_id_fk": {
+          "name": "case_handoffs_responded_by_user_id_users_id_fk",
+          "tableFrom": "case_handoffs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "responded_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "case_handoffs_consent_id_person_partner_consents_id_fk": {
+          "name": "case_handoffs_consent_id_person_partner_consents_id_fk",
+          "tableFrom": "case_handoffs",
+          "tableTo": "person_partner_consents",
+          "columnsFrom": [
+            "consent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "case_handoffs_distinct_orgs": {
+          "name": "case_handoffs_distinct_orgs",
+          "value": "from_partner_org_id <> to_partner_org_id"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.client_case_notes": {
+      "name": "client_case_notes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "synthetic_person_ref": {
+          "name": "synthetic_person_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body_md": {
+          "name": "body_md",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "drafted_by_ai": {
+          "name": "drafted_by_ai",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "ai_model_id": {
+          "name": "ai_model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ai_prompt_version": {
+          "name": "ai_prompt_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_note_id": {
+          "name": "parent_note_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "client_case_notes_synthetic_ref_idx": {
+          "name": "client_case_notes_synthetic_ref_idx",
+          "columns": [
+            {
+              "expression": "synthetic_person_ref",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "client_case_notes_parent_idx": {
+          "name": "client_case_notes_parent_idx",
+          "columns": [
+            {
+              "expression": "parent_note_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "client_case_notes_created_by_idx": {
+          "name": "client_case_notes_created_by_idx",
+          "columns": [
+            {
+              "expression": "created_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "client_case_notes_parent_note_id_client_case_notes_id_fk": {
+          "name": "client_case_notes_parent_note_id_client_case_notes_id_fk",
+          "tableFrom": "client_case_notes",
+          "tableTo": "client_case_notes",
+          "columnsFrom": [
+            "parent_note_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "client_case_notes_created_by_user_id_users_id_fk": {
+          "name": "client_case_notes_created_by_user_id_users_id_fk",
+          "tableFrom": "client_case_notes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.client_documents": {
+      "name": "client_documents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "synthetic_person_ref": {
+          "name": "synthetic_person_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "client_document_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_md": {
+          "name": "content_md",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "extracted_fields": {
+          "name": "extracted_fields",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extraction_notes": {
+          "name": "extraction_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extraction_model": {
+          "name": "extraction_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "client_document_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'uploaded'"
+        },
+        "uploaded_by_user_id": {
+          "name": "uploaded_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "client_documents_kind_idx": {
+          "name": "client_documents_kind_idx",
+          "columns": [
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "client_documents_status_idx": {
+          "name": "client_documents_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "client_documents_uploaded_by_idx": {
+          "name": "client_documents_uploaded_by_idx",
+          "columns": [
+            {
+              "expression": "uploaded_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "client_documents_synthetic_ref_idx": {
+          "name": "client_documents_synthetic_ref_idx",
+          "columns": [
+            {
+              "expression": "synthetic_person_ref",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "client_documents_uploaded_by_user_id_users_id_fk": {
+          "name": "client_documents_uploaded_by_user_id_users_id_fk",
+          "tableFrom": "client_documents",
+          "tableTo": "users",
+          "columnsFrom": [
+            "uploaded_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.client_intakes": {
+      "name": "client_intakes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "synthetic_person_ref": {
+          "name": "synthetic_person_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transcript_md": {
+          "name": "transcript_md",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "audio_duration_sec": {
+          "name": "audio_duration_sec",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extracted_profile": {
+          "name": "extracted_profile",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extraction_notes": {
+          "name": "extraction_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extraction_model": {
+          "name": "extraction_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "client_intake_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'recording'"
+        },
+        "recorded_by_user_id": {
+          "name": "recorded_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "client_intakes_status_idx": {
+          "name": "client_intakes_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "client_intakes_recorded_by_idx": {
+          "name": "client_intakes_recorded_by_idx",
+          "columns": [
+            {
+              "expression": "recorded_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "client_intakes_synthetic_ref_idx": {
+          "name": "client_intakes_synthetic_ref_idx",
+          "columns": [
+            {
+              "expression": "synthetic_person_ref",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "client_intakes_recorded_by_user_id_users_id_fk": {
+          "name": "client_intakes_recorded_by_user_id_users_id_fk",
+          "tableFrom": "client_intakes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "recorded_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.comms_advisories": {
+      "name": "comms_advisories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body_md": {
+          "name": "body_md",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "spokesperson_name": {
+          "name": "spokesperson_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "spokesperson_contact": {
+          "name": "spokesperson_contact",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "posted_by_user_id": {
+          "name": "posted_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ended_by_user_id": {
+          "name": "ended_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "comms_advisories_active_idx": {
+          "name": "comms_advisories_active_idx",
+          "columns": [
+            {
+              "expression": "active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "comms_advisories_created_idx": {
+          "name": "comms_advisories_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "comms_advisories_posted_by_user_id_users_id_fk": {
+          "name": "comms_advisories_posted_by_user_id_users_id_fk",
+          "tableFrom": "comms_advisories",
+          "tableTo": "users",
+          "columnsFrom": [
+            "posted_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "comms_advisories_ended_by_user_id_users_id_fk": {
+          "name": "comms_advisories_ended_by_user_id_users_id_fk",
+          "tableFrom": "comms_advisories",
+          "tableTo": "users",
+          "columnsFrom": [
+            "ended_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.consent_access_tokens": {
+      "name": "consent_access_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "synthetic_person_ref": {
+          "name": "synthetic_person_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issued_by_user_id": {
+          "name": "issued_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "consent_access_tokens_token_idx": {
+          "name": "consent_access_tokens_token_idx",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "consent_access_tokens_ref_idx": {
+          "name": "consent_access_tokens_ref_idx",
+          "columns": [
+            {
+              "expression": "synthetic_person_ref",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "consent_access_tokens_expires_idx": {
+          "name": "consent_access_tokens_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "consent_access_tokens_issued_by_user_id_users_id_fk": {
+          "name": "consent_access_tokens_issued_by_user_id_users_id_fk",
+          "tableFrom": "consent_access_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "issued_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.consents": {
+      "name": "consents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "subject_external_id": {
+          "name": "subject_external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consent_type": {
+          "name": "consent_type",
+          "type": "consent_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "granted_via": {
+          "name": "granted_via",
+          "type": "consent_channel",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consent_version": {
+          "name": "consent_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'2026-04-1'"
+        },
+        "scope_partner_ids": {
+          "name": "scope_partner_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope_data_classes": {
+          "name": "scope_data_classes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "signature_text": {
+          "name": "signature_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "granted_at": {
+          "name": "granted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "consents_subject_idx": {
+          "name": "consents_subject_idx",
+          "columns": [
+            {
+              "expression": "subject_external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "consents_type_idx": {
+          "name": "consents_type_idx",
+          "columns": [
+            {
+              "expression": "consent_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "consents_expires_at_idx": {
+          "name": "consents_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.dv_flagged_persons": {
+      "name": "dv_flagged_persons",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "subject_identifier": {
+          "name": "subject_identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "flag_set_at": {
+          "name": "flag_set_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "flag_cleared_at": {
+          "name": "flag_cleared_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "dv_flagged_persons_subject_idx": {
+          "name": "dv_flagged_persons_subject_idx",
+          "columns": [
+            {
+              "expression": "subject_identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dv_flagged_persons_set_at_idx": {
+          "name": "dv_flagged_persons_set_at_idx",
+          "columns": [
+            {
+              "expression": "flag_set_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.dv_safety_events": {
+      "name": "dv_safety_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "survivor_id": {
+          "name": "survivor_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "dv_safety_event_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "recorded_by_user_id": {
+          "name": "recorded_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "dv_safety_events_survivor_idx": {
+          "name": "dv_safety_events_survivor_idx",
+          "columns": [
+            {
+              "expression": "survivor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dv_safety_events_occurred_idx": {
+          "name": "dv_safety_events_occurred_idx",
+          "columns": [
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dv_safety_events_type_idx": {
+          "name": "dv_safety_events_type_idx",
+          "columns": [
+            {
+              "expression": "event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "dv_safety_events_survivor_id_dv_survivors_id_fk": {
+          "name": "dv_safety_events_survivor_id_dv_survivors_id_fk",
+          "tableFrom": "dv_safety_events",
+          "tableTo": "dv_survivors",
+          "columnsFrom": [
+            "survivor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "dv_safety_events_recorded_by_user_id_users_id_fk": {
+          "name": "dv_safety_events_recorded_by_user_id_users_id_fk",
+          "tableFrom": "dv_safety_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "recorded_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.dv_survivors": {
+      "name": "dv_survivors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "oasis_partner_org_id": {
+          "name": "oasis_partner_org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "oasis_case_id": {
+          "name": "oasis_case_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enrolled_at": {
+          "name": "enrolled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "status": {
+          "name": "status",
+          "type": "dv_survivor_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "assigned_advocate_user_id": {
+          "name": "assigned_advocate_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "safety_plan_on_file": {
+          "name": "safety_plan_on_file",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "safety_plan_last_reviewed_at": {
+          "name": "safety_plan_last_reviewed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "needs_assessment": {
+          "name": "needs_assessment",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "risk_tier": {
+          "name": "risk_tier",
+          "type": "dv_risk_tier",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unknown'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "dv_survivors_oasis_partner_idx": {
+          "name": "dv_survivors_oasis_partner_idx",
+          "columns": [
+            {
+              "expression": "oasis_partner_org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dv_survivors_assigned_advocate_idx": {
+          "name": "dv_survivors_assigned_advocate_idx",
+          "columns": [
+            {
+              "expression": "assigned_advocate_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dv_survivors_status_idx": {
+          "name": "dv_survivors_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dv_survivors_risk_tier_idx": {
+          "name": "dv_survivors_risk_tier_idx",
+          "columns": [
+            {
+              "expression": "risk_tier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "dv_survivors_oasis_partner_org_id_partner_orgs_id_fk": {
+          "name": "dv_survivors_oasis_partner_org_id_partner_orgs_id_fk",
+          "tableFrom": "dv_survivors",
+          "tableTo": "partner_orgs",
+          "columnsFrom": [
+            "oasis_partner_org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "dv_survivors_assigned_advocate_user_id_users_id_fk": {
+          "name": "dv_survivors_assigned_advocate_user_id_users_id_fk",
+          "tableFrom": "dv_survivors",
+          "tableTo": "users",
+          "columnsFrom": [
+            "assigned_advocate_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ed_encounters": {
+      "name": "ed_encounters",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encounter_external_id": {
+          "name": "encounter_external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "arrived_at": {
+          "name": "arrived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discharged_at": {
+          "name": "discharged_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chief_complaint": {
+          "name": "chief_complaint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "disposition": {
+          "name": "disposition",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "housing_status": {
+          "name": "housing_status",
+          "type": "housing_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unknown'"
+        },
+        "charge_cents": {
+          "name": "charge_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_json": {
+          "name": "raw_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "ed_encounter_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'synthetic'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ed_encounters_external_idx": {
+          "name": "ed_encounters_external_idx",
+          "columns": [
+            {
+              "expression": "encounter_external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ed_encounters_patient_idx": {
+          "name": "ed_encounters_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ed_encounters_arrived_idx": {
+          "name": "ed_encounters_arrived_idx",
+          "columns": [
+            {
+              "expression": "arrived_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ed_encounters_housing_idx": {
+          "name": "ed_encounters_housing_idx",
+          "columns": [
+            {
+              "expression": "housing_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.esuc_care_plans": {
+      "name": "esuc_care_plans",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plan_md": {
+          "name": "plan_md",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt_version": {
+          "name": "prompt_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "generated_by_user_id": {
+          "name": "generated_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "esuc_care_plan_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "care_plans_patient_version_idx": {
+          "name": "care_plans_patient_version_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "prompt_version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "care_plans_patient_idx": {
+          "name": "care_plans_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "care_plans_status_idx": {
+          "name": "care_plans_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "esuc_care_plans_generated_by_user_id_users_id_fk": {
+          "name": "esuc_care_plans_generated_by_user_id_users_id_fk",
+          "tableFrom": "esuc_care_plans",
+          "tableTo": "users",
+          "columnsFrom": [
+            "generated_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.eviction_case_outcomes": {
+      "name": "eviction_case_outcomes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "filing_id": {
+          "name": "filing_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "eviction_case_outcome",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recorded_by_user_id": {
+          "name": "recorded_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "case_outcomes_filing_idx": {
+          "name": "case_outcomes_filing_idx",
+          "columns": [
+            {
+              "expression": "filing_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "case_outcomes_outcome_idx": {
+          "name": "case_outcomes_outcome_idx",
+          "columns": [
+            {
+              "expression": "outcome",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "case_outcomes_created_at_idx": {
+          "name": "case_outcomes_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "eviction_case_outcomes_filing_id_eviction_filings_id_fk": {
+          "name": "eviction_case_outcomes_filing_id_eviction_filings_id_fk",
+          "tableFrom": "eviction_case_outcomes",
+          "tableTo": "eviction_filings",
+          "columnsFrom": [
+            "filing_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "eviction_case_outcomes_recorded_by_user_id_users_id_fk": {
+          "name": "eviction_case_outcomes_recorded_by_user_id_users_id_fk",
+          "tableFrom": "eviction_case_outcomes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "recorded_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.eviction_filing_risk_scores": {
+      "name": "eviction_filing_risk_scores",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "filing_id": {
+          "name": "filing_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rationale": {
+          "name": "rationale",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model_version": {
+          "name": "model_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "risk_scores_filing_version_idx": {
+          "name": "risk_scores_filing_version_idx",
+          "columns": [
+            {
+              "expression": "filing_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "model_version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "risk_scores_filing_idx": {
+          "name": "risk_scores_filing_idx",
+          "columns": [
+            {
+              "expression": "filing_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "risk_scores_score_idx": {
+          "name": "risk_scores_score_idx",
+          "columns": [
+            {
+              "expression": "score",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "eviction_filing_risk_scores_filing_id_eviction_filings_id_fk": {
+          "name": "eviction_filing_risk_scores_filing_id_eviction_filings_id_fk",
+          "tableFrom": "eviction_filing_risk_scores",
+          "tableTo": "eviction_filings",
+          "columnsFrom": [
+            "filing_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.eviction_filings": {
+      "name": "eviction_filings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "case_number": {
+          "name": "case_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filed_at": {
+          "name": "filed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "court_division": {
+          "name": "court_division",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plaintiff": {
+          "name": "plaintiff",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "defendant_first_name": {
+          "name": "defendant_first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "defendant_last_name": {
+          "name": "defendant_last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "defendant_address": {
+          "name": "defendant_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cause_type": {
+          "name": "cause_type",
+          "type": "eviction_cause_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_claimed_cents": {
+          "name": "amount_claimed_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "eviction_filing_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'filed'"
+        },
+        "source": {
+          "name": "source",
+          "type": "eviction_filing_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "raw_json": {
+          "name": "raw_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dv_flag": {
+          "name": "dv_flag",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "eviction_filings_case_source_idx": {
+          "name": "eviction_filings_case_source_idx",
+          "columns": [
+            {
+              "expression": "case_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "eviction_filings_filed_at_idx": {
+          "name": "eviction_filings_filed_at_idx",
+          "columns": [
+            {
+              "expression": "filed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "eviction_filings_status_idx": {
+          "name": "eviction_filings_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.eviction_response_packets": {
+      "name": "eviction_response_packets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "filing_id": {
+          "name": "filing_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "packet_md": {
+          "name": "packet_md",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt_version": {
+          "name": "prompt_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "generated_by_user_id": {
+          "name": "generated_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "eviction_response_packet_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "response_packets_filing_version_idx": {
+          "name": "response_packets_filing_version_idx",
+          "columns": [
+            {
+              "expression": "filing_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "prompt_version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "response_packets_filing_idx": {
+          "name": "response_packets_filing_idx",
+          "columns": [
+            {
+              "expression": "filing_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "response_packets_status_idx": {
+          "name": "response_packets_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "eviction_response_packets_filing_id_eviction_filings_id_fk": {
+          "name": "eviction_response_packets_filing_id_eviction_filings_id_fk",
+          "tableFrom": "eviction_response_packets",
+          "tableTo": "eviction_filings",
+          "columnsFrom": [
+            "filing_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "eviction_response_packets_generated_by_user_id_users_id_fk": {
+          "name": "eviction_response_packets_generated_by_user_id_users_id_fk",
+          "tableFrom": "eviction_response_packets",
+          "tableTo": "users",
+          "columnsFrom": [
+            "generated_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.fag_compensation_entries": {
+      "name": "fag_compensation_entries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "member_id": {
+          "name": "member_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurred_on": {
+          "name": "occurred_on",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hours_tenths": {
+          "name": "hours_tenths",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hourly_rate_cents": {
+          "name": "hourly_rate_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_cents": {
+          "name": "total_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "fag_payout_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unpaid'"
+        },
+        "paid_at": {
+          "name": "paid_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "paid_by_user_id": {
+          "name": "paid_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "fag_compensation_member_idx": {
+          "name": "fag_compensation_member_idx",
+          "columns": [
+            {
+              "expression": "member_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "fag_compensation_status_idx": {
+          "name": "fag_compensation_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "fag_compensation_occurred_idx": {
+          "name": "fag_compensation_occurred_idx",
+          "columns": [
+            {
+              "expression": "occurred_on",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "fag_compensation_entries_member_id_fag_members_id_fk": {
+          "name": "fag_compensation_entries_member_id_fag_members_id_fk",
+          "tableFrom": "fag_compensation_entries",
+          "tableTo": "fag_members",
+          "columnsFrom": [
+            "member_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "fag_compensation_entries_paid_by_user_id_users_id_fk": {
+          "name": "fag_compensation_entries_paid_by_user_id_users_id_fk",
+          "tableFrom": "fag_compensation_entries",
+          "tableTo": "users",
+          "columnsFrom": [
+            "paid_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.fag_members": {
+      "name": "fag_members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "full_name": {
+          "name": "full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_phone": {
+          "name": "contact_phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_email": {
+          "name": "contact_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hourly_rate_cents": {
+          "name": "hourly_rate_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 10000
+        },
+        "status": {
+          "name": "status",
+          "type": "fag_member_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onboarded_on": {
+          "name": "onboarded_on",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "fag_members_status_idx": {
+          "name": "fag_members_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.faith_aggregate_breakouts": {
+      "name": "faith_aggregate_breakouts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "submission_id": {
+          "name": "submission_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dimension": {
+          "name": "dimension",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bucket": {
+          "name": "bucket",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "suppressed": {
+          "name": "suppressed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "faith_aggregate_breakouts_dim_idx": {
+          "name": "faith_aggregate_breakouts_dim_idx",
+          "columns": [
+            {
+              "expression": "submission_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "dimension",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "bucket",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "faith_aggregate_breakouts_submission_id_faith_aggregate_submissions_id_fk": {
+          "name": "faith_aggregate_breakouts_submission_id_faith_aggregate_submissions_id_fk",
+          "tableFrom": "faith_aggregate_breakouts",
+          "tableTo": "faith_aggregate_submissions",
+          "columnsFrom": [
+            "submission_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "faith_aggregate_breakouts_count_or_suppressed": {
+          "name": "faith_aggregate_breakouts_count_or_suppressed",
+          "value": "(count IS NOT NULL AND suppressed = false) OR (count IS NULL AND suppressed = true)"
+        },
+        "faith_aggregate_breakouts_count_nonneg": {
+          "name": "faith_aggregate_breakouts_count_nonneg",
+          "value": "count IS NULL OR count >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.faith_aggregate_metrics": {
+      "name": "faith_aggregate_metrics",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "submission_id": {
+          "name": "submission_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metric_key": {
+          "name": "metric_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "suppressed": {
+          "name": "suppressed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "faith_aggregate_metrics_key_idx": {
+          "name": "faith_aggregate_metrics_key_idx",
+          "columns": [
+            {
+              "expression": "submission_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "metric_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "faith_aggregate_metrics_submission_id_faith_aggregate_submissions_id_fk": {
+          "name": "faith_aggregate_metrics_submission_id_faith_aggregate_submissions_id_fk",
+          "tableFrom": "faith_aggregate_metrics",
+          "tableTo": "faith_aggregate_submissions",
+          "columnsFrom": [
+            "submission_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "faith_aggregate_metrics_value_or_suppressed": {
+          "name": "faith_aggregate_metrics_value_or_suppressed",
+          "value": "(value IS NOT NULL AND suppressed = false) OR (value IS NULL AND suppressed = true)"
+        },
+        "faith_aggregate_metrics_value_nonneg": {
+          "name": "faith_aggregate_metrics_value_nonneg",
+          "value": "value IS NULL OR value >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.faith_aggregate_submissions": {
+      "name": "faith_aggregate_submissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "ministry_id": {
+          "name": "ministry_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_kind": {
+          "name": "period_kind",
+          "type": "faith_aggregate_period_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_start": {
+          "name": "period_start",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_end": {
+          "name": "period_end",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "submitted_by_user_id": {
+          "name": "submitted_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submitted_at": {
+          "name": "submitted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "faith_aggregate_submissions_period_idx": {
+          "name": "faith_aggregate_submissions_period_idx",
+          "columns": [
+            {
+              "expression": "ministry_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "period_start",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "period_end",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "faith_aggregate_submissions_ministry_idx": {
+          "name": "faith_aggregate_submissions_ministry_idx",
+          "columns": [
+            {
+              "expression": "ministry_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "faith_aggregate_submissions_period_start_idx": {
+          "name": "faith_aggregate_submissions_period_start_idx",
+          "columns": [
+            {
+              "expression": "period_start",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "faith_aggregate_submissions_ministry_id_faith_ministries_id_fk": {
+          "name": "faith_aggregate_submissions_ministry_id_faith_ministries_id_fk",
+          "tableFrom": "faith_aggregate_submissions",
+          "tableTo": "faith_ministries",
+          "columnsFrom": [
+            "ministry_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "faith_aggregate_submissions_submitted_by_user_id_users_id_fk": {
+          "name": "faith_aggregate_submissions_submitted_by_user_id_users_id_fk",
+          "tableFrom": "faith_aggregate_submissions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "submitted_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "faith_aggregate_submissions_period_order": {
+          "name": "faith_aggregate_submissions_period_order",
+          "value": "period_start <= period_end"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.faith_ministries": {
+      "name": "faith_ministries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "partner_org_id": {
+          "name": "partner_org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "umbrella_ministry_id": {
+          "name": "umbrella_ministry_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_name": {
+          "name": "contact_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_email": {
+          "name": "contact_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_phone": {
+          "name": "contact_phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "faith_ministry_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'opted_in'"
+        },
+        "min_cell_size": {
+          "name": "min_cell_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 10
+        },
+        "opted_in_at": {
+          "name": "opted_in_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "opted_out_at": {
+          "name": "opted_out_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "faith_ministries_name_idx": {
+          "name": "faith_ministries_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "faith_ministries_umbrella_idx": {
+          "name": "faith_ministries_umbrella_idx",
+          "columns": [
+            {
+              "expression": "umbrella_ministry_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "faith_ministries_status_idx": {
+          "name": "faith_ministries_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "faith_ministries_partner_org_id_partner_orgs_id_fk": {
+          "name": "faith_ministries_partner_org_id_partner_orgs_id_fk",
+          "tableFrom": "faith_ministries",
+          "tableTo": "partner_orgs",
+          "columnsFrom": [
+            "partner_org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "faith_ministries_umbrella_ministry_id_faith_ministries_id_fk": {
+          "name": "faith_ministries_umbrella_ministry_id_faith_ministries_id_fk",
+          "tableFrom": "faith_ministries",
+          "tableTo": "faith_ministries",
+          "columnsFrom": [
+            "umbrella_ministry_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.family_children": {
+      "name": "family_children",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "family_unit_id": {
+          "name": "family_unit_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "child_ref": {
+          "name": "child_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date_of_birth": {
+          "name": "date_of_birth",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_school_id": {
+          "name": "current_school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enrolled_in_mckinney_vento": {
+          "name": "enrolled_in_mckinney_vento",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"flagged\":false,\"flaggedAt\":null,\"source\":null}'::jsonb"
+        },
+        "grade_band": {
+          "name": "grade_band",
+          "type": "family_child_grade_band",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "family_children_family_idx": {
+          "name": "family_children_family_idx",
+          "columns": [
+            {
+              "expression": "family_unit_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "family_children_school_idx": {
+          "name": "family_children_school_idx",
+          "columns": [
+            {
+              "expression": "current_school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "family_children_grade_idx": {
+          "name": "family_children_grade_idx",
+          "columns": [
+            {
+              "expression": "grade_band",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "family_children_family_unit_id_family_units_id_fk": {
+          "name": "family_children_family_unit_id_family_units_id_fk",
+          "tableFrom": "family_children",
+          "tableTo": "family_units",
+          "columnsFrom": [
+            "family_unit_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "family_children_current_school_id_partner_orgs_id_fk": {
+          "name": "family_children_current_school_id_partner_orgs_id_fk",
+          "tableFrom": "family_children",
+          "tableTo": "partner_orgs",
+          "columnsFrom": [
+            "current_school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.family_units": {
+      "name": "family_units",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "primary_caregiver_name": {
+          "name": "primary_caregiver_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "household_size": {
+          "name": "household_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "children_count": {
+          "name": "children_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "family_unit_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "entry_signal": {
+          "name": "entry_signal",
+          "type": "family_entry_signal",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entry_signal_id": {
+          "name": "entry_signal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_housing_status": {
+          "name": "current_housing_status",
+          "type": "family_housing_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assigned_caseworker_user_id": {
+          "name": "assigned_caseworker_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "receiving_school_district_id": {
+          "name": "receiving_school_district_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "family_units_status_idx": {
+          "name": "family_units_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "family_units_entry_signal_idx": {
+          "name": "family_units_entry_signal_idx",
+          "columns": [
+            {
+              "expression": "entry_signal",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "family_units_assigned_caseworker_idx": {
+          "name": "family_units_assigned_caseworker_idx",
+          "columns": [
+            {
+              "expression": "assigned_caseworker_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "family_units_school_district_idx": {
+          "name": "family_units_school_district_idx",
+          "columns": [
+            {
+              "expression": "receiving_school_district_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "family_units_assigned_caseworker_user_id_users_id_fk": {
+          "name": "family_units_assigned_caseworker_user_id_users_id_fk",
+          "tableFrom": "family_units",
+          "tableTo": "users",
+          "columnsFrom": [
+            "assigned_caseworker_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "family_units_receiving_school_district_id_partner_orgs_id_fk": {
+          "name": "family_units_receiving_school_district_id_partner_orgs_id_fk",
+          "tableFrom": "family_units",
+          "tableTo": "partner_orgs",
+          "columnsFrom": [
+            "receiving_school_district_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.foster_aging_out_alerts": {
+      "name": "foster_aging_out_alerts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "youth_id": {
+          "name": "youth_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "milestone": {
+          "name": "milestone",
+          "type": "foster_aging_out_milestone",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fired_at": {
+          "name": "fired_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "acknowledged_by_user_id": {
+          "name": "acknowledged_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "acknowledged_at": {
+          "name": "acknowledged_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "foster_aging_out_alerts_youth_milestone_uniq": {
+          "name": "foster_aging_out_alerts_youth_milestone_uniq",
+          "columns": [
+            {
+              "expression": "youth_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "milestone",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "foster_aging_out_alerts_unack_idx": {
+          "name": "foster_aging_out_alerts_unack_idx",
+          "columns": [
+            {
+              "expression": "acknowledged_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "foster_aging_out_alerts_fired_idx": {
+          "name": "foster_aging_out_alerts_fired_idx",
+          "columns": [
+            {
+              "expression": "fired_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "foster_aging_out_alerts_youth_id_foster_youth_id_fk": {
+          "name": "foster_aging_out_alerts_youth_id_foster_youth_id_fk",
+          "tableFrom": "foster_aging_out_alerts",
+          "tableTo": "foster_youth",
+          "columnsFrom": [
+            "youth_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "foster_aging_out_alerts_acknowledged_by_user_id_users_id_fk": {
+          "name": "foster_aging_out_alerts_acknowledged_by_user_id_users_id_fk",
+          "tableFrom": "foster_aging_out_alerts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "acknowledged_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.foster_youth": {
+      "name": "foster_youth",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "dcbs_partner_org_id": {
+          "name": "dcbs_partner_org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dcbs_case_id": {
+          "name": "dcbs_case_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "legal_first_name": {
+          "name": "legal_first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "legal_last_name": {
+          "name": "legal_last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date_of_birth": {
+          "name": "date_of_birth",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "placement_type": {
+          "name": "placement_type",
+          "type": "foster_placement_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "placement_changes_count": {
+          "name": "placement_changes_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "assigned_caseworker_user_id": {
+          "name": "assigned_caseworker_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supports_in_place": {
+          "name": "supports_in_place",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "foster_youth_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "foster_youth_dcbs_partner_idx": {
+          "name": "foster_youth_dcbs_partner_idx",
+          "columns": [
+            {
+              "expression": "dcbs_partner_org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "foster_youth_assigned_caseworker_idx": {
+          "name": "foster_youth_assigned_caseworker_idx",
+          "columns": [
+            {
+              "expression": "assigned_caseworker_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "foster_youth_status_idx": {
+          "name": "foster_youth_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "foster_youth_dob_idx": {
+          "name": "foster_youth_dob_idx",
+          "columns": [
+            {
+              "expression": "date_of_birth",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "foster_youth_dcbs_partner_org_id_partner_orgs_id_fk": {
+          "name": "foster_youth_dcbs_partner_org_id_partner_orgs_id_fk",
+          "tableFrom": "foster_youth",
+          "tableTo": "partner_orgs",
+          "columnsFrom": [
+            "dcbs_partner_org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "foster_youth_assigned_caseworker_user_id_users_id_fk": {
+          "name": "foster_youth_assigned_caseworker_user_id_users_id_fk",
+          "tableFrom": "foster_youth",
+          "tableTo": "users",
+          "columnsFrom": [
+            "assigned_caseworker_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.health_check": {
+      "name": "health_check",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.hud_vash_vouchers": {
+      "name": "hud_vash_vouchers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "voucher_code": {
+          "name": "voucher_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unit_type": {
+          "name": "unit_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bedrooms": {
+          "name": "bedrooms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "zip": {
+          "name": "zip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accessible": {
+          "name": "accessible",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "availability_status": {
+          "name": "availability_status",
+          "type": "hud_vash_voucher_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'available'"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "hud_vash_vouchers_status_idx": {
+          "name": "hud_vash_vouchers_status_idx",
+          "columns": [
+            {
+              "expression": "availability_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.veteran_voucher_applications": {
+      "name": "veteran_voucher_applications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "veteran_id": {
+          "name": "veteran_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "voucher_id": {
+          "name": "voucher_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "veteran_voucher_application_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'applied'"
+        },
+        "applied_by_user_id": {
+          "name": "applied_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "veteran_voucher_applications_unique_idx": {
+          "name": "veteran_voucher_applications_unique_idx",
+          "columns": [
+            {
+              "expression": "veteran_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "voucher_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "veteran_voucher_applications_veteran_idx": {
+          "name": "veteran_voucher_applications_veteran_idx",
+          "columns": [
+            {
+              "expression": "veteran_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "veteran_voucher_applications_veteran_id_veterans_id_fk": {
+          "name": "veteran_voucher_applications_veteran_id_veterans_id_fk",
+          "tableFrom": "veteran_voucher_applications",
+          "tableTo": "veterans",
+          "columnsFrom": [
+            "veteran_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "veteran_voucher_applications_voucher_id_hud_vash_vouchers_id_fk": {
+          "name": "veteran_voucher_applications_voucher_id_hud_vash_vouchers_id_fk",
+          "tableFrom": "veteran_voucher_applications",
+          "tableTo": "hud_vash_vouchers",
+          "columnsFrom": [
+            "voucher_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "veteran_voucher_applications_applied_by_user_id_users_id_fk": {
+          "name": "veteran_voucher_applications_applied_by_user_id_users_id_fk",
+          "tableFrom": "veteran_voucher_applications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "applied_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.medicaid_extension_applications": {
+      "name": "medicaid_extension_applications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "youth_id": {
+          "name": "youth_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "medicaid_extension_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'drafted'"
+        },
+        "kynect_reference": {
+          "name": "kynect_reference",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "application_payload": {
+          "name": "application_payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "drafted_by_user_id": {
+          "name": "drafted_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "drafted_at": {
+          "name": "drafted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "submitted_at": {
+          "name": "submitted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decision_at": {
+          "name": "decision_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decision_reason": {
+          "name": "decision_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "withdrawn_at": {
+          "name": "withdrawn_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "medicaid_extension_applications_youth_idx": {
+          "name": "medicaid_extension_applications_youth_idx",
+          "columns": [
+            {
+              "expression": "youth_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "medicaid_extension_applications_status_idx": {
+          "name": "medicaid_extension_applications_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "medicaid_extension_applications_drafted_at_idx": {
+          "name": "medicaid_extension_applications_drafted_at_idx",
+          "columns": [
+            {
+              "expression": "drafted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "medicaid_extension_applications_youth_id_foster_youth_id_fk": {
+          "name": "medicaid_extension_applications_youth_id_foster_youth_id_fk",
+          "tableFrom": "medicaid_extension_applications",
+          "tableTo": "foster_youth",
+          "columnsFrom": [
+            "youth_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "medicaid_extension_applications_drafted_by_user_id_users_id_fk": {
+          "name": "medicaid_extension_applications_drafted_by_user_id_users_id_fk",
+          "tableFrom": "medicaid_extension_applications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "drafted_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_memberships": {
+      "name": "org_memberships",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "partner_org_id": {
+          "name": "partner_org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "org_memberships_user_org_idx": {
+          "name": "org_memberships_user_org_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "partner_org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "org_memberships_user_idx": {
+          "name": "org_memberships_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "org_memberships_partner_org_idx": {
+          "name": "org_memberships_partner_org_idx",
+          "columns": [
+            {
+              "expression": "partner_org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "org_memberships_user_id_users_id_fk": {
+          "name": "org_memberships_user_id_users_id_fk",
+          "tableFrom": "org_memberships",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "org_memberships_partner_org_id_partner_orgs_id_fk": {
+          "name": "org_memberships_partner_org_id_partner_orgs_id_fk",
+          "tableFrom": "org_memberships",
+          "tableTo": "partner_orgs",
+          "columnsFrom": [
+            "partner_org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.outbound_messages_test": {
+      "name": "outbound_messages_test",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to": {
+          "name": "to",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.partner_agreements": {
+      "name": "partner_agreements",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "partner_org_id": {
+          "name": "partner_org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "partner_agreement_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "partner_agreement_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "effective_date": {
+          "name": "effective_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "signed_by_partner": {
+          "name": "signed_by_partner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "signed_by_coalition_user_id": {
+          "name": "signed_by_coalition_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "template_version": {
+          "name": "template_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "template_rendered": {
+          "name": "template_rendered",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "terms": {
+          "name": "terms",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "partner_agreements_partner_idx": {
+          "name": "partner_agreements_partner_idx",
+          "columns": [
+            {
+              "expression": "partner_org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "partner_agreements_kind_status_idx": {
+          "name": "partner_agreements_kind_status_idx",
+          "columns": [
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "partner_agreements_active_idx": {
+          "name": "partner_agreements_active_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "status = 'active'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "partner_agreements_partner_org_id_partner_orgs_id_fk": {
+          "name": "partner_agreements_partner_org_id_partner_orgs_id_fk",
+          "tableFrom": "partner_agreements",
+          "tableTo": "partner_orgs",
+          "columnsFrom": [
+            "partner_org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "partner_agreements_signed_by_coalition_user_id_users_id_fk": {
+          "name": "partner_agreements_signed_by_coalition_user_id_users_id_fk",
+          "tableFrom": "partner_agreements",
+          "tableTo": "users",
+          "columnsFrom": [
+            "signed_by_coalition_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "partner_agreements_date_order": {
+          "name": "partner_agreements_date_order",
+          "value": "effective_date IS NULL OR end_date IS NULL OR effective_date <= end_date"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.partner_orgs": {
+      "name": "partner_orgs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "partner_org_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_email": {
+          "name": "contact_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_phone": {
+          "name": "contact_phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "website": {
+          "name": "website",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data_sharing_tier": {
+          "name": "data_sharing_tier",
+          "type": "data_sharing_tier",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "partner_orgs_slug_idx": {
+          "name": "partner_orgs_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.partner_service_events": {
+      "name": "partner_service_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "partner_org_id": {
+          "name": "partner_org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "synthetic_person_ref": {
+          "name": "synthetic_person_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "partner_service_event_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_at": {
+          "name": "event_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "ed_encounter_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'synthetic'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "partner_service_events_person_idx": {
+          "name": "partner_service_events_person_idx",
+          "columns": [
+            {
+              "expression": "synthetic_person_ref",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "partner_service_events_partner_idx": {
+          "name": "partner_service_events_partner_idx",
+          "columns": [
+            {
+              "expression": "partner_org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "partner_service_events_at_idx": {
+          "name": "partner_service_events_at_idx",
+          "columns": [
+            {
+              "expression": "event_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "partner_service_events_partner_org_id_partner_orgs_id_fk": {
+          "name": "partner_service_events_partner_org_id_partner_orgs_id_fk",
+          "tableFrom": "partner_service_events",
+          "tableTo": "partner_orgs",
+          "columnsFrom": [
+            "partner_org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.person_partner_consent_events": {
+      "name": "person_partner_consent_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "consent_id": {
+          "name": "consent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "person_partner_consent_event_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_at": {
+          "name": "event_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "person_partner_consent_events_consent_idx": {
+          "name": "person_partner_consent_events_consent_idx",
+          "columns": [
+            {
+              "expression": "consent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "person_partner_consent_events_consent_id_person_partner_consents_id_fk": {
+          "name": "person_partner_consent_events_consent_id_person_partner_consents_id_fk",
+          "tableFrom": "person_partner_consent_events",
+          "tableTo": "person_partner_consents",
+          "columnsFrom": [
+            "consent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "person_partner_consent_events_actor_user_id_users_id_fk": {
+          "name": "person_partner_consent_events_actor_user_id_users_id_fk",
+          "tableFrom": "person_partner_consent_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.person_partner_consents": {
+      "name": "person_partner_consents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "synthetic_person_ref": {
+          "name": "synthetic_person_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "partner_org_id": {
+          "name": "partner_org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "granted_at": {
+          "name": "granted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "person_partner_consents_unique_idx": {
+          "name": "person_partner_consents_unique_idx",
+          "columns": [
+            {
+              "expression": "synthetic_person_ref",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "partner_org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "person_partner_consents_partner_org_id_partner_orgs_id_fk": {
+          "name": "person_partner_consents_partner_org_id_partner_orgs_id_fk",
+          "tableFrom": "person_partner_consents",
+          "tableTo": "partner_orgs",
+          "columnsFrom": [
+            "partner_org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pre_release_subjects": {
+      "name": "pre_release_subjects",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "ky_doc_partner_org_id": {
+          "name": "ky_doc_partner_org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ky_doc_inmate_id": {
+          "name": "ky_doc_inmate_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "legal_first_name": {
+          "name": "legal_first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "legal_last_name": {
+          "name": "legal_last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date_of_birth": {
+          "name": "date_of_birth",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "projected_release_date": {
+          "name": "projected_release_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "release_type": {
+          "name": "release_type",
+          "type": "pre_release_release_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "designated_destination": {
+          "name": "designated_destination",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assigned_caseworker_user_id": {
+          "name": "assigned_caseworker_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supports_in_place": {
+          "name": "supports_in_place",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "pre_release_subject_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "handed_off_at": {
+          "name": "handed_off_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pre_release_subjects_partner_idx": {
+          "name": "pre_release_subjects_partner_idx",
+          "columns": [
+            {
+              "expression": "ky_doc_partner_org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pre_release_subjects_caseworker_idx": {
+          "name": "pre_release_subjects_caseworker_idx",
+          "columns": [
+            {
+              "expression": "assigned_caseworker_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pre_release_subjects_status_idx": {
+          "name": "pre_release_subjects_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pre_release_subjects_release_date_idx": {
+          "name": "pre_release_subjects_release_date_idx",
+          "columns": [
+            {
+              "expression": "projected_release_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pre_release_subjects_ky_doc_partner_org_id_partner_orgs_id_fk": {
+          "name": "pre_release_subjects_ky_doc_partner_org_id_partner_orgs_id_fk",
+          "tableFrom": "pre_release_subjects",
+          "tableTo": "partner_orgs",
+          "columnsFrom": [
+            "ky_doc_partner_org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "pre_release_subjects_assigned_caseworker_user_id_users_id_fk": {
+          "name": "pre_release_subjects_assigned_caseworker_user_id_users_id_fk",
+          "tableFrom": "pre_release_subjects",
+          "tableTo": "users",
+          "columnsFrom": [
+            "assigned_caseworker_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rental_assistance_programs": {
+      "name": "rental_assistance_programs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agency": {
+          "name": "agency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "website": {
+          "name": "website",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "eligibility_summary": {
+          "name": "eligibility_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "max_award_cents": {
+          "name": "max_award_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_note": {
+          "name": "source_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "rental_assistance_programs_active_idx": {
+          "name": "rental_assistance_programs_active_idx",
+          "columns": [
+            {
+              "expression": "active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.school_referral_consents": {
+      "name": "school_referral_consents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "referral_id": {
+          "name": "referral_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "basis": {
+          "name": "basis",
+          "type": "school_referral_basis",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consenter_relationship": {
+          "name": "consenter_relationship",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "consenter_name": {
+          "name": "consenter_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "consent_text_version": {
+          "name": "consent_text_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "signed_at": {
+          "name": "signed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "signed_method": {
+          "name": "signed_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "school_referral_consents_referral_idx": {
+          "name": "school_referral_consents_referral_idx",
+          "columns": [
+            {
+              "expression": "referral_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "school_referral_consents_referral_id_school_referrals_id_fk": {
+          "name": "school_referral_consents_referral_id_school_referrals_id_fk",
+          "tableFrom": "school_referral_consents",
+          "tableTo": "school_referrals",
+          "columnsFrom": [
+            "referral_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.school_referral_disclosures": {
+      "name": "school_referral_disclosures",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "referral_id": {
+          "name": "referral_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accessed_by_user_id": {
+          "name": "accessed_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accessed_by_partner_org_id": {
+          "name": "accessed_by_partner_org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "purpose": {
+          "name": "purpose",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "basis": {
+          "name": "basis",
+          "type": "school_referral_basis",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accessed_at": {
+          "name": "accessed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "data_classes_disclosed": {
+          "name": "data_classes_disclosed",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        }
+      },
+      "indexes": {
+        "school_referral_disclosures_referral_idx": {
+          "name": "school_referral_disclosures_referral_idx",
+          "columns": [
+            {
+              "expression": "referral_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "school_referral_disclosures_user_idx": {
+          "name": "school_referral_disclosures_user_idx",
+          "columns": [
+            {
+              "expression": "accessed_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "school_referral_disclosures_accessed_at_idx": {
+          "name": "school_referral_disclosures_accessed_at_idx",
+          "columns": [
+            {
+              "expression": "accessed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "school_referral_disclosures_referral_id_school_referrals_id_fk": {
+          "name": "school_referral_disclosures_referral_id_school_referrals_id_fk",
+          "tableFrom": "school_referral_disclosures",
+          "tableTo": "school_referrals",
+          "columnsFrom": [
+            "referral_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "school_referral_disclosures_accessed_by_user_id_users_id_fk": {
+          "name": "school_referral_disclosures_accessed_by_user_id_users_id_fk",
+          "tableFrom": "school_referral_disclosures",
+          "tableTo": "users",
+          "columnsFrom": [
+            "accessed_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "school_referral_disclosures_accessed_by_partner_org_id_partner_orgs_id_fk": {
+          "name": "school_referral_disclosures_accessed_by_partner_org_id_partner_orgs_id_fk",
+          "tableFrom": "school_referral_disclosures",
+          "tableTo": "partner_orgs",
+          "columnsFrom": [
+            "accessed_by_partner_org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.school_referral_status_events": {
+      "name": "school_referral_status_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "referral_id": {
+          "name": "referral_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_status": {
+          "name": "from_status",
+          "type": "school_referral_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "to_status": {
+          "name": "to_status",
+          "type": "school_referral_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "school_referral_status_events_referral_idx": {
+          "name": "school_referral_status_events_referral_idx",
+          "columns": [
+            {
+              "expression": "referral_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"occurred_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "school_referral_status_events_referral_id_school_referrals_id_fk": {
+          "name": "school_referral_status_events_referral_id_school_referrals_id_fk",
+          "tableFrom": "school_referral_status_events",
+          "tableTo": "school_referrals",
+          "columnsFrom": [
+            "referral_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "school_referral_status_events_actor_user_id_users_id_fk": {
+          "name": "school_referral_status_events_actor_user_id_users_id_fk",
+          "tableFrom": "school_referral_status_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.school_referrals": {
+      "name": "school_referrals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "partner_org_id": {
+          "name": "partner_org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "referring_user_id": {
+          "name": "referring_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_first_initial": {
+          "name": "student_first_initial",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_age": {
+          "name": "student_age",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "student_grade_band": {
+          "name": "student_grade_band",
+          "type": "school_referral_grade_band",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "guardian_name": {
+          "name": "guardian_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "guardian_contact": {
+          "name": "guardian_contact",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "housing_situation": {
+          "name": "housing_situation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "services_requested": {
+          "name": "services_requested",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "urgency": {
+          "name": "urgency",
+          "type": "school_referral_urgency",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'medium'"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "school_referral_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'received'"
+        },
+        "mv_authorization_confirmed": {
+          "name": "mv_authorization_confirmed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_updated_at": {
+          "name": "last_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "school_referrals_partner_org_idx": {
+          "name": "school_referrals_partner_org_idx",
+          "columns": [
+            {
+              "expression": "partner_org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "school_referrals_status_idx": {
+          "name": "school_referrals_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "school_referrals_received_at_idx": {
+          "name": "school_referrals_received_at_idx",
+          "columns": [
+            {
+              "expression": "received_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "school_referrals_partner_org_id_partner_orgs_id_fk": {
+          "name": "school_referrals_partner_org_id_partner_orgs_id_fk",
+          "tableFrom": "school_referrals",
+          "tableTo": "partner_orgs",
+          "columnsFrom": [
+            "partner_org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "school_referrals_referring_user_id_users_id_fk": {
+          "name": "school_referrals_referring_user_id_users_id_fk",
+          "tableFrom": "school_referrals",
+          "tableTo": "users",
+          "columnsFrom": [
+            "referring_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bed_count_updates": {
+      "name": "bed_count_updates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "shelter_id": {
+          "name": "shelter_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_user_id": {
+          "name": "updated_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "previous_occupancy": {
+          "name": "previous_occupancy",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "new_occupancy": {
+          "name": "new_occupancy",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "bed_count_updates_shelter_idx": {
+          "name": "bed_count_updates_shelter_idx",
+          "columns": [
+            {
+              "expression": "shelter_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bed_count_updates_created_idx": {
+          "name": "bed_count_updates_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bed_count_updates_shelter_id_shelters_id_fk": {
+          "name": "bed_count_updates_shelter_id_shelters_id_fk",
+          "tableFrom": "bed_count_updates",
+          "tableTo": "shelters",
+          "columnsFrom": [
+            "shelter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bed_holds": {
+      "name": "bed_holds",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "shelter_id": {
+          "name": "shelter_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "held_by_user_id": {
+          "name": "held_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "person_label": {
+          "name": "person_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "bed_hold_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "released_at": {
+          "name": "released_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "bed_holds_shelter_idx": {
+          "name": "bed_holds_shelter_idx",
+          "columns": [
+            {
+              "expression": "shelter_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bed_holds_status_idx": {
+          "name": "bed_holds_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bed_holds_expires_idx": {
+          "name": "bed_holds_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bed_holds_shelter_id_shelters_id_fk": {
+          "name": "bed_holds_shelter_id_shelters_id_fk",
+          "tableFrom": "bed_holds",
+          "tableTo": "shelters",
+          "columnsFrom": [
+            "shelter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.shelters": {
+      "name": "shelters",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "partner_org_id": {
+          "name": "partner_org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address_line1": {
+          "name": "address_line1",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "city": {
+          "name": "city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "postal_code": {
+          "name": "postal_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_phone": {
+          "name": "contact_phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capacity": {
+          "name": "capacity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_occupancy": {
+          "name": "current_occupancy",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "accepts_men": {
+          "name": "accepts_men",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "accepts_women": {
+          "name": "accepts_women",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "accepts_families": {
+          "name": "accepts_families",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "pet_friendly": {
+          "name": "pet_friendly",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "sud_friendly": {
+          "name": "sud_friendly",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "shelters_slug_idx": {
+          "name": "shelters_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "shelters_partner_org_idx": {
+          "name": "shelters_partner_org_idx",
+          "columns": [
+            {
+              "expression": "partner_org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "shelters_partner_org_id_partner_orgs_id_fk": {
+          "name": "shelters_partner_org_id_partner_orgs_id_fk",
+          "tableFrom": "shelters",
+          "tableTo": "partner_orgs",
+          "columnsFrom": [
+            "partner_org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "shelters_capacity_nonneg": {
+          "name": "shelters_capacity_nonneg",
+          "value": "\"shelters\".\"capacity\" >= 0"
+        },
+        "shelters_occupancy_nonneg": {
+          "name": "shelters_occupancy_nonneg",
+          "value": "\"shelters\".\"current_occupancy\" >= 0"
+        },
+        "shelters_occupancy_le_capacity": {
+          "name": "shelters_occupancy_le_capacity",
+          "value": "\"shelters\".\"current_occupancy\" <= \"shelters\".\"capacity\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.sms_conversations": {
+      "name": "sms_conversations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "from_number": {
+          "name": "from_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "sms_conversation_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'idle'"
+        },
+        "pending_filter": {
+          "name": "pending_filter",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_location": {
+          "name": "last_location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_results": {
+          "name": "last_results",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_hold_id": {
+          "name": "last_hold_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_message_at": {
+          "name": "last_message_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sms_conversations_from_idx": {
+          "name": "sms_conversations_from_idx",
+          "columns": [
+            {
+              "expression": "from_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_conversations_state_idx": {
+          "name": "sms_conversations_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_conversations_expires_idx": {
+          "name": "sms_conversations_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sms_messages": {
+      "name": "sms_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "provider_message_id": {
+          "name": "provider_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "from_number": {
+          "name": "from_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_number": {
+          "name": "to_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "intent": {
+          "name": "intent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reply_body": {
+          "name": "reply_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sms_messages_received_idx": {
+          "name": "sms_messages_received_idx",
+          "columns": [
+            {
+              "expression": "received_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_messages_from_idx": {
+          "name": "sms_messages_from_idx",
+          "columns": [
+            {
+              "expression": "from_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.steering_meetings": {
+      "name": "steering_meetings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "held_on": {
+          "name": "held_on",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attendees": {
+          "name": "attendees",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agenda_md": {
+          "name": "agenda_md",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "decisions_md": {
+          "name": "decisions_md",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "action_items_md": {
+          "name": "action_items_md",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "posted_at": {
+          "name": "posted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "steering_meetings_held_on_idx": {
+          "name": "steering_meetings_held_on_idx",
+          "columns": [
+            {
+              "expression": "held_on",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "steering_meetings_created_by_idx": {
+          "name": "steering_meetings_created_by_idx",
+          "columns": [
+            {
+              "expression": "created_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "steering_meetings_created_by_user_id_users_id_fk": {
+          "name": "steering_meetings_created_by_user_id_users_id_fk",
+          "tableFrom": "steering_meetings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.triage_overrides": {
+      "name": "triage_overrides",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recommended_tier": {
+          "name": "recommended_tier",
+          "type": "triage_tier",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recommended_score": {
+          "name": "recommended_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chosen_tier": {
+          "name": "chosen_tier",
+          "type": "triage_tier",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "override_reason": {
+          "name": "override_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "inputs_snapshot": {
+          "name": "inputs_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recommended_factors": {
+          "name": "recommended_factors",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "triage_overrides_actor_idx": {
+          "name": "triage_overrides_actor_idx",
+          "columns": [
+            {
+              "expression": "actor_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "triage_overrides_created_idx": {
+          "name": "triage_overrides_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "triage_overrides_recommended_idx": {
+          "name": "triage_overrides_recommended_idx",
+          "columns": [
+            {
+              "expression": "recommended_tier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "triage_overrides_actor_user_id_users_id_fk": {
+          "name": "triage_overrides_actor_user_id_users_id_fk",
+          "tableFrom": "triage_overrides",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "clerk_user_id": {
+          "name": "clerk_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "users_clerk_user_id_idx": {
+          "name": "users_clerk_user_id_idx",
+          "columns": [
+            {
+              "expression": "clerk_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.veterans": {
+      "name": "veterans",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "synthetic_person_ref": {
+          "name": "synthetic_person_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "legal_first_name": {
+          "name": "legal_first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "legal_last_name": {
+          "name": "legal_last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "branch_of_service": {
+          "name": "branch_of_service",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "eligibility_source": {
+          "name": "eligibility_source",
+          "type": "veteran_eligibility_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "caseworker_verified": {
+          "name": "caseworker_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "assigned_caseworker_user_id": {
+          "name": "assigned_caseworker_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "veteran_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "bedroom_need": {
+          "name": "bedroom_need",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accessibility_need": {
+          "name": "accessibility_need",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "target_zip": {
+          "name": "target_zip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "veterans_caseworker_idx": {
+          "name": "veterans_caseworker_idx",
+          "columns": [
+            {
+              "expression": "assigned_caseworker_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "veterans_status_idx": {
+          "name": "veterans_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "veterans_synthetic_ref_idx": {
+          "name": "veterans_synthetic_ref_idx",
+          "columns": [
+            {
+              "expression": "synthetic_person_ref",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "veterans_assigned_caseworker_user_id_users_id_fk": {
+          "name": "veterans_assigned_caseworker_user_id_users_id_fk",
+          "tableFrom": "veterans",
+          "tableTo": "users",
+          "columnsFrom": [
+            "assigned_caseworker_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.bed_hold_status": {
+      "name": "bed_hold_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "released",
+        "expired",
+        "converted"
+      ]
+    },
+    "public.case_handoff_scope_kind": {
+      "name": "case_handoff_scope_kind",
+      "schema": "public",
+      "values": [
+        "intakes",
+        "case_notes",
+        "service_events",
+        "consents"
+      ]
+    },
+    "public.case_handoff_status": {
+      "name": "case_handoff_status",
+      "schema": "public",
+      "values": [
+        "pending_consent",
+        "pending_acceptance",
+        "accepted",
+        "declined",
+        "revoked",
+        "expired"
+      ]
+    },
+    "public.client_document_kind": {
+      "name": "client_document_kind",
+      "schema": "public",
+      "values": [
+        "photo_id",
+        "ssn_card",
+        "birth_certificate",
+        "dd_214",
+        "lease",
+        "paystub",
+        "court_record",
+        "other"
+      ]
+    },
+    "public.client_document_status": {
+      "name": "client_document_status",
+      "schema": "public",
+      "values": [
+        "uploaded",
+        "extracting",
+        "extracted",
+        "failed"
+      ]
+    },
+    "public.client_intake_status": {
+      "name": "client_intake_status",
+      "schema": "public",
+      "values": [
+        "recording",
+        "transcribed",
+        "extracting",
+        "extracted",
+        "failed"
+      ]
+    },
+    "public.consent_channel": {
+      "name": "consent_channel",
+      "schema": "public",
+      "values": [
+        "sms",
+        "in_person",
+        "web_form",
+        "phone",
+        "paper"
+      ]
+    },
+    "public.consent_type": {
+      "name": "consent_type",
+      "schema": "public",
+      "values": [
+        "phi_share_within_coalition",
+        "sms_communication",
+        "data_for_program_eval"
+      ]
+    },
+    "public.data_sharing_tier": {
+      "name": "data_sharing_tier",
+      "schema": "public",
+      "values": [
+        "none",
+        "aggregate",
+        "individual"
+      ]
+    },
+    "public.dv_risk_tier": {
+      "name": "dv_risk_tier",
+      "schema": "public",
+      "values": [
+        "unknown",
+        "lethality_low",
+        "lethality_moderate",
+        "lethality_high"
+      ]
+    },
+    "public.dv_safety_event_type": {
+      "name": "dv_safety_event_type",
+      "schema": "public",
+      "values": [
+        "intake",
+        "safety_plan_update",
+        "escalation",
+        "service_referral",
+        "exit"
+      ]
+    },
+    "public.dv_survivor_status": {
+      "name": "dv_survivor_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "exited",
+        "transferred",
+        "deceased"
+      ]
+    },
+    "public.ed_encounter_source": {
+      "name": "ed_encounter_source",
+      "schema": "public",
+      "values": [
+        "synthetic",
+        "epic_fhir",
+        "manual"
+      ]
+    },
+    "public.esuc_care_plan_status": {
+      "name": "esuc_care_plan_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "approved",
+        "active",
+        "archived"
+      ]
+    },
+    "public.eviction_case_outcome": {
+      "name": "eviction_case_outcome",
+      "schema": "public",
+      "values": [
+        "dismissed",
+        "judgment_for_plaintiff",
+        "judgment_for_defendant",
+        "settled",
+        "default_judgment",
+        "withdrawn"
+      ]
+    },
+    "public.eviction_cause_type": {
+      "name": "eviction_cause_type",
+      "schema": "public",
+      "values": [
+        "non_payment",
+        "lease_violation",
+        "holdover",
+        "other"
+      ]
+    },
+    "public.eviction_filing_source": {
+      "name": "eviction_filing_source",
+      "schema": "public",
+      "values": [
+        "courtnet",
+        "manual",
+        "synthetic"
+      ]
+    },
+    "public.eviction_filing_status": {
+      "name": "eviction_filing_status",
+      "schema": "public",
+      "values": [
+        "filed",
+        "served",
+        "judgment",
+        "dismissed",
+        "sealed"
+      ]
+    },
+    "public.eviction_response_packet_status": {
+      "name": "eviction_response_packet_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "approved",
+        "filed",
+        "rejected"
+      ]
+    },
+    "public.fag_member_status": {
+      "name": "fag_member_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "paused",
+        "ended"
+      ]
+    },
+    "public.fag_payout_status": {
+      "name": "fag_payout_status",
+      "schema": "public",
+      "values": [
+        "unpaid",
+        "paid",
+        "voided"
+      ]
+    },
+    "public.faith_aggregate_period_kind": {
+      "name": "faith_aggregate_period_kind",
+      "schema": "public",
+      "values": [
+        "week",
+        "month",
+        "quarter"
+      ]
+    },
+    "public.faith_ministry_status": {
+      "name": "faith_ministry_status",
+      "schema": "public",
+      "values": [
+        "opted_in",
+        "paused",
+        "opted_out"
+      ]
+    },
+    "public.family_child_grade_band": {
+      "name": "family_child_grade_band",
+      "schema": "public",
+      "values": [
+        "pre_k",
+        "elementary",
+        "middle",
+        "high",
+        "not_enrolled"
+      ]
+    },
+    "public.family_entry_signal": {
+      "name": "family_entry_signal",
+      "schema": "public",
+      "values": [
+        "eviction",
+        "ed_encounter",
+        "school_referral",
+        "sms_intake",
+        "walk_in"
+      ]
+    },
+    "public.family_housing_status": {
+      "name": "family_housing_status",
+      "schema": "public",
+      "values": [
+        "stably_housed",
+        "doubled_up",
+        "shelter",
+        "unsheltered",
+        "hotel"
+      ]
+    },
+    "public.family_unit_status": {
+      "name": "family_unit_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "rehoused",
+        "exited"
+      ]
+    },
+    "public.foster_aging_out_milestone": {
+      "name": "foster_aging_out_milestone",
+      "schema": "public",
+      "values": [
+        "d90",
+        "d60",
+        "d30",
+        "d14",
+        "d7",
+        "aged_out"
+      ]
+    },
+    "public.foster_placement_type": {
+      "name": "foster_placement_type",
+      "schema": "public",
+      "values": [
+        "family_foster",
+        "kinship",
+        "group_home",
+        "residential",
+        "independent_living",
+        "unknown"
+      ]
+    },
+    "public.foster_youth_status": {
+      "name": "foster_youth_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "aged_out",
+        "exited"
+      ]
+    },
+    "public.housing_status": {
+      "name": "housing_status",
+      "schema": "public",
+      "values": [
+        "housed",
+        "doubled_up",
+        "shelter",
+        "unsheltered",
+        "unknown"
+      ]
+    },
+    "public.medicaid_extension_status": {
+      "name": "medicaid_extension_status",
+      "schema": "public",
+      "values": [
+        "drafted",
+        "submitted",
+        "approved",
+        "denied",
+        "withdrawn"
+      ]
+    },
+    "public.partner_agreement_kind": {
+      "name": "partner_agreement_kind",
+      "schema": "public",
+      "values": [
+        "mou",
+        "ferpa",
+        "baa",
+        "qsoa",
+        "dsa",
+        "memo_of_cooperation"
+      ]
+    },
+    "public.partner_agreement_status": {
+      "name": "partner_agreement_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "active",
+        "expired",
+        "terminated",
+        "superseded"
+      ]
+    },
+    "public.partner_org_type": {
+      "name": "partner_org_type",
+      "schema": "public",
+      "values": [
+        "hospital",
+        "legal_aid",
+        "shelter",
+        "community_org",
+        "government",
+        "faith_based",
+        "school",
+        "philanthropy",
+        "education",
+        "public_health",
+        "media",
+        "other"
+      ]
+    },
+    "public.partner_service_event_type": {
+      "name": "partner_service_event_type",
+      "schema": "public",
+      "values": [
+        "food_pantry",
+        "shelter_intake",
+        "shelter_bed_night",
+        "utility_assistance",
+        "rent_assistance",
+        "counseling_visit",
+        "medical_visit",
+        "school_attendance_flag",
+        "volunteer_hours",
+        "other"
+      ]
+    },
+    "public.pre_release_subject_status": {
+      "name": "pre_release_subject_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "handed_off"
+      ]
+    },
+    "public.pre_release_release_type": {
+      "name": "pre_release_release_type",
+      "schema": "public",
+      "values": [
+        "sentence_expiration",
+        "parole",
+        "transfer",
+        "other"
+      ]
+    },
+    "public.school_referral_basis": {
+      "name": "school_referral_basis",
+      "schema": "public",
+      "values": [
+        "mckinney_vento_authorization",
+        "parental_consent",
+        "eligible_student_consent",
+        "directory_info_only",
+        "health_safety_emergency"
+      ]
+    },
+    "public.school_referral_grade_band": {
+      "name": "school_referral_grade_band",
+      "schema": "public",
+      "values": [
+        "elementary",
+        "middle",
+        "high"
+      ]
+    },
+    "public.school_referral_status": {
+      "name": "school_referral_status",
+      "schema": "public",
+      "values": [
+        "received",
+        "triaged",
+        "in_progress",
+        "connected",
+        "closed_unreachable",
+        "closed_completed"
+      ]
+    },
+    "public.school_referral_urgency": {
+      "name": "school_referral_urgency",
+      "schema": "public",
+      "values": [
+        "low",
+        "medium",
+        "high"
+      ]
+    },
+    "public.sms_conversation_state": {
+      "name": "sms_conversation_state",
+      "schema": "public",
+      "values": [
+        "idle",
+        "awaiting_location"
+      ]
+    },
+    "public.triage_tier": {
+      "name": "triage_tier",
+      "schema": "public",
+      "values": [
+        "high",
+        "medium",
+        "low"
+      ]
+    },
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "pending",
+        "attorney",
+        "caseworker",
+        "ed_coordinator",
+        "shelter_staff",
+        "admin"
+      ]
+    },
+    "public.veteran_eligibility_source": {
+      "name": "veteran_eligibility_source",
+      "schema": "public",
+      "values": [
+        "va_confirmed",
+        "self_reported"
+      ]
+    },
+    "public.veteran_status": {
+      "name": "veteran_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "exited"
+      ]
+    },
+    "public.hud_vash_voucher_status": {
+      "name": "hud_vash_voucher_status",
+      "schema": "public",
+      "values": [
+        "available",
+        "pending",
+        "leased"
+      ]
+    },
+    "public.veteran_voucher_application_status": {
+      "name": "veteran_voucher_application_status",
+      "schema": "public",
+      "values": [
+        "applied",
+        "withdrawn"
+      ]
+    },
+    "public.person_partner_consent_event_type": {
+      "name": "person_partner_consent_event_type",
+      "schema": "public",
+      "values": [
+        "granted",
+        "revoked"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/migrations/meta/_journal.json
+++ b/drizzle/migrations/meta/_journal.json
@@ -323,6 +323,13 @@
 			"when": 1782201339661,
 			"tag": "0045_SUBP-006a_veterans",
 			"breakpoints": true
+		},
+		{
+			"idx": 46,
+			"version": "7",
+			"when": 1782220835048,
+			"tag": "0046_SUBP-006b_voucher_matching",
+			"breakpoints": true
 		}
 	]
 }

--- a/src/app/actions/vouchers.ts
+++ b/src/app/actions/vouchers.ts
@@ -1,0 +1,113 @@
+'use server';
+
+import { revalidatePath } from 'next/cache';
+import {
+  applyToVoucher,
+  createVoucher,
+  deleteVoucher,
+  updateVoucher,
+} from '@/db/queries/hud-vash-vouchers';
+import type { HudVashVoucherStatus } from '@/db/schema/hud-vash-vouchers';
+import { requireRole } from '@/lib/auth';
+
+export type VoucherActionResult = { ok: true } | { ok: false; error: string };
+
+const VALID_STATUS: readonly HudVashVoucherStatus[] = ['available', 'pending', 'leased'];
+
+/** SUBP-006b — caseworker records a veteran's application to a voucher. */
+export async function applyToVoucherAction(
+  veteranId: string,
+  voucherId: string,
+): Promise<VoucherActionResult> {
+  const actor = await requireRole(['caseworker', 'admin']);
+  if (!veteranId || !voucherId) return { ok: false, error: 'Missing veteran or voucher.' };
+  await applyToVoucher(veteranId, voucherId, actor.id);
+  revalidatePath(`/app/clients/veterans/${veteranId}`);
+  return { ok: true };
+}
+
+interface ParsedVoucher {
+  voucherCode: string;
+  unitType: string;
+  bedrooms: number;
+  location: string;
+  zip: string | null;
+  accessible: boolean;
+  availabilityStatus: HudVashVoucherStatus;
+  notes: string | null;
+}
+
+function parseVoucherForm(
+  fd: FormData,
+): { ok: true; value: ParsedVoucher } | { ok: false; error: string } {
+  const str = (k: string) => (fd.get(k) ?? '').toString().trim();
+  const voucherCode = str('voucherCode');
+  if (!voucherCode) return { ok: false, error: 'Voucher code is required.' };
+  const unitType = str('unitType');
+  if (!unitType) return { ok: false, error: 'Unit type is required.' };
+  const location = str('location');
+  if (!location) return { ok: false, error: 'Location is required.' };
+
+  const bedroomsRaw = str('bedrooms');
+  const bedrooms = Number(bedroomsRaw);
+  if (!Number.isInteger(bedrooms) || bedrooms < 0 || bedrooms > 10) {
+    return { ok: false, error: 'Bedrooms must be a whole number between 0 and 10.' };
+  }
+
+  const zipRaw = str('zip');
+  if (zipRaw && !/^\d{5}$/.test(zipRaw)) {
+    return { ok: false, error: 'ZIP must be 5 digits.' };
+  }
+
+  const status = str('availabilityStatus') as HudVashVoucherStatus;
+  if (!VALID_STATUS.includes(status)) {
+    return { ok: false, error: 'Availability status is required.' };
+  }
+
+  const notes = str('notes');
+  return {
+    ok: true,
+    value: {
+      voucherCode,
+      unitType,
+      bedrooms,
+      location,
+      zip: zipRaw || null,
+      accessible: str('accessible') === 'true' || fd.get('accessible') === 'on',
+      availabilityStatus: status,
+      notes: notes || null,
+    },
+  };
+}
+
+export async function createVoucherAction(fd: FormData): Promise<VoucherActionResult> {
+  const actor = await requireRole(['admin']);
+  const parsed = parseVoucherForm(fd);
+  if (!parsed.ok) return parsed;
+  await createVoucher(parsed.value, actor.id);
+  revalidatePath('/app/admin/vouchers');
+  return { ok: true };
+}
+
+export async function updateVoucherAction(
+  voucherId: string,
+  fd: FormData,
+): Promise<VoucherActionResult> {
+  const actor = await requireRole(['admin']);
+  if (!voucherId) return { ok: false, error: 'Missing voucher id.' };
+  const parsed = parseVoucherForm(fd);
+  if (!parsed.ok) return parsed;
+  const updated = await updateVoucher(voucherId, parsed.value, actor.id);
+  if (!updated) return { ok: false, error: 'Voucher not found.' };
+  revalidatePath('/app/admin/vouchers');
+  return { ok: true };
+}
+
+export async function deleteVoucherAction(voucherId: string): Promise<VoucherActionResult> {
+  const actor = await requireRole(['admin']);
+  if (!voucherId) return { ok: false, error: 'Missing voucher id.' };
+  const ok = await deleteVoucher(voucherId, actor.id);
+  if (!ok) return { ok: false, error: 'Voucher not found.' };
+  revalidatePath('/app/admin/vouchers');
+  return { ok: true };
+}

--- a/src/app/app/admin/vouchers/page.tsx
+++ b/src/app/app/admin/vouchers/page.tsx
@@ -1,0 +1,24 @@
+import { VoucherAdmin } from '@/components/subp/voucher-admin';
+import { listVouchers } from '@/db/queries/hud-vash-vouchers';
+import { requireRole } from '@/lib/auth';
+
+export const dynamic = 'force-dynamic';
+
+export default async function AdminVouchersPage() {
+  await requireRole(['admin']);
+  const vouchers = await listVouchers();
+
+  return (
+    <div className="mx-auto max-w-4xl space-y-4 p-6">
+      <header>
+        <h1 className="font-serif text-3xl font-bold text-primary">HUD-VASH vouchers</h1>
+        <p className="text-sm text-muted-foreground">
+          Admin-managed seed data for the veteran pathway (SUBP-006b). These vouchers are matched
+          against veteran subject profiles on the veteran detail view. The live VA feed replaces
+          this once the DTRS-015 data-sharing agreement is in place. Synthetic data only.
+        </p>
+      </header>
+      <VoucherAdmin vouchers={vouchers} />
+    </div>
+  );
+}

--- a/src/app/app/clients/veterans/[id]/page.tsx
+++ b/src/app/app/clients/veterans/[id]/page.tsx
@@ -1,0 +1,155 @@
+import Link from 'next/link';
+import { notFound } from 'next/navigation';
+import { VoucherApplyButton } from '@/components/subp/voucher-apply-button';
+import { listApplicationsForVeteran, listVouchers } from '@/db/queries/hud-vash-vouchers';
+import { getVeteran } from '@/db/queries/veterans';
+import { requireRole } from '@/lib/auth';
+import { describeVeteranEligibility, isVeteranEligible, scoreVoucherMatch } from '@/lib/subp';
+
+export const dynamic = 'force-dynamic';
+
+interface Props {
+  params: Promise<{ id: string }>;
+}
+
+export default async function VeteranDetailPage({ params }: Props) {
+  await requireRole(['caseworker', 'admin']);
+  const { id } = await params;
+
+  const veteran = await getVeteran(id);
+  if (!veteran) notFound();
+
+  const eligible = isVeteranEligible(veteran);
+
+  // Voucher panel only when the veteran flag is set (SUBP-006b AC).
+  const [vouchers, applications] = eligible
+    ? await Promise.all([listVouchers({ availableOnly: true }), listApplicationsForVeteran(id)])
+    : [[], []];
+
+  const appliedVoucherIds = new Set(
+    applications.filter((a) => a.status === 'applied').map((a) => a.voucherId),
+  );
+
+  const scored = vouchers
+    .map((v) => ({
+      voucher: v,
+      match: scoreVoucherMatch(
+        {
+          bedroomNeed: veteran.bedroomNeed,
+          accessibilityNeed: veteran.accessibilityNeed,
+          targetZip: veteran.targetZip,
+        },
+        { bedrooms: v.bedrooms, accessible: v.accessible, zip: v.zip },
+      ),
+      applied: appliedVoucherIds.has(v.id),
+    }))
+    .sort((a, b) => b.match.score - a.match.score);
+
+  return (
+    <div className="mx-auto max-w-3xl space-y-6 p-4 md:p-6">
+      <div className="text-xs">
+        <Link href="/app/clients/veterans" className="text-muted-foreground hover:underline">
+          ← Back to veterans
+        </Link>
+      </div>
+
+      <header>
+        <h1 className="font-serif text-3xl font-bold text-primary">
+          {veteran.legalFirstName} {veteran.legalLastName}
+        </h1>
+        <p className="mt-1 text-sm text-muted-foreground">
+          {veteran.branchOfService ?? 'Branch unknown'} ·{' '}
+          <span className={eligible ? 'text-emerald-700 dark:text-emerald-400' : ''}>
+            {describeVeteranEligibility(veteran)}
+          </span>{' '}
+          · <span className="font-mono text-xs">{veteran.syntheticPersonRef}</span>
+        </p>
+      </header>
+
+      <section className="rounded-md border border-border p-4 text-sm">
+        <h2 className="text-sm font-semibold">Housing profile</h2>
+        <dl className="mt-2 grid grid-cols-2 gap-x-3 gap-y-1 text-xs text-muted-foreground sm:grid-cols-3">
+          <div>
+            <dt className="inline font-medium">Bedrooms needed: </dt>
+            <dd className="inline tabular-nums">{veteran.bedroomNeed ?? '—'}</dd>
+          </div>
+          <div>
+            <dt className="inline font-medium">Accessible unit: </dt>
+            <dd className="inline">{veteran.accessibilityNeed ? 'required' : 'no'}</dd>
+          </div>
+          <div>
+            <dt className="inline font-medium">Target ZIP: </dt>
+            <dd className="inline">{veteran.targetZip ?? '—'}</dd>
+          </div>
+        </dl>
+      </section>
+
+      <section className="space-y-3">
+        <h2 className="text-sm font-semibold">HUD-VASH voucher matches</h2>
+        {!eligible ? (
+          <div className="rounded-md border border-amber-500/40 bg-amber-500/5 p-4 text-sm">
+            <p className="font-medium text-amber-700 dark:text-amber-400">
+              Voucher matching is hidden until veteran status is confirmed.
+            </p>
+            <p className="mt-1 text-xs text-muted-foreground">
+              Confirm eligibility from the veterans list to surface matched vouchers.
+            </p>
+          </div>
+        ) : scored.length === 0 ? (
+          <div className="rounded-md border border-border bg-muted/20 p-4 text-sm text-muted-foreground">
+            No available vouchers in the seed data. An admin can add vouchers under{' '}
+            <Link href="/app/admin/vouchers" className="underline">
+              admin → vouchers
+            </Link>
+            .
+          </div>
+        ) : (
+          <ul className="space-y-2">
+            {scored.map(({ voucher: v, match, applied }) => (
+              <li key={v.id} className="rounded-md border border-border bg-card p-3 text-sm">
+                <div className="flex items-start justify-between gap-2">
+                  <div>
+                    <p className="font-medium">
+                      {v.unitType}{' '}
+                      <span className="font-mono text-[10px] text-muted-foreground">
+                        {v.voucherCode}
+                      </span>
+                    </p>
+                    <p className="text-xs text-muted-foreground">
+                      {v.location}
+                      {v.zip ? ` · ${v.zip}` : ''} · {v.bedrooms}br
+                      {v.accessible ? ' · accessible' : ''} · {v.availabilityStatus}
+                    </p>
+                  </div>
+                  <span
+                    className={`shrink-0 rounded px-2 py-0.5 text-xs font-semibold tabular-nums ${
+                      match.score >= 70
+                        ? 'bg-emerald-100 text-emerald-700 dark:bg-emerald-900/40 dark:text-emerald-400'
+                        : match.score >= 40
+                          ? 'bg-amber-100 text-amber-700 dark:bg-amber-900/40 dark:text-amber-400'
+                          : 'bg-zinc-100 text-zinc-600 dark:bg-zinc-800 dark:text-zinc-300'
+                    }`}
+                  >
+                    {match.score}% match
+                  </span>
+                </div>
+                <p className="mt-1 text-[10px] text-muted-foreground">
+                  {match.factors.map((f) => `${f.label}: ${f.detail}`).join(' · ')}
+                </p>
+                <div className="mt-2">
+                  {applied ? (
+                    <span className="rounded bg-emerald-600/15 px-2 py-0.5 text-xs text-emerald-700 dark:text-emerald-400">
+                      Applied
+                    </span>
+                  ) : (
+                    <VoucherApplyButton veteranId={veteran.id} voucherId={v.id} />
+                  )}
+                </div>
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/src/app/app/clients/veterans/page.tsx
+++ b/src/app/app/clients/veterans/page.tsx
@@ -81,9 +81,12 @@ export default async function VeteransListPage({
                 return (
                   <tr key={v.id} className="border-b last:border-0 hover:bg-muted/10">
                     <td className="px-3 py-2">
-                      <span className="font-medium">
+                      <Link
+                        href={`/app/clients/veterans/${v.id}`}
+                        className="font-medium hover:underline"
+                      >
                         {v.legalFirstName} {v.legalLastName}
-                      </span>
+                      </Link>
                       <div className="font-mono text-[10px] text-muted-foreground">
                         {v.syntheticPersonRef}
                       </div>

--- a/src/components/app-shell/nav-config.ts
+++ b/src/components/app-shell/nav-config.ts
@@ -156,6 +156,7 @@ export const NAV_ITEMS: NavItem[] = [
   { label: 'Admin · Audit log', href: '/app/admin/audit', roles: ['admin'] },
   { label: 'Admin · Triage overrides', href: '/app/admin/triage-overrides', roles: ['admin'] },
   { label: 'Admin · Agreements', href: '/app/admin/agreements', roles: ['admin'] },
+  { label: 'Admin · HUD-VASH vouchers', href: '/app/admin/vouchers', roles: ['admin'] },
   { label: 'Admin · Faith aggregate', href: '/app/admin/faith-aggregate', roles: ['admin'] },
   {
     label: 'Admin · Faith insights',

--- a/src/components/subp/voucher-admin.tsx
+++ b/src/components/subp/voucher-admin.tsx
@@ -1,0 +1,203 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { useState, useTransition } from 'react';
+import {
+  createVoucherAction,
+  deleteVoucherAction,
+  updateVoucherAction,
+} from '@/app/actions/vouchers';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+// Type-only deep import — no server code reaches the client bundle.
+import type { HudVashVoucher } from '@/db/schema/hud-vash-vouchers';
+
+const STATUSES = ['available', 'pending', 'leased'] as const;
+
+function VoucherFields({ voucher }: { voucher?: HudVashVoucher }) {
+  return (
+    <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
+      <div>
+        <Label htmlFor="voucherCode">Voucher code</Label>
+        <Input
+          id="voucherCode"
+          name="voucherCode"
+          defaultValue={voucher?.voucherCode ?? ''}
+          required
+        />
+      </div>
+      <div>
+        <Label htmlFor="unitType">Unit type</Label>
+        <Input id="unitType" name="unitType" defaultValue={voucher?.unitType ?? ''} required />
+      </div>
+      <div>
+        <Label htmlFor="bedrooms">Bedrooms</Label>
+        <Input
+          id="bedrooms"
+          name="bedrooms"
+          type="number"
+          min={0}
+          max={10}
+          defaultValue={voucher?.bedrooms ?? 1}
+          required
+        />
+      </div>
+      <div>
+        <Label htmlFor="location">Location</Label>
+        <Input id="location" name="location" defaultValue={voucher?.location ?? ''} required />
+      </div>
+      <div>
+        <Label htmlFor="zip">ZIP</Label>
+        <Input id="zip" name="zip" defaultValue={voucher?.zip ?? ''} placeholder="42301" />
+      </div>
+      <div>
+        <Label htmlFor="availabilityStatus">Availability</Label>
+        <select
+          id="availabilityStatus"
+          name="availabilityStatus"
+          defaultValue={voucher?.availabilityStatus ?? 'available'}
+          className="h-9 w-full rounded-md border border-input bg-card px-2 text-sm"
+        >
+          {STATUSES.map((s) => (
+            <option key={s} value={s}>
+              {s}
+            </option>
+          ))}
+        </select>
+      </div>
+      <label className="flex items-center gap-2 text-sm">
+        <input
+          type="checkbox"
+          name="accessible"
+          value="true"
+          defaultChecked={voucher?.accessible ?? false}
+        />
+        Accessible unit
+      </label>
+      <div className="sm:col-span-2">
+        <Label htmlFor="notes">Notes</Label>
+        <Input id="notes" name="notes" defaultValue={voucher?.notes ?? ''} />
+      </div>
+    </div>
+  );
+}
+
+export function VoucherAdmin({ vouchers }: { vouchers: HudVashVoucher[] }) {
+  const router = useRouter();
+  const [pending, startTransition] = useTransition();
+  const [error, setError] = useState<string | null>(null);
+  const [editingId, setEditingId] = useState<string | null>(null);
+
+  const submitNew = (fd: FormData) => {
+    setError(null);
+    startTransition(async () => {
+      const r = await createVoucherAction(fd);
+      if (!r.ok) {
+        setError(r.error);
+        return;
+      }
+      router.refresh();
+    });
+  };
+
+  const submitEdit = (id: string, fd: FormData) => {
+    setError(null);
+    startTransition(async () => {
+      const r = await updateVoucherAction(id, fd);
+      if (!r.ok) {
+        setError(r.error);
+        return;
+      }
+      setEditingId(null);
+      router.refresh();
+    });
+  };
+
+  const remove = (id: string) => {
+    setError(null);
+    startTransition(async () => {
+      const r = await deleteVoucherAction(id);
+      if (!r.ok) {
+        setError(r.error);
+        return;
+      }
+      router.refresh();
+    });
+  };
+
+  return (
+    <div className="space-y-6">
+      {error ? <p className="text-destructive text-sm">{error}</p> : null}
+
+      <form action={submitNew} className="rounded-md border border-border p-4">
+        <h2 className="mb-3 text-sm font-semibold">Add voucher</h2>
+        <VoucherFields />
+        <Button type="submit" size="sm" disabled={pending} className="mt-3">
+          {pending ? 'Saving…' : 'Add voucher'}
+        </Button>
+      </form>
+
+      <div className="space-y-2">
+        <h2 className="text-sm font-semibold">Vouchers ({vouchers.length})</h2>
+        {vouchers.length === 0 ? (
+          <p className="text-sm text-muted-foreground">No vouchers yet.</p>
+        ) : (
+          <ul className="space-y-2">
+            {vouchers.map((v) => (
+              <li key={v.id} className="rounded-md border border-border bg-card p-3 text-sm">
+                {editingId === v.id ? (
+                  <form action={(fd) => submitEdit(v.id, fd)}>
+                    <VoucherFields voucher={v} />
+                    <div className="mt-3 flex gap-2">
+                      <Button type="submit" size="sm" disabled={pending}>
+                        Save
+                      </Button>
+                      <Button
+                        type="button"
+                        size="sm"
+                        variant="ghost"
+                        onClick={() => setEditingId(null)}
+                      >
+                        Cancel
+                      </Button>
+                    </div>
+                  </form>
+                ) : (
+                  <div className="flex flex-wrap items-center justify-between gap-2">
+                    <div>
+                      <p className="font-medium">
+                        {v.unitType}{' '}
+                        <span className="font-mono text-[10px] text-muted-foreground">
+                          {v.voucherCode}
+                        </span>
+                      </p>
+                      <p className="text-xs text-muted-foreground">
+                        {v.location}
+                        {v.zip ? ` · ${v.zip}` : ''} · {v.bedrooms}br
+                        {v.accessible ? ' · accessible' : ''} · {v.availabilityStatus}
+                      </p>
+                    </div>
+                    <div className="flex gap-2">
+                      <Button size="sm" variant="outline" onClick={() => setEditingId(v.id)}>
+                        Edit
+                      </Button>
+                      <Button
+                        size="sm"
+                        variant="destructive"
+                        disabled={pending}
+                        onClick={() => remove(v.id)}
+                      >
+                        Remove
+                      </Button>
+                    </div>
+                  </div>
+                )}
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/subp/voucher-apply-button.tsx
+++ b/src/components/subp/voucher-apply-button.tsx
@@ -1,0 +1,34 @@
+'use client';
+
+import { useState, useTransition } from 'react';
+import { applyToVoucherAction } from '@/app/actions/vouchers';
+import { Button } from '@/components/ui/button';
+
+/** SUBP-006b — caseworker marks a HUD-VASH voucher as applied for a veteran. */
+export function VoucherApplyButton({
+  veteranId,
+  voucherId,
+}: {
+  veteranId: string;
+  voucherId: string;
+}) {
+  const [pending, startTransition] = useTransition();
+  const [error, setError] = useState<string | null>(null);
+
+  const onClick = () => {
+    setError(null);
+    startTransition(async () => {
+      const r = await applyToVoucherAction(veteranId, voucherId);
+      if (!r.ok) setError(r.error);
+    });
+  };
+
+  return (
+    <span className="inline-flex items-center gap-2">
+      <Button size="sm" variant="outline" disabled={pending} onClick={onClick}>
+        {pending ? '…' : 'Mark applied'}
+      </Button>
+      {error ? <span className="text-destructive text-xs">{error}</span> : null}
+    </span>
+  );
+}

--- a/src/db/queries/hud-vash-vouchers.ts
+++ b/src/db/queries/hud-vash-vouchers.ts
@@ -1,0 +1,156 @@
+/**
+ * SUBP-006b — HUD-VASH voucher + application query layer.
+ *
+ * Vouchers are admin-managed seed data (manual CRUD). Applications track a
+ * (veteran, voucher) pair. All mutations are audit-logged in the same
+ * transaction as the write.
+ */
+import { and, asc, eq } from 'drizzle-orm';
+import { db } from '@/db/client';
+import {
+  type HudVashVoucher,
+  hudVashVouchers,
+  type NewHudVashVoucher,
+  type VeteranVoucherApplication,
+  veteranVoucherApplications,
+} from '@/db/schema/hud-vash-vouchers';
+import { logAuditEvent } from '@/lib/audit';
+
+// ---------------------------------------------------------------------------
+// Vouchers (admin-managed)
+// ---------------------------------------------------------------------------
+
+export async function listVouchers(
+  opts: { availableOnly?: boolean } = {},
+): Promise<HudVashVoucher[]> {
+  const rows = await db
+    .select()
+    .from(hudVashVouchers)
+    .orderBy(asc(hudVashVouchers.location), asc(hudVashVouchers.voucherCode));
+  return opts.availableOnly ? rows.filter((v) => v.availabilityStatus === 'available') : rows;
+}
+
+export async function getVoucher(id: string): Promise<HudVashVoucher | null> {
+  const [row] = await db.select().from(hudVashVouchers).where(eq(hudVashVouchers.id, id)).limit(1);
+  return row ?? null;
+}
+
+export async function createVoucher(
+  input: NewHudVashVoucher,
+  actorUserId: string,
+): Promise<HudVashVoucher> {
+  return db.transaction(async (tx) => {
+    const [row] = await tx.insert(hudVashVouchers).values(input).returning();
+    await logAuditEvent({
+      actorUserId,
+      action: 'hud_vash_voucher.created',
+      targetTable: 'hud_vash_vouchers',
+      targetId: row.id,
+      metadata: { voucherCode: row.voucherCode, bedrooms: row.bedrooms },
+      tx,
+    });
+    return row;
+  });
+}
+
+export async function updateVoucher(
+  id: string,
+  patch: Partial<NewHudVashVoucher>,
+  actorUserId: string,
+): Promise<HudVashVoucher | null> {
+  return db.transaction(async (tx) => {
+    const [row] = await tx
+      .update(hudVashVouchers)
+      .set({ ...patch, updatedAt: new Date() })
+      .where(eq(hudVashVouchers.id, id))
+      .returning();
+    if (!row) return null;
+    await logAuditEvent({
+      actorUserId,
+      action: 'hud_vash_voucher.updated',
+      targetTable: 'hud_vash_vouchers',
+      targetId: id,
+      metadata: { fields: Object.keys(patch) },
+      tx,
+    });
+    return row;
+  });
+}
+
+export async function deleteVoucher(id: string, actorUserId: string): Promise<boolean> {
+  return db.transaction(async (tx) => {
+    const [row] = await tx
+      .delete(hudVashVouchers)
+      .where(eq(hudVashVouchers.id, id))
+      .returning({ id: hudVashVouchers.id });
+    if (!row) return false;
+    await logAuditEvent({
+      actorUserId,
+      action: 'hud_vash_voucher.deleted',
+      targetTable: 'hud_vash_vouchers',
+      targetId: id,
+      tx,
+    });
+    return true;
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Applications (per veteran)
+// ---------------------------------------------------------------------------
+
+export async function listApplicationsForVeteran(
+  veteranId: string,
+): Promise<VeteranVoucherApplication[]> {
+  return db
+    .select()
+    .from(veteranVoucherApplications)
+    .where(eq(veteranVoucherApplications.veteranId, veteranId));
+}
+
+/**
+ * Record (or re-activate) a veteran's application to a voucher. Idempotent on
+ * the (veteran, voucher) pair: a withdrawn row flips back to 'applied'.
+ */
+export async function applyToVoucher(
+  veteranId: string,
+  voucherId: string,
+  actorUserId: string,
+): Promise<VeteranVoucherApplication> {
+  return db.transaction(async (tx) => {
+    const [existing] = await tx
+      .select()
+      .from(veteranVoucherApplications)
+      .where(
+        and(
+          eq(veteranVoucherApplications.veteranId, veteranId),
+          eq(veteranVoucherApplications.voucherId, voucherId),
+        ),
+      )
+      .limit(1);
+
+    let row: VeteranVoucherApplication;
+    if (existing) {
+      [row] = await tx
+        .update(veteranVoucherApplications)
+        .set({ status: 'applied', appliedByUserId: actorUserId, updatedAt: new Date() })
+        .where(eq(veteranVoucherApplications.id, existing.id))
+        .returning();
+    } else {
+      [row] = await tx
+        .insert(veteranVoucherApplications)
+        .values({ veteranId, voucherId, status: 'applied', appliedByUserId: actorUserId })
+        .returning();
+    }
+
+    await logAuditEvent({
+      actorUserId,
+      action: 'veteran_voucher.applied',
+      targetTable: 'veteran_voucher_applications',
+      targetId: row.id,
+      metadata: { veteranId, voucherId },
+      tx,
+    });
+    return row;
+  });
+}

--- a/src/db/schema/hud-vash-vouchers.ts
+++ b/src/db/schema/hud-vash-vouchers.ts
@@ -1,0 +1,96 @@
+/**
+ * SUBP-006b — HUD-VASH vouchers + per-veteran applications.
+ *
+ * `hud_vash_vouchers` is admin-managed seed data (manual entry) until the
+ * DTRS-015 VA HUD-VASH DSA unlocks a live feed. `veteran_voucher_applications`
+ * tracks which subject has applied to which voucher (one row per pair).
+ *
+ * PHI fence: synthetic data only until the relevant BAA closes.
+ */
+import {
+  boolean,
+  index,
+  integer,
+  pgEnum,
+  pgTable,
+  text,
+  timestamp,
+  uniqueIndex,
+  uuid,
+} from 'drizzle-orm/pg-core';
+import { users } from './users';
+import { veterans } from './veterans';
+
+/** Availability of a voucher's unit. */
+export const hudVashVoucherStatusEnum = pgEnum('hud_vash_voucher_status', [
+  'available',
+  'pending',
+  'leased',
+]);
+
+export type HudVashVoucherStatus = (typeof hudVashVoucherStatusEnum.enumValues)[number];
+
+export const hudVashVouchers = pgTable(
+  'hud_vash_vouchers',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    /** Human-facing voucher identifier (e.g. PHA voucher number). */
+    voucherCode: text('voucher_code').notNull(),
+    /** Unit-type label shown in the UI (e.g. "1BR apartment"). */
+    unitType: text('unit_type').notNull(),
+    /** Bedroom count — the numeric input to match scoring. */
+    bedrooms: integer('bedrooms').notNull(),
+    /** Locality label (city/neighborhood). */
+    location: text('location').notNull(),
+    /** 5-digit ZIP — proximity input to match scoring; null = unknown. */
+    zip: text('zip'),
+    /** Whether the unit is accessible. */
+    accessible: boolean('accessible').notNull().default(false),
+    availabilityStatus: hudVashVoucherStatusEnum('availability_status')
+      .notNull()
+      .default('available'),
+    notes: text('notes'),
+    createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),
+  },
+  (t) => [index('hud_vash_vouchers_status_idx').on(t.availabilityStatus)],
+);
+
+export type HudVashVoucher = typeof hudVashVouchers.$inferSelect;
+export type NewHudVashVoucher = typeof hudVashVouchers.$inferInsert;
+
+/** Application status of a (veteran, voucher) pair. */
+export const veteranVoucherApplicationStatusEnum = pgEnum('veteran_voucher_application_status', [
+  'applied',
+  'withdrawn',
+]);
+
+export type VeteranVoucherApplicationStatus =
+  (typeof veteranVoucherApplicationStatusEnum.enumValues)[number];
+
+export const veteranVoucherApplications = pgTable(
+  'veteran_voucher_applications',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    veteranId: uuid('veteran_id')
+      .notNull()
+      .references(() => veterans.id, { onDelete: 'cascade' }),
+    voucherId: uuid('voucher_id')
+      .notNull()
+      .references(() => hudVashVouchers.id, { onDelete: 'cascade' }),
+    status: veteranVoucherApplicationStatusEnum('status').notNull().default('applied'),
+    /** Caseworker who recorded the application; null if system/seed. */
+    appliedByUserId: uuid('applied_by_user_id').references(() => users.id, {
+      onDelete: 'set null',
+    }),
+    createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),
+  },
+  (t) => [
+    uniqueIndex('veteran_voucher_applications_unique_idx').on(t.veteranId, t.voucherId),
+    index('veteran_voucher_applications_veteran_idx').on(t.veteranId),
+  ],
+);
+
+export type VeteranVoucherApplication = typeof veteranVoucherApplications.$inferSelect;
+export type NewVeteranVoucherApplication = typeof veteranVoucherApplications.$inferInsert;

--- a/src/db/schema/index.ts
+++ b/src/db/schema/index.ts
@@ -21,6 +21,7 @@ export * from './family-units';
 export * from './foster-aging-out-alerts';
 export * from './foster-youth';
 export * from './health-check';
+export * from './hud-vash-vouchers';
 export * from './medicaid-extension-applications';
 export * from './org-memberships';
 export * from './outbound-messages-test';

--- a/src/db/schema/veterans.ts
+++ b/src/db/schema/veterans.ts
@@ -14,7 +14,7 @@
  *
  * PHI fence: synthetic data only until the relevant BAA closes.
  */
-import { boolean, index, pgTable, text, timestamp, uuid } from 'drizzle-orm/pg-core';
+import { boolean, index, integer, pgTable, text, timestamp, uuid } from 'drizzle-orm/pg-core';
 import { veteranEligibilitySourceEnum, veteranStatusEnum } from './enums';
 import { users } from './users';
 
@@ -46,6 +46,13 @@ export const veterans = pgTable(
       onDelete: 'set null',
     }),
     status: veteranStatusEnum('status').notNull().default('active'),
+    // SUBP-006b housing profile — inputs to HUD-VASH voucher match scoring.
+    /** Bedrooms the household needs; null = unknown / no stated constraint. */
+    bedroomNeed: integer('bedroom_need'),
+    /** True when the subject requires an accessible unit. */
+    accessibilityNeed: boolean('accessibility_need').notNull().default(false),
+    /** Target 5-digit ZIP for voucher proximity matching; null = unknown. */
+    targetZip: text('target_zip'),
     notes: text('notes'),
     createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
     updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),

--- a/src/db/seed.ts
+++ b/src/db/seed.ts
@@ -13,6 +13,7 @@ import { db } from './client';
 import { auditLog } from './schema/audit-log';
 import type { UserRole } from './schema/enums';
 import { faithMinistries } from './schema/faith-ministries';
+import { hudVashVouchers, type NewHudVashVoucher } from './schema/hud-vash-vouchers';
 import { orgMemberships } from './schema/org-memberships';
 import { type NewPartnerOrg, partnerOrgs } from './schema/partner-orgs';
 import { type NewPartnerServiceEvent, partnerServiceEvents } from './schema/partner-service-events';
@@ -846,6 +847,9 @@ async function main() {
           | 'branchOfService'
           | 'eligibilitySource'
           | 'caseworkerVerified'
+          | 'bedroomNeed'
+          | 'accessibilityNeed'
+          | 'targetZip'
         >
       > = [
         {
@@ -854,6 +858,9 @@ async function main() {
           branchOfService: 'Army',
           eligibilitySource: 'va_confirmed',
           caseworkerVerified: false,
+          bedroomNeed: 2,
+          accessibilityNeed: false,
+          targetZip: '42301',
         },
         {
           legalFirstName: 'Tanya',
@@ -861,6 +868,9 @@ async function main() {
           branchOfService: 'Navy',
           eligibilitySource: 'self_reported',
           caseworkerVerified: true,
+          bedroomNeed: 1,
+          accessibilityNeed: true,
+          targetZip: '42303',
         },
         {
           legalFirstName: 'Earl',
@@ -868,6 +878,9 @@ async function main() {
           branchOfService: 'Marine Corps',
           eligibilitySource: 'self_reported',
           caseworkerVerified: false,
+          bedroomNeed: 3,
+          accessibilityNeed: false,
+          targetZip: '42301',
         },
         {
           legalFirstName: 'Renee',
@@ -875,6 +888,9 @@ async function main() {
           branchOfService: null,
           eligibilitySource: 'va_confirmed',
           caseworkerVerified: false,
+          bedroomNeed: null,
+          accessibilityNeed: false,
+          targetZip: null,
         },
       ];
       const veteranRows: NewVeteran[] = refs.map((ref, i) => ({
@@ -887,6 +903,60 @@ async function main() {
     }
   } else {
     console.log('[seed]   = veteran-pathway records (exist)');
+  }
+
+  // ---- SUBP-006b: synthetic HUD-VASH vouchers (admin-managed seed) ----
+  const existingVouchers = await db
+    .select({ id: hudVashVouchers.id })
+    .from(hudVashVouchers)
+    .limit(1);
+  if (existingVouchers.length === 0) {
+    const voucherRows: NewHudVashVoucher[] = [
+      {
+        voucherCode: 'HV-0001',
+        unitType: '2BR apartment',
+        bedrooms: 2,
+        location: 'Owensboro - downtown',
+        zip: '42301',
+        accessible: false,
+        availabilityStatus: 'available',
+        notes: 'Synthetic SUBP-006b seed.',
+      },
+      {
+        voucherCode: 'HV-0002',
+        unitType: '1BR accessible',
+        bedrooms: 1,
+        location: 'Owensboro - east',
+        zip: '42303',
+        accessible: true,
+        availabilityStatus: 'available',
+        notes: 'Synthetic SUBP-006b seed.',
+      },
+      {
+        voucherCode: 'HV-0003',
+        unitType: '3BR house',
+        bedrooms: 3,
+        location: 'Owensboro - west',
+        zip: '42301',
+        accessible: false,
+        availabilityStatus: 'available',
+        notes: 'Synthetic SUBP-006b seed.',
+      },
+      {
+        voucherCode: 'HV-0004',
+        unitType: 'Studio',
+        bedrooms: 0,
+        location: 'Whitesville',
+        zip: '42378',
+        accessible: false,
+        availabilityStatus: 'leased',
+        notes: 'Synthetic SUBP-006b seed.',
+      },
+    ];
+    await db.insert(hudVashVouchers).values(voucherRows);
+    console.log(`[seed]   + ${voucherRows.length} HUD-VASH vouchers`);
+  } else {
+    console.log('[seed]   = HUD-VASH vouchers (exist)');
   }
 
   // ---- 3 sample audit entries ----

--- a/src/lib/subp/index.ts
+++ b/src/lib/subp/index.ts
@@ -15,3 +15,4 @@ export * from './pre-release-engine';
 export * from './pre-release-supports';
 export * from './supports-in-place';
 export * from './veteran-eligibility';
+export * from './voucher-match';

--- a/src/lib/subp/voucher-match.test.ts
+++ b/src/lib/subp/voucher-match.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from 'vitest';
+import { scoreVoucherMatch } from './voucher-match';
+
+const unit = (over: Partial<Parameters<typeof scoreVoucherMatch>[1]> = {}) => ({
+  bedrooms: 2,
+  accessible: false,
+  zip: '42301',
+  ...over,
+});
+const subject = (over: Partial<Parameters<typeof scoreVoucherMatch>[0]> = {}) => ({
+  bedroomNeed: 2 as number | null,
+  accessibilityNeed: false,
+  targetZip: '42301' as string | null,
+  ...over,
+});
+
+describe('scoreVoucherMatch', () => {
+  it('scores a perfect match at 100', () => {
+    const r = scoreVoucherMatch(subject(), unit());
+    expect(r.score).toBe(100);
+  });
+
+  it('gives full bedroom credit when subject has no stated need', () => {
+    const r = scoreVoucherMatch(subject({ bedroomNeed: null }), unit());
+    const bed = r.factors.find((f) => f.label === 'Bedrooms');
+    expect(bed?.points).toBe(50);
+  });
+
+  it('penalises an undersized unit (one short → 15, too small → 0)', () => {
+    const oneShort = scoreVoucherMatch(subject({ bedroomNeed: 3 }), unit({ bedrooms: 2 }));
+    expect(oneShort.factors.find((f) => f.label === 'Bedrooms')?.points).toBe(15);
+    const tooSmall = scoreVoucherMatch(subject({ bedroomNeed: 4 }), unit({ bedrooms: 2 }));
+    expect(tooSmall.factors.find((f) => f.label === 'Bedrooms')?.points).toBe(0);
+  });
+
+  it('gives partial credit for an oversized unit', () => {
+    const r = scoreVoucherMatch(subject({ bedroomNeed: 1 }), unit({ bedrooms: 2 }));
+    expect(r.factors.find((f) => f.label === 'Bedrooms')?.points).toBe(35);
+  });
+
+  it('zeroes accessibility when needed but the unit is not accessible', () => {
+    const r = scoreVoucherMatch(subject({ accessibilityNeed: true }), unit({ accessible: false }));
+    expect(r.factors.find((f) => f.label === 'Accessibility')?.points).toBe(0);
+  });
+
+  it('credits accessibility when needed and the unit is accessible', () => {
+    const r = scoreVoucherMatch(subject({ accessibilityNeed: true }), unit({ accessible: true }));
+    expect(r.factors.find((f) => f.label === 'Accessibility')?.points).toBe(30);
+  });
+
+  it('gives full accessibility credit when there is no need', () => {
+    const r = scoreVoucherMatch(subject({ accessibilityNeed: false }), unit({ accessible: false }));
+    expect(r.factors.find((f) => f.label === 'Accessibility')?.points).toBe(30);
+  });
+
+  it('scores location: same ZIP=20, ZIP-3 match=12, different=0, unknown=10', () => {
+    expect(
+      scoreVoucherMatch(subject({ targetZip: '42301' }), unit({ zip: '42301' })).factors.find(
+        (f) => f.label === 'Location',
+      )?.points,
+    ).toBe(20);
+    expect(
+      scoreVoucherMatch(subject({ targetZip: '42301' }), unit({ zip: '42303' })).factors.find(
+        (f) => f.label === 'Location',
+      )?.points,
+    ).toBe(12);
+    expect(
+      scoreVoucherMatch(subject({ targetZip: '42301' }), unit({ zip: '40001' })).factors.find(
+        (f) => f.label === 'Location',
+      )?.points,
+    ).toBe(0);
+    expect(
+      scoreVoucherMatch(subject({ targetZip: null }), unit({ zip: '42301' })).factors.find(
+        (f) => f.label === 'Location',
+      )?.points,
+    ).toBe(10);
+  });
+
+  it('never exceeds 100 or drops below 0', () => {
+    const worst = scoreVoucherMatch(
+      subject({ bedroomNeed: 4, accessibilityNeed: true, targetZip: '42301' }),
+      unit({ bedrooms: 1, accessible: false, zip: '99999' }),
+    );
+    expect(worst.score).toBeGreaterThanOrEqual(0);
+    expect(worst.score).toBeLessThanOrEqual(100);
+  });
+});

--- a/src/lib/subp/voucher-match.ts
+++ b/src/lib/subp/voucher-match.ts
@@ -1,0 +1,103 @@
+/**
+ * SUBP-006b — HUD-VASH voucher ↔ veteran match scoring (pure, DB-free).
+ *
+ * Produces a 0–100 score for how well an available voucher's unit fits a
+ * veteran subject's housing profile, plus an explainable factor breakdown.
+ * Kept pure so it can be unit-tested without a DB and reused by the query
+ * layer and the detail view (the established subp factoring).
+ *
+ * Weights (sum 100): bedroom fit 50, accessibility 30, location proximity 20.
+ * A missing subject constraint is treated as "no constraint" → full credit for
+ * that factor, so an unprofiled subject isn't penalised.
+ */
+
+export interface VoucherMatchSubject {
+  /** Bedrooms the household needs; null = unknown / no constraint. */
+  bedroomNeed: number | null;
+  /** True when the subject requires an accessible (e.g. wheelchair) unit. */
+  accessibilityNeed: boolean;
+  /** Subject's target 5-digit ZIP for proximity; null = unknown. */
+  targetZip: string | null;
+}
+
+export interface VoucherMatchUnit {
+  bedrooms: number;
+  accessible: boolean;
+  /** Unit 5-digit ZIP; null = unknown. */
+  zip: string | null;
+}
+
+export interface VoucherMatchFactor {
+  label: string;
+  points: number;
+  max: number;
+  detail: string;
+}
+
+export interface VoucherMatchResult {
+  /** 0–100, rounded. */
+  score: number;
+  factors: VoucherMatchFactor[];
+}
+
+const BEDROOM_MAX = 50;
+const ACCESS_MAX = 30;
+const ZIP_MAX = 20;
+
+function scoreBedroom(need: number | null, unitBedrooms: number): VoucherMatchFactor {
+  if (need == null) {
+    return { label: 'Bedrooms', points: BEDROOM_MAX, max: BEDROOM_MAX, detail: 'no stated need' };
+  }
+  const diff = unitBedrooms - need;
+  let points: number;
+  let detail: string;
+  if (diff === 0) {
+    points = BEDROOM_MAX;
+    detail = `exact fit (${unitBedrooms}br)`;
+  } else if (diff > 0) {
+    points = 35;
+    detail = `${unitBedrooms}br for ${need}br need (oversized)`;
+  } else if (diff === -1) {
+    points = 15;
+    detail = `${unitBedrooms}br for ${need}br need (one short)`;
+  } else {
+    points = 0;
+    detail = `${unitBedrooms}br for ${need}br need (too small)`;
+  }
+  return { label: 'Bedrooms', points, max: BEDROOM_MAX, detail };
+}
+
+function scoreAccessibility(need: boolean, unitAccessible: boolean): VoucherMatchFactor {
+  if (!need) {
+    return { label: 'Accessibility', points: ACCESS_MAX, max: ACCESS_MAX, detail: 'no need' };
+  }
+  return unitAccessible
+    ? { label: 'Accessibility', points: ACCESS_MAX, max: ACCESS_MAX, detail: 'accessible unit' }
+    : { label: 'Accessibility', points: 0, max: ACCESS_MAX, detail: 'unit not accessible' };
+}
+
+function scoreZip(targetZip: string | null, unitZip: string | null): VoucherMatchFactor {
+  if (!targetZip || !unitZip) {
+    return { label: 'Location', points: 10, max: ZIP_MAX, detail: 'ZIP unknown' };
+  }
+  if (targetZip === unitZip) {
+    return { label: 'Location', points: ZIP_MAX, max: ZIP_MAX, detail: 'same ZIP' };
+  }
+  if (targetZip.slice(0, 3) === unitZip.slice(0, 3)) {
+    return { label: 'Location', points: 12, max: ZIP_MAX, detail: 'nearby (ZIP-3 match)' };
+  }
+  return { label: 'Location', points: 0, max: ZIP_MAX, detail: 'different area' };
+}
+
+export function scoreVoucherMatch(
+  subject: VoucherMatchSubject,
+  unit: VoucherMatchUnit,
+): VoucherMatchResult {
+  const factors = [
+    scoreBedroom(subject.bedroomNeed, unit.bedrooms),
+    scoreAccessibility(subject.accessibilityNeed, unit.accessible),
+    scoreZip(subject.targetZip, unit.zip),
+  ];
+  const score = Math.round(factors.reduce((sum, f) => sum + f.points, 0));
+  return { score, factors };
+}


### PR DESCRIPTION
Refs #383

## Summary

Second slice of the veteran pathway (SUBP-006b), building on the merged 006a veterans table. Surfaces HUD-VASH vouchers with a match score against each veteran subject's housing profile, lets caseworkers mark vouchers applied, and gives admins CRUD over the (synthetic, seed-managed) voucher data.

## Changes

- **Schema (migration `0046`):** new `hud_vash_vouchers` (admin-managed) + `veteran_voucher_applications` tables + enums. Added housing-profile fields to `veterans` — `bedroom_need`, `accessibility_need`, `target_zip` — the inputs to match scoring.
- **Match scoring (testable core):** `src/lib/subp/voucher-match.ts` — pure 0-100 score = bedroom fit (50) + accessibility (30) + ZIP proximity (20), with an explainable factor breakdown. A missing subject constraint is treated as no-constraint (no penalty). 9 unit tests.
- **Veteran detail view** `/app/clients/veterans/[id]` (new — 006a shipped only the list): housing profile + the voucher panel **shown only when the veteran flag is set**, vouchers ranked by match score with factor detail, and a "mark applied" action (audit-logged, per-subject status). List rows now link here.
- **Admin CRUD** `/app/admin/vouchers` (nav entry added): add / update / remove vouchers in the seed data.
- **Seed:** 4 synthetic vouchers + housing profiles on the seeded veterans.

## Acceptance criteria

- [x] HUD-VASH voucher panel on the veteran detail view, only when the veteran flag is set
- [x] Voucher data source = admin-managed seed (manual entry); live feed unlocks later via DTRS-015
- [x] Each voucher shows voucher ID, unit type, location, availability + a match score (bedroom count, accessibility, ZIP proximity)
- [x] Caseworker can mark a voucher "applied" — status tracked per subject (audit-logged)
- [x] Admin can add/update/remove vouchers via an admin panel
- [x] Definition of Done

## Verification

- `pnpm lint` (no --write) / `pnpm typecheck` / `pnpm lint:boundaries` — clean (1 pre-existing unrelated info)
- `pnpm test` — **854 passed (53 files)**; +9 new match-score unit tests
- `pnpm build` — ✓ compiled; `/app/clients/veterans/[id]` + `/app/admin/vouchers` routes emit
- **Migration round-trip** — full chain **0000→0046** applied cleanly on a throwaway Postgres (the #388 fix holds); both new tables + the 3 new `veterans` columns verified.

## Notes

- PHI fence respected — synthetic data only; no live VA feed in this slice.
- Bundle safety — the admin client component imports the voucher type via a deep type-only import; the server query/page import the match helper through the `@/lib/subp` barrel (boundary-lint clean).
- "Applied" status is modeled minimally (applied/withdrawn); the richer voucher-stage lifecycle from the original SUBP-006 can layer on later if wanted.
