### PR TITLE
feat(DTRS-014a-1): academic-partner role + invite/redeem/revoke portal

### DIFF
--- a/drizzle/migrations/meta/0046_snapshot.json
+++ b/drizzle/migrations/meta/0046_snapshot.json
@@ -1,5 +1,5 @@
 {
-  "id": "9afd9685-2a8c-4116-a48b-53dd36409846",
+  "id": "e9bb47cb-896d-4129-aaa7-f892ad4c2a40",
   "prevId": "a0965f96-59ee-420b-b3d4-9447b6ec8cdf",
   "version": "7",
   "dialect": "postgresql",
@@ -4024,244 +4024,6 @@
       "checkConstraints": {},
       "isRLSEnabled": false
     },
-    "public.hud_vash_vouchers": {
-      "name": "hud_vash_vouchers",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "uuid",
-          "primaryKey": true,
-          "notNull": true,
-          "default": "gen_random_uuid()"
-        },
-        "voucher_code": {
-          "name": "voucher_code",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "unit_type": {
-          "name": "unit_type",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "bedrooms": {
-          "name": "bedrooms",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "location": {
-          "name": "location",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "zip": {
-          "name": "zip",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "accessible": {
-          "name": "accessible",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": true,
-          "default": false
-        },
-        "availability_status": {
-          "name": "availability_status",
-          "type": "hud_vash_voucher_status",
-          "typeSchema": "public",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "'available'"
-        },
-        "notes": {
-          "name": "notes",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "now()"
-        },
-        "updated_at": {
-          "name": "updated_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "now()"
-        }
-      },
-      "indexes": {
-        "hud_vash_vouchers_status_idx": {
-          "name": "hud_vash_vouchers_status_idx",
-          "columns": [
-            {
-              "expression": "availability_status",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {},
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.veteran_voucher_applications": {
-      "name": "veteran_voucher_applications",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "uuid",
-          "primaryKey": true,
-          "notNull": true,
-          "default": "gen_random_uuid()"
-        },
-        "veteran_id": {
-          "name": "veteran_id",
-          "type": "uuid",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "voucher_id": {
-          "name": "voucher_id",
-          "type": "uuid",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "status": {
-          "name": "status",
-          "type": "veteran_voucher_application_status",
-          "typeSchema": "public",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "'applied'"
-        },
-        "applied_by_user_id": {
-          "name": "applied_by_user_id",
-          "type": "uuid",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "now()"
-        },
-        "updated_at": {
-          "name": "updated_at",
-          "type": "timestamp with time zone",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "now()"
-        }
-      },
-      "indexes": {
-        "veteran_voucher_applications_unique_idx": {
-          "name": "veteran_voucher_applications_unique_idx",
-          "columns": [
-            {
-              "expression": "veteran_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "voucher_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": true,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        },
-        "veteran_voucher_applications_veteran_idx": {
-          "name": "veteran_voucher_applications_veteran_idx",
-          "columns": [
-            {
-              "expression": "veteran_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {
-        "veteran_voucher_applications_veteran_id_veterans_id_fk": {
-          "name": "veteran_voucher_applications_veteran_id_veterans_id_fk",
-          "tableFrom": "veteran_voucher_applications",
-          "tableTo": "veterans",
-          "columnsFrom": [
-            "veteran_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        },
-        "veteran_voucher_applications_voucher_id_hud_vash_vouchers_id_fk": {
-          "name": "veteran_voucher_applications_voucher_id_hud_vash_vouchers_id_fk",
-          "tableFrom": "veteran_voucher_applications",
-          "tableTo": "hud_vash_vouchers",
-          "columnsFrom": [
-            "voucher_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        },
-        "veteran_voucher_applications_applied_by_user_id_users_id_fk": {
-          "name": "veteran_voucher_applications_applied_by_user_id_users_id_fk",
-          "tableFrom": "veteran_voucher_applications",
-          "tableTo": "users",
-          "columnsFrom": [
-            "applied_by_user_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
-          "onDelete": "set null",
-          "onUpdate": "no action"
-        }
-      },
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
     "public.medicaid_extension_applications": {
       "name": "medicaid_extension_applications",
       "schema": "",
@@ -4795,6 +4557,133 @@
           "value": "effective_date IS NULL OR end_date IS NULL OR effective_date <= end_date"
         }
       },
+      "isRLSEnabled": false
+    },
+    "public.partner_invitations": {
+      "name": "partner_invitations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invited_email": {
+          "name": "invited_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invited_by_user_id": {
+          "name": "invited_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redeemed_at": {
+          "name": "redeemed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "redeemed_by_user_id": {
+          "name": "redeemed_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "partner_invitations_token_hash_idx": {
+          "name": "partner_invitations_token_hash_idx",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "partner_invitations_email_idx": {
+          "name": "partner_invitations_email_idx",
+          "columns": [
+            {
+              "expression": "invited_email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "partner_invitations_invited_by_user_id_users_id_fk": {
+          "name": "partner_invitations_invited_by_user_id_users_id_fk",
+          "tableFrom": "partner_invitations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "invited_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "partner_invitations_redeemed_by_user_id_users_id_fk": {
+          "name": "partner_invitations_redeemed_by_user_id_users_id_fk",
+          "tableFrom": "partner_invitations",
+          "tableTo": "users",
+          "columnsFrom": [
+            "redeemed_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
       "isRLSEnabled": false
     },
     "public.partner_orgs": {
@@ -7177,25 +7066,6 @@
           "notNull": true,
           "default": "'active'"
         },
-        "bedroom_need": {
-          "name": "bedroom_need",
-          "type": "integer",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "accessibility_need": {
-          "name": "accessibility_need",
-          "type": "boolean",
-          "primaryKey": false,
-          "notNull": true,
-          "default": false
-        },
-        "target_zip": {
-          "name": "target_zip",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
         "notes": {
           "name": "notes",
           "type": "text",
@@ -7760,7 +7630,8 @@
         "caseworker",
         "ed_coordinator",
         "shelter_staff",
-        "admin"
+        "admin",
+        "academic_partner"
       ]
     },
     "public.veteran_eligibility_source": {
@@ -7777,23 +7648,6 @@
       "values": [
         "active",
         "exited"
-      ]
-    },
-    "public.hud_vash_voucher_status": {
-      "name": "hud_vash_voucher_status",
-      "schema": "public",
-      "values": [
-        "available",
-        "pending",
-        "leased"
-      ]
-    },
-    "public.veteran_voucher_application_status": {
-      "name": "veteran_voucher_application_status",
-      "schema": "public",
-      "values": [
-        "applied",
-        "withdrawn"
       ]
     },
     "public.person_partner_consent_event_type": {

--- a/drizzle/migrations/meta/_journal.json
+++ b/drizzle/migrations/meta/_journal.json
@@ -327,8 +327,8 @@
 		{
 			"idx": 46,
 			"version": "7",
-			"when": 1782220835048,
-			"tag": "0046_SUBP-006b_voucher_matching",
+			"when": 1782221540007,
+			"tag": "0046_DTRS-014a-1_partner_invitations",
 			"breakpoints": true
 		}
 	]

--- a/src/app/actions/partner-invitations.ts
+++ b/src/app/actions/partner-invitations.ts
@@ -1,0 +1,63 @@
+'use server';
+
+import { revalidatePath } from 'next/cache';
+import {
+  createPartnerInvitation,
+  redeemPartnerInvitation,
+  revokeAcademicPartnerRole,
+  revokePartnerInvitation,
+} from '@/db/queries/partner-invitations';
+import { requireRole, requireUser } from '@/lib/auth';
+
+export type InviteActionResult =
+  | { ok: true; token: string; expiresAt: string }
+  | { ok: false; error: string };
+
+export type SimpleActionResult = { ok: true } | { ok: false; error: string };
+
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+/**
+ * DTRS-014a-1 — admin mints an academic-partner invitation. Returns the raw
+ * token once so the admin can share the invite link. (Email delivery via
+ * Resend is deferred until that infra lands; the link is shown in the UI.)
+ */
+export async function invitePartnerAction(fd: FormData): Promise<InviteActionResult> {
+  const actor = await requireRole(['admin']);
+  const email = (fd.get('invitedEmail') ?? '').toString().trim().toLowerCase();
+  if (!EMAIL_RE.test(email)) return { ok: false, error: 'Enter a valid email address.' };
+
+  const created = await createPartnerInvitation({ invitedEmail: email, invitedByUserId: actor.id });
+  revalidatePath('/app/admin/academic-partners');
+  return { ok: true, token: created.token, expiresAt: created.expiresAt.toISOString() };
+}
+
+export async function revokeInvitationAction(id: string): Promise<SimpleActionResult> {
+  const actor = await requireRole(['admin']);
+  if (!id) return { ok: false, error: 'Missing invitation id.' };
+  const ok = await revokePartnerInvitation(id, actor.id);
+  if (!ok) return { ok: false, error: 'Invitation not found.' };
+  revalidatePath('/app/admin/academic-partners');
+  return { ok: true };
+}
+
+export async function revokePartnerRoleAction(targetUserId: string): Promise<SimpleActionResult> {
+  const actor = await requireRole(['admin']);
+  if (!targetUserId) return { ok: false, error: 'Missing user id.' };
+  const ok = await revokeAcademicPartnerRole(targetUserId, actor.id);
+  if (!ok) return { ok: false, error: 'User is not an academic partner.' };
+  revalidatePath('/app/admin/academic-partners');
+  return { ok: true };
+}
+
+/**
+ * Redeem an invitation for the signed-in user, granting the academic_partner
+ * role. Any signed-in user (typically a freshly-signed-up invitee) may call it.
+ */
+export async function redeemPartnerInviteAction(token: string): Promise<SimpleActionResult> {
+  const user = await requireUser();
+  const result = await redeemPartnerInvitation(token, user);
+  if (!result.ok) return { ok: false, error: result.error };
+  revalidatePath('/app/invite/accept');
+  return { ok: true };
+}

--- a/src/app/app/admin/academic-partners/page.tsx
+++ b/src/app/app/admin/academic-partners/page.tsx
@@ -1,0 +1,37 @@
+import { PartnerInviteAdmin } from '@/components/dtrs/partner-invite-admin';
+import { listAcademicPartners, listPartnerInvitations } from '@/db/queries/partner-invitations';
+import { requireRole } from '@/lib/auth';
+
+export const dynamic = 'force-dynamic';
+
+export default async function AcademicPartnersAdminPage() {
+  await requireRole(['admin']);
+  const [invitations, partners] = await Promise.all([
+    listPartnerInvitations(),
+    listAcademicPartners(),
+  ]);
+
+  return (
+    <div className="mx-auto max-w-3xl space-y-4 p-6">
+      <header>
+        <h1 className="font-serif text-3xl font-bold text-primary">Academic partners</h1>
+        <p className="text-sm text-muted-foreground">
+          Invite external academic partners (DTRS-014a-1). The <code>academic_partner</code> role is
+          read-only and reaches only aggregate, de-identified surfaces — every individual-record
+          route denies it. Invitations are single-use and expire after 7 days; revoking an invite or
+          a partner's role takes effect immediately.
+        </p>
+      </header>
+      <PartnerInviteAdmin
+        invitations={invitations.map((i) => ({
+          id: i.id,
+          invitedEmail: i.invitedEmail,
+          expiresAt: i.expiresAt.toISOString(),
+          redeemedAt: i.redeemedAt ? i.redeemedAt.toISOString() : null,
+          revokedAt: i.revokedAt ? i.revokedAt.toISOString() : null,
+        }))}
+        partners={partners.map((p) => ({ id: p.id, email: p.email }))}
+      />
+    </div>
+  );
+}

--- a/src/app/app/dashboard/page.tsx
+++ b/src/app/app/dashboard/page.tsx
@@ -85,6 +85,7 @@ const ROLE_LABEL: Record<UserRole, string> = {
   ed_coordinator: 'ED coordinator',
   shelter_staff: 'Shelter staff',
   admin: 'Admin',
+  academic_partner: 'Academic partner',
 };
 
 export default async function DashboardPage() {

--- a/src/app/app/invite/accept/page.tsx
+++ b/src/app/app/invite/accept/page.tsx
@@ -1,0 +1,41 @@
+import { InviteAcceptClient } from '@/components/dtrs/invite-accept-client';
+import { requireUser } from '@/lib/auth';
+
+export const dynamic = 'force-dynamic';
+
+/**
+ * DTRS-014a-1 — academic-partner invitation accept surface. Any signed-in user
+ * may redeem (a freshly-signed-up invitee lands here via the invite link).
+ * requireUser() bounces unauthenticated visitors to sign-in, then back here.
+ */
+export default async function InviteAcceptPage({
+  searchParams,
+}: {
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+}) {
+  await requireUser();
+  const sp = await searchParams;
+  const token = (Array.isArray(sp.token) ? sp.token[0] : sp.token)?.trim() ?? '';
+
+  return (
+    <div className="mx-auto max-w-lg space-y-4 p-6">
+      <header>
+        <h1 className="font-serif text-2xl font-bold text-primary">
+          Accept academic-partner invite
+        </h1>
+        <p className="text-sm text-muted-foreground">
+          Accepting grants your account read-only access to the coalition's aggregate, de-identified
+          outcomes — no individual records.
+        </p>
+      </header>
+      {token ? (
+        <InviteAcceptClient token={token} />
+      ) : (
+        <p className="rounded-md border border-amber-500/40 bg-amber-500/5 p-3 text-sm">
+          This link is missing its invitation token. Ask your coalition contact for a fresh invite
+          link.
+        </p>
+      )}
+    </div>
+  );
+}

--- a/src/app/app/settings/page.tsx
+++ b/src/app/app/settings/page.tsx
@@ -16,6 +16,7 @@ const ROLE_LABEL: Record<UserRole, string> = {
   ed_coordinator: 'ED coordinator',
   shelter_staff: 'Shelter staff',
   admin: 'Admin',
+  academic_partner: 'Academic partner',
 };
 
 const ROLE_DESCRIPTION: Record<UserRole, string> = {
@@ -27,6 +28,8 @@ const ROLE_DESCRIPTION: Record<UserRole, string> = {
   ed_coordinator: 'ED super-utilizer queue, AI care plans, care-coordinator workflow.',
   shelter_staff: 'Bed-count updates, bed availability board, SMS bed-finder playground.',
   admin: 'Everything plus user management, audit log, SMS metrics.',
+  academic_partner:
+    'Read-only access to aggregate, de-identified coalition outcomes — no individual records.',
 };
 
 export default async function SettingsPage() {

--- a/src/components/admin/users-table.tsx
+++ b/src/components/admin/users-table.tsx
@@ -15,6 +15,7 @@ const roleBadge: Record<string, string> = {
   ed_coordinator: 'bg-secondary text-secondary-foreground',
   shelter_staff: 'bg-secondary text-secondary-foreground',
   admin: 'bg-emerald-600/15 text-emerald-700 dark:text-emerald-400',
+  academic_partner: 'bg-indigo-600/15 text-indigo-700 dark:text-indigo-400',
 };
 
 export function UsersTable({

--- a/src/components/app-shell/nav-config.ts
+++ b/src/components/app-shell/nav-config.ts
@@ -157,6 +157,7 @@ export const NAV_ITEMS: NavItem[] = [
   { label: 'Admin · Triage overrides', href: '/app/admin/triage-overrides', roles: ['admin'] },
   { label: 'Admin · Agreements', href: '/app/admin/agreements', roles: ['admin'] },
   { label: 'Admin · HUD-VASH vouchers', href: '/app/admin/vouchers', roles: ['admin'] },
+  { label: 'Admin · Academic partners', href: '/app/admin/academic-partners', roles: ['admin'] },
   { label: 'Admin · Faith aggregate', href: '/app/admin/faith-aggregate', roles: ['admin'] },
   {
     label: 'Admin · Faith insights',

--- a/src/components/dtrs/invite-accept-client.tsx
+++ b/src/components/dtrs/invite-accept-client.tsx
@@ -1,0 +1,44 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { useState, useTransition } from 'react';
+import { redeemPartnerInviteAction } from '@/app/actions/partner-invitations';
+import { Button } from '@/components/ui/button';
+
+/** DTRS-014a-1 — signed-in invitee redeems their academic-partner invitation. */
+export function InviteAcceptClient({ token }: { token: string }) {
+  const router = useRouter();
+  const [pending, startTransition] = useTransition();
+  const [state, setState] = useState<'idle' | 'done'>('idle');
+  const [error, setError] = useState<string | null>(null);
+
+  const accept = () => {
+    setError(null);
+    startTransition(async () => {
+      const r = await redeemPartnerInviteAction(token);
+      if (!r.ok) {
+        setError(r.error);
+        return;
+      }
+      setState('done');
+      router.refresh();
+    });
+  };
+
+  if (state === 'done') {
+    return (
+      <p className="rounded-md border border-emerald-500/40 bg-emerald-500/5 p-3 text-sm text-emerald-700 dark:text-emerald-400">
+        Invitation accepted — your account now has academic-partner access.
+      </p>
+    );
+  }
+
+  return (
+    <div className="space-y-2">
+      <Button onClick={accept} disabled={pending}>
+        {pending ? 'Accepting…' : 'Accept invitation'}
+      </Button>
+      {error ? <p className="text-destructive text-sm">{error}</p> : null}
+    </div>
+  );
+}

--- a/src/components/dtrs/partner-invite-admin.tsx
+++ b/src/components/dtrs/partner-invite-admin.tsx
@@ -1,0 +1,172 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { useState, useTransition } from 'react';
+import {
+  invitePartnerAction,
+  revokeInvitationAction,
+  revokePartnerRoleAction,
+} from '@/app/actions/partner-invitations';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+
+export interface InvitationRow {
+  id: string;
+  invitedEmail: string;
+  expiresAt: string;
+  redeemedAt: string | null;
+  revokedAt: string | null;
+}
+export interface PartnerRow {
+  id: string;
+  email: string;
+}
+
+const fmt = (iso: string | null) =>
+  iso == null
+    ? '—'
+    : new Intl.DateTimeFormat('en-US', { dateStyle: 'medium' }).format(new Date(iso));
+
+function invitationStatus(inv: InvitationRow): string {
+  if (inv.revokedAt) return 'revoked';
+  if (inv.redeemedAt) return 'redeemed';
+  if (new Date(inv.expiresAt).getTime() <= Date.now()) return 'expired';
+  return 'active';
+}
+
+export function PartnerInviteAdmin({
+  invitations,
+  partners,
+}: {
+  invitations: InvitationRow[];
+  partners: PartnerRow[];
+}) {
+  const router = useRouter();
+  const [pending, startTransition] = useTransition();
+  const [error, setError] = useState<string | null>(null);
+  const [inviteLink, setInviteLink] = useState<string | null>(null);
+
+  const sendInvite = (fd: FormData) => {
+    setError(null);
+    setInviteLink(null);
+    startTransition(async () => {
+      const r = await invitePartnerAction(fd);
+      if (!r.ok) {
+        setError(r.error);
+        return;
+      }
+      const origin = typeof window !== 'undefined' ? window.location.origin : '';
+      setInviteLink(`${origin}/app/invite/accept?token=${r.token}`);
+      router.refresh();
+    });
+  };
+
+  const run = (fn: () => Promise<{ ok: boolean; error?: string }>) => {
+    setError(null);
+    startTransition(async () => {
+      const r = await fn();
+      if (!r.ok) {
+        setError(r.error ?? 'Action failed.');
+        return;
+      }
+      router.refresh();
+    });
+  };
+
+  return (
+    <div className="space-y-6">
+      {error ? <p className="text-destructive text-sm">{error}</p> : null}
+
+      <form action={sendInvite} className="rounded-md border border-border p-4">
+        <h2 className="mb-2 text-sm font-semibold">Invite an academic partner</h2>
+        <div className="flex flex-wrap items-end gap-2">
+          <div className="flex-1">
+            <Label htmlFor="invitedEmail">Email</Label>
+            <Input
+              id="invitedEmail"
+              name="invitedEmail"
+              type="email"
+              placeholder="researcher@university.edu"
+              required
+            />
+          </div>
+          <Button type="submit" size="sm" disabled={pending}>
+            {pending ? 'Minting…' : 'Create invite'}
+          </Button>
+        </div>
+        {inviteLink ? (
+          <div className="mt-3 rounded-md border border-emerald-500/40 bg-emerald-500/5 p-2 text-xs">
+            <p className="font-medium text-emerald-700 dark:text-emerald-400">
+              Invite link (valid 7 days — share it with the invitee):
+            </p>
+            <code className="mt-1 block break-all font-mono">{inviteLink}</code>
+          </div>
+        ) : null}
+      </form>
+
+      <div className="space-y-2">
+        <h2 className="text-sm font-semibold">Invitations ({invitations.length})</h2>
+        {invitations.length === 0 ? (
+          <p className="text-sm text-muted-foreground">No invitations yet.</p>
+        ) : (
+          <ul className="space-y-2">
+            {invitations.map((inv) => {
+              const status = invitationStatus(inv);
+              return (
+                <li
+                  key={inv.id}
+                  className="flex flex-wrap items-center justify-between gap-2 rounded-md border border-border bg-card p-3 text-sm"
+                >
+                  <div>
+                    <p className="font-medium">{inv.invitedEmail}</p>
+                    <p className="text-xs text-muted-foreground">
+                      {status} · expires {fmt(inv.expiresAt)}
+                      {inv.redeemedAt ? ` · redeemed ${fmt(inv.redeemedAt)}` : ''}
+                    </p>
+                  </div>
+                  {status === 'active' ? (
+                    <Button
+                      size="sm"
+                      variant="outline"
+                      disabled={pending}
+                      onClick={() => run(() => revokeInvitationAction(inv.id))}
+                    >
+                      Revoke
+                    </Button>
+                  ) : null}
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </div>
+
+      <div className="space-y-2">
+        <h2 className="text-sm font-semibold">Active academic partners ({partners.length})</h2>
+        {partners.length === 0 ? (
+          <p className="text-sm text-muted-foreground">No active academic partners.</p>
+        ) : (
+          <ul className="space-y-2">
+            {partners.map((p) => (
+              <li
+                key={p.id}
+                className="flex flex-wrap items-center justify-between gap-2 rounded-md border border-border bg-card p-3 text-sm"
+              >
+                <span className="font-medium">{p.email}</span>
+                <Button
+                  size="sm"
+                  variant="destructive"
+                  disabled={pending}
+                  onClick={() => run(() => revokePartnerRoleAction(p.id))}
+                >
+                  Revoke access
+                </Button>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/db/queries/partner-invitations.ts
+++ b/src/db/queries/partner-invitations.ts
@@ -1,0 +1,160 @@
+/**
+ * DTRS-014a-1 — academic-partner invitation query layer.
+ *
+ * Mint / list / revoke invitations, redeem an invitation (granting the
+ * `academic_partner` role to the redeeming user), and strip the role from an
+ * existing user. All mutations are audit-logged in the same transaction.
+ */
+import { desc, eq } from 'drizzle-orm';
+import { db } from '@/db/client';
+import { type PartnerInvitation, partnerInvitations } from '@/db/schema/partner-invitations';
+import { type User, users } from '@/db/schema/users';
+import { logAuditEvent } from '@/lib/audit';
+import {
+  hashInviteToken,
+  isInvitationRedeemable,
+  looksLikeInviteToken,
+  mintInviteToken,
+  PARTNER_INVITE_TTL_MS,
+} from '@/lib/dtrs';
+
+export interface CreatedInvitation {
+  id: string;
+  /** Raw token — returned once for the invite link; never re-readable. */
+  token: string;
+  expiresAt: Date;
+}
+
+export async function createPartnerInvitation(input: {
+  invitedEmail: string;
+  invitedByUserId: string;
+  ttlMs?: number;
+}): Promise<CreatedInvitation> {
+  const token = mintInviteToken();
+  const tokenHash = hashInviteToken(token);
+  const expiresAt = new Date(Date.now() + (input.ttlMs ?? PARTNER_INVITE_TTL_MS));
+
+  return db.transaction(async (tx) => {
+    const [row] = await tx
+      .insert(partnerInvitations)
+      .values({
+        tokenHash,
+        invitedEmail: input.invitedEmail,
+        invitedByUserId: input.invitedByUserId,
+        expiresAt,
+      })
+      .returning({ id: partnerInvitations.id });
+    await logAuditEvent({
+      actorUserId: input.invitedByUserId,
+      action: 'partner_invitation.created',
+      targetTable: 'partner_invitations',
+      targetId: row.id,
+      metadata: { invitedEmail: input.invitedEmail, expiresAt: expiresAt.toISOString() },
+      tx,
+    });
+    return { id: row.id, token, expiresAt };
+  });
+}
+
+export async function listPartnerInvitations(): Promise<PartnerInvitation[]> {
+  return db.select().from(partnerInvitations).orderBy(desc(partnerInvitations.createdAt));
+}
+
+export async function revokePartnerInvitation(id: string, actorUserId: string): Promise<boolean> {
+  return db.transaction(async (tx) => {
+    const [row] = await tx
+      .update(partnerInvitations)
+      .set({ revokedAt: new Date() })
+      .where(eq(partnerInvitations.id, id))
+      .returning({ id: partnerInvitations.id });
+    if (!row) return false;
+    await logAuditEvent({
+      actorUserId,
+      action: 'partner_invitation.revoked',
+      targetTable: 'partner_invitations',
+      targetId: id,
+      tx,
+    });
+    return true;
+  });
+}
+
+export type RedeemResult = { ok: true; user: User } | { ok: false; error: string };
+
+/**
+ * Atomically redeem an invitation for the signed-in user: validate the token,
+ * mark it redeemed, and set the user's role to `academic_partner`.
+ */
+export async function redeemPartnerInvitation(
+  rawToken: string,
+  redeemingUser: User,
+): Promise<RedeemResult> {
+  if (!looksLikeInviteToken(rawToken)) return { ok: false, error: 'Invalid invitation link.' };
+  const tokenHash = hashInviteToken(rawToken);
+
+  return db.transaction(async (tx) => {
+    const [inv] = await tx
+      .select()
+      .from(partnerInvitations)
+      .where(eq(partnerInvitations.tokenHash, tokenHash))
+      .limit(1);
+    if (!inv) return { ok: false, error: 'Invitation not found.' };
+    if (!isInvitationRedeemable(inv, new Date())) {
+      return { ok: false, error: 'This invitation has expired or already been used.' };
+    }
+
+    await tx
+      .update(partnerInvitations)
+      .set({ redeemedAt: new Date(), redeemedByUserId: redeemingUser.id })
+      .where(eq(partnerInvitations.id, inv.id));
+
+    const [updated] = await tx
+      .update(users)
+      .set({ role: 'academic_partner', updatedAt: new Date() })
+      .where(eq(users.id, redeemingUser.id))
+      .returning();
+
+    await logAuditEvent({
+      actorUserId: redeemingUser.id,
+      action: 'partner_invitation.redeemed',
+      targetTable: 'users',
+      targetId: redeemingUser.id,
+      metadata: { invitationId: inv.id, previousRole: redeemingUser.role },
+      tx,
+    });
+    return { ok: true, user: updated };
+  });
+}
+
+export async function listAcademicPartners(): Promise<User[]> {
+  return db.select().from(users).where(eq(users.role, 'academic_partner'));
+}
+
+/** Strip the academic_partner role (back to 'pending'); access is gone immediately. */
+export async function revokeAcademicPartnerRole(
+  targetUserId: string,
+  actorUserId: string,
+): Promise<boolean> {
+  return db.transaction(async (tx) => {
+    const [target] = await tx
+      .select({ id: users.id, role: users.role, email: users.email })
+      .from(users)
+      .where(eq(users.id, targetUserId))
+      .limit(1);
+    if (!target || target.role !== 'academic_partner') return false;
+
+    await tx
+      .update(users)
+      .set({ role: 'pending', updatedAt: new Date() })
+      .where(eq(users.id, targetUserId));
+    await logAuditEvent({
+      actorUserId,
+      action: 'partner_role.revoked',
+      targetTable: 'users',
+      targetId: targetUserId,
+      metadata: { targetEmail: target.email },
+      tx,
+    });
+    return true;
+  });
+}

--- a/src/db/schema/enums.ts
+++ b/src/db/schema/enums.ts
@@ -7,6 +7,10 @@ export const userRoleEnum = pgEnum('user_role', [
   'ed_coordinator',
   'shelter_staff',
   'admin',
+  // DTRS-014a-1: external read-only role, scoped to aggregate surfaces only.
+  // Granted exclusively by redeeming a partner invitation; in NO individual-
+  // record route's requireRole allow-list, so those routes 404 it by default.
+  'academic_partner',
 ]);
 
 export type UserRole = (typeof userRoleEnum.enumValues)[number];

--- a/src/db/schema/index.ts
+++ b/src/db/schema/index.ts
@@ -26,6 +26,7 @@ export * from './medicaid-extension-applications';
 export * from './org-memberships';
 export * from './outbound-messages-test';
 export * from './partner-agreements';
+export * from './partner-invitations';
 export * from './partner-orgs';
 export * from './partner-service-events';
 export * from './person-partner-consent-events';

--- a/src/db/schema/partner-invitations.ts
+++ b/src/db/schema/partner-invitations.ts
@@ -1,0 +1,37 @@
+/**
+ * DTRS-014a-1 — academic-partner invitations.
+ *
+ * An admin mints an invitation for an external email; the raw token is shown
+ * once (in the invite link) and only its SHA-256 hash is stored. The invitee
+ * redeems it while signed in to receive the `academic_partner` role. Tokens
+ * are single-use and expire 7 days after mint. Revoking sets `revoked_at`.
+ */
+import { index, pgTable, text, timestamp, uniqueIndex, uuid } from 'drizzle-orm/pg-core';
+import { users } from './users';
+
+export const partnerInvitations = pgTable(
+  'partner_invitations',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    /** SHA-256 hex of the opaque token; the raw token is never stored. */
+    tokenHash: text('token_hash').notNull(),
+    invitedEmail: text('invited_email').notNull(),
+    invitedByUserId: uuid('invited_by_user_id')
+      .notNull()
+      .references(() => users.id, { onDelete: 'restrict' }),
+    expiresAt: timestamp('expires_at', { withTimezone: true }).notNull(),
+    redeemedAt: timestamp('redeemed_at', { withTimezone: true }),
+    redeemedByUserId: uuid('redeemed_by_user_id').references(() => users.id, {
+      onDelete: 'set null',
+    }),
+    revokedAt: timestamp('revoked_at', { withTimezone: true }),
+    createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+  },
+  (t) => [
+    uniqueIndex('partner_invitations_token_hash_idx').on(t.tokenHash),
+    index('partner_invitations_email_idx').on(t.invitedEmail),
+  ],
+);
+
+export type PartnerInvitation = typeof partnerInvitations.$inferSelect;
+export type NewPartnerInvitation = typeof partnerInvitations.$inferInsert;

--- a/src/lib/dtrs/index.ts
+++ b/src/lib/dtrs/index.ts
@@ -13,6 +13,7 @@ export * from './faith-aggregate';
 export * from './ferpa-consent-text';
 export * from './fiscal-court-brief';
 export * from './partner-agreements';
+export * from './partner-invite-token';
 export * from './rate-limit';
 export * from './school-referral-insights';
 export * from './school-referral-policy';

--- a/src/lib/dtrs/partner-invite-token.test.ts
+++ b/src/lib/dtrs/partner-invite-token.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from 'vitest';
+import {
+  hashInviteToken,
+  isInvitationRedeemable,
+  looksLikeInviteToken,
+  mintInviteToken,
+  PARTNER_INVITE_TTL_MS,
+} from './partner-invite-token';
+
+const at = (iso: string) => new Date(iso);
+
+describe('mintInviteToken / looksLikeInviteToken', () => {
+  it('mints a 43-char url-safe token that passes the shape guard', () => {
+    const t = mintInviteToken();
+    expect(t).toHaveLength(43);
+    expect(t).toMatch(/^[A-Za-z0-9_-]+$/);
+    expect(looksLikeInviteToken(t)).toBe(true);
+  });
+
+  it('mints distinct tokens', () => {
+    expect(mintInviteToken()).not.toBe(mintInviteToken());
+  });
+
+  it('rejects wrong-length strings', () => {
+    expect(looksLikeInviteToken('short')).toBe(false);
+    expect(looksLikeInviteToken('')).toBe(false);
+  });
+});
+
+describe('hashInviteToken', () => {
+  it('is deterministic and trims input', () => {
+    expect(hashInviteToken('abc')).toBe(hashInviteToken('abc'));
+    expect(hashInviteToken('  abc  ')).toBe(hashInviteToken('abc'));
+  });
+
+  it('produces a 64-char hex digest that differs per token and is not the raw token', () => {
+    const raw = mintInviteToken();
+    const h = hashInviteToken(raw);
+    expect(h).toMatch(/^[0-9a-f]{64}$/);
+    expect(h).not.toBe(raw);
+    expect(hashInviteToken(mintInviteToken())).not.toBe(h);
+  });
+});
+
+describe('isInvitationRedeemable', () => {
+  const now = at('2026-06-23T12:00:00Z');
+  const future = at('2026-06-30T12:00:00Z');
+  const past = at('2026-06-20T12:00:00Z');
+
+  it('is redeemable when unredeemed, unrevoked, and unexpired', () => {
+    expect(
+      isInvitationRedeemable({ expiresAt: future, redeemedAt: null, revokedAt: null }, now),
+    ).toBe(true);
+  });
+
+  it('is not redeemable once redeemed', () => {
+    expect(
+      isInvitationRedeemable({ expiresAt: future, redeemedAt: past, revokedAt: null }, now),
+    ).toBe(false);
+  });
+
+  it('is not redeemable once revoked', () => {
+    expect(
+      isInvitationRedeemable({ expiresAt: future, redeemedAt: null, revokedAt: past }, now),
+    ).toBe(false);
+  });
+
+  it('is not redeemable once expired (boundary = exclusive)', () => {
+    expect(
+      isInvitationRedeemable({ expiresAt: past, redeemedAt: null, revokedAt: null }, now),
+    ).toBe(false);
+    expect(isInvitationRedeemable({ expiresAt: now, redeemedAt: null, revokedAt: null }, now)).toBe(
+      false,
+    );
+  });
+});
+
+describe('PARTNER_INVITE_TTL_MS', () => {
+  it('is 7 days', () => {
+    expect(PARTNER_INVITE_TTL_MS).toBe(7 * 24 * 60 * 60 * 1000);
+  });
+});

--- a/src/lib/dtrs/partner-invite-token.ts
+++ b/src/lib/dtrs/partner-invite-token.ts
@@ -1,0 +1,50 @@
+import { createHash, randomBytes } from 'node:crypto';
+
+/**
+ * DTRS-014a-1 — academic-partner invitation tokens.
+ *
+ * Mirrors the `consent_access_tokens` opaque-token pattern, but stores only a
+ * SHA-256 *hash* of the token at rest (the raw token is shown once, in the
+ * invite link) — invitations grant a role, so we don't keep the live secret in
+ * the DB. The pure helpers here (hash + redeemability) are unit-tested; the
+ * query layer handles persistence + the atomic redeem.
+ */
+
+/** 7-day lifetime — long enough to accept, short enough to bound exposure. */
+export const PARTNER_INVITE_TTL_MS = 7 * 24 * 60 * 60 * 1000;
+
+/** base64url of 32 random bytes = 43 chars, ~256 bits of entropy. */
+const TOKEN_LEN = 43;
+
+/** Mint a fresh URL-safe invite token (the raw secret handed to the invitee). */
+export function mintInviteToken(): string {
+  return randomBytes(32).toString('base64url');
+}
+
+/** SHA-256 hex of a raw token — what we persist and look up by. */
+export function hashInviteToken(rawToken: string): string {
+  return createHash('sha256').update(rawToken.trim()).digest('hex');
+}
+
+/** Shape of the fields that determine whether an invitation can still be redeemed. */
+export interface InvitationRedeemability {
+  expiresAt: Date;
+  redeemedAt: Date | null;
+  revokedAt: Date | null;
+}
+
+/**
+ * Pure check: is this invitation redeemable as of `now`? An invitation is
+ * redeemable only when it is unredeemed, unrevoked, and unexpired.
+ */
+export function isInvitationRedeemable(inv: InvitationRedeemability, now: Date): boolean {
+  if (inv.redeemedAt !== null) return false;
+  if (inv.revokedAt !== null) return false;
+  if (inv.expiresAt.getTime() <= now.getTime()) return false;
+  return true;
+}
+
+/** Quick shape guard for a raw token before hitting the DB. */
+export function looksLikeInviteToken(raw: string): boolean {
+  return raw.trim().length === TOKEN_LEN;
+}


### PR DESCRIPTION
## DTRS-014a-1 — Academic-partner portal: role + invite/redeem/revoke + audit

Refs #394

Adds an `academic_partner` role and an admin-driven invitation workflow that grants it. Read-only access reaches only aggregate, de-identified surfaces — `requireRole` allow-lists mean every individual-record route denies the new role by default (explicit deny is inherent, not a separate check).

### Acceptance criteria
- [x] New `academic_partner` role on `userRoleEnum`
- [x] `requireRole`-gated admin surface (`/app/admin/academic-partners`) — admins only
- [x] Custom invite flow (not Clerk org roles): admin mints an invite, invitee redeems
- [x] Revoke an outstanding invite **and** revoke an active partner's role
- [x] Audit log entries on invite / redeem / revoke
- [x] Happy-path tests (token mint/hash/redeemability + TTL boundary — 10 tests)

### Interpretations (vs. ticket wording)
- **"signed JWT" → opaque hashed token.** Mirrors the existing `consent_access_tokens` pattern: `randomBytes(32).base64url` (43 chars), only the SHA-256 hash is persisted. Single-use, 7-day TTL. No JWT secret to manage; revocation is a DB write, not a denylist.
- **"Clerk org roles" → DB `userRoleEnum`.** This repo stores role in `users.role`, not Clerk metadata (see `requireRole`/`requireUser`). Adding a Clerk-org parallel would fork the authz model.
- **Email delivery deferred.** Resend infra isn't wired yet; the admin UI shows the invite link to copy/share. Swapping in email later is additive.

### Verification
- `pnpm lint` (no --write) · `pnpm typecheck` · `pnpm lint:boundaries` · `pnpm test` (855 pass) · `pnpm build` — all clean.
- Migration `0046_DTRS-014a-1_partner_invitations.sql` round-tripped on a throwaway Postgres 16 (full chain): `user_role` gains `academic_partner`, `partner_invitations` table + unique token-hash index + FKs created. `ADD VALUE` is not used in-migration, so the batched-transaction migrator is safe (cf. FND-388).

### ⚠️ Migration number collision
This is `0046`, same number as my in-flight #398 (SUBP-006b). Whichever merges second must renumber to `0047` + retag its journal entry. Flagging so the merge step expects it.
