### PR TITLE
feat(SUBP-006c): VFW Owensboro referral, pipeline status view + PDF export

### DIFF
--- a/drizzle/migrations/0047_SUBP-006c_vfw_referrals.sql
+++ b/drizzle/migrations/0047_SUBP-006c_vfw_referrals.sql
@@ -1,0 +1,16 @@
+ALTER TYPE "public"."veteran_voucher_application_status" ADD VALUE 'pending' BEFORE 'withdrawn';--> statement-breakpoint
+ALTER TYPE "public"."veteran_voucher_application_status" ADD VALUE 'approved' BEFORE 'withdrawn';--> statement-breakpoint
+ALTER TYPE "public"."veteran_voucher_application_status" ADD VALUE 'housed' BEFORE 'withdrawn';--> statement-breakpoint
+CREATE TABLE "vfw_referrals" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"veteran_id" uuid NOT NULL,
+	"triggered_by_user_id" uuid,
+	"recipient" text NOT NULL,
+	"packet" jsonb NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "vfw_referrals" ADD CONSTRAINT "vfw_referrals_veteran_id_veterans_id_fk" FOREIGN KEY ("veteran_id") REFERENCES "public"."veterans"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "vfw_referrals" ADD CONSTRAINT "vfw_referrals_triggered_by_user_id_users_id_fk" FOREIGN KEY ("triggered_by_user_id") REFERENCES "public"."users"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "vfw_referrals_veteran_idx" ON "vfw_referrals" USING btree ("veteran_id");--> statement-breakpoint
+CREATE INDEX "vfw_referrals_created_idx" ON "vfw_referrals" USING btree ("created_at");

--- a/drizzle/migrations/meta/0047_snapshot.json
+++ b/drizzle/migrations/meta/0047_snapshot.json
@@ -1,0 +1,7930 @@
+{
+  "id": "2e078c5b-de07-4348-8bb8-f69f8907fb97",
+  "prevId": "9afd9685-2a8c-4116-a48b-53dd36409846",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.audit_log": {
+      "name": "audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_table": {
+          "name": "target_table",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "audit_log_actor_idx": {
+          "name": "audit_log_actor_idx",
+          "columns": [
+            {
+              "expression": "actor_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_log_action_idx": {
+          "name": "audit_log_action_idx",
+          "columns": [
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_log_created_at_idx": {
+          "name": "audit_log_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audit_log_actor_user_id_users_id_fk": {
+          "name": "audit_log_actor_user_id_users_id_fk",
+          "tableFrom": "audit_log",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.case_handoffs": {
+      "name": "case_handoffs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "synthetic_person_ref": {
+          "name": "synthetic_person_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_partner_org_id": {
+          "name": "from_partner_org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_partner_org_id": {
+          "name": "to_partner_org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "initiated_by_user_id": {
+          "name": "initiated_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "responded_by_user_id": {
+          "name": "responded_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "case_handoff_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending_consent'"
+        },
+        "purpose": {
+          "name": "purpose",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requested_scope": {
+          "name": "requested_scope",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consent_id": {
+          "name": "consent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decline_reason": {
+          "name": "decline_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "closed_at": {
+          "name": "closed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "case_handoffs_to_partner_idx": {
+          "name": "case_handoffs_to_partner_idx",
+          "columns": [
+            {
+              "expression": "to_partner_org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "case_handoffs_from_partner_idx": {
+          "name": "case_handoffs_from_partner_idx",
+          "columns": [
+            {
+              "expression": "from_partner_org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "case_handoffs_person_ref_idx": {
+          "name": "case_handoffs_person_ref_idx",
+          "columns": [
+            {
+              "expression": "synthetic_person_ref",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "case_handoffs_status_idx": {
+          "name": "case_handoffs_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "case_handoffs_expires_at_idx": {
+          "name": "case_handoffs_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "case_handoffs_from_partner_org_id_partner_orgs_id_fk": {
+          "name": "case_handoffs_from_partner_org_id_partner_orgs_id_fk",
+          "tableFrom": "case_handoffs",
+          "tableTo": "partner_orgs",
+          "columnsFrom": [
+            "from_partner_org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "case_handoffs_to_partner_org_id_partner_orgs_id_fk": {
+          "name": "case_handoffs_to_partner_org_id_partner_orgs_id_fk",
+          "tableFrom": "case_handoffs",
+          "tableTo": "partner_orgs",
+          "columnsFrom": [
+            "to_partner_org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "case_handoffs_initiated_by_user_id_users_id_fk": {
+          "name": "case_handoffs_initiated_by_user_id_users_id_fk",
+          "tableFrom": "case_handoffs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "initiated_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "case_handoffs_responded_by_user_id_users_id_fk": {
+          "name": "case_handoffs_responded_by_user_id_users_id_fk",
+          "tableFrom": "case_handoffs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "responded_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "case_handoffs_consent_id_person_partner_consents_id_fk": {
+          "name": "case_handoffs_consent_id_person_partner_consents_id_fk",
+          "tableFrom": "case_handoffs",
+          "tableTo": "person_partner_consents",
+          "columnsFrom": [
+            "consent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "case_handoffs_distinct_orgs": {
+          "name": "case_handoffs_distinct_orgs",
+          "value": "from_partner_org_id <> to_partner_org_id"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.client_case_notes": {
+      "name": "client_case_notes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "synthetic_person_ref": {
+          "name": "synthetic_person_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body_md": {
+          "name": "body_md",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "drafted_by_ai": {
+          "name": "drafted_by_ai",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "ai_model_id": {
+          "name": "ai_model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ai_prompt_version": {
+          "name": "ai_prompt_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_note_id": {
+          "name": "parent_note_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "client_case_notes_synthetic_ref_idx": {
+          "name": "client_case_notes_synthetic_ref_idx",
+          "columns": [
+            {
+              "expression": "synthetic_person_ref",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "client_case_notes_parent_idx": {
+          "name": "client_case_notes_parent_idx",
+          "columns": [
+            {
+              "expression": "parent_note_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "client_case_notes_created_by_idx": {
+          "name": "client_case_notes_created_by_idx",
+          "columns": [
+            {
+              "expression": "created_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "client_case_notes_parent_note_id_client_case_notes_id_fk": {
+          "name": "client_case_notes_parent_note_id_client_case_notes_id_fk",
+          "tableFrom": "client_case_notes",
+          "tableTo": "client_case_notes",
+          "columnsFrom": [
+            "parent_note_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "client_case_notes_created_by_user_id_users_id_fk": {
+          "name": "client_case_notes_created_by_user_id_users_id_fk",
+          "tableFrom": "client_case_notes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.client_documents": {
+      "name": "client_documents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "synthetic_person_ref": {
+          "name": "synthetic_person_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "client_document_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_md": {
+          "name": "content_md",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "extracted_fields": {
+          "name": "extracted_fields",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extraction_notes": {
+          "name": "extraction_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extraction_model": {
+          "name": "extraction_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "client_document_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'uploaded'"
+        },
+        "uploaded_by_user_id": {
+          "name": "uploaded_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "client_documents_kind_idx": {
+          "name": "client_documents_kind_idx",
+          "columns": [
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "client_documents_status_idx": {
+          "name": "client_documents_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "client_documents_uploaded_by_idx": {
+          "name": "client_documents_uploaded_by_idx",
+          "columns": [
+            {
+              "expression": "uploaded_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "client_documents_synthetic_ref_idx": {
+          "name": "client_documents_synthetic_ref_idx",
+          "columns": [
+            {
+              "expression": "synthetic_person_ref",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "client_documents_uploaded_by_user_id_users_id_fk": {
+          "name": "client_documents_uploaded_by_user_id_users_id_fk",
+          "tableFrom": "client_documents",
+          "tableTo": "users",
+          "columnsFrom": [
+            "uploaded_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.client_intakes": {
+      "name": "client_intakes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "synthetic_person_ref": {
+          "name": "synthetic_person_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transcript_md": {
+          "name": "transcript_md",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "audio_duration_sec": {
+          "name": "audio_duration_sec",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extracted_profile": {
+          "name": "extracted_profile",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extraction_notes": {
+          "name": "extraction_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extraction_model": {
+          "name": "extraction_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "client_intake_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'recording'"
+        },
+        "recorded_by_user_id": {
+          "name": "recorded_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "client_intakes_status_idx": {
+          "name": "client_intakes_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "client_intakes_recorded_by_idx": {
+          "name": "client_intakes_recorded_by_idx",
+          "columns": [
+            {
+              "expression": "recorded_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "client_intakes_synthetic_ref_idx": {
+          "name": "client_intakes_synthetic_ref_idx",
+          "columns": [
+            {
+              "expression": "synthetic_person_ref",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "client_intakes_recorded_by_user_id_users_id_fk": {
+          "name": "client_intakes_recorded_by_user_id_users_id_fk",
+          "tableFrom": "client_intakes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "recorded_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.comms_advisories": {
+      "name": "comms_advisories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body_md": {
+          "name": "body_md",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "spokesperson_name": {
+          "name": "spokesperson_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "spokesperson_contact": {
+          "name": "spokesperson_contact",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "posted_by_user_id": {
+          "name": "posted_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ended_by_user_id": {
+          "name": "ended_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "comms_advisories_active_idx": {
+          "name": "comms_advisories_active_idx",
+          "columns": [
+            {
+              "expression": "active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "comms_advisories_created_idx": {
+          "name": "comms_advisories_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "comms_advisories_posted_by_user_id_users_id_fk": {
+          "name": "comms_advisories_posted_by_user_id_users_id_fk",
+          "tableFrom": "comms_advisories",
+          "tableTo": "users",
+          "columnsFrom": [
+            "posted_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "comms_advisories_ended_by_user_id_users_id_fk": {
+          "name": "comms_advisories_ended_by_user_id_users_id_fk",
+          "tableFrom": "comms_advisories",
+          "tableTo": "users",
+          "columnsFrom": [
+            "ended_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.consent_access_tokens": {
+      "name": "consent_access_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "synthetic_person_ref": {
+          "name": "synthetic_person_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issued_by_user_id": {
+          "name": "issued_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "consent_access_tokens_token_idx": {
+          "name": "consent_access_tokens_token_idx",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "consent_access_tokens_ref_idx": {
+          "name": "consent_access_tokens_ref_idx",
+          "columns": [
+            {
+              "expression": "synthetic_person_ref",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "consent_access_tokens_expires_idx": {
+          "name": "consent_access_tokens_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "consent_access_tokens_issued_by_user_id_users_id_fk": {
+          "name": "consent_access_tokens_issued_by_user_id_users_id_fk",
+          "tableFrom": "consent_access_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "issued_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.consents": {
+      "name": "consents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "subject_external_id": {
+          "name": "subject_external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consent_type": {
+          "name": "consent_type",
+          "type": "consent_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "granted_via": {
+          "name": "granted_via",
+          "type": "consent_channel",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consent_version": {
+          "name": "consent_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'2026-04-1'"
+        },
+        "scope_partner_ids": {
+          "name": "scope_partner_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope_data_classes": {
+          "name": "scope_data_classes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "signature_text": {
+          "name": "signature_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "granted_at": {
+          "name": "granted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "consents_subject_idx": {
+          "name": "consents_subject_idx",
+          "columns": [
+            {
+              "expression": "subject_external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "consents_type_idx": {
+          "name": "consents_type_idx",
+          "columns": [
+            {
+              "expression": "consent_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "consents_expires_at_idx": {
+          "name": "consents_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.dv_flagged_persons": {
+      "name": "dv_flagged_persons",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "subject_identifier": {
+          "name": "subject_identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "flag_set_at": {
+          "name": "flag_set_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "flag_cleared_at": {
+          "name": "flag_cleared_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "dv_flagged_persons_subject_idx": {
+          "name": "dv_flagged_persons_subject_idx",
+          "columns": [
+            {
+              "expression": "subject_identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dv_flagged_persons_set_at_idx": {
+          "name": "dv_flagged_persons_set_at_idx",
+          "columns": [
+            {
+              "expression": "flag_set_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.dv_safety_events": {
+      "name": "dv_safety_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "survivor_id": {
+          "name": "survivor_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "dv_safety_event_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "recorded_by_user_id": {
+          "name": "recorded_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "dv_safety_events_survivor_idx": {
+          "name": "dv_safety_events_survivor_idx",
+          "columns": [
+            {
+              "expression": "survivor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dv_safety_events_occurred_idx": {
+          "name": "dv_safety_events_occurred_idx",
+          "columns": [
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dv_safety_events_type_idx": {
+          "name": "dv_safety_events_type_idx",
+          "columns": [
+            {
+              "expression": "event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "dv_safety_events_survivor_id_dv_survivors_id_fk": {
+          "name": "dv_safety_events_survivor_id_dv_survivors_id_fk",
+          "tableFrom": "dv_safety_events",
+          "tableTo": "dv_survivors",
+          "columnsFrom": [
+            "survivor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "dv_safety_events_recorded_by_user_id_users_id_fk": {
+          "name": "dv_safety_events_recorded_by_user_id_users_id_fk",
+          "tableFrom": "dv_safety_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "recorded_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.dv_survivors": {
+      "name": "dv_survivors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "oasis_partner_org_id": {
+          "name": "oasis_partner_org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "oasis_case_id": {
+          "name": "oasis_case_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enrolled_at": {
+          "name": "enrolled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "status": {
+          "name": "status",
+          "type": "dv_survivor_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "assigned_advocate_user_id": {
+          "name": "assigned_advocate_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "safety_plan_on_file": {
+          "name": "safety_plan_on_file",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "safety_plan_last_reviewed_at": {
+          "name": "safety_plan_last_reviewed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "needs_assessment": {
+          "name": "needs_assessment",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "risk_tier": {
+          "name": "risk_tier",
+          "type": "dv_risk_tier",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unknown'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "dv_survivors_oasis_partner_idx": {
+          "name": "dv_survivors_oasis_partner_idx",
+          "columns": [
+            {
+              "expression": "oasis_partner_org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dv_survivors_assigned_advocate_idx": {
+          "name": "dv_survivors_assigned_advocate_idx",
+          "columns": [
+            {
+              "expression": "assigned_advocate_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dv_survivors_status_idx": {
+          "name": "dv_survivors_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "dv_survivors_risk_tier_idx": {
+          "name": "dv_survivors_risk_tier_idx",
+          "columns": [
+            {
+              "expression": "risk_tier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "dv_survivors_oasis_partner_org_id_partner_orgs_id_fk": {
+          "name": "dv_survivors_oasis_partner_org_id_partner_orgs_id_fk",
+          "tableFrom": "dv_survivors",
+          "tableTo": "partner_orgs",
+          "columnsFrom": [
+            "oasis_partner_org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "dv_survivors_assigned_advocate_user_id_users_id_fk": {
+          "name": "dv_survivors_assigned_advocate_user_id_users_id_fk",
+          "tableFrom": "dv_survivors",
+          "tableTo": "users",
+          "columnsFrom": [
+            "assigned_advocate_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ed_encounters": {
+      "name": "ed_encounters",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encounter_external_id": {
+          "name": "encounter_external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "arrived_at": {
+          "name": "arrived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discharged_at": {
+          "name": "discharged_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chief_complaint": {
+          "name": "chief_complaint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "disposition": {
+          "name": "disposition",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "housing_status": {
+          "name": "housing_status",
+          "type": "housing_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unknown'"
+        },
+        "charge_cents": {
+          "name": "charge_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_json": {
+          "name": "raw_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "ed_encounter_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'synthetic'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ed_encounters_external_idx": {
+          "name": "ed_encounters_external_idx",
+          "columns": [
+            {
+              "expression": "encounter_external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ed_encounters_patient_idx": {
+          "name": "ed_encounters_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ed_encounters_arrived_idx": {
+          "name": "ed_encounters_arrived_idx",
+          "columns": [
+            {
+              "expression": "arrived_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ed_encounters_housing_idx": {
+          "name": "ed_encounters_housing_idx",
+          "columns": [
+            {
+              "expression": "housing_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.esuc_care_plans": {
+      "name": "esuc_care_plans",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "patient_id": {
+          "name": "patient_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plan_md": {
+          "name": "plan_md",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt_version": {
+          "name": "prompt_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "generated_by_user_id": {
+          "name": "generated_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "esuc_care_plan_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "care_plans_patient_version_idx": {
+          "name": "care_plans_patient_version_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "prompt_version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "care_plans_patient_idx": {
+          "name": "care_plans_patient_idx",
+          "columns": [
+            {
+              "expression": "patient_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "care_plans_status_idx": {
+          "name": "care_plans_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "esuc_care_plans_generated_by_user_id_users_id_fk": {
+          "name": "esuc_care_plans_generated_by_user_id_users_id_fk",
+          "tableFrom": "esuc_care_plans",
+          "tableTo": "users",
+          "columnsFrom": [
+            "generated_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.eviction_case_outcomes": {
+      "name": "eviction_case_outcomes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "filing_id": {
+          "name": "filing_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "eviction_case_outcome",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recorded_by_user_id": {
+          "name": "recorded_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "case_outcomes_filing_idx": {
+          "name": "case_outcomes_filing_idx",
+          "columns": [
+            {
+              "expression": "filing_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "case_outcomes_outcome_idx": {
+          "name": "case_outcomes_outcome_idx",
+          "columns": [
+            {
+              "expression": "outcome",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "case_outcomes_created_at_idx": {
+          "name": "case_outcomes_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "eviction_case_outcomes_filing_id_eviction_filings_id_fk": {
+          "name": "eviction_case_outcomes_filing_id_eviction_filings_id_fk",
+          "tableFrom": "eviction_case_outcomes",
+          "tableTo": "eviction_filings",
+          "columnsFrom": [
+            "filing_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "eviction_case_outcomes_recorded_by_user_id_users_id_fk": {
+          "name": "eviction_case_outcomes_recorded_by_user_id_users_id_fk",
+          "tableFrom": "eviction_case_outcomes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "recorded_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.eviction_filing_risk_scores": {
+      "name": "eviction_filing_risk_scores",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "filing_id": {
+          "name": "filing_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rationale": {
+          "name": "rationale",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model_version": {
+          "name": "model_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "risk_scores_filing_version_idx": {
+          "name": "risk_scores_filing_version_idx",
+          "columns": [
+            {
+              "expression": "filing_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "model_version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "risk_scores_filing_idx": {
+          "name": "risk_scores_filing_idx",
+          "columns": [
+            {
+              "expression": "filing_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "risk_scores_score_idx": {
+          "name": "risk_scores_score_idx",
+          "columns": [
+            {
+              "expression": "score",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "eviction_filing_risk_scores_filing_id_eviction_filings_id_fk": {
+          "name": "eviction_filing_risk_scores_filing_id_eviction_filings_id_fk",
+          "tableFrom": "eviction_filing_risk_scores",
+          "tableTo": "eviction_filings",
+          "columnsFrom": [
+            "filing_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.eviction_filings": {
+      "name": "eviction_filings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "case_number": {
+          "name": "case_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filed_at": {
+          "name": "filed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "court_division": {
+          "name": "court_division",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plaintiff": {
+          "name": "plaintiff",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "defendant_first_name": {
+          "name": "defendant_first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "defendant_last_name": {
+          "name": "defendant_last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "defendant_address": {
+          "name": "defendant_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cause_type": {
+          "name": "cause_type",
+          "type": "eviction_cause_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_claimed_cents": {
+          "name": "amount_claimed_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "eviction_filing_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'filed'"
+        },
+        "source": {
+          "name": "source",
+          "type": "eviction_filing_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "raw_json": {
+          "name": "raw_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dv_flag": {
+          "name": "dv_flag",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "eviction_filings_case_source_idx": {
+          "name": "eviction_filings_case_source_idx",
+          "columns": [
+            {
+              "expression": "case_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "eviction_filings_filed_at_idx": {
+          "name": "eviction_filings_filed_at_idx",
+          "columns": [
+            {
+              "expression": "filed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "eviction_filings_status_idx": {
+          "name": "eviction_filings_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.eviction_response_packets": {
+      "name": "eviction_response_packets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "filing_id": {
+          "name": "filing_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "packet_md": {
+          "name": "packet_md",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt_version": {
+          "name": "prompt_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "generated_by_user_id": {
+          "name": "generated_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "eviction_response_packet_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "response_packets_filing_version_idx": {
+          "name": "response_packets_filing_version_idx",
+          "columns": [
+            {
+              "expression": "filing_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "prompt_version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "response_packets_filing_idx": {
+          "name": "response_packets_filing_idx",
+          "columns": [
+            {
+              "expression": "filing_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "response_packets_status_idx": {
+          "name": "response_packets_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "eviction_response_packets_filing_id_eviction_filings_id_fk": {
+          "name": "eviction_response_packets_filing_id_eviction_filings_id_fk",
+          "tableFrom": "eviction_response_packets",
+          "tableTo": "eviction_filings",
+          "columnsFrom": [
+            "filing_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "eviction_response_packets_generated_by_user_id_users_id_fk": {
+          "name": "eviction_response_packets_generated_by_user_id_users_id_fk",
+          "tableFrom": "eviction_response_packets",
+          "tableTo": "users",
+          "columnsFrom": [
+            "generated_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.fag_compensation_entries": {
+      "name": "fag_compensation_entries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "member_id": {
+          "name": "member_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurred_on": {
+          "name": "occurred_on",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hours_tenths": {
+          "name": "hours_tenths",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hourly_rate_cents": {
+          "name": "hourly_rate_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_cents": {
+          "name": "total_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "fag_payout_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unpaid'"
+        },
+        "paid_at": {
+          "name": "paid_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "paid_by_user_id": {
+          "name": "paid_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "fag_compensation_member_idx": {
+          "name": "fag_compensation_member_idx",
+          "columns": [
+            {
+              "expression": "member_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "fag_compensation_status_idx": {
+          "name": "fag_compensation_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "fag_compensation_occurred_idx": {
+          "name": "fag_compensation_occurred_idx",
+          "columns": [
+            {
+              "expression": "occurred_on",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "fag_compensation_entries_member_id_fag_members_id_fk": {
+          "name": "fag_compensation_entries_member_id_fag_members_id_fk",
+          "tableFrom": "fag_compensation_entries",
+          "tableTo": "fag_members",
+          "columnsFrom": [
+            "member_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "fag_compensation_entries_paid_by_user_id_users_id_fk": {
+          "name": "fag_compensation_entries_paid_by_user_id_users_id_fk",
+          "tableFrom": "fag_compensation_entries",
+          "tableTo": "users",
+          "columnsFrom": [
+            "paid_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.fag_members": {
+      "name": "fag_members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "full_name": {
+          "name": "full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_phone": {
+          "name": "contact_phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_email": {
+          "name": "contact_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hourly_rate_cents": {
+          "name": "hourly_rate_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 10000
+        },
+        "status": {
+          "name": "status",
+          "type": "fag_member_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onboarded_on": {
+          "name": "onboarded_on",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "fag_members_status_idx": {
+          "name": "fag_members_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.faith_aggregate_breakouts": {
+      "name": "faith_aggregate_breakouts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "submission_id": {
+          "name": "submission_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dimension": {
+          "name": "dimension",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bucket": {
+          "name": "bucket",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "suppressed": {
+          "name": "suppressed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "faith_aggregate_breakouts_dim_idx": {
+          "name": "faith_aggregate_breakouts_dim_idx",
+          "columns": [
+            {
+              "expression": "submission_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "dimension",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "bucket",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "faith_aggregate_breakouts_submission_id_faith_aggregate_submissions_id_fk": {
+          "name": "faith_aggregate_breakouts_submission_id_faith_aggregate_submissions_id_fk",
+          "tableFrom": "faith_aggregate_breakouts",
+          "tableTo": "faith_aggregate_submissions",
+          "columnsFrom": [
+            "submission_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "faith_aggregate_breakouts_count_or_suppressed": {
+          "name": "faith_aggregate_breakouts_count_or_suppressed",
+          "value": "(count IS NOT NULL AND suppressed = false) OR (count IS NULL AND suppressed = true)"
+        },
+        "faith_aggregate_breakouts_count_nonneg": {
+          "name": "faith_aggregate_breakouts_count_nonneg",
+          "value": "count IS NULL OR count >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.faith_aggregate_metrics": {
+      "name": "faith_aggregate_metrics",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "submission_id": {
+          "name": "submission_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metric_key": {
+          "name": "metric_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "suppressed": {
+          "name": "suppressed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "faith_aggregate_metrics_key_idx": {
+          "name": "faith_aggregate_metrics_key_idx",
+          "columns": [
+            {
+              "expression": "submission_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "metric_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "faith_aggregate_metrics_submission_id_faith_aggregate_submissions_id_fk": {
+          "name": "faith_aggregate_metrics_submission_id_faith_aggregate_submissions_id_fk",
+          "tableFrom": "faith_aggregate_metrics",
+          "tableTo": "faith_aggregate_submissions",
+          "columnsFrom": [
+            "submission_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "faith_aggregate_metrics_value_or_suppressed": {
+          "name": "faith_aggregate_metrics_value_or_suppressed",
+          "value": "(value IS NOT NULL AND suppressed = false) OR (value IS NULL AND suppressed = true)"
+        },
+        "faith_aggregate_metrics_value_nonneg": {
+          "name": "faith_aggregate_metrics_value_nonneg",
+          "value": "value IS NULL OR value >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.faith_aggregate_submissions": {
+      "name": "faith_aggregate_submissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "ministry_id": {
+          "name": "ministry_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_kind": {
+          "name": "period_kind",
+          "type": "faith_aggregate_period_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_start": {
+          "name": "period_start",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_end": {
+          "name": "period_end",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "submitted_by_user_id": {
+          "name": "submitted_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submitted_at": {
+          "name": "submitted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "faith_aggregate_submissions_period_idx": {
+          "name": "faith_aggregate_submissions_period_idx",
+          "columns": [
+            {
+              "expression": "ministry_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "period_start",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "period_end",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "faith_aggregate_submissions_ministry_idx": {
+          "name": "faith_aggregate_submissions_ministry_idx",
+          "columns": [
+            {
+              "expression": "ministry_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "faith_aggregate_submissions_period_start_idx": {
+          "name": "faith_aggregate_submissions_period_start_idx",
+          "columns": [
+            {
+              "expression": "period_start",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "faith_aggregate_submissions_ministry_id_faith_ministries_id_fk": {
+          "name": "faith_aggregate_submissions_ministry_id_faith_ministries_id_fk",
+          "tableFrom": "faith_aggregate_submissions",
+          "tableTo": "faith_ministries",
+          "columnsFrom": [
+            "ministry_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "faith_aggregate_submissions_submitted_by_user_id_users_id_fk": {
+          "name": "faith_aggregate_submissions_submitted_by_user_id_users_id_fk",
+          "tableFrom": "faith_aggregate_submissions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "submitted_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "faith_aggregate_submissions_period_order": {
+          "name": "faith_aggregate_submissions_period_order",
+          "value": "period_start <= period_end"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.faith_ministries": {
+      "name": "faith_ministries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "partner_org_id": {
+          "name": "partner_org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "umbrella_ministry_id": {
+          "name": "umbrella_ministry_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_name": {
+          "name": "contact_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_email": {
+          "name": "contact_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_phone": {
+          "name": "contact_phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "faith_ministry_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'opted_in'"
+        },
+        "min_cell_size": {
+          "name": "min_cell_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 10
+        },
+        "opted_in_at": {
+          "name": "opted_in_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "opted_out_at": {
+          "name": "opted_out_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "faith_ministries_name_idx": {
+          "name": "faith_ministries_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "faith_ministries_umbrella_idx": {
+          "name": "faith_ministries_umbrella_idx",
+          "columns": [
+            {
+              "expression": "umbrella_ministry_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "faith_ministries_status_idx": {
+          "name": "faith_ministries_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "faith_ministries_partner_org_id_partner_orgs_id_fk": {
+          "name": "faith_ministries_partner_org_id_partner_orgs_id_fk",
+          "tableFrom": "faith_ministries",
+          "tableTo": "partner_orgs",
+          "columnsFrom": [
+            "partner_org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "faith_ministries_umbrella_ministry_id_faith_ministries_id_fk": {
+          "name": "faith_ministries_umbrella_ministry_id_faith_ministries_id_fk",
+          "tableFrom": "faith_ministries",
+          "tableTo": "faith_ministries",
+          "columnsFrom": [
+            "umbrella_ministry_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.family_children": {
+      "name": "family_children",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "family_unit_id": {
+          "name": "family_unit_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "child_ref": {
+          "name": "child_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date_of_birth": {
+          "name": "date_of_birth",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_school_id": {
+          "name": "current_school_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enrolled_in_mckinney_vento": {
+          "name": "enrolled_in_mckinney_vento",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"flagged\":false,\"flaggedAt\":null,\"source\":null}'::jsonb"
+        },
+        "grade_band": {
+          "name": "grade_band",
+          "type": "family_child_grade_band",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "family_children_family_idx": {
+          "name": "family_children_family_idx",
+          "columns": [
+            {
+              "expression": "family_unit_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "family_children_school_idx": {
+          "name": "family_children_school_idx",
+          "columns": [
+            {
+              "expression": "current_school_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "family_children_grade_idx": {
+          "name": "family_children_grade_idx",
+          "columns": [
+            {
+              "expression": "grade_band",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "family_children_family_unit_id_family_units_id_fk": {
+          "name": "family_children_family_unit_id_family_units_id_fk",
+          "tableFrom": "family_children",
+          "tableTo": "family_units",
+          "columnsFrom": [
+            "family_unit_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "family_children_current_school_id_partner_orgs_id_fk": {
+          "name": "family_children_current_school_id_partner_orgs_id_fk",
+          "tableFrom": "family_children",
+          "tableTo": "partner_orgs",
+          "columnsFrom": [
+            "current_school_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.family_units": {
+      "name": "family_units",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "primary_caregiver_name": {
+          "name": "primary_caregiver_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "household_size": {
+          "name": "household_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "children_count": {
+          "name": "children_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "family_unit_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "entry_signal": {
+          "name": "entry_signal",
+          "type": "family_entry_signal",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entry_signal_id": {
+          "name": "entry_signal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_housing_status": {
+          "name": "current_housing_status",
+          "type": "family_housing_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assigned_caseworker_user_id": {
+          "name": "assigned_caseworker_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "receiving_school_district_id": {
+          "name": "receiving_school_district_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "family_units_status_idx": {
+          "name": "family_units_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "family_units_entry_signal_idx": {
+          "name": "family_units_entry_signal_idx",
+          "columns": [
+            {
+              "expression": "entry_signal",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "family_units_assigned_caseworker_idx": {
+          "name": "family_units_assigned_caseworker_idx",
+          "columns": [
+            {
+              "expression": "assigned_caseworker_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "family_units_school_district_idx": {
+          "name": "family_units_school_district_idx",
+          "columns": [
+            {
+              "expression": "receiving_school_district_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "family_units_assigned_caseworker_user_id_users_id_fk": {
+          "name": "family_units_assigned_caseworker_user_id_users_id_fk",
+          "tableFrom": "family_units",
+          "tableTo": "users",
+          "columnsFrom": [
+            "assigned_caseworker_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "family_units_receiving_school_district_id_partner_orgs_id_fk": {
+          "name": "family_units_receiving_school_district_id_partner_orgs_id_fk",
+          "tableFrom": "family_units",
+          "tableTo": "partner_orgs",
+          "columnsFrom": [
+            "receiving_school_district_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.foster_aging_out_alerts": {
+      "name": "foster_aging_out_alerts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "youth_id": {
+          "name": "youth_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "milestone": {
+          "name": "milestone",
+          "type": "foster_aging_out_milestone",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fired_at": {
+          "name": "fired_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "acknowledged_by_user_id": {
+          "name": "acknowledged_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "acknowledged_at": {
+          "name": "acknowledged_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "foster_aging_out_alerts_youth_milestone_uniq": {
+          "name": "foster_aging_out_alerts_youth_milestone_uniq",
+          "columns": [
+            {
+              "expression": "youth_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "milestone",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "foster_aging_out_alerts_unack_idx": {
+          "name": "foster_aging_out_alerts_unack_idx",
+          "columns": [
+            {
+              "expression": "acknowledged_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "foster_aging_out_alerts_fired_idx": {
+          "name": "foster_aging_out_alerts_fired_idx",
+          "columns": [
+            {
+              "expression": "fired_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "foster_aging_out_alerts_youth_id_foster_youth_id_fk": {
+          "name": "foster_aging_out_alerts_youth_id_foster_youth_id_fk",
+          "tableFrom": "foster_aging_out_alerts",
+          "tableTo": "foster_youth",
+          "columnsFrom": [
+            "youth_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "foster_aging_out_alerts_acknowledged_by_user_id_users_id_fk": {
+          "name": "foster_aging_out_alerts_acknowledged_by_user_id_users_id_fk",
+          "tableFrom": "foster_aging_out_alerts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "acknowledged_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.foster_youth": {
+      "name": "foster_youth",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "dcbs_partner_org_id": {
+          "name": "dcbs_partner_org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dcbs_case_id": {
+          "name": "dcbs_case_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "legal_first_name": {
+          "name": "legal_first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "legal_last_name": {
+          "name": "legal_last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date_of_birth": {
+          "name": "date_of_birth",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "placement_type": {
+          "name": "placement_type",
+          "type": "foster_placement_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "placement_changes_count": {
+          "name": "placement_changes_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "assigned_caseworker_user_id": {
+          "name": "assigned_caseworker_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supports_in_place": {
+          "name": "supports_in_place",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "foster_youth_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "foster_youth_dcbs_partner_idx": {
+          "name": "foster_youth_dcbs_partner_idx",
+          "columns": [
+            {
+              "expression": "dcbs_partner_org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "foster_youth_assigned_caseworker_idx": {
+          "name": "foster_youth_assigned_caseworker_idx",
+          "columns": [
+            {
+              "expression": "assigned_caseworker_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "foster_youth_status_idx": {
+          "name": "foster_youth_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "foster_youth_dob_idx": {
+          "name": "foster_youth_dob_idx",
+          "columns": [
+            {
+              "expression": "date_of_birth",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "foster_youth_dcbs_partner_org_id_partner_orgs_id_fk": {
+          "name": "foster_youth_dcbs_partner_org_id_partner_orgs_id_fk",
+          "tableFrom": "foster_youth",
+          "tableTo": "partner_orgs",
+          "columnsFrom": [
+            "dcbs_partner_org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "foster_youth_assigned_caseworker_user_id_users_id_fk": {
+          "name": "foster_youth_assigned_caseworker_user_id_users_id_fk",
+          "tableFrom": "foster_youth",
+          "tableTo": "users",
+          "columnsFrom": [
+            "assigned_caseworker_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.health_check": {
+      "name": "health_check",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.hud_vash_vouchers": {
+      "name": "hud_vash_vouchers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "voucher_code": {
+          "name": "voucher_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unit_type": {
+          "name": "unit_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bedrooms": {
+          "name": "bedrooms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "zip": {
+          "name": "zip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accessible": {
+          "name": "accessible",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "availability_status": {
+          "name": "availability_status",
+          "type": "hud_vash_voucher_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'available'"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "hud_vash_vouchers_status_idx": {
+          "name": "hud_vash_vouchers_status_idx",
+          "columns": [
+            {
+              "expression": "availability_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.veteran_voucher_applications": {
+      "name": "veteran_voucher_applications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "veteran_id": {
+          "name": "veteran_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "voucher_id": {
+          "name": "voucher_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "veteran_voucher_application_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'applied'"
+        },
+        "applied_by_user_id": {
+          "name": "applied_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "veteran_voucher_applications_unique_idx": {
+          "name": "veteran_voucher_applications_unique_idx",
+          "columns": [
+            {
+              "expression": "veteran_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "voucher_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "veteran_voucher_applications_veteran_idx": {
+          "name": "veteran_voucher_applications_veteran_idx",
+          "columns": [
+            {
+              "expression": "veteran_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "veteran_voucher_applications_veteran_id_veterans_id_fk": {
+          "name": "veteran_voucher_applications_veteran_id_veterans_id_fk",
+          "tableFrom": "veteran_voucher_applications",
+          "tableTo": "veterans",
+          "columnsFrom": [
+            "veteran_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "veteran_voucher_applications_voucher_id_hud_vash_vouchers_id_fk": {
+          "name": "veteran_voucher_applications_voucher_id_hud_vash_vouchers_id_fk",
+          "tableFrom": "veteran_voucher_applications",
+          "tableTo": "hud_vash_vouchers",
+          "columnsFrom": [
+            "voucher_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "veteran_voucher_applications_applied_by_user_id_users_id_fk": {
+          "name": "veteran_voucher_applications_applied_by_user_id_users_id_fk",
+          "tableFrom": "veteran_voucher_applications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "applied_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.medicaid_extension_applications": {
+      "name": "medicaid_extension_applications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "youth_id": {
+          "name": "youth_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "medicaid_extension_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'drafted'"
+        },
+        "kynect_reference": {
+          "name": "kynect_reference",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "application_payload": {
+          "name": "application_payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "drafted_by_user_id": {
+          "name": "drafted_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "drafted_at": {
+          "name": "drafted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "submitted_at": {
+          "name": "submitted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decision_at": {
+          "name": "decision_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decision_reason": {
+          "name": "decision_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "withdrawn_at": {
+          "name": "withdrawn_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "medicaid_extension_applications_youth_idx": {
+          "name": "medicaid_extension_applications_youth_idx",
+          "columns": [
+            {
+              "expression": "youth_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "medicaid_extension_applications_status_idx": {
+          "name": "medicaid_extension_applications_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "medicaid_extension_applications_drafted_at_idx": {
+          "name": "medicaid_extension_applications_drafted_at_idx",
+          "columns": [
+            {
+              "expression": "drafted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "medicaid_extension_applications_youth_id_foster_youth_id_fk": {
+          "name": "medicaid_extension_applications_youth_id_foster_youth_id_fk",
+          "tableFrom": "medicaid_extension_applications",
+          "tableTo": "foster_youth",
+          "columnsFrom": [
+            "youth_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "medicaid_extension_applications_drafted_by_user_id_users_id_fk": {
+          "name": "medicaid_extension_applications_drafted_by_user_id_users_id_fk",
+          "tableFrom": "medicaid_extension_applications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "drafted_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_memberships": {
+      "name": "org_memberships",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "partner_org_id": {
+          "name": "partner_org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "org_memberships_user_org_idx": {
+          "name": "org_memberships_user_org_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "partner_org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "org_memberships_user_idx": {
+          "name": "org_memberships_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "org_memberships_partner_org_idx": {
+          "name": "org_memberships_partner_org_idx",
+          "columns": [
+            {
+              "expression": "partner_org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "org_memberships_user_id_users_id_fk": {
+          "name": "org_memberships_user_id_users_id_fk",
+          "tableFrom": "org_memberships",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "org_memberships_partner_org_id_partner_orgs_id_fk": {
+          "name": "org_memberships_partner_org_id_partner_orgs_id_fk",
+          "tableFrom": "org_memberships",
+          "tableTo": "partner_orgs",
+          "columnsFrom": [
+            "partner_org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.outbound_messages_test": {
+      "name": "outbound_messages_test",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to": {
+          "name": "to",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.partner_agreements": {
+      "name": "partner_agreements",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "partner_org_id": {
+          "name": "partner_org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "partner_agreement_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "partner_agreement_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "effective_date": {
+          "name": "effective_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "signed_by_partner": {
+          "name": "signed_by_partner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "signed_by_coalition_user_id": {
+          "name": "signed_by_coalition_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "template_version": {
+          "name": "template_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "template_rendered": {
+          "name": "template_rendered",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "terms": {
+          "name": "terms",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "partner_agreements_partner_idx": {
+          "name": "partner_agreements_partner_idx",
+          "columns": [
+            {
+              "expression": "partner_org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "partner_agreements_kind_status_idx": {
+          "name": "partner_agreements_kind_status_idx",
+          "columns": [
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "partner_agreements_active_idx": {
+          "name": "partner_agreements_active_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "status = 'active'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "partner_agreements_partner_org_id_partner_orgs_id_fk": {
+          "name": "partner_agreements_partner_org_id_partner_orgs_id_fk",
+          "tableFrom": "partner_agreements",
+          "tableTo": "partner_orgs",
+          "columnsFrom": [
+            "partner_org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "partner_agreements_signed_by_coalition_user_id_users_id_fk": {
+          "name": "partner_agreements_signed_by_coalition_user_id_users_id_fk",
+          "tableFrom": "partner_agreements",
+          "tableTo": "users",
+          "columnsFrom": [
+            "signed_by_coalition_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "partner_agreements_date_order": {
+          "name": "partner_agreements_date_order",
+          "value": "effective_date IS NULL OR end_date IS NULL OR effective_date <= end_date"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.partner_orgs": {
+      "name": "partner_orgs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "partner_org_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contact_email": {
+          "name": "contact_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_phone": {
+          "name": "contact_phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "website": {
+          "name": "website",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data_sharing_tier": {
+          "name": "data_sharing_tier",
+          "type": "data_sharing_tier",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'none'"
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "partner_orgs_slug_idx": {
+          "name": "partner_orgs_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.partner_service_events": {
+      "name": "partner_service_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "partner_org_id": {
+          "name": "partner_org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "synthetic_person_ref": {
+          "name": "synthetic_person_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "partner_service_event_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_at": {
+          "name": "event_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "ed_encounter_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'synthetic'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "partner_service_events_person_idx": {
+          "name": "partner_service_events_person_idx",
+          "columns": [
+            {
+              "expression": "synthetic_person_ref",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "partner_service_events_partner_idx": {
+          "name": "partner_service_events_partner_idx",
+          "columns": [
+            {
+              "expression": "partner_org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "partner_service_events_at_idx": {
+          "name": "partner_service_events_at_idx",
+          "columns": [
+            {
+              "expression": "event_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "partner_service_events_partner_org_id_partner_orgs_id_fk": {
+          "name": "partner_service_events_partner_org_id_partner_orgs_id_fk",
+          "tableFrom": "partner_service_events",
+          "tableTo": "partner_orgs",
+          "columnsFrom": [
+            "partner_org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.person_partner_consent_events": {
+      "name": "person_partner_consent_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "consent_id": {
+          "name": "consent_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "person_partner_consent_event_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_at": {
+          "name": "event_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "person_partner_consent_events_consent_idx": {
+          "name": "person_partner_consent_events_consent_idx",
+          "columns": [
+            {
+              "expression": "consent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "person_partner_consent_events_consent_id_person_partner_consents_id_fk": {
+          "name": "person_partner_consent_events_consent_id_person_partner_consents_id_fk",
+          "tableFrom": "person_partner_consent_events",
+          "tableTo": "person_partner_consents",
+          "columnsFrom": [
+            "consent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "person_partner_consent_events_actor_user_id_users_id_fk": {
+          "name": "person_partner_consent_events_actor_user_id_users_id_fk",
+          "tableFrom": "person_partner_consent_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.person_partner_consents": {
+      "name": "person_partner_consents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "synthetic_person_ref": {
+          "name": "synthetic_person_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "partner_org_id": {
+          "name": "partner_org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "granted_at": {
+          "name": "granted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "person_partner_consents_unique_idx": {
+          "name": "person_partner_consents_unique_idx",
+          "columns": [
+            {
+              "expression": "synthetic_person_ref",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "partner_org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "person_partner_consents_partner_org_id_partner_orgs_id_fk": {
+          "name": "person_partner_consents_partner_org_id_partner_orgs_id_fk",
+          "tableFrom": "person_partner_consents",
+          "tableTo": "partner_orgs",
+          "columnsFrom": [
+            "partner_org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pre_release_subjects": {
+      "name": "pre_release_subjects",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "ky_doc_partner_org_id": {
+          "name": "ky_doc_partner_org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ky_doc_inmate_id": {
+          "name": "ky_doc_inmate_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "legal_first_name": {
+          "name": "legal_first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "legal_last_name": {
+          "name": "legal_last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date_of_birth": {
+          "name": "date_of_birth",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "projected_release_date": {
+          "name": "projected_release_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "release_type": {
+          "name": "release_type",
+          "type": "pre_release_release_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "designated_destination": {
+          "name": "designated_destination",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assigned_caseworker_user_id": {
+          "name": "assigned_caseworker_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "supports_in_place": {
+          "name": "supports_in_place",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "pre_release_subject_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "handed_off_at": {
+          "name": "handed_off_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pre_release_subjects_partner_idx": {
+          "name": "pre_release_subjects_partner_idx",
+          "columns": [
+            {
+              "expression": "ky_doc_partner_org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pre_release_subjects_caseworker_idx": {
+          "name": "pre_release_subjects_caseworker_idx",
+          "columns": [
+            {
+              "expression": "assigned_caseworker_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pre_release_subjects_status_idx": {
+          "name": "pre_release_subjects_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pre_release_subjects_release_date_idx": {
+          "name": "pre_release_subjects_release_date_idx",
+          "columns": [
+            {
+              "expression": "projected_release_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pre_release_subjects_ky_doc_partner_org_id_partner_orgs_id_fk": {
+          "name": "pre_release_subjects_ky_doc_partner_org_id_partner_orgs_id_fk",
+          "tableFrom": "pre_release_subjects",
+          "tableTo": "partner_orgs",
+          "columnsFrom": [
+            "ky_doc_partner_org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "pre_release_subjects_assigned_caseworker_user_id_users_id_fk": {
+          "name": "pre_release_subjects_assigned_caseworker_user_id_users_id_fk",
+          "tableFrom": "pre_release_subjects",
+          "tableTo": "users",
+          "columnsFrom": [
+            "assigned_caseworker_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rental_assistance_programs": {
+      "name": "rental_assistance_programs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agency": {
+          "name": "agency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "website": {
+          "name": "website",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "eligibility_summary": {
+          "name": "eligibility_summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "max_award_cents": {
+          "name": "max_award_cents",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_note": {
+          "name": "source_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "rental_assistance_programs_active_idx": {
+          "name": "rental_assistance_programs_active_idx",
+          "columns": [
+            {
+              "expression": "active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.school_referral_consents": {
+      "name": "school_referral_consents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "referral_id": {
+          "name": "referral_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "basis": {
+          "name": "basis",
+          "type": "school_referral_basis",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consenter_relationship": {
+          "name": "consenter_relationship",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "consenter_name": {
+          "name": "consenter_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "consent_text_version": {
+          "name": "consent_text_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "signed_at": {
+          "name": "signed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "signed_method": {
+          "name": "signed_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "school_referral_consents_referral_idx": {
+          "name": "school_referral_consents_referral_idx",
+          "columns": [
+            {
+              "expression": "referral_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "school_referral_consents_referral_id_school_referrals_id_fk": {
+          "name": "school_referral_consents_referral_id_school_referrals_id_fk",
+          "tableFrom": "school_referral_consents",
+          "tableTo": "school_referrals",
+          "columnsFrom": [
+            "referral_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.school_referral_disclosures": {
+      "name": "school_referral_disclosures",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "referral_id": {
+          "name": "referral_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accessed_by_user_id": {
+          "name": "accessed_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accessed_by_partner_org_id": {
+          "name": "accessed_by_partner_org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "purpose": {
+          "name": "purpose",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "basis": {
+          "name": "basis",
+          "type": "school_referral_basis",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accessed_at": {
+          "name": "accessed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "data_classes_disclosed": {
+          "name": "data_classes_disclosed",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        }
+      },
+      "indexes": {
+        "school_referral_disclosures_referral_idx": {
+          "name": "school_referral_disclosures_referral_idx",
+          "columns": [
+            {
+              "expression": "referral_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "school_referral_disclosures_user_idx": {
+          "name": "school_referral_disclosures_user_idx",
+          "columns": [
+            {
+              "expression": "accessed_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "school_referral_disclosures_accessed_at_idx": {
+          "name": "school_referral_disclosures_accessed_at_idx",
+          "columns": [
+            {
+              "expression": "accessed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "school_referral_disclosures_referral_id_school_referrals_id_fk": {
+          "name": "school_referral_disclosures_referral_id_school_referrals_id_fk",
+          "tableFrom": "school_referral_disclosures",
+          "tableTo": "school_referrals",
+          "columnsFrom": [
+            "referral_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "school_referral_disclosures_accessed_by_user_id_users_id_fk": {
+          "name": "school_referral_disclosures_accessed_by_user_id_users_id_fk",
+          "tableFrom": "school_referral_disclosures",
+          "tableTo": "users",
+          "columnsFrom": [
+            "accessed_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "school_referral_disclosures_accessed_by_partner_org_id_partner_orgs_id_fk": {
+          "name": "school_referral_disclosures_accessed_by_partner_org_id_partner_orgs_id_fk",
+          "tableFrom": "school_referral_disclosures",
+          "tableTo": "partner_orgs",
+          "columnsFrom": [
+            "accessed_by_partner_org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.school_referral_status_events": {
+      "name": "school_referral_status_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "referral_id": {
+          "name": "referral_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_status": {
+          "name": "from_status",
+          "type": "school_referral_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "to_status": {
+          "name": "to_status",
+          "type": "school_referral_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "school_referral_status_events_referral_idx": {
+          "name": "school_referral_status_events_referral_idx",
+          "columns": [
+            {
+              "expression": "referral_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"occurred_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "school_referral_status_events_referral_id_school_referrals_id_fk": {
+          "name": "school_referral_status_events_referral_id_school_referrals_id_fk",
+          "tableFrom": "school_referral_status_events",
+          "tableTo": "school_referrals",
+          "columnsFrom": [
+            "referral_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "school_referral_status_events_actor_user_id_users_id_fk": {
+          "name": "school_referral_status_events_actor_user_id_users_id_fk",
+          "tableFrom": "school_referral_status_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.school_referrals": {
+      "name": "school_referrals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "partner_org_id": {
+          "name": "partner_org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "referring_user_id": {
+          "name": "referring_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_first_initial": {
+          "name": "student_first_initial",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_age": {
+          "name": "student_age",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "student_grade_band": {
+          "name": "student_grade_band",
+          "type": "school_referral_grade_band",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "guardian_name": {
+          "name": "guardian_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "guardian_contact": {
+          "name": "guardian_contact",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "housing_situation": {
+          "name": "housing_situation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "services_requested": {
+          "name": "services_requested",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "urgency": {
+          "name": "urgency",
+          "type": "school_referral_urgency",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'medium'"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "school_referral_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'received'"
+        },
+        "mv_authorization_confirmed": {
+          "name": "mv_authorization_confirmed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_updated_at": {
+          "name": "last_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "school_referrals_partner_org_idx": {
+          "name": "school_referrals_partner_org_idx",
+          "columns": [
+            {
+              "expression": "partner_org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "school_referrals_status_idx": {
+          "name": "school_referrals_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "school_referrals_received_at_idx": {
+          "name": "school_referrals_received_at_idx",
+          "columns": [
+            {
+              "expression": "received_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "school_referrals_partner_org_id_partner_orgs_id_fk": {
+          "name": "school_referrals_partner_org_id_partner_orgs_id_fk",
+          "tableFrom": "school_referrals",
+          "tableTo": "partner_orgs",
+          "columnsFrom": [
+            "partner_org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "school_referrals_referring_user_id_users_id_fk": {
+          "name": "school_referrals_referring_user_id_users_id_fk",
+          "tableFrom": "school_referrals",
+          "tableTo": "users",
+          "columnsFrom": [
+            "referring_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bed_count_updates": {
+      "name": "bed_count_updates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "shelter_id": {
+          "name": "shelter_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_by_user_id": {
+          "name": "updated_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "previous_occupancy": {
+          "name": "previous_occupancy",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "new_occupancy": {
+          "name": "new_occupancy",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "bed_count_updates_shelter_idx": {
+          "name": "bed_count_updates_shelter_idx",
+          "columns": [
+            {
+              "expression": "shelter_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bed_count_updates_created_idx": {
+          "name": "bed_count_updates_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bed_count_updates_shelter_id_shelters_id_fk": {
+          "name": "bed_count_updates_shelter_id_shelters_id_fk",
+          "tableFrom": "bed_count_updates",
+          "tableTo": "shelters",
+          "columnsFrom": [
+            "shelter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bed_holds": {
+      "name": "bed_holds",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "shelter_id": {
+          "name": "shelter_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "held_by_user_id": {
+          "name": "held_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "person_label": {
+          "name": "person_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "bed_hold_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "released_at": {
+          "name": "released_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "bed_holds_shelter_idx": {
+          "name": "bed_holds_shelter_idx",
+          "columns": [
+            {
+              "expression": "shelter_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bed_holds_status_idx": {
+          "name": "bed_holds_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bed_holds_expires_idx": {
+          "name": "bed_holds_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bed_holds_shelter_id_shelters_id_fk": {
+          "name": "bed_holds_shelter_id_shelters_id_fk",
+          "tableFrom": "bed_holds",
+          "tableTo": "shelters",
+          "columnsFrom": [
+            "shelter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.shelters": {
+      "name": "shelters",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "partner_org_id": {
+          "name": "partner_org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address_line1": {
+          "name": "address_line1",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "city": {
+          "name": "city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "postal_code": {
+          "name": "postal_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_phone": {
+          "name": "contact_phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capacity": {
+          "name": "capacity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_occupancy": {
+          "name": "current_occupancy",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "accepts_men": {
+          "name": "accepts_men",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "accepts_women": {
+          "name": "accepts_women",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "accepts_families": {
+          "name": "accepts_families",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "pet_friendly": {
+          "name": "pet_friendly",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "sud_friendly": {
+          "name": "sud_friendly",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "shelters_slug_idx": {
+          "name": "shelters_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "shelters_partner_org_idx": {
+          "name": "shelters_partner_org_idx",
+          "columns": [
+            {
+              "expression": "partner_org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "shelters_partner_org_id_partner_orgs_id_fk": {
+          "name": "shelters_partner_org_id_partner_orgs_id_fk",
+          "tableFrom": "shelters",
+          "tableTo": "partner_orgs",
+          "columnsFrom": [
+            "partner_org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "shelters_capacity_nonneg": {
+          "name": "shelters_capacity_nonneg",
+          "value": "\"shelters\".\"capacity\" >= 0"
+        },
+        "shelters_occupancy_nonneg": {
+          "name": "shelters_occupancy_nonneg",
+          "value": "\"shelters\".\"current_occupancy\" >= 0"
+        },
+        "shelters_occupancy_le_capacity": {
+          "name": "shelters_occupancy_le_capacity",
+          "value": "\"shelters\".\"current_occupancy\" <= \"shelters\".\"capacity\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.sms_conversations": {
+      "name": "sms_conversations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "from_number": {
+          "name": "from_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "sms_conversation_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'idle'"
+        },
+        "pending_filter": {
+          "name": "pending_filter",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_location": {
+          "name": "last_location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_results": {
+          "name": "last_results",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_hold_id": {
+          "name": "last_hold_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_message_at": {
+          "name": "last_message_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sms_conversations_from_idx": {
+          "name": "sms_conversations_from_idx",
+          "columns": [
+            {
+              "expression": "from_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_conversations_state_idx": {
+          "name": "sms_conversations_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_conversations_expires_idx": {
+          "name": "sms_conversations_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sms_messages": {
+      "name": "sms_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "provider_message_id": {
+          "name": "provider_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "from_number": {
+          "name": "from_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_number": {
+          "name": "to_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "intent": {
+          "name": "intent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reply_body": {
+          "name": "reply_body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sms_messages_received_idx": {
+          "name": "sms_messages_received_idx",
+          "columns": [
+            {
+              "expression": "received_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sms_messages_from_idx": {
+          "name": "sms_messages_from_idx",
+          "columns": [
+            {
+              "expression": "from_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.steering_meetings": {
+      "name": "steering_meetings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "held_on": {
+          "name": "held_on",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attendees": {
+          "name": "attendees",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agenda_md": {
+          "name": "agenda_md",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "decisions_md": {
+          "name": "decisions_md",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "action_items_md": {
+          "name": "action_items_md",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "posted_at": {
+          "name": "posted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "steering_meetings_held_on_idx": {
+          "name": "steering_meetings_held_on_idx",
+          "columns": [
+            {
+              "expression": "held_on",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "steering_meetings_created_by_idx": {
+          "name": "steering_meetings_created_by_idx",
+          "columns": [
+            {
+              "expression": "created_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "steering_meetings_created_by_user_id_users_id_fk": {
+          "name": "steering_meetings_created_by_user_id_users_id_fk",
+          "tableFrom": "steering_meetings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.triage_overrides": {
+      "name": "triage_overrides",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recommended_tier": {
+          "name": "recommended_tier",
+          "type": "triage_tier",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recommended_score": {
+          "name": "recommended_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chosen_tier": {
+          "name": "chosen_tier",
+          "type": "triage_tier",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "override_reason": {
+          "name": "override_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "inputs_snapshot": {
+          "name": "inputs_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recommended_factors": {
+          "name": "recommended_factors",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "triage_overrides_actor_idx": {
+          "name": "triage_overrides_actor_idx",
+          "columns": [
+            {
+              "expression": "actor_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "triage_overrides_created_idx": {
+          "name": "triage_overrides_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "triage_overrides_recommended_idx": {
+          "name": "triage_overrides_recommended_idx",
+          "columns": [
+            {
+              "expression": "recommended_tier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "triage_overrides_actor_user_id_users_id_fk": {
+          "name": "triage_overrides_actor_user_id_users_id_fk",
+          "tableFrom": "triage_overrides",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "clerk_user_id": {
+          "name": "clerk_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "users_clerk_user_id_idx": {
+          "name": "users_clerk_user_id_idx",
+          "columns": [
+            {
+              "expression": "clerk_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.veterans": {
+      "name": "veterans",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "synthetic_person_ref": {
+          "name": "synthetic_person_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "legal_first_name": {
+          "name": "legal_first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "legal_last_name": {
+          "name": "legal_last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "branch_of_service": {
+          "name": "branch_of_service",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "eligibility_source": {
+          "name": "eligibility_source",
+          "type": "veteran_eligibility_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "caseworker_verified": {
+          "name": "caseworker_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "assigned_caseworker_user_id": {
+          "name": "assigned_caseworker_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "veteran_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "bedroom_need": {
+          "name": "bedroom_need",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accessibility_need": {
+          "name": "accessibility_need",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "target_zip": {
+          "name": "target_zip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "veterans_caseworker_idx": {
+          "name": "veterans_caseworker_idx",
+          "columns": [
+            {
+              "expression": "assigned_caseworker_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "veterans_status_idx": {
+          "name": "veterans_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "veterans_synthetic_ref_idx": {
+          "name": "veterans_synthetic_ref_idx",
+          "columns": [
+            {
+              "expression": "synthetic_person_ref",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "veterans_assigned_caseworker_user_id_users_id_fk": {
+          "name": "veterans_assigned_caseworker_user_id_users_id_fk",
+          "tableFrom": "veterans",
+          "tableTo": "users",
+          "columnsFrom": [
+            "assigned_caseworker_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.vfw_referrals": {
+      "name": "vfw_referrals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "veteran_id": {
+          "name": "veteran_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "triggered_by_user_id": {
+          "name": "triggered_by_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recipient": {
+          "name": "recipient",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "packet": {
+          "name": "packet",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "vfw_referrals_veteran_idx": {
+          "name": "vfw_referrals_veteran_idx",
+          "columns": [
+            {
+              "expression": "veteran_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "vfw_referrals_created_idx": {
+          "name": "vfw_referrals_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "vfw_referrals_veteran_id_veterans_id_fk": {
+          "name": "vfw_referrals_veteran_id_veterans_id_fk",
+          "tableFrom": "vfw_referrals",
+          "tableTo": "veterans",
+          "columnsFrom": [
+            "veteran_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "vfw_referrals_triggered_by_user_id_users_id_fk": {
+          "name": "vfw_referrals_triggered_by_user_id_users_id_fk",
+          "tableFrom": "vfw_referrals",
+          "tableTo": "users",
+          "columnsFrom": [
+            "triggered_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.bed_hold_status": {
+      "name": "bed_hold_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "released",
+        "expired",
+        "converted"
+      ]
+    },
+    "public.case_handoff_scope_kind": {
+      "name": "case_handoff_scope_kind",
+      "schema": "public",
+      "values": [
+        "intakes",
+        "case_notes",
+        "service_events",
+        "consents"
+      ]
+    },
+    "public.case_handoff_status": {
+      "name": "case_handoff_status",
+      "schema": "public",
+      "values": [
+        "pending_consent",
+        "pending_acceptance",
+        "accepted",
+        "declined",
+        "revoked",
+        "expired"
+      ]
+    },
+    "public.client_document_kind": {
+      "name": "client_document_kind",
+      "schema": "public",
+      "values": [
+        "photo_id",
+        "ssn_card",
+        "birth_certificate",
+        "dd_214",
+        "lease",
+        "paystub",
+        "court_record",
+        "other"
+      ]
+    },
+    "public.client_document_status": {
+      "name": "client_document_status",
+      "schema": "public",
+      "values": [
+        "uploaded",
+        "extracting",
+        "extracted",
+        "failed"
+      ]
+    },
+    "public.client_intake_status": {
+      "name": "client_intake_status",
+      "schema": "public",
+      "values": [
+        "recording",
+        "transcribed",
+        "extracting",
+        "extracted",
+        "failed"
+      ]
+    },
+    "public.consent_channel": {
+      "name": "consent_channel",
+      "schema": "public",
+      "values": [
+        "sms",
+        "in_person",
+        "web_form",
+        "phone",
+        "paper"
+      ]
+    },
+    "public.consent_type": {
+      "name": "consent_type",
+      "schema": "public",
+      "values": [
+        "phi_share_within_coalition",
+        "sms_communication",
+        "data_for_program_eval"
+      ]
+    },
+    "public.data_sharing_tier": {
+      "name": "data_sharing_tier",
+      "schema": "public",
+      "values": [
+        "none",
+        "aggregate",
+        "individual"
+      ]
+    },
+    "public.dv_risk_tier": {
+      "name": "dv_risk_tier",
+      "schema": "public",
+      "values": [
+        "unknown",
+        "lethality_low",
+        "lethality_moderate",
+        "lethality_high"
+      ]
+    },
+    "public.dv_safety_event_type": {
+      "name": "dv_safety_event_type",
+      "schema": "public",
+      "values": [
+        "intake",
+        "safety_plan_update",
+        "escalation",
+        "service_referral",
+        "exit"
+      ]
+    },
+    "public.dv_survivor_status": {
+      "name": "dv_survivor_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "exited",
+        "transferred",
+        "deceased"
+      ]
+    },
+    "public.ed_encounter_source": {
+      "name": "ed_encounter_source",
+      "schema": "public",
+      "values": [
+        "synthetic",
+        "epic_fhir",
+        "manual"
+      ]
+    },
+    "public.esuc_care_plan_status": {
+      "name": "esuc_care_plan_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "approved",
+        "active",
+        "archived"
+      ]
+    },
+    "public.eviction_case_outcome": {
+      "name": "eviction_case_outcome",
+      "schema": "public",
+      "values": [
+        "dismissed",
+        "judgment_for_plaintiff",
+        "judgment_for_defendant",
+        "settled",
+        "default_judgment",
+        "withdrawn"
+      ]
+    },
+    "public.eviction_cause_type": {
+      "name": "eviction_cause_type",
+      "schema": "public",
+      "values": [
+        "non_payment",
+        "lease_violation",
+        "holdover",
+        "other"
+      ]
+    },
+    "public.eviction_filing_source": {
+      "name": "eviction_filing_source",
+      "schema": "public",
+      "values": [
+        "courtnet",
+        "manual",
+        "synthetic"
+      ]
+    },
+    "public.eviction_filing_status": {
+      "name": "eviction_filing_status",
+      "schema": "public",
+      "values": [
+        "filed",
+        "served",
+        "judgment",
+        "dismissed",
+        "sealed"
+      ]
+    },
+    "public.eviction_response_packet_status": {
+      "name": "eviction_response_packet_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "approved",
+        "filed",
+        "rejected"
+      ]
+    },
+    "public.fag_member_status": {
+      "name": "fag_member_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "paused",
+        "ended"
+      ]
+    },
+    "public.fag_payout_status": {
+      "name": "fag_payout_status",
+      "schema": "public",
+      "values": [
+        "unpaid",
+        "paid",
+        "voided"
+      ]
+    },
+    "public.faith_aggregate_period_kind": {
+      "name": "faith_aggregate_period_kind",
+      "schema": "public",
+      "values": [
+        "week",
+        "month",
+        "quarter"
+      ]
+    },
+    "public.faith_ministry_status": {
+      "name": "faith_ministry_status",
+      "schema": "public",
+      "values": [
+        "opted_in",
+        "paused",
+        "opted_out"
+      ]
+    },
+    "public.family_child_grade_band": {
+      "name": "family_child_grade_band",
+      "schema": "public",
+      "values": [
+        "pre_k",
+        "elementary",
+        "middle",
+        "high",
+        "not_enrolled"
+      ]
+    },
+    "public.family_entry_signal": {
+      "name": "family_entry_signal",
+      "schema": "public",
+      "values": [
+        "eviction",
+        "ed_encounter",
+        "school_referral",
+        "sms_intake",
+        "walk_in"
+      ]
+    },
+    "public.family_housing_status": {
+      "name": "family_housing_status",
+      "schema": "public",
+      "values": [
+        "stably_housed",
+        "doubled_up",
+        "shelter",
+        "unsheltered",
+        "hotel"
+      ]
+    },
+    "public.family_unit_status": {
+      "name": "family_unit_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "rehoused",
+        "exited"
+      ]
+    },
+    "public.foster_aging_out_milestone": {
+      "name": "foster_aging_out_milestone",
+      "schema": "public",
+      "values": [
+        "d90",
+        "d60",
+        "d30",
+        "d14",
+        "d7",
+        "aged_out"
+      ]
+    },
+    "public.foster_placement_type": {
+      "name": "foster_placement_type",
+      "schema": "public",
+      "values": [
+        "family_foster",
+        "kinship",
+        "group_home",
+        "residential",
+        "independent_living",
+        "unknown"
+      ]
+    },
+    "public.foster_youth_status": {
+      "name": "foster_youth_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "aged_out",
+        "exited"
+      ]
+    },
+    "public.housing_status": {
+      "name": "housing_status",
+      "schema": "public",
+      "values": [
+        "housed",
+        "doubled_up",
+        "shelter",
+        "unsheltered",
+        "unknown"
+      ]
+    },
+    "public.medicaid_extension_status": {
+      "name": "medicaid_extension_status",
+      "schema": "public",
+      "values": [
+        "drafted",
+        "submitted",
+        "approved",
+        "denied",
+        "withdrawn"
+      ]
+    },
+    "public.partner_agreement_kind": {
+      "name": "partner_agreement_kind",
+      "schema": "public",
+      "values": [
+        "mou",
+        "ferpa",
+        "baa",
+        "qsoa",
+        "dsa",
+        "memo_of_cooperation"
+      ]
+    },
+    "public.partner_agreement_status": {
+      "name": "partner_agreement_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "active",
+        "expired",
+        "terminated",
+        "superseded"
+      ]
+    },
+    "public.partner_org_type": {
+      "name": "partner_org_type",
+      "schema": "public",
+      "values": [
+        "hospital",
+        "legal_aid",
+        "shelter",
+        "community_org",
+        "government",
+        "faith_based",
+        "school",
+        "philanthropy",
+        "education",
+        "public_health",
+        "media",
+        "other"
+      ]
+    },
+    "public.partner_service_event_type": {
+      "name": "partner_service_event_type",
+      "schema": "public",
+      "values": [
+        "food_pantry",
+        "shelter_intake",
+        "shelter_bed_night",
+        "utility_assistance",
+        "rent_assistance",
+        "counseling_visit",
+        "medical_visit",
+        "school_attendance_flag",
+        "volunteer_hours",
+        "other"
+      ]
+    },
+    "public.pre_release_subject_status": {
+      "name": "pre_release_subject_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "handed_off"
+      ]
+    },
+    "public.pre_release_release_type": {
+      "name": "pre_release_release_type",
+      "schema": "public",
+      "values": [
+        "sentence_expiration",
+        "parole",
+        "transfer",
+        "other"
+      ]
+    },
+    "public.school_referral_basis": {
+      "name": "school_referral_basis",
+      "schema": "public",
+      "values": [
+        "mckinney_vento_authorization",
+        "parental_consent",
+        "eligible_student_consent",
+        "directory_info_only",
+        "health_safety_emergency"
+      ]
+    },
+    "public.school_referral_grade_band": {
+      "name": "school_referral_grade_band",
+      "schema": "public",
+      "values": [
+        "elementary",
+        "middle",
+        "high"
+      ]
+    },
+    "public.school_referral_status": {
+      "name": "school_referral_status",
+      "schema": "public",
+      "values": [
+        "received",
+        "triaged",
+        "in_progress",
+        "connected",
+        "closed_unreachable",
+        "closed_completed"
+      ]
+    },
+    "public.school_referral_urgency": {
+      "name": "school_referral_urgency",
+      "schema": "public",
+      "values": [
+        "low",
+        "medium",
+        "high"
+      ]
+    },
+    "public.sms_conversation_state": {
+      "name": "sms_conversation_state",
+      "schema": "public",
+      "values": [
+        "idle",
+        "awaiting_location"
+      ]
+    },
+    "public.triage_tier": {
+      "name": "triage_tier",
+      "schema": "public",
+      "values": [
+        "high",
+        "medium",
+        "low"
+      ]
+    },
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "pending",
+        "attorney",
+        "caseworker",
+        "ed_coordinator",
+        "shelter_staff",
+        "admin"
+      ]
+    },
+    "public.veteran_eligibility_source": {
+      "name": "veteran_eligibility_source",
+      "schema": "public",
+      "values": [
+        "va_confirmed",
+        "self_reported"
+      ]
+    },
+    "public.veteran_status": {
+      "name": "veteran_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "exited"
+      ]
+    },
+    "public.hud_vash_voucher_status": {
+      "name": "hud_vash_voucher_status",
+      "schema": "public",
+      "values": [
+        "available",
+        "pending",
+        "leased"
+      ]
+    },
+    "public.veteran_voucher_application_status": {
+      "name": "veteran_voucher_application_status",
+      "schema": "public",
+      "values": [
+        "applied",
+        "pending",
+        "approved",
+        "housed",
+        "withdrawn"
+      ]
+    },
+    "public.person_partner_consent_event_type": {
+      "name": "person_partner_consent_event_type",
+      "schema": "public",
+      "values": [
+        "granted",
+        "revoked"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/migrations/meta/_journal.json
+++ b/drizzle/migrations/meta/_journal.json
@@ -330,6 +330,13 @@
 			"when": 1782220835048,
 			"tag": "0046_SUBP-006b_voucher_matching",
 			"breakpoints": true
+		},
+		{
+			"idx": 47,
+			"version": "7",
+			"when": 1782223990102,
+			"tag": "0047_SUBP-006c_vfw_referrals",
+			"breakpoints": true
 		}
 	]
 }

--- a/src/app/actions/vfw-referrals.ts
+++ b/src/app/actions/vfw-referrals.ts
@@ -1,0 +1,126 @@
+'use server';
+
+import { revalidatePath } from 'next/cache';
+import {
+  listApplicationsForVeteran,
+  listVouchers,
+  setApplicationStatus,
+} from '@/db/queries/hud-vash-vouchers';
+import { getVeteran } from '@/db/queries/veterans';
+import { createVfwReferral } from '@/db/queries/vfw-referrals';
+import type { VeteranVoucherApplicationStatus } from '@/db/schema/hud-vash-vouchers';
+import { requireRole } from '@/lib/auth';
+import {
+  buildVfwReferralPacket,
+  describeVeteranEligibility,
+  isVeteranEligible,
+  type ReferralMatchInput,
+  scoreVoucherMatch,
+  type VeteranVoucherStage,
+} from '@/lib/subp';
+
+export type TriggerReferralResult = { ok: true; referralId: string } | { ok: false; error: string };
+
+export type SimpleResult = { ok: true } | { ok: false; error: string };
+
+const VALID_STATUSES: readonly VeteranVoucherApplicationStatus[] = [
+  'applied',
+  'pending',
+  'approved',
+  'housed',
+  'withdrawn',
+];
+
+function stageOf(status: string | undefined): VeteranVoucherStage {
+  switch (status) {
+    case 'applied':
+    case 'pending':
+    case 'approved':
+    case 'housed':
+      return status;
+    default:
+      return 'not_applied';
+  }
+}
+
+/**
+ * SUBP-006c — caseworker triggers a VFW Owensboro referral from a veteran's
+ * detail view. Builds a packet snapshot from the live match data, persists the
+ * referral (audit-logged inside the query), and returns its id.
+ */
+export async function triggerVfwReferralAction(veteranId: string): Promise<TriggerReferralResult> {
+  const actor = await requireRole(['caseworker', 'admin']);
+
+  const veteran = await getVeteran(veteranId);
+  if (!veteran) return { ok: false, error: 'Veteran not found.' };
+  if (!isVeteranEligible(veteran)) {
+    return { ok: false, error: 'Veteran eligibility must be confirmed before referral.' };
+  }
+
+  const [vouchers, applications] = await Promise.all([
+    listVouchers({ availableOnly: true }),
+    listApplicationsForVeteran(veteranId),
+  ]);
+  const statusByVoucher = new Map(applications.map((a) => [a.voucherId, a.status]));
+
+  const matches: ReferralMatchInput[] = vouchers.map((v) => {
+    const match = scoreVoucherMatch(
+      {
+        bedroomNeed: veteran.bedroomNeed,
+        accessibilityNeed: veteran.accessibilityNeed,
+        targetZip: veteran.targetZip,
+      },
+      { bedrooms: v.bedrooms, accessible: v.accessible, zip: v.zip },
+    );
+    const status = statusByVoucher.get(v.id);
+    return {
+      voucherCode: v.voucherCode,
+      unitType: v.unitType,
+      bedrooms: v.bedrooms,
+      location: v.location,
+      zip: v.zip,
+      score: match.score,
+      applied: status === 'applied' || status === 'pending' || status === 'approved',
+      stage: stageOf(status),
+    };
+  });
+
+  const caseworkerName =
+    [actor.firstName, actor.lastName].filter(Boolean).join(' ').trim() || actor.email || null;
+
+  const packet = buildVfwReferralPacket({
+    veteran,
+    caseworkerName,
+    matches,
+    eligibilitySummary: describeVeteranEligibility(veteran),
+  });
+
+  const referral = await createVfwReferral({
+    veteranId,
+    triggeredByUserId: actor.id,
+    packet,
+  });
+
+  revalidatePath(`/app/clients/veterans/${veteranId}`);
+  return { ok: true, referralId: referral.id };
+}
+
+/** Advance a voucher application's status along the pipeline. */
+export async function advanceApplicationStatusAction(
+  applicationId: string,
+  status: string,
+): Promise<SimpleResult> {
+  const actor = await requireRole(['caseworker', 'admin']);
+  if (!applicationId) return { ok: false, error: 'Missing application id.' };
+  if (!VALID_STATUSES.includes(status as VeteranVoucherApplicationStatus)) {
+    return { ok: false, error: 'Invalid status.' };
+  }
+  const row = await setApplicationStatus(
+    applicationId,
+    status as VeteranVoucherApplicationStatus,
+    actor.id,
+  );
+  if (!row) return { ok: false, error: 'Application not found.' };
+  revalidatePath(`/app/clients/veterans/${row.veteranId}`);
+  return { ok: true };
+}

--- a/src/app/app/clients/veterans/[id]/page.tsx
+++ b/src/app/app/clients/veterans/[id]/page.tsx
@@ -1,10 +1,19 @@
 import Link from 'next/link';
 import { notFound } from 'next/navigation';
+import { ApplicationStageControl } from '@/components/subp/application-stage-control';
+import { VfwReferralControl } from '@/components/subp/vfw-referral-control';
 import { VoucherApplyButton } from '@/components/subp/voucher-apply-button';
 import { listApplicationsForVeteran, listVouchers } from '@/db/queries/hud-vash-vouchers';
 import { getVeteran } from '@/db/queries/veterans';
+import { getLatestVfwReferral } from '@/db/queries/vfw-referrals';
 import { requireRole } from '@/lib/auth';
-import { describeVeteranEligibility, isVeteranEligible, scoreVoucherMatch } from '@/lib/subp';
+import {
+  deriveVeteranVoucherStage,
+  describeVeteranEligibility,
+  isVeteranEligible,
+  scoreVoucherMatch,
+  VETERAN_VOUCHER_STAGE_LABELS,
+} from '@/lib/subp';
 
 export const dynamic = 'force-dynamic';
 
@@ -22,13 +31,18 @@ export default async function VeteranDetailPage({ params }: Props) {
   const eligible = isVeteranEligible(veteran);
 
   // Voucher panel only when the veteran flag is set (SUBP-006b AC).
-  const [vouchers, applications] = eligible
-    ? await Promise.all([listVouchers({ availableOnly: true }), listApplicationsForVeteran(id)])
-    : [[], []];
+  const [vouchers, applications, latestReferral] = eligible
+    ? await Promise.all([
+        listVouchers({ availableOnly: true }),
+        listApplicationsForVeteran(id),
+        getLatestVfwReferral(id),
+      ])
+    : [[], [], null];
 
-  const appliedVoucherIds = new Set(
-    applications.filter((a) => a.status === 'applied').map((a) => a.voucherId),
-  );
+  // SUBP-006c: map each voucher to its application (id + status) for the
+  // inline stage control, and roll the subject up to a single pipeline stage.
+  const appByVoucher = new Map(applications.map((a) => [a.voucherId, a]));
+  const subjectStage = deriveVeteranVoucherStage(applications);
 
   const scored = vouchers
     .map((v) => ({
@@ -41,7 +55,7 @@ export default async function VeteranDetailPage({ params }: Props) {
         },
         { bedrooms: v.bedrooms, accessible: v.accessible, zip: v.zip },
       ),
-      applied: appliedVoucherIds.has(v.id),
+      application: appByVoucher.get(v.id) ?? null,
     }))
     .sort((a, b) => b.match.score - a.match.score);
 
@@ -105,7 +119,7 @@ export default async function VeteranDetailPage({ params }: Props) {
           </div>
         ) : (
           <ul className="space-y-2">
-            {scored.map(({ voucher: v, match, applied }) => (
+            {scored.map(({ voucher: v, match, application }) => (
               <li key={v.id} className="rounded-md border border-border bg-card p-3 text-sm">
                 <div className="flex items-start justify-between gap-2">
                   <div>
@@ -137,9 +151,13 @@ export default async function VeteranDetailPage({ params }: Props) {
                   {match.factors.map((f) => `${f.label}: ${f.detail}`).join(' · ')}
                 </p>
                 <div className="mt-2">
-                  {applied ? (
-                    <span className="rounded bg-emerald-600/15 px-2 py-0.5 text-xs text-emerald-700 dark:text-emerald-400">
-                      Applied
+                  {application ? (
+                    <span className="inline-flex items-center gap-2 text-xs text-muted-foreground">
+                      Stage:{' '}
+                      <ApplicationStageControl
+                        applicationId={application.id}
+                        status={application.status}
+                      />
                     </span>
                   ) : (
                     <VoucherApplyButton veteranId={veteran.id} voucherId={v.id} />
@@ -150,6 +168,31 @@ export default async function VeteranDetailPage({ params }: Props) {
           </ul>
         )}
       </section>
+
+      {eligible ? (
+        <section className="space-y-3 rounded-md border border-border p-4">
+          <div className="flex flex-wrap items-center justify-between gap-2">
+            <h2 className="text-sm font-semibold">VFW Owensboro referral</h2>
+            <span className="rounded bg-secondary px-2 py-0.5 text-xs text-secondary-foreground">
+              Pipeline stage: {VETERAN_VOUCHER_STAGE_LABELS[subjectStage]}
+            </span>
+          </div>
+          <p className="text-xs text-muted-foreground">
+            Generates a referral packet (subject, contact, eligibility, matched vouchers) for VFW
+            staff and logs the event. Open the printable packet to export as PDF.
+          </p>
+          <VfwReferralControl veteranId={veteran.id} hasReferral={latestReferral !== null} />
+          {latestReferral ? (
+            <p className="text-[10px] text-muted-foreground">
+              Last referred{' '}
+              {new Intl.DateTimeFormat('en-US', { dateStyle: 'medium', timeStyle: 'short' }).format(
+                new Date(latestReferral.createdAt),
+              )}
+              .
+            </p>
+          ) : null}
+        </section>
+      ) : null}
     </div>
   );
 }

--- a/src/app/app/clients/veterans/[id]/referral/print/page.tsx
+++ b/src/app/app/clients/veterans/[id]/referral/print/page.tsx
@@ -1,0 +1,147 @@
+import Link from 'next/link';
+import { notFound } from 'next/navigation';
+import { PrintButton } from '@/components/coordination/print-button';
+import { getVeteran } from '@/db/queries/veterans';
+import { getLatestVfwReferral } from '@/db/queries/vfw-referrals';
+import { requireRole } from '@/lib/auth';
+import { VETERAN_VOUCHER_STAGE_LABELS, type VfwReferralPacket } from '@/lib/subp';
+
+export const dynamic = 'force-dynamic';
+
+interface Props {
+  params: Promise<{ id: string }>;
+}
+
+/**
+ * SUBP-006c — printable VFW referral packet. Renders the latest referral's
+ * JSONB snapshot in a print-optimized layout; VFW staff print it to PDF
+ * (the app chrome is `print:hidden` at the layout level).
+ */
+export default async function VfwReferralPrintPage({ params }: Props) {
+  await requireRole(['caseworker', 'admin']);
+  const { id } = await params;
+
+  const veteran = await getVeteran(id);
+  if (!veteran) notFound();
+
+  const referral = await getLatestVfwReferral(id);
+  if (!referral) {
+    return (
+      <div className="mx-auto max-w-2xl space-y-3 p-6">
+        <h1 className="font-serif text-2xl font-bold text-primary">No referral yet</h1>
+        <p className="text-sm text-muted-foreground">
+          Generate a VFW referral from the{' '}
+          <Link href={`/app/clients/veterans/${id}`} className="underline">
+            veteran detail view
+          </Link>{' '}
+          first.
+        </p>
+      </div>
+    );
+  }
+
+  const packet = referral.packet as VfwReferralPacket;
+  const dateStr = new Intl.DateTimeFormat('en-US', { dateStyle: 'long' }).format(
+    new Date(referral.createdAt),
+  );
+
+  return (
+    <div className="mx-auto max-w-3xl p-8 print:p-0">
+      <div className="mb-4 flex items-center justify-between print:hidden">
+        <Link
+          href={`/app/clients/veterans/${id}`}
+          className="text-xs text-muted-foreground hover:underline"
+        >
+          ← Back to veteran
+        </Link>
+        <PrintButton />
+      </div>
+
+      <div className="space-y-6 rounded-lg border border-border bg-white p-8 text-black shadow-sm print:border-0 print:shadow-none">
+        <header className="border-b pb-4">
+          <p className="text-xs font-medium uppercase tracking-widest text-zinc-500">
+            Daviess County Homeless Coalition · HUD-VASH Veteran Pathway
+          </p>
+          <h1 className="mt-1 font-serif text-2xl font-bold">VFW Housing Referral</h1>
+          <p className="mt-1 text-sm text-zinc-600">
+            To: {packet.recipient} · {dateStr}
+          </p>
+        </header>
+
+        <section>
+          <h2 className="text-sm font-semibold">Subject</h2>
+          <dl className="mt-1 grid grid-cols-2 gap-x-4 gap-y-1 text-sm">
+            <div>
+              <dt className="inline font-medium">Name: </dt>
+              <dd className="inline">{packet.subject.fullName}</dd>
+            </div>
+            <div>
+              <dt className="inline font-medium">Reference: </dt>
+              <dd className="inline font-mono text-xs">{packet.subject.personRef}</dd>
+            </div>
+            <div>
+              <dt className="inline font-medium">Branch: </dt>
+              <dd className="inline">{packet.subject.branchOfService}</dd>
+            </div>
+            <div className="col-span-2">
+              <dt className="inline font-medium">Housing profile: </dt>
+              <dd className="inline">{packet.subject.housingProfile}</dd>
+            </div>
+          </dl>
+        </section>
+
+        <section>
+          <h2 className="text-sm font-semibold">Eligibility</h2>
+          <p className="mt-1 text-sm">{packet.eligibilitySummary}</p>
+        </section>
+
+        <section>
+          <h2 className="text-sm font-semibold">Coalition contact</h2>
+          <p className="mt-1 text-sm">{packet.contact.caseworkerName}</p>
+        </section>
+
+        <section>
+          <h2 className="text-sm font-semibold">
+            Matched HUD-VASH vouchers ({packet.matchedVouchers.length})
+          </h2>
+          {packet.matchedVouchers.length === 0 ? (
+            <p className="mt-1 text-sm text-zinc-600">No available vouchers at referral time.</p>
+          ) : (
+            <table className="mt-2 w-full border-collapse text-sm">
+              <thead>
+                <tr className="border-b text-left">
+                  <th className="py-1 pr-2 font-medium">Voucher</th>
+                  <th className="py-1 pr-2 font-medium">Unit</th>
+                  <th className="py-1 pr-2 font-medium">Location</th>
+                  <th className="py-1 pr-2 font-medium">Match</th>
+                  <th className="py-1 font-medium">Stage</th>
+                </tr>
+              </thead>
+              <tbody>
+                {packet.matchedVouchers.map((m) => (
+                  <tr key={m.voucherCode} className="border-b last:border-0">
+                    <td className="py-1 pr-2 font-mono text-xs">{m.voucherCode}</td>
+                    <td className="py-1 pr-2">
+                      {m.unitType} ({m.bedrooms}br)
+                    </td>
+                    <td className="py-1 pr-2">
+                      {m.location}
+                      {m.zip ? ` · ${m.zip}` : ''}
+                    </td>
+                    <td className="py-1 pr-2 tabular-nums">{m.score}%</td>
+                    <td className="py-1">{VETERAN_VOUCHER_STAGE_LABELS[m.stage]}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          )}
+        </section>
+
+        <footer className="border-t pt-3 text-xs text-zinc-500">
+          Synthetic / pilot data — not a legal instrument. Generated by the Daviess Coalition
+          platform for VFW review.
+        </footer>
+      </div>
+    </div>
+  );
+}

--- a/src/app/app/clients/veterans/page.tsx
+++ b/src/app/app/clients/veterans/page.tsx
@@ -1,10 +1,25 @@
 import Link from 'next/link';
 import { VeteranVerifyControl } from '@/components/subp/veteran-verify-control';
+import { listAllVoucherApplications } from '@/db/queries/hud-vash-vouchers';
 import { listVeterans } from '@/db/queries/veterans';
 import { requireRole } from '@/lib/auth';
-import { describeVeteranEligibility, isVeteranEligible } from '@/lib/subp';
+import {
+  deriveVeteranVoucherStage,
+  describeVeteranEligibility,
+  isVeteranEligible,
+  VETERAN_VOUCHER_STAGE_LABELS,
+  type VeteranVoucherStage,
+} from '@/lib/subp';
 
 export const dynamic = 'force-dynamic';
+
+const STAGE_BADGE: Record<VeteranVoucherStage, string> = {
+  not_applied: 'bg-zinc-100 text-zinc-600 dark:bg-zinc-800 dark:text-zinc-300',
+  applied: 'bg-sky-100 text-sky-700 dark:bg-sky-900/40 dark:text-sky-400',
+  pending: 'bg-amber-100 text-amber-700 dark:bg-amber-900/40 dark:text-amber-400',
+  approved: 'bg-indigo-100 text-indigo-700 dark:bg-indigo-900/40 dark:text-indigo-400',
+  housed: 'bg-emerald-100 text-emerald-700 dark:bg-emerald-900/40 dark:text-emerald-400',
+};
 
 export default async function VeteransListPage({
   searchParams,
@@ -16,7 +31,20 @@ export default async function VeteransListPage({
   const sp = await searchParams;
   const eligibleOnly = (Array.isArray(sp.filter) ? sp.filter[0] : sp.filter) === 'eligible';
 
-  const subjects = await listVeterans({ status: 'any', eligibleOnly });
+  const [subjects, allApplications] = await Promise.all([
+    listVeterans({ status: 'any', eligibleOnly }),
+    listAllVoucherApplications(),
+  ]);
+
+  // SUBP-006c: roll each subject's applications up to a single pipeline stage.
+  const appsByVeteran = new Map<string, { status: string }[]>();
+  for (const a of allApplications) {
+    const list = appsByVeteran.get(a.veteranId) ?? [];
+    list.push(a);
+    appsByVeteran.set(a.veteranId, list);
+  }
+  const stageFor = (veteranId: string): VeteranVoucherStage =>
+    deriveVeteranVoucherStage(appsByVeteran.get(veteranId) ?? []);
 
   return (
     <div className="mx-auto max-w-5xl space-y-6 p-4 md:p-6">
@@ -71,6 +99,7 @@ export default async function VeteransListPage({
                 <th className="px-3 py-2 font-medium">Name</th>
                 <th className="px-3 py-2 font-medium">Branch</th>
                 <th className="px-3 py-2 font-medium">Eligibility</th>
+                <th className="px-3 py-2 font-medium">Voucher stage</th>
                 <th className="px-3 py-2 font-medium">Status</th>
                 <th className="px-3 py-2 font-medium">Action</th>
               </tr>
@@ -107,6 +136,18 @@ export default async function VeteransListPage({
                       <div className="mt-0.5 text-[10px] text-muted-foreground">
                         {describeVeteranEligibility(v)}
                       </div>
+                    </td>
+                    <td className="px-3 py-2">
+                      {(() => {
+                        const stage = stageFor(v.id);
+                        return (
+                          <span
+                            className={`rounded px-1.5 py-0.5 text-[10px] font-medium ${STAGE_BADGE[stage]}`}
+                          >
+                            {VETERAN_VOUCHER_STAGE_LABELS[stage]}
+                          </span>
+                        );
+                      })()}
                     </td>
                     <td className="px-3 py-2 capitalize text-muted-foreground">{v.status}</td>
                     <td className="px-3 py-2">

--- a/src/app/app/layout.tsx
+++ b/src/app/app/layout.tsx
@@ -19,13 +19,15 @@ export default async function AppLayout({ children }: { children: React.ReactNod
       >
         Skip to main content
       </a>
-      <aside className="hidden md:block">
+      <aside className="hidden md:block print:hidden">
         <Sidebar items={items} brand={brand} />
       </aside>
       <div className="flex min-h-screen flex-col">
-        <Topbar menuButton={<MobileNav items={items} brand={brand} />} />
-        <CommsAdvisoryBanner />
-        {user.role === 'pending' ? <PendingBanner /> : null}
+        <div className="print:hidden">
+          <Topbar menuButton={<MobileNav items={items} brand={brand} />} />
+          <CommsAdvisoryBanner />
+          {user.role === 'pending' ? <PendingBanner /> : null}
+        </div>
         <main id="main-content" tabIndex={-1} className="flex-1 bg-background">
           {children}
         </main>

--- a/src/components/subp/application-stage-control.tsx
+++ b/src/components/subp/application-stage-control.tsx
@@ -1,0 +1,65 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { useState, useTransition } from 'react';
+import { advanceApplicationStatusAction } from '@/app/actions/vfw-referrals';
+
+/** Pipeline statuses a caseworker can move an application through. */
+const STATUS_OPTIONS: { value: string; label: string }[] = [
+  { value: 'applied', label: 'Applied' },
+  { value: 'pending', label: 'Pending' },
+  { value: 'approved', label: 'Approved' },
+  { value: 'housed', label: 'Housed' },
+  { value: 'withdrawn', label: 'Withdrawn' },
+];
+
+/**
+ * SUBP-006c — inline status selector for a (veteran, voucher) application.
+ * Persists immediately via the server action; refreshes the pipeline view.
+ */
+export function ApplicationStageControl({
+  applicationId,
+  status,
+}: {
+  applicationId: string;
+  status: string;
+}) {
+  const router = useRouter();
+  const [pending, startTransition] = useTransition();
+  const [error, setError] = useState<string | null>(null);
+
+  const onChange = (next: string) => {
+    if (next === status) return;
+    setError(null);
+    startTransition(async () => {
+      const r = await advanceApplicationStatusAction(applicationId, next);
+      if (!r.ok) {
+        setError(r.error);
+        return;
+      }
+      router.refresh();
+    });
+  };
+
+  return (
+    <span className="inline-flex items-center gap-1">
+      <label className="sr-only" htmlFor={`stage-${applicationId}`}>
+        Application status
+      </label>
+      <select
+        id={`stage-${applicationId}`}
+        value={status}
+        disabled={pending}
+        onChange={(e) => onChange(e.target.value)}
+        className="rounded border border-input bg-transparent px-1.5 py-0.5 text-xs outline-none focus-visible:ring-2 focus-visible:ring-ring"
+      >
+        {STATUS_OPTIONS.map((o) => (
+          <option key={o.value} value={o.value}>
+            {o.label}
+          </option>
+        ))}
+      </select>
+      {error ? <span className="text-destructive text-[10px]">{error}</span> : null}
+    </span>
+  );
+}

--- a/src/components/subp/vfw-referral-control.tsx
+++ b/src/components/subp/vfw-referral-control.tsx
@@ -1,0 +1,68 @@
+'use client';
+
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+import { useState, useTransition } from 'react';
+import { triggerVfwReferralAction } from '@/app/actions/vfw-referrals';
+import { Button } from '@/components/ui/button';
+
+/**
+ * SUBP-006c — one-action "Refer to VFW Owensboro" trigger. On success the
+ * printable packet link is revealed (VFW staff print it to PDF).
+ */
+export function VfwReferralControl({
+  veteranId,
+  hasReferral,
+}: {
+  veteranId: string;
+  hasReferral: boolean;
+}) {
+  const router = useRouter();
+  const [pending, startTransition] = useTransition();
+  const [error, setError] = useState<string | null>(null);
+  const [done, setDone] = useState(false);
+
+  const printHref = `/app/clients/veterans/${veteranId}/referral/print`;
+
+  const trigger = () => {
+    setError(null);
+    startTransition(async () => {
+      const r = await triggerVfwReferralAction(veteranId);
+      if (!r.ok) {
+        setError(r.error);
+        return;
+      }
+      setDone(true);
+      router.refresh();
+    });
+  };
+
+  return (
+    <div className="space-y-2">
+      <div className="flex flex-wrap items-center gap-2">
+        <Button type="button" size="sm" onClick={trigger} disabled={pending}>
+          {pending
+            ? 'Generating…'
+            : hasReferral
+              ? 'Re-generate referral'
+              : 'Refer to VFW Owensboro'}
+        </Button>
+        {(hasReferral || done) && (
+          <Link
+            href={printHref}
+            target="_blank"
+            className="rounded-md border border-input px-3 py-1.5 text-xs hover:bg-muted"
+          >
+            Open printable packet (PDF)
+          </Link>
+        )}
+      </div>
+      {done ? (
+        <p className="text-xs text-emerald-700 dark:text-emerald-400">
+          Referral packet generated and logged.
+        </p>
+      ) : null}
+      {error ? <p className="text-destructive text-xs">{error}</p> : null}
+    </div>
+  );
+}

--- a/src/db/queries/hud-vash-vouchers.ts
+++ b/src/db/queries/hud-vash-vouchers.ts
@@ -12,6 +12,7 @@ import {
   hudVashVouchers,
   type NewHudVashVoucher,
   type VeteranVoucherApplication,
+  type VeteranVoucherApplicationStatus,
   veteranVoucherApplications,
 } from '@/db/schema/hud-vash-vouchers';
 import { logAuditEvent } from '@/lib/audit';
@@ -153,4 +154,38 @@ export async function applyToVoucher(
     });
     return row;
   });
+}
+
+/**
+ * SUBP-006c — set a (veteran, voucher) application's status along the
+ * pipeline (applied → pending → approved → housed, or withdrawn). Audit-logged
+ * in the same transaction. Returns the updated row, or null if not found.
+ */
+export async function setApplicationStatus(
+  applicationId: string,
+  status: VeteranVoucherApplicationStatus,
+  actorUserId: string,
+): Promise<VeteranVoucherApplication | null> {
+  return db.transaction(async (tx) => {
+    const [row] = await tx
+      .update(veteranVoucherApplications)
+      .set({ status, updatedAt: new Date() })
+      .where(eq(veteranVoucherApplications.id, applicationId))
+      .returning();
+    if (!row) return null;
+    await logAuditEvent({
+      actorUserId,
+      action: 'veteran_voucher.status_changed',
+      targetTable: 'veteran_voucher_applications',
+      targetId: row.id,
+      metadata: { veteranId: row.veteranId, voucherId: row.voucherId, status },
+      tx,
+    });
+    return row;
+  });
+}
+
+/** All voucher applications across subjects — used to derive list-view stages. */
+export async function listAllVoucherApplications(): Promise<VeteranVoucherApplication[]> {
+  return db.select().from(veteranVoucherApplications);
 }

--- a/src/db/queries/vfw-referrals.ts
+++ b/src/db/queries/vfw-referrals.ts
@@ -1,0 +1,58 @@
+/**
+ * SUBP-006c — VFW referral query layer. Creating a referral persists a JSONB
+ * packet snapshot and audit-logs the event in the same transaction.
+ */
+import { desc, eq } from 'drizzle-orm';
+import { db } from '@/db/client';
+import { type NewVfwReferral, type VfwReferral, vfwReferrals } from '@/db/schema/vfw-referrals';
+import { logAuditEvent } from '@/lib/audit';
+import type { VfwReferralPacket } from '@/lib/subp';
+
+export interface CreateVfwReferralInput {
+  veteranId: string;
+  triggeredByUserId: string;
+  packet: VfwReferralPacket;
+}
+
+export async function createVfwReferral(input: CreateVfwReferralInput): Promise<VfwReferral> {
+  return db.transaction(async (tx) => {
+    const values: NewVfwReferral = {
+      veteranId: input.veteranId,
+      triggeredByUserId: input.triggeredByUserId,
+      recipient: input.packet.recipient,
+      packet: input.packet,
+    };
+    const [row] = await tx.insert(vfwReferrals).values(values).returning();
+    await logAuditEvent({
+      actorUserId: input.triggeredByUserId,
+      action: 'vfw_referral.triggered',
+      targetTable: 'vfw_referrals',
+      targetId: row.id,
+      metadata: {
+        veteranId: input.veteranId,
+        recipient: input.packet.recipient,
+        voucherCount: input.packet.matchedVouchers.length,
+      },
+      tx,
+    });
+    return row;
+  });
+}
+
+export async function listVfwReferralsForVeteran(veteranId: string): Promise<VfwReferral[]> {
+  return db
+    .select()
+    .from(vfwReferrals)
+    .where(eq(vfwReferrals.veteranId, veteranId))
+    .orderBy(desc(vfwReferrals.createdAt));
+}
+
+export async function getLatestVfwReferral(veteranId: string): Promise<VfwReferral | null> {
+  const [row] = await db
+    .select()
+    .from(vfwReferrals)
+    .where(eq(vfwReferrals.veteranId, veteranId))
+    .orderBy(desc(vfwReferrals.createdAt))
+    .limit(1);
+  return row ?? null;
+}

--- a/src/db/schema/hud-vash-vouchers.ts
+++ b/src/db/schema/hud-vash-vouchers.ts
@@ -59,9 +59,16 @@ export const hudVashVouchers = pgTable(
 export type HudVashVoucher = typeof hudVashVouchers.$inferSelect;
 export type NewHudVashVoucher = typeof hudVashVouchers.$inferInsert;
 
-/** Application status of a (veteran, voucher) pair. */
+/**
+ * Application status of a (veteran, voucher) pair. SUBP-006c extends the
+ * lifecycle past applied/withdrawn so the caseworker pipeline view can show a
+ * subject's stage (see `deriveVeteranVoucherStage`).
+ */
 export const veteranVoucherApplicationStatusEnum = pgEnum('veteran_voucher_application_status', [
   'applied',
+  'pending',
+  'approved',
+  'housed',
   'withdrawn',
 ]);
 

--- a/src/db/schema/index.ts
+++ b/src/db/schema/index.ts
@@ -43,3 +43,4 @@ export * from './steering-meetings';
 export * from './triage-overrides';
 export * from './users';
 export * from './veterans';
+export * from './vfw-referrals';

--- a/src/db/schema/vfw-referrals.ts
+++ b/src/db/schema/vfw-referrals.ts
@@ -1,0 +1,39 @@
+/**
+ * SUBP-006c — VFW Owensboro referral events.
+ *
+ * One row per referral a caseworker triggers from a veteran's detail view.
+ * `packet` is a JSONB snapshot of the referral packet at trigger time (subject,
+ * contact, eligibility summary, matched vouchers) so the printable copy and the
+ * audit trail reflect what was actually sent, independent of later edits.
+ *
+ * PHI fence: synthetic subject data only until the relevant BAA closes.
+ */
+import { index, jsonb, pgTable, text, timestamp, uuid } from 'drizzle-orm/pg-core';
+import { users } from './users';
+import { veterans } from './veterans';
+
+export const vfwReferrals = pgTable(
+  'vfw_referrals',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    veteranId: uuid('veteran_id')
+      .notNull()
+      .references(() => veterans.id, { onDelete: 'cascade' }),
+    /** Caseworker who triggered the referral; null if the actor is later removed. */
+    triggeredByUserId: uuid('triggered_by_user_id').references(() => users.id, {
+      onDelete: 'set null',
+    }),
+    /** Where the referral was sent (fixed to the local VFW post for now). */
+    recipient: text('recipient').notNull(),
+    /** JSONB snapshot of the packet at trigger time. */
+    packet: jsonb('packet').notNull(),
+    createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+  },
+  (t) => [
+    index('vfw_referrals_veteran_idx').on(t.veteranId),
+    index('vfw_referrals_created_idx').on(t.createdAt),
+  ],
+);
+
+export type VfwReferral = typeof vfwReferrals.$inferSelect;
+export type NewVfwReferral = typeof vfwReferrals.$inferInsert;

--- a/src/lib/subp/index.ts
+++ b/src/lib/subp/index.ts
@@ -15,4 +15,5 @@ export * from './pre-release-engine';
 export * from './pre-release-supports';
 export * from './supports-in-place';
 export * from './veteran-eligibility';
+export * from './vfw-referral';
 export * from './voucher-match';

--- a/src/lib/subp/vfw-referral.test.ts
+++ b/src/lib/subp/vfw-referral.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildVfwReferralPacket,
+  deriveVeteranVoucherStage,
+  VFW_OWENSBORO_RECIPIENT,
+} from './vfw-referral';
+
+describe('deriveVeteranVoucherStage', () => {
+  it('returns not_applied when there are no applications', () => {
+    expect(deriveVeteranVoucherStage([])).toBe('not_applied');
+  });
+
+  it('ignores withdrawn applications', () => {
+    expect(deriveVeteranVoucherStage([{ status: 'withdrawn' }])).toBe('not_applied');
+  });
+
+  it('returns the furthest stage across applications', () => {
+    expect(deriveVeteranVoucherStage([{ status: 'applied' }, { status: 'pending' }])).toBe(
+      'pending',
+    );
+    expect(
+      deriveVeteranVoucherStage([
+        { status: 'applied' },
+        { status: 'housed' },
+        { status: 'pending' },
+      ]),
+    ).toBe('housed');
+    expect(deriveVeteranVoucherStage([{ status: 'approved' }, { status: 'applied' }])).toBe(
+      'approved',
+    );
+  });
+});
+
+describe('buildVfwReferralPacket', () => {
+  const veteran = {
+    legalFirstName: 'Dana',
+    legalLastName: 'Reyes',
+    syntheticPersonRef: 'SP-0007',
+    branchOfService: 'Army',
+    eligibilitySource: 'va_confirmed' as const,
+    caseworkerVerified: false,
+    bedroomNeed: 2,
+    accessibilityNeed: true,
+    targetZip: '42301',
+  };
+
+  const matches = [
+    {
+      voucherCode: 'V-101',
+      unitType: '2BR apartment',
+      bedrooms: 2,
+      location: 'Owensboro',
+      zip: '42301',
+      score: 100,
+      applied: true,
+      stage: 'applied' as const,
+    },
+    {
+      voucherCode: 'V-202',
+      unitType: '1BR apartment',
+      bedrooms: 1,
+      location: 'Whitesville',
+      zip: '42378',
+      score: 45,
+      applied: false,
+      stage: 'not_applied' as const,
+    },
+  ];
+
+  it('addresses the packet to VFW Owensboro and stamps the subject', () => {
+    const p = buildVfwReferralPacket({
+      veteran,
+      caseworkerName: 'C. Worker',
+      matches,
+      eligibilitySummary: 'VA documentation confirmed.',
+    });
+    expect(p.recipient).toBe(VFW_OWENSBORO_RECIPIENT);
+    expect(p.subject.fullName).toBe('Dana Reyes');
+    expect(p.subject.personRef).toBe('SP-0007');
+    expect(p.subject.branchOfService).toBe('Army');
+    expect(p.contact.caseworkerName).toBe('C. Worker');
+    expect(p.eligibilitySummary).toBe('VA documentation confirmed.');
+  });
+
+  it('carries the matched vouchers sorted by score (highest first)', () => {
+    const p = buildVfwReferralPacket({
+      veteran,
+      caseworkerName: null,
+      matches: [matches[1], matches[0]],
+      eligibilitySummary: 'x',
+    });
+    expect(p.matchedVouchers.map((m) => m.voucherCode)).toEqual(['V-101', 'V-202']);
+    expect(p.matchedVouchers[0].score).toBe(100);
+  });
+
+  it('falls back to a placeholder when no caseworker is named', () => {
+    const p = buildVfwReferralPacket({
+      veteran,
+      caseworkerName: null,
+      matches,
+      eligibilitySummary: 'x',
+    });
+    expect(p.contact.caseworkerName).toBe('Unassigned');
+  });
+
+  it('summarizes the housing profile', () => {
+    const p = buildVfwReferralPacket({
+      veteran,
+      caseworkerName: null,
+      matches,
+      eligibilitySummary: 'x',
+    });
+    expect(p.subject.housingProfile).toContain('2 bedroom');
+    expect(p.subject.housingProfile).toContain('accessible');
+    expect(p.subject.housingProfile).toContain('42301');
+  });
+});

--- a/src/lib/subp/vfw-referral.ts
+++ b/src/lib/subp/vfw-referral.ts
@@ -1,0 +1,144 @@
+/**
+ * SUBP-006c — VFW Owensboro referral packet builder + voucher-stage rollup.
+ *
+ * Pure, DB-free helpers (the established subp factoring) so they're unit-
+ * testable and reusable by the query layer, the server action, and the
+ * printable packet route. No PHI: synthetic subject data only until BAA close.
+ */
+
+/** Fixed referral recipient for the veteran pathway (single local post). */
+export const VFW_OWENSBORO_RECIPIENT = 'VFW Post — Owensboro, KY';
+
+/**
+ * Per-subject voucher pipeline stage. `not_applied` is the derived default;
+ * the rest mirror the `veteran_voucher_application_status` lifecycle (minus
+ * `withdrawn`, which rolls back to `not_applied`).
+ */
+export type VeteranVoucherStage = 'not_applied' | 'applied' | 'pending' | 'approved' | 'housed';
+
+/** Ordering for "furthest stage wins" rollup + display. */
+export const VETERAN_VOUCHER_STAGE_ORDER: VeteranVoucherStage[] = [
+  'not_applied',
+  'applied',
+  'pending',
+  'approved',
+  'housed',
+];
+
+export const VETERAN_VOUCHER_STAGE_LABELS: Record<VeteranVoucherStage, string> = {
+  not_applied: 'Not applied',
+  applied: 'Applied',
+  pending: 'Pending',
+  approved: 'Approved',
+  housed: 'Housed',
+};
+
+/** Application-status values that map onto a pipeline stage. */
+type ApplicationStatusish = { status: string };
+
+function stageForStatus(status: string): VeteranVoucherStage {
+  switch (status) {
+    case 'applied':
+    case 'pending':
+    case 'approved':
+    case 'housed':
+      return status;
+    default:
+      // 'withdrawn' or anything unknown → not in the active pipeline.
+      return 'not_applied';
+  }
+}
+
+/**
+ * Roll a subject's voucher applications up to a single pipeline stage: the
+ * furthest any application has reached. No applications (or only withdrawn
+ * ones) → `not_applied`.
+ */
+export function deriveVeteranVoucherStage(
+  applications: ApplicationStatusish[],
+): VeteranVoucherStage {
+  let best: VeteranVoucherStage = 'not_applied';
+  let bestRank = 0;
+  for (const app of applications) {
+    const stage = stageForStatus(app.status);
+    const rank = VETERAN_VOUCHER_STAGE_ORDER.indexOf(stage);
+    if (rank > bestRank) {
+      bestRank = rank;
+      best = stage;
+    }
+  }
+  return best;
+}
+
+export interface ReferralVeteranInput {
+  legalFirstName: string;
+  legalLastName: string;
+  syntheticPersonRef: string;
+  branchOfService: string | null;
+  eligibilitySource: 'va_confirmed' | 'self_reported';
+  caseworkerVerified: boolean;
+  bedroomNeed: number | null;
+  accessibilityNeed: boolean;
+  targetZip: string | null;
+}
+
+export interface ReferralMatchInput {
+  voucherCode: string;
+  unitType: string;
+  bedrooms: number;
+  location: string;
+  zip: string | null;
+  score: number;
+  applied: boolean;
+  stage: VeteranVoucherStage;
+}
+
+export interface BuildPacketInput {
+  veteran: ReferralVeteranInput;
+  caseworkerName: string | null;
+  matches: ReferralMatchInput[];
+  eligibilitySummary: string;
+}
+
+export interface VfwReferralPacket {
+  recipient: string;
+  subject: {
+    fullName: string;
+    personRef: string;
+    branchOfService: string;
+    housingProfile: string;
+  };
+  contact: { caseworkerName: string };
+  eligibilitySummary: string;
+  matchedVouchers: ReferralMatchInput[];
+}
+
+function describeHousingProfile(v: ReferralVeteranInput): string {
+  const parts: string[] = [];
+  parts.push(v.bedroomNeed == null ? 'bedrooms: no stated need' : `${v.bedroomNeed} bedroom need`);
+  parts.push(v.accessibilityNeed ? 'requires accessible unit' : 'no accessibility need');
+  parts.push(v.targetZip ? `target ZIP ${v.targetZip}` : 'target ZIP: unknown');
+  return parts.join(' · ');
+}
+
+/**
+ * Assemble a referral packet ready for caseworker review and printing. The
+ * matched vouchers are sorted highest-score-first so the strongest options
+ * lead. A snapshot of this object is persisted with the referral event.
+ */
+export function buildVfwReferralPacket(input: BuildPacketInput): VfwReferralPacket {
+  const { veteran, caseworkerName, matches, eligibilitySummary } = input;
+  const matchedVouchers = [...matches].sort((a, b) => b.score - a.score);
+  return {
+    recipient: VFW_OWENSBORO_RECIPIENT,
+    subject: {
+      fullName: `${veteran.legalFirstName} ${veteran.legalLastName}`,
+      personRef: veteran.syntheticPersonRef,
+      branchOfService: veteran.branchOfService ?? 'Branch unknown',
+      housingProfile: describeHousingProfile(veteran),
+    },
+    contact: { caseworkerName: caseworkerName ?? 'Unassigned' },
+    eligibilitySummary,
+    matchedVouchers,
+  };
+}


### PR DESCRIPTION
## SUBP-006c — VFW Owensboro referral, caseworker pipeline status + PDF export

Refs #384 · third veteran-pathway slice (builds on SUBP-006a #382 + SUBP-006b #383, both merged).

### Acceptance criteria
- [x] System generates a referral packet (name, contact, eligibility summary, matched vouchers) ready for caseworker review — `buildVfwReferralPacket` snapshots live match data
- [x] Caseworker triggers the VFW Owensboro referral from the veteran detail view with one action — `VfwReferralControl` → `triggerVfwReferralAction`
- [x] Referral packet is PDF-exportable (printable) — `/app/clients/veterans/[id]/referral/print` renders the snapshot print-clean; VFW staff print-to-PDF
- [x] Caseworker pathway view: status column showing voucher stage per subject (not applied / applied / pending / approved / housed) — derived via `deriveVeteranVoucherStage`, shown on the veterans list + detail
- [x] Referral events audit-logged (who, when, what) — `vfw_referral.triggered` with recipient + voucher count; stage changes audit `veteran_voucher.status_changed`
- [x] DoD

### Design notes
- **PDF = print-styled HTML route** (the repo's established export mechanism — agreement/outcomes pages use `print:` variants), not a new PDF dependency. Added `print:hidden` to the app shell (sidebar/topbar/banners) so any in-`/app` printable renders clean — a small incidental fix that also benefits the existing handout/outcomes print pages.
- **Pipeline stages** extend the `veteran_voucher_application_status` enum (`pending`/`approved`/`housed` added; `withdrawn` kept). Per-subject stage = furthest application stage. A caseworker advances an application's stage inline on the detail view.
- **Packet snapshot** stored as JSONB on `vfw_referrals` so the printed copy + audit reflect what was actually sent.
- Referral recipient fixed to "VFW Post — Owensboro, KY". Synthetic data only (PHI fence).

### Verification
`pnpm lint` (no --write) · `typecheck` · `lint:boundaries` · `test` (861 pass, +7 new) · `build` — all clean. Migration `0047_SUBP-006c_vfw_referrals.sql` round-tripped on a throwaway Postgres 16: enum now `applied/pending/approved/housed/withdrawn`, `vfw_referrals` table created. The `ADD VALUE`s aren't used in-migration, so the batched-transaction migrator is safe (cf. FND-388).

### ⚠️ Migration number collision
This is `0047`, the same slot as in-flight #399 (DTRS-014a-1). They must merge sequentially — whichever merges second renumbers (`0048`) on rebase. (#400 CWT-023a is also queued behind these.) A dev-loop pass will handle the rebase once the first lands.
